### PR TITLE
Prevent assert on non-linux machine

### DIFF
--- a/src/main/check.cpp
+++ b/src/main/check.cpp
@@ -79,6 +79,13 @@ int main(int argc, char** argv) {
         return 0;
     }
 
+#if !__linux__
+    if (domain == "linux") {
+        std::cerr << "linux domain is unsupported on this machine\n";
+        return 64;
+    }
+#endif
+
     auto create_map = domain == "linux" ? create_map_linux : create_map_crab;
     auto raw_progs = read_elf(filename, desired_section, create_map);
 


### PR DESCRIPTION
linux_verifier.hpp has code for non-linux to print an appropriate message
and exit with status 64 in such a case, when bpf_verify_program is called.

However, check never gets that far since read_elf() asserts in line 91
of asm_files.cpp due to fd_alloc being null (since linux_verifier.hpp
defines create_map_linux to nullptr).

This PR copies the same message and status code check to be done before
calling read_elf().

Signed-off-by: Dave Thaler <dthaler@microsoft.com>