### PR TITLE
Fix heap corruption

### DIFF
--- a/src/crab_utils/heap.hpp
+++ b/src/crab_utils/heap.hpp
@@ -87,7 +87,8 @@ class Heap {
     }
 
     void insert(int n) {
-        indices.resize(n + 1, -1);
+        if (n >= indices.size())
+            indices.resize(n + 1, -1);
         assert(!inHeap(n));
 
         indices[n] = heap.size();


### PR DESCRIPTION
The indices[] array was incorrectly resized downwards when it should
only be resized to be bigger.  Compare line 93 at
https://github.com/seahorn/crab/blob/master/include/crab/domains/graphs/util/Heap.h
which uses a custom growTo() function instead of resize(), and line
172 of
https://github.com/seahorn/crab/blob/master/include/crab/domains/graphs/util/Vec.h
avoids resizing downwards, which the ebpf_verifier version didn't do.

The symptom is that depending on how vector.resize() is implemented
on the platform, the code would then index into memory past the end of the array in percolateUp, which should be illegal, and either
a) not be caught and just read out of memory it shouldn't, OR
b) crash due to accessing invalid memory

Signed-off-by: Dave Thaler <dthaler@ntdev.microsoft.com>