### PR TITLE
Configure Travis CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,27 @@
+language: cpp
+dist: bionic
+jobs:
+  include:
+    - stage: Bare metal build
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-8
+      env:
+        - CXX: g++-8
+      before_install:
+        - sudo apt update
+        - sudo apt install cmake libboost-dev
+      install:
+        - mkdir build
+        - cd build
+        - cmake .. -DCMAKE_BUILD_TYPE=Release
+      script:
+        - make -j
+    - stage: Dockerfile build
+      services:
+        - docker
+      script:
+        - docker build .


### PR DESCRIPTION
The Travis CI configuration defines two builds:
- the first just builds the Dockerfile;
- the second builds it without Docker but is essentially the same.
