### PR TITLE
Fix warning on comparison of integers

### DIFF
--- a/src/asm_files.cpp
+++ b/src/asm_files.cpp
@@ -141,7 +141,7 @@ vector<raw_program> create_blowup(size_t size, MapFd* fd_alloc)
     
     blowup.emplace_back(to_string(i++), Bin{Bin::Op::MOV, true, Reg{7}, (Value)Imm{1}, false});
 
-    blowup.emplace_back(to_string(i++), LoadMapFd{Reg{1}, (size_t)fd});
+    blowup.emplace_back(to_string(i++), LoadMapFd{Reg{1}, fd});
     blowup.emplace_back(to_string(i++), Mem{Deref{4, Reg{10}, -4}, Reg{7}, false});
     blowup.emplace_back(to_string(i++), Bin{Bin::Op::MOV, true, Reg{2}, (Value)Reg{10}, false});
     blowup.emplace_back(to_string(i++), Bin{Bin::Op::ADD, true, Reg{2}, (Value)Imm{(unsigned)-4}, false});
@@ -149,7 +149,7 @@ vector<raw_program> create_blowup(size_t size, MapFd* fd_alloc)
     blowup.emplace_back(to_string(i), Jmp{Condition{Condition::Op::EQ, Reg{0}, (Value)Imm{0}}, to_string(out_err)}); i++;
     blowup.emplace_back(to_string(i++), Bin{Bin::Op::MOV, true, Reg{6}, (Value)Reg{0}, false});
 
-    blowup.emplace_back(to_string(i++), LoadMapFd{Reg{1}, (size_t)fd});
+    blowup.emplace_back(to_string(i++), LoadMapFd{Reg{1}, fd});
     blowup.emplace_back(to_string(i++), Mem{Deref{4, Reg{10}, -4}, Reg{7}, false});
     blowup.emplace_back(to_string(i++), Bin{Bin::Op::MOV, true, Reg{2}, (Value)Reg{10}, false});
     blowup.emplace_back(to_string(i++), Bin{Bin::Op::ADD, true, Reg{2}, (Value)Imm{(unsigned)-4}, false});

--- a/src/asm_syntax.hpp
+++ b/src/asm_syntax.hpp
@@ -44,7 +44,7 @@ struct Un {
 
 struct LoadMapFd {
     Reg dst;
-    size_t mapfd{};
+    int mapfd{};
 };
 
 struct Condition {

--- a/src/asm_unmarshal.cpp
+++ b/src/asm_unmarshal.cpp
@@ -248,7 +248,7 @@ struct Unmarshaller {
             // (for details, look for BPF_PSEUDO_MAP_FD in the kernel)
             return LoadMapFd{
                 .dst = Reg{inst.dst},
-                .mapfd = static_cast<size_t>(inst.imm)
+                .mapfd = inst.imm
             };
         }
 


### PR DESCRIPTION
This change fixes the following warning:
```
$ make
...
build/asm_cfg.o <- src/asm_cfg.cpp
src/asm_cfg.cpp: In member function 'std::map<std::__cxx11::basic_string<char>, int> Cfg::collect_stats() const':
src/asm_cfg.cpp:301:52: warning: comparison of integer expressions of different signedness: 'size_t' {aka 'long unsigned int'} and 'int' [-Wsign-compare]
                 if (std::get<LoadMapFd>(ins).mapfd == -1) {
                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~
At global scope:
cc1plus: warning: unrecognized command line option '-Wno-inconsistent-missing-override'
...
```