### PR TITLE
Allow eBPF program to be in the .text section

### DIFF
--- a/src/asm_files.cpp
+++ b/src/asm_files.cpp
@@ -131,7 +131,7 @@ vector<raw_program> read_elf(const std::string& path, const std::string& desired
             continue;
         if (name == "license" || name == "version" || name == "maps")
             continue;
-        if (name.find('.') == 0) {
+        if (name != ".text" && name.find('.') == 0) {
             continue;
         }
         info.program_type = section_to_progtype(name, path);


### PR DESCRIPTION
Currently the verifier skips all sections starting with a ".", including ".text".
However, if there is no pragma in the ebpf program, the program goes into the .text section by default (e.g., if one follows the sample walkthrough [here](https://qmonnet.github.io/whirl-offload/2020/04/12/llvm-ebpf-asm/)).
As a result, the verifier cannot find the program at all.

This patch fixes the verifier to recognize a non-empty .text section (the check for non-empty was already present in line 139).

Signed-off-by: Dave Thaler <dthaler@microsoft.com>