### PR TITLE
Remove obsolete unary_function

### DIFF
--- a/src/crab/cfg.hpp
+++ b/src/crab/cfg.hpp
@@ -181,7 +181,7 @@ class cfg_t final {
     using basic_block_map_t = std::unordered_map<label_t, basic_block_t>;
     using binding_t = typename basic_block_map_t::value_type;
 
-    struct get_label : public std::unary_function<binding_t, label_t> {
+    struct get_label {
         label_t operator()(const binding_t& p) const { return p.second.label(); }
     };
 

--- a/src/crab/cfg_bgl.hpp
+++ b/src/crab/cfg_bgl.hpp
@@ -13,8 +13,7 @@ namespace crab {
 
 namespace graph {
 template <typename G>
-struct mk_in_edge : public std::unary_function<typename boost::graph_traits<G>::vertex_descriptor,
-                                               typename boost::graph_traits<G>::edge_descriptor> {
+struct mk_in_edge {
     using Node = typename boost::graph_traits<G>::vertex_descriptor;
     using Edge = typename boost::graph_traits<G>::edge_descriptor;
 
@@ -25,8 +24,7 @@ struct mk_in_edge : public std::unary_function<typename boost::graph_traits<G>::
 };
 
 template <typename G>
-struct mk_out_edge : public std::unary_function<typename boost::graph_traits<G>::vertex_descriptor,
-                                                typename boost::graph_traits<G>::edge_descriptor> {
+struct mk_out_edge {
     using Node = typename boost::graph_traits<G>::vertex_descriptor;
     using Edge = typename boost::graph_traits<G>::edge_descriptor;
 


### PR DESCRIPTION
C++17 is required for compilation, since std::variant was added
in C++17 (see https://en.cppreference.com/w/cpp/utility/variant)

However std::unary_function was removed in C++17 (see
https://en.cppreference.com/w/cpp/utility/functional/unary_function and
it was originally deprecated in C++11 with rationale in
http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2010/n3145.html)
and so cannot be safely used in code that needs to compile with C++17.
This causes the CRAB library to fail to compile with some compilers,
and any compiler that simultaneously supports std::variant and std::unary_function
is arguably non-conformant with the C++ standard.

Per https://stackoverflow.com/questions/22386882/why-have-unary-function-binary-function-been-removed-from-c11
the correct resolution is to simply delete the inheritance.

Signed-off-by: Dave Thaler <dthaler@microsoft.com>