### PR TITLE
Add copyright/license headers to files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,13 @@
+# Copyright (c) Prevail Verifier contributors.
+# SPDX-License-Identifier: MIT
 cmake_minimum_required(VERSION 3.10)
 project(ebpf_verifier)
+
+if (IS_DIRECTORY "${PROJECT_SOURCE_DIR}/.git")
+  # Install Git pre-commit hook
+  file(COPY scripts/pre-commit scripts/commit-msg
+       DESTINATION "${PROJECT_SOURCE_DIR}/.git/hooks")
+endif ()
 
 set(CMAKE_CXX_STANDARD 17)
 

--- a/Doxyfile
+++ b/Doxyfile
@@ -1,5 +1,8 @@
 # Doxyfile 1.8.17
 
+# Copyright (c) Prevail Verifier contributors.
+# SPDX-License-Identifier: MIT
+
 # This file describes the settings to be used by the documentation system
 # doxygen (www.doxygen.org) for a project.
 #

--- a/FindGMP.cmake
+++ b/FindGMP.cmake
@@ -1,3 +1,6 @@
+# Copyright (c) Prevail Verifier contributors.
+# SPDX-License-Identifier: MIT
+
 # Try to find the GNU Multiple Precision Arithmetic Library (GMP)
 # See http://gmplib.org/
 

--- a/scripts/.check-license.ignore
+++ b/scripts/.check-license.ignore
@@ -1,0 +1,16 @@
+# This file uses regular expressions, not shell globs!
+
+# File extensions
+.*\.md$
+.*\.patch$
+
+# Directories
+external/.*
+external/elfio/.*
+
+# Files
+\.check-license\.ignore
+\.clang-format
+\.gitattributes
+\.gitignore
+\.gitmodules

--- a/scripts/.check-license.ignore
+++ b/scripts/.check-license.ignore
@@ -1,16 +1,42 @@
 # This file uses regular expressions, not shell globs!
 
-# File extensions
+# File extensions that don't support embedding license info
+.*\.a$
 .*\.md$
 .*\.patch$
 
-# Directories
-external/.*
-external/elfio/.*
+# Directories using GPL
+src/gpl
+counter
 
-# Files
+# Other Directories
+ebpf-samples
+external
+
+# Files using NASA-1.3 license
+src/crab/linear_constraints.hpp
+src/crab/split_dbm.hpp
+src/crab/wto.hpp
+src/crab_utils/bignums.hpp
+src/crab_utils/patricia_trees.hpp
+src/crab_utils/safeint.hpp
+
+# Files using Apache-2.0 license
+src/crab_utils/debug.cpp
+
+# Files using CC-BY-SA-2.5 license
+src/memsize.hpp
+
+# Files with custom licenses embedded
+src/crab_utils/heap.hpp
+
+# Other Files
 \.check-license\.ignore
 \.clang-format
+\.dockerignore
 \.gitattributes
 \.gitignore
 \.gitmodules
+\.travis.yml
+\Dockerfile
+\LICENSE.txt

--- a/scripts/check-license.sh
+++ b/scripts/check-license.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+
+# Copyright (c) Prevail Verifier contributors.
+# SPDX-License-Identifier: MIT
+
+# This script accepts either a list of files relative to the current
+# working directory, or it will check all files tracked in Git. In
+# both cases, it ignores files matching any regular expression listed
+# in '.check-license.ignore'.
+
+set -o errexit
+set -o pipefail
+
+license=("Copyright (c) Prevail Verifier contributors." "SPDX-License-Identifier: MIT")
+
+root=$(git rev-parse --show-toplevel)
+
+# If we are inside mingw* environment, then we update the path to proper format
+if [[ $(uname) == MINGW* ]] ; then
+      root=$(cygpath -u "${root}")
+fi
+
+ignore_res=()
+while IFS= read -r i; do
+      if [[ $i =~ ^# ]] || [[ -z $i ]]; then # ignore comments
+          continue
+      fi
+      ignore_res+=("$i")
+done <"$root/scripts/.check-license.ignore"
+
+
+should_ignore() {
+    for re in "${ignore_res[@]}"; do
+        if [[ $1 =~ $re ]]; then
+            return
+        fi
+    done
+    false
+}
+
+# Create array of files to check, either from the given arguments or
+# all files in Git, ignore any that match a regex in the ignore file.
+files=()
+if [[ $# -ne 0 ]]; then
+    for f in "$@"; do
+        file=$(realpath "$f")
+
+        if [[ ! -f $file ]]; then # skip non-existent files
+            continue
+        fi
+
+        file=${file#$root/} # remove the prefix
+
+        if should_ignore "$file"; then
+            continue
+        fi
+
+        files+=("$file")
+    done
+else
+    # Find all files in Git. These are guaranteed to exist, to not be
+    # generated, and to not have the prefix.
+    cd "$root"
+    while IFS= read -r -d '' file; do
+        if should_ignore "$file"; then
+            continue
+        fi
+
+        files+=("$file")
+    done < <(git ls-files -z)
+fi
+
+failures=0
+for file in "${files[@]}"; do
+    for line in "${license[@]}"; do
+        # We check only the first four lines to avoid false positives
+        # (such as this script), but to allow for a shebang and empty
+        # line between it and the license.
+        if ! head -n4 "${root}/${file}" | grep --quiet --fixed-strings --max-count=1 "${line}"; then
+            echo "${file}"
+            failures=$((failures + 1))
+            break
+        fi
+    done
+done
+
+exit $failures

--- a/scripts/commit-msg
+++ b/scripts/commit-msg
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+# Copyright (c) Prevail Verifier contributors.
+# SPDX-License-Identifier: MIT
+
+set -o errexit
+
+exit_() {
+    echo ""
+    echo "$1"
+    echo ""
+    echo "This hook can be skipped if needed with 'git commit --no-verify'"
+    echo "See '.git/hooks/commit-msg., installed from 'scripts/commit-msg'"
+    exit 1
+}
+
+sign_offs="$(grep '^Signed-off-by: ' "$1" || test $? = 1 )"
+
+if [[ -z $sign_offs ]]; then
+    exit_ "Commit failed: please sign-off on the DCO with 'git commit -s'"
+fi
+
+if [[ -n $(echo "$sign_offs" | sort | uniq -c | sed -e '/^[ 	]*1[ 	]/d') ]]; then
+    exit_ "Commit failed: please remove duplicate Signed-off-by lines"
+fi

--- a/scripts/experiment.sh
+++ b/scripts/experiment.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Copyright (c) Prevail Verifier contributors.
+# SPDX-License-Identifier: MIT
+
 # double-strncmp loop experiment
 # generate increasingly long unrolled versions of the function
 # 

--- a/scripts/hist.py
+++ b/scripts/hist.py
@@ -1,4 +1,7 @@
 #!/usr/bin/python3
+# Copyright (c) Prevail Verifier contributors.
+# SPDX-License-Identifier: MIT
+#
 # Usage: python3 hist.py results.csv [loads|stores|instructions|...]
 import matplotlib.pyplot as plt
 import numpy as np

--- a/scripts/makeplot.py
+++ b/scripts/makeplot.py
@@ -1,4 +1,7 @@
 #!/usr/bin/python3
+# Copyright (c) Prevail Verifier contributors.
+# SPDX-License-Identifier: MIT
+#
 # Usage: python3 makeplot.py results.csv [loads|stores|instructions|...]
 import matplotlib.pyplot as plt
 import numpy as np

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -37,6 +37,6 @@ fi
 
 scripts=$(git rev-parse --show-toplevel)/scripts
 
-if ! "$scripts/check-license" "${files[@]}"; then
+if ! "$scripts/check-license.sh" "${files[@]}"; then
     exit_ "Commit failed: please add license headers to the above files"
 fi

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+# Copyright (c) Prevail Verifier contributors.
+# SPDX-License-Identifier: MIT
+
+set -o errexit
+
+exit_() {
+    echo ""
+    echo "$1"
+    echo ""
+    echo "This hook can be skipped if needed with 'git commit --no-verify'"
+    echo "See '.git/hooks/pre-commit', installed from 'scripts/pre-commit'"
+    exit 1
+}
+
+if [[ $(git config --get user.name | wc -w) -lt 2 ]]; then
+    # This heuristic avoids bad user names such as "root" or "Ubuntu"
+    # or a computer login name. A full name should (usually) have at
+    # least two words. We can change this if needed later.
+    exit_ "Commit failed: please fix your Git user name (see docs/Contributing.md)"
+fi
+
+if ! git diff-index --check --cached HEAD --; then
+    exit_ "Commit failed: please fix the conflict markers or whitespace errors"
+fi
+
+mapfile -t files < <(git diff --cached --name-only --diff-filter=ACMR)
+
+if [[ ${#files[@]} -eq 0 ]]; then
+    # When 'git commit --amend' is used, the files list is empty. The
+    # scripts below interpret an empty file set as a directive to
+    # check all the files, which is slow (but used in CI). So in this
+    # Git hook, we just skip the following checks instead.
+    exit 0
+fi
+
+scripts=$(git rev-parse --show-toplevel)/scripts
+
+if ! "$scripts/check-license" "${files[@]}"; then
+    exit_ "Commit failed: please add license headers to the above files"
+fi

--- a/scripts/runperf.sh
+++ b/scripts/runperf.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Copyright (c) Prevail Verifier contributors.
+# SPDX-License-Identifier: MIT
+
 dir=$1
 test -d $dir || (echo "first argument should be a directory"; exit 1)
 shift

--- a/scripts/save_outputs.py
+++ b/scripts/save_outputs.py
@@ -1,4 +1,6 @@
 #!/usr/bin/python3
+# Copyright (c) Prevail Verifier contributors.
+# SPDX-License-Identifier: MIT
 import subprocess
 import shutil
 import glob

--- a/scripts/uniq_hash.py
+++ b/scripts/uniq_hash.py
@@ -1,4 +1,6 @@
 #!/usr/bin/python3
+# Copyright (c) Prevail Verifier contributors.
+# SPDX-License-Identifier: MIT
 import fileinput
 import sys
 

--- a/src/asm_cfg.cpp
+++ b/src/asm_cfg.cpp
@@ -1,3 +1,5 @@
+// Copyright (c) Prevail Verifier contributors.
+// SPDX-License-Identifier: MIT
 #include <cassert>
 
 #include <algorithm>

--- a/src/asm_files.cpp
+++ b/src/asm_files.cpp
@@ -1,3 +1,5 @@
+// Copyright (c) Prevail Verifier contributors.
+// SPDX-License-Identifier: MIT
 #include <cassert>
 #include <iostream>
 #include <string>

--- a/src/asm_files.hpp
+++ b/src/asm_files.hpp
@@ -1,3 +1,5 @@
+// Copyright (c) Prevail Verifier contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include <fstream>

--- a/src/asm_marshal.cpp
+++ b/src/asm_marshal.cpp
@@ -1,3 +1,5 @@
+// Copyright (c) Prevail Verifier contributors.
+// SPDX-License-Identifier: MIT
 #include <cassert>
 #include <unordered_map>
 #include <variant>

--- a/src/asm_marshal.hpp
+++ b/src/asm_marshal.hpp
@@ -1,3 +1,5 @@
+// Copyright (c) Prevail Verifier contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include "asm_syntax.hpp"

--- a/src/asm_ostream.cpp
+++ b/src/asm_ostream.cpp
@@ -1,3 +1,5 @@
+// Copyright (c) Prevail Verifier contributors.
+// SPDX-License-Identifier: MIT
 #include <fstream>
 #include <iomanip>
 #include <iostream>

--- a/src/asm_ostream.hpp
+++ b/src/asm_ostream.hpp
@@ -1,3 +1,5 @@
+// Copyright (c) Prevail Verifier contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include <functional>

--- a/src/asm_parse.cpp
+++ b/src/asm_parse.cpp
@@ -1,3 +1,5 @@
+// Copyright (c) Prevail Verifier contributors.
+// SPDX-License-Identifier: MIT
 #include <algorithm>
 #include <boost/lexical_cast.hpp>
 #include <map>

--- a/src/asm_parse.hpp
+++ b/src/asm_parse.hpp
@@ -1,3 +1,5 @@
+// Copyright (c) Prevail Verifier contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include <tuple>

--- a/src/asm_syntax.hpp
+++ b/src/asm_syntax.hpp
@@ -1,3 +1,5 @@
+// Copyright (c) Prevail Verifier contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include <optional>

--- a/src/asm_unmarshal.cpp
+++ b/src/asm_unmarshal.cpp
@@ -1,3 +1,5 @@
+// Copyright (c) Prevail Verifier contributors.
+// SPDX-License-Identifier: MIT
 #include <cassert>
 #include <cstring> // memcmp
 #include <iostream>

--- a/src/asm_unmarshal.hpp
+++ b/src/asm_unmarshal.hpp
@@ -1,3 +1,5 @@
+// Copyright (c) Prevail Verifier contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include <istream>

--- a/src/assertions.cpp
+++ b/src/assertions.cpp
@@ -1,3 +1,5 @@
+// Copyright (c) Prevail Verifier contributors.
+// SPDX-License-Identifier: MIT
 #include <cinttypes>
 
 #include <utility>

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -1,3 +1,5 @@
+// Copyright (c) Prevail Verifier contributors.
+// SPDX-License-Identifier: MIT
 #include "config.hpp"
 
 global_options_t global_options{

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -1,3 +1,5 @@
+// Copyright (c) Prevail Verifier contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 
 // defaults are in definition

--- a/src/crab/array_domain.cpp
+++ b/src/crab/array_domain.cpp
@@ -1,3 +1,5 @@
+// Copyright (c) Prevail Verifier contributors.
+// SPDX-License-Identifier: MIT
 #include <algorithm>
 #include <bitset>
 #include <optional>

--- a/src/crab/array_domain.hpp
+++ b/src/crab/array_domain.hpp
@@ -1,3 +1,5 @@
+// Copyright (c) Prevail Verifier contributors.
+// SPDX-License-Identifier: MIT
 /*******************************************************************************
  * Array expansion domain
  *

--- a/src/crab/bitset_domain.cpp
+++ b/src/crab/bitset_domain.cpp
@@ -1,3 +1,5 @@
+// Copyright (c) Prevail Verifier contributors.
+// SPDX-License-Identifier: MIT
 #include "bitset_domain.hpp"
 #include <ostream>
 

--- a/src/crab/bitset_domain.hpp
+++ b/src/crab/bitset_domain.hpp
@@ -1,3 +1,5 @@
+// Copyright (c) Prevail Verifier contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include <bitset>

--- a/src/crab/cfg.hpp
+++ b/src/crab/cfg.hpp
@@ -1,3 +1,5 @@
+// Copyright (c) Prevail Verifier contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 
 /*

--- a/src/crab/cfg_bgl.hpp
+++ b/src/crab/cfg_bgl.hpp
@@ -1,3 +1,5 @@
+// Copyright (c) Prevail Verifier contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 
 /*

--- a/src/crab/dsl_syntax.hpp
+++ b/src/crab/dsl_syntax.hpp
@@ -1,3 +1,5 @@
+// Copyright (c) Prevail Verifier contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include <utility>

--- a/src/crab/ebpf_domain.hpp
+++ b/src/crab/ebpf_domain.hpp
@@ -1,3 +1,5 @@
+// Copyright (c) Prevail Verifier contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 
 // This file is eBPF-specific, not derived from CRAB.

--- a/src/crab/fwd_analyzer.cpp
+++ b/src/crab/fwd_analyzer.cpp
@@ -1,3 +1,5 @@
+// Copyright (c) Prevail Verifier contributors.
+// SPDX-License-Identifier: MIT
 #include <utility>
 #include <variant>
 

--- a/src/crab/fwd_analyzer.hpp
+++ b/src/crab/fwd_analyzer.hpp
@@ -1,3 +1,5 @@
+// Copyright (c) Prevail Verifier contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include <unordered_map>

--- a/src/crab/interval.cpp
+++ b/src/crab/interval.cpp
@@ -1,3 +1,5 @@
+// Copyright (c) Prevail Verifier contributors.
+// SPDX-License-Identifier: MIT
 #include "crab/interval.hpp"
 
 namespace crab {

--- a/src/crab/interval.hpp
+++ b/src/crab/interval.hpp
@@ -1,3 +1,5 @@
+// Copyright (c) Prevail Verifier contributors.
+// SPDX-License-Identifier: MIT
 /*******************************************************************************
  *
  * A simple class for representing intervals and performing interval arithmetic.

--- a/src/crab/linear_constraints.hpp
+++ b/src/crab/linear_constraints.hpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: NASA-1.3
 /*******************************************************************************
  *
  * Data structures for the symbolic manipulation of linear constraints.

--- a/src/crab/split_dbm.cpp
+++ b/src/crab/split_dbm.cpp
@@ -1,3 +1,5 @@
+// Copyright (c) Prevail Verifier contributors.
+// SPDX-License-Identifier: MIT
 #include "crab/split_dbm.hpp"
 
 #include <utility>

--- a/src/crab/split_dbm.hpp
+++ b/src/crab/split_dbm.hpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: NASA-1.3
 /*******************************************************************************
  *
  * Difference Bound Matrix domain based on the paper "Exploiting

--- a/src/crab/thresholds.cpp
+++ b/src/crab/thresholds.cpp
@@ -1,3 +1,5 @@
+// Copyright (c) Prevail Verifier contributors.
+// SPDX-License-Identifier: MIT
 #include "crab/thresholds.hpp"
 #include "crab/cfg.hpp"
 

--- a/src/crab/thresholds.hpp
+++ b/src/crab/thresholds.hpp
@@ -1,3 +1,5 @@
+// Copyright (c) Prevail Verifier contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include <unordered_map>

--- a/src/crab/var_factory.cpp
+++ b/src/crab/var_factory.cpp
@@ -1,3 +1,5 @@
+// Copyright (c) Prevail Verifier contributors.
+// SPDX-License-Identifier: MIT
 /*
  * Factories for variable names.
  */

--- a/src/crab/variable.hpp
+++ b/src/crab/variable.hpp
@@ -1,3 +1,5 @@
+// Copyright (c) Prevail Verifier contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include <iosfwd>

--- a/src/crab/wto.hpp
+++ b/src/crab/wto.hpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: NASA-1.3
 /*******************************************************************************
  *
  * Construction and management of weak topological orderings (WTOs).

--- a/src/crab_utils/adapt_sgraph.hpp
+++ b/src/crab_utils/adapt_sgraph.hpp
@@ -1,3 +1,5 @@
+// Copyright (c) Prevail Verifier contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include <memory>

--- a/src/crab_utils/bignums.hpp
+++ b/src/crab_utils/bignums.hpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: NASA-1.3
 /*******************************************************************************
  *
  * Implementation of bignums based on GMP, the Gnu Multiple Precision Arithmetic

--- a/src/crab_utils/debug.cpp
+++ b/src/crab_utils/debug.cpp
@@ -1,3 +1,5 @@
+// Copyright (c) Prevail Verifier contributors.
+// SPDX-License-Identifier: Apache-2.0
 #include "debug.hpp"
 
 namespace crab {

--- a/src/crab_utils/debug.hpp
+++ b/src/crab_utils/debug.hpp
@@ -1,3 +1,5 @@
+// Copyright (c) Prevail Verifier contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 
 /* Logging and debug messages */

--- a/src/crab_utils/graph_ops.hpp
+++ b/src/crab_utils/graph_ops.hpp
@@ -1,3 +1,5 @@
+// Copyright (c) Prevail Verifier contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include <algorithm>

--- a/src/crab_utils/patricia_trees.hpp
+++ b/src/crab_utils/patricia_trees.hpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: NASA-1.3
 /*******************************************************************************
  *
  * Implementation of Patricia trees based on the algorithms described in

--- a/src/crab_utils/safeint.hpp
+++ b/src/crab_utils/safeint.hpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: NASA-1.3
 #pragma once
 
 /**

--- a/src/crab_utils/stats.cpp
+++ b/src/crab_utils/stats.cpp
@@ -1,3 +1,5 @@
+// Copyright (c) Prevail Verifier contributors.
+// SPDX-License-Identifier: MIT
 #include "stats.hpp"
 
 #include <sys/resource.h>

--- a/src/crab_utils/stats.hpp
+++ b/src/crab_utils/stats.hpp
@@ -1,3 +1,5 @@
+// Copyright (c) Prevail Verifier contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include <map>

--- a/src/crab_verifier.cpp
+++ b/src/crab_verifier.cpp
@@ -1,3 +1,5 @@
+// Copyright (c) Prevail Verifier contributors.
+// SPDX-License-Identifier: MIT
 /**
  *  This module is about selecting the numerical and memory domains, initiating
  *  the verification process and returning the results.

--- a/src/crab_verifier.hpp
+++ b/src/crab_verifier.hpp
@@ -1,3 +1,5 @@
+// Copyright (c) Prevail Verifier contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include <tuple>

--- a/src/linux_ebpf.hpp
+++ b/src/linux_ebpf.hpp
@@ -1,3 +1,5 @@
+// Copyright (c) Prevail Verifier contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 #include <cinttypes>
 

--- a/src/linux_verifier.cpp
+++ b/src/linux_verifier.cpp
@@ -1,4 +1,5 @@
-
+// Copyright (c) Prevail Verifier contributors.
+// SPDX-License-Identifier: MIT
 #if __linux__
 
 #include <unistd.h>

--- a/src/linux_verifier.hpp
+++ b/src/linux_verifier.hpp
@@ -1,3 +1,5 @@
+// Copyright (c) Prevail Verifier contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #if __linux__

--- a/src/main/check.cpp
+++ b/src/main/check.cpp
@@ -1,3 +1,5 @@
+// Copyright (c) Prevail Verifier contributors.
+// // SPDX-License-Identifier: MIT
 #include <iostream>
 #include <vector>
 

--- a/src/memsize.hpp
+++ b/src/memsize.hpp
@@ -1,5 +1,7 @@
+// SPDX-License-Identifier: CC-BY-SA-2.5
 #pragma once
 // from https://stackoverflow.com/a/671389/2289509
+// see https://stackoverflow.com/help/licensing
 
 #include <fstream>
 #include <ios>

--- a/src/test/test.cpp
+++ b/src/test/test.cpp
@@ -1,3 +1,5 @@
+// Copyright (c) Prevail Verifier contributors.
+// SPDX-License-Identifier: MIT
 #define CATCH_CONFIG_MAIN
 #include "catch.hpp"
 

--- a/src/test/test_marshal.cpp
+++ b/src/test/test_marshal.cpp
@@ -1,3 +1,5 @@
+// Copyright (c) Prevail Verifier contributors.
+// SPDX-License-Identifier: MIT
 #include "catch.hpp"
 
 #include "asm_ostream.hpp"


### PR DESCRIPTION
This pull request does two things:
1) It adds headers to existing files.  (I am not certain they are all correct in this PR, so please review.)
2) It checks any new commits to make sure files have such headers.

The .check-license.ignore file lists file types, directories, and files, that intentionally do not have the usual license header for this project.

Fixes #105 