### PR TITLE
Dockerfile based on Ubuntu 18.10

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM ubuntu:18.10
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update
+RUN apt-get install -y build-essential git cmake libboost-dev libgmp-dev libbz2-dev libmpfr-dev g++-8 python3-pip python3-tk
+RUN pip3 install matplotlib
+
+WORKDIR /verifier
+COPY . /verifier/
+RUN make crab_install
+RUN make
+ENTRYPOINT ["./check"]

--- a/README.md
+++ b/README.md
@@ -21,6 +21,16 @@ make crab_install
 make
 ```
 
+### Running with Docker
+Build and run:
+```bash
+docker build -t verifier .
+docker run -it verifier ebpf-samples/cilium/bpf_lxc.o 2/1 --domain=zoneCrab
+1,0.062802,21792
+# To run the Linux verifier you'll need a privileged container:
+docker run --privileged -it verifier ebpf-samples/linux/cpustat_kern.o --domain=linux
+```
+
 ### 
 
 Example:


### PR DESCRIPTION
Since this runs in userspace, it seems like a good fit for a Dockerfile. With this pull request, only the following is required to try out this new verifier:
```bash
docker build -t verifier .
docker run -it verifier ebpf-samples/cilium/bpf_lxc.o 2/1 --domain=zoneCrab
1,0.062802,21792
# To run the Linux verifier you'll need a privileged container:
docker run --privileged -it verifier ebpf-samples/linux/cpustat_kern.o --domain=linux
```

The libboost library v1.70.0 is installed from sources. A single core is used to build libboost, crab, and ebpf-verifier itself.
