### PR TITLE
Print correct list of sections when specified section is not found

### DIFF
--- a/src/main/check.cpp
+++ b/src/main/check.cpp
@@ -99,6 +99,11 @@ int main(int argc, char** argv) {
             std::cout << "please specify a section\n";
             std::cout << "available sections:\n";
         }
+        if (!desired_section.empty() && raw_progs.size() == 0) {
+            // We could not find the desired section, so get the full list
+            // of possibilities.
+            raw_progs = read_elf(filename, string(), create_map);
+        }
         for (const raw_program& raw_prog : raw_progs) {
             std::cout << raw_prog.section << " ";
         }


### PR DESCRIPTION
This PR fixes output when a bad section number is passed in on the command line.  Previously the list of available sections was shown as empty.

Example before fix:
```
$ ./check ebpf-samples/cilium/bpf_lxc.o 2/100 --domain=zoneCrab
Could not find relevant section!
please specify a section
available sections:
```

Example after fix:
```
$ ./check ebpf-samples/cilium/bpf_lxc.o 2/100 --domain=zoneCrab
Could not find relevant section!
please specify a section
available sections:
2/1 2/3 2/5 2/4 2/10 2/7 2/6 from-container 2/12 2/11 1/0x1010 2/8 2/9
```

Signed-off-by: Dave Thaler <dthaler@microsoft.com>