### PR TITLE
Fix Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,2 @@
 Dockerfile
+build/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.13)
+cmake_minimum_required(VERSION 3.12)
 project(ebpf_verifier)
 
 set(CMAKE_CXX_STANDARD 17)

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,6 @@ COPY . /verifier/
 RUN mkdir build
 WORKDIR /verifier/build
 RUN cmake .. -DCMAKE_BUILD_TYPE=Release
-RUN make
+RUN make -j
 WORKDIR /verifier
 ENTRYPOINT ["./check"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,14 @@ FROM ubuntu:18.10
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update
-RUN apt-get install -y build-essential git libboost-dev libgmp-dev g++-8 python3-pip python3-tk
+RUN apt-get install -y build-essential git cmake libboost-dev libgmp-dev g++-8 python3-pip python3-tk
 RUN pip3 install matplotlib
 
 WORKDIR /verifier
 COPY . /verifier/
-RUN cmake -B build -DCMAKE_BUILD_TYPE=Release
-RUN cmake --build build
+RUN mkdir build
+WORKDIR /verifier/build
+RUN cmake .. -DCMAKE_BUILD_TYPE=Release
+RUN make
+WORKDIR /verifier
 ENTRYPOINT ["./check"]


### PR DESCRIPTION
The Dockerfile was broken by the switch to CMake in #91. This pull request fixes it.

Only CMake v3.12 is available in Ubuntu 18.04's repositories. It doesn't look like CMake v3.13 is actually needed (wrong?), so the first commit loosen the required version to v3.12. Then, the Dockerfile didn't have CMake installed. Once installed, CMake was complaining that the `build/` directory is missing. The second commit fixes issues in the Dockerfile itself.

The last commit is not a fix. It simply updates the Dockerfile to use all cores at build time. Users can still limit the number of cores used through `docker run`'s options.