### PR TITLE
Fix missing comma error

### DIFF
--- a/scripts/runperf.sh
+++ b/scripts/runperf.sh
@@ -10,9 +10,10 @@ with_timeout() {
 
 files=($(find ${dir} -name '*.o'  -exec ls -Sd {} + ))
 
-echo -n suite,project,file,section,
+echo -n suite,project,file,section
 for dom in "$@"
 do
+	echo -n ,
 	./check @headers --domain=${dom} | tr -d '\n'
 done
 echo


### PR DESCRIPTION
Actually I just found a bug in PR #106 which is a missing comma when multiple domains are specified, somehow missed it when testing 106

Signed-off-by: Dave Thaler <dthaler@microsoft.com>