### PR TITLE
Don't require g++-8

### DIFF
--- a/src/asm_marshal.cpp
+++ b/src/asm_marshal.cpp
@@ -254,7 +254,7 @@ vector<ebpf_inst> marshal(InstructionSeq insts) {
     vector<ebpf_inst> res;
     auto pc_of_label = get_labels(insts);
     pc_t pc = 0;
-    for (auto [label, ins] : insts) {
+    for (auto [_, ins] : insts) {
         if (std::holds_alternative<Jmp>(ins)) {
             Jmp& jmp = std::get<Jmp>(ins);
             jmp.target = std::to_string(pc_of_label.at(jmp.target));

--- a/src/asm_marshal.cpp
+++ b/src/asm_marshal.cpp
@@ -70,7 +70,7 @@ struct MarshalVisitor {
                           .src = static_cast<uint8_t>(isFd ? 1 : 0),
                           .offset = 0,
                           .imm = imm},
-                ebpf_inst{.imm = next_imm}};
+                ebpf_inst{.opcode = 0, .dst = 0, .src = 0, .offset = 0, .imm = next_imm}};
     }
 
   public:
@@ -110,6 +110,8 @@ struct MarshalVisitor {
                 // FIX: should be EBPF_CLS_ALU / EBPF_CLS_ALU64
                 .opcode = static_cast<uint8_t>(EBPF_CLS_ALU | 0x3 | (0x8 << 4)),
                 .dst = b.dst.v,
+                .src = 0,
+                .offset = 0,
                 .imm = imm(b.op),
             }};
         } else {
@@ -118,6 +120,8 @@ struct MarshalVisitor {
             return {ebpf_inst{
                 .opcode = static_cast<uint8_t>(cls | 0x8 | (0xd << 4)),
                 .dst = b.dst.v,
+                .src = 0,
+                .offset = 0,
                 .imm = imm(b.op),
             }};
         }
@@ -141,6 +145,7 @@ struct MarshalVisitor {
             ebpf_inst res{
                 .opcode = static_cast<uint8_t>(EBPF_CLS_JMP | (op(b.cond->op) << 4)),
                 .dst = b.cond->left.v,
+                .src = 0,
                 .offset = label_to_offset(b.target),
             };
             visit(overloaded{[&](Reg right) {
@@ -159,6 +164,8 @@ struct MarshalVisitor {
         Deref access = b.access;
         ebpf_inst res{
             .opcode = static_cast<uint8_t>((EBPF_MEM << 5) | width_to_opcode(access.width)),
+            .dst = 0,
+            .src = 0,
             .offset = static_cast<int16_t>(access.offset),
         };
         if (b.is_load) {
@@ -184,6 +191,9 @@ struct MarshalVisitor {
     vector<ebpf_inst> operator()(Packet const& b) {
         ebpf_inst res{
             .opcode = static_cast<uint8_t>(EBPF_CLS_LD | width_to_opcode(b.width)),
+            .dst = 0,
+            .src = 0,
+            .offset = 0,
             .imm = static_cast<int32_t>(b.offset),
         };
         if (b.regoffset) {

--- a/src/assertions.cpp
+++ b/src/assertions.cpp
@@ -176,7 +176,7 @@ class AssertExtractor {
 };
 
 void explicate_assertions(cfg_t& cfg, const program_info& info) {
-    for (auto& [this_label, bb] : cfg) {
+    for (auto& [_, bb] : cfg) {
         vector<Instruction> insts;
         for (const auto& ins : vector<Instruction>(bb.begin(), bb.end())) {
             for (auto a : std::visit(AssertExtractor{info}, ins))

--- a/src/crab/cfg.hpp
+++ b/src/crab/cfg.hpp
@@ -552,7 +552,7 @@ inline void cfg_t::remove_unreachable_blocks() {
     visited_t alive, dead;
     mark_alive_blocks(entry(), *this, alive);
 
-    for (auto const& [label, bb] : *this) {
+    for (auto const& [label, _] : *this) {
         if (alive.count(label) <= 0) {
             dead.insert(label);
         }

--- a/src/crab/linear_constraints.hpp
+++ b/src/crab/linear_constraints.hpp
@@ -255,7 +255,7 @@ class linear_expression_t final {
 
     variable_set_t variables() const {
         variable_set_t variables;
-        for (auto [var, _] : (*this)) {
+        for (auto [var, _] : *this) {
             variables += var;
         }
         return variables;

--- a/src/crab_verifier.cpp
+++ b/src/crab_verifier.cpp
@@ -59,7 +59,7 @@ inline int first_num(const label_t& s) {
 
 static std::vector<string> sorted_labels(cfg_t& cfg) {
     std::vector<string> labels;
-    for (const auto& [label, block] : cfg)
+    for (const auto& [label, _] : cfg)
         labels.push_back(label);
 
     std::sort(labels.begin(), labels.end(), [](const string& a, const string& b) {

--- a/src/spec_prototypes.cpp
+++ b/src/spec_prototypes.cpp
@@ -328,10 +328,13 @@ static const struct bpf_func_proto bpf_map_lookup_elem_proto = {
     .name = "map_lookup_elem",
     //.func		= bpf_map_lookup_elem,
     //.gpl_only	= false,
-    .pkt_access = true,
     .ret_type = Ret::PTR_TO_MAP_VALUE_OR_NULL,
     .arg1_type = Arg::CONST_SHARED_PTR,
     .arg2_type = Arg::PTR_TO_MAP_KEY,
+    .arg3_type = Arg::DONTCARE,
+    .arg4_type = Arg::DONTCARE,
+    .arg5_type = Arg::DONTCARE,
+    .pkt_access = true,
 };
 
 /*
@@ -342,12 +345,13 @@ static const struct bpf_func_proto bpf_map_update_elem_proto = {
     .name = "map_update_elem",
     //.func		= bpf_map_update_elem,
     //.gpl_only	= false,
-    .pkt_access = true,
     .ret_type = Ret::INTEGER,
     .arg1_type = Arg::CONST_SHARED_PTR,
     .arg2_type = Arg::PTR_TO_MAP_KEY,
     .arg3_type = Arg::PTR_TO_MAP_VALUE,
     .arg4_type = Arg::ANYTHING,
+    .arg5_type = Arg::DONTCARE,
+    .pkt_access = true,
 };
 
 /*
@@ -358,10 +362,13 @@ static const struct bpf_func_proto bpf_map_delete_elem_proto = {
     .name = "map_delete_elem",
     //.func		= bpf_map_delete_elem,
     //.gpl_only	= false,
-    .pkt_access = true,
     .ret_type = Ret::INTEGER,
     .arg1_type = Arg::CONST_SHARED_PTR,
     .arg2_type = Arg::PTR_TO_MAP_KEY,
+    .arg3_type = Arg::DONTCARE,
+    .arg4_type = Arg::DONTCARE,
+    .arg5_type = Arg::DONTCARE,
+    .pkt_access = true,
 };
 
 /*
@@ -466,24 +473,26 @@ static const struct bpf_func_proto bpf_sock_map_update_proto = {
     .name = "sock_map_update",
     //.func		= bpf_sock_map_update,
     //.gpl_only	= false,
-    .pkt_access = true,
     .ret_type = Ret::INTEGER,
     .arg1_type = Arg::PTR_TO_CTX,
     .arg2_type = Arg::CONST_SHARED_PTR,
     .arg3_type = Arg::PTR_TO_MAP_KEY,
     .arg4_type = Arg::ANYTHING,
+    .arg5_type = Arg::DONTCARE,
+    .pkt_access = true,
 };
 
 static const struct bpf_func_proto bpf_sock_hash_update_proto = {
     .name = "sock_hash_update",
     //.func		= bpf_sock_hash_update,
     //.gpl_only	= false,
-    .pkt_access = true,
     .ret_type = Ret::INTEGER,
     .arg1_type = Arg::PTR_TO_CTX,
     .arg2_type = Arg::CONST_SHARED_PTR,
     .arg3_type = Arg::PTR_TO_MAP_KEY,
     .arg4_type = Arg::ANYTHING,
+    .arg5_type = Arg::DONTCARE,
+    .pkt_access = true,
 };
 
 /*
@@ -730,13 +739,13 @@ static const struct bpf_func_proto bpf_csum_diff_proto = {
     .name = "csum_diff",
     //.func		= bpf_csum_diff,
     //.gpl_only	= false,
-    .pkt_access = true,
     .ret_type = Ret::INTEGER,
     .arg1_type = Arg::PTR_TO_MEM_OR_NULL,
     .arg2_type = Arg::CONST_SIZE_OR_ZERO,
     .arg3_type = Arg::PTR_TO_MEM_OR_NULL,
     .arg4_type = Arg::CONST_SIZE_OR_ZERO,
     .arg5_type = Arg::ANYTHING,
+    .pkt_access = true,
 };
 
 static const struct bpf_func_proto bpf_csum_update_proto = {

--- a/src/spec_prototypes.hpp
+++ b/src/spec_prototypes.hpp
@@ -51,13 +51,13 @@ enum class Arg {
 
 struct bpf_func_proto {
     const char* name;
-    bool pkt_access;
     Ret ret_type;
     Arg arg1_type;
     Arg arg2_type;
     Arg arg3_type;
     Arg arg4_type;
     Arg arg5_type;
+    bool pkt_access;
 };
 
 bpf_func_proto get_prototype(unsigned int n);


### PR DESCRIPTION
Zero-initialize any needed designated initializers.

Also, since g++-7 warns about unused variables in structural binding, name them all "_".