### PR TITLE
Add missing newline to @headers output

### DIFF
--- a/scripts/runperf.sh
+++ b/scripts/runperf.sh
@@ -11,11 +11,9 @@ with_timeout() {
 files=($(find ${dir} -name '*.o'  -exec ls -Sd {} + ))
 
 echo -n suite,project,file,section,
-echo -n $(./check @headers --domain=stats)
 for dom in "$@"
 do
-	echo -n ,
-	./check @headers --domain=${dom} | tr '\n' ' '
+	./check @headers --domain=${dom} | tr -d '\n'
 done
 echo
 

--- a/scripts/runperf.sh
+++ b/scripts/runperf.sh
@@ -14,7 +14,8 @@ echo -n suite,project,file,section,
 echo -n $(./check @headers --domain=stats)
 for dom in "$@"
 do
-	echo -n ,$(./check @headers --domain=${dom})
+	echo -n ,
+	./check @headers --domain=${dom} | tr '\n' ' '
 done
 echo
 

--- a/src/main/check.cpp
+++ b/src/main/check.cpp
@@ -78,6 +78,7 @@ int main(int argc, char** argv) {
             std::cout << domain << "_sec,";
             std::cout << domain << "_kb";
         }
+        std::cout << "\n";
         return 0;
     }
 


### PR DESCRIPTION
All the other commands print a newline at the end, but @headers did not,
resulting in the command line prompt printing on the same line as the
output which was hard to read.

Signed-off-by: Dave Thaler <dthaler@microsoft.com>