### PR TITLE
Add static casts for intentional loss of precision

### DIFF
--- a/src/asm_cfg.cpp
+++ b/src/asm_cfg.cpp
@@ -200,7 +200,11 @@ std::map<std::string, int> collect_stats(const cfg_t& cfg) {
     for (const auto& this_label : cfg.labels()) {
         res["basic_blocks"]++;
         basic_block_t const& bb = cfg.get_node(this_label);
-        res["instructions"] += bb.size();
+
+        // We assume that the total number of instructions <= INT_MAX
+        // and so casting from size_t to int is safe, as is the addition.
+        res["instructions"] += static_cast<int>(bb.size());
+
         for (Instruction ins : bb) {
             if (std::holds_alternative<LoadMapFd>(ins)) {
                 if (std::get<LoadMapFd>(ins).mapfd == -1) {

--- a/src/asm_files.cpp
+++ b/src/asm_files.cpp
@@ -122,7 +122,9 @@ vector<raw_program> read_elf(const std::string& path, const std::string& desired
         ELFIO::Elf_Half section_index;
         unsigned char other;
         symbols.get_symbol(symbol, symbol_name, value, size, bind, type, section_index, other);
-        return value / sizeof(bpf_load_map_def);
+
+        // We assume the reloc value fits safely in an int, but cast to avoid compiler warnings.
+        return static_cast<int>(value / sizeof(bpf_load_map_def));
     };
 
     vector<raw_program> res;

--- a/src/crab/array_domain.cpp
+++ b/src/crab/array_domain.cpp
@@ -183,7 +183,7 @@ std::vector<cell_t> offset_map_t::get_overlap_cells(offset_t o, unsigned size) {
         }
         upto_lb.push_back(lb_it->second);
 
-        for (int i = upto_lb.size() - 1; i >= 0; --i) {
+        for (int i = static_cast<int>(upto_lb.size() - 1); i >= 0; --i) {
             ///////
             // All the cells in upto_lb[i] have the same offset. They
             // just differ in the size.

--- a/src/crab/bitset_domain.hpp
+++ b/src/crab/bitset_domain.hpp
@@ -52,7 +52,7 @@ class bitset_domain_t final {
         return non_numerical_bytes & other.non_numerical_bytes;
     }
 
-    std::pair<bool, bool> uniformity(int lb, int width) {
+    std::pair<bool, bool> uniformity(size_t lb, int width) {
         bool only_num = true;
         bool only_non_num = true;
         for (int j = 0; j < width; j++) {
@@ -63,13 +63,13 @@ class bitset_domain_t final {
         return std::make_pair(only_num, only_non_num);
     }
 
-    void reset(int lb, int n) {
+    void reset(size_t lb, int n) {
         for (int i = 0; i < n; i++) {
             non_numerical_bytes.reset(lb + i);
         }
     }
 
-    void havoc(int lb, int width) {
+    void havoc(size_t lb, int width) {
         for (int i = 0; i < width; i++) {
             non_numerical_bytes.set(lb + i);
         }

--- a/src/crab/split_dbm.cpp
+++ b/src/crab/split_dbm.cpp
@@ -492,7 +492,7 @@ SplitDBM SplitDBM::operator|(const SplitDBM& _o) & {
         auto it = o.vert_map.find(v);
         // Variable exists in both
         if (it != o.vert_map.end()) {
-            out_vmap.insert(vmap_elt_t(v, perm_x.size()));
+            out_vmap.insert(vmap_elt_t(v, static_cast<vert_id>(perm_x.size())));
             out_revmap.push_back(v);
 
             pot_rx.push_back(potential[n] - potential[0]);
@@ -504,7 +504,7 @@ SplitDBM SplitDBM::operator|(const SplitDBM& _o) & {
             perm_y.push_back(it->second);
         }
     }
-    unsigned int sz = perm_x.size();
+    size_t sz = perm_x.size();
 
     // Build the permuted view of x and y.
     assert(g.size() > 0);
@@ -665,7 +665,7 @@ SplitDBM SplitDBM::widen(SplitDBM o) {
             auto it = o.vert_map.find(v);
             // Variable exists in both
             if (it != o.vert_map.end()) {
-                out_vmap.insert(vmap_elt_t(v, perm_x.size()));
+                out_vmap.insert(vmap_elt_t(v, static_cast<vert_id>(perm_x.size())));
                 out_revmap.push_back(v);
 
                 widen_pot.push_back(potential[n] - potential[0]);
@@ -725,7 +725,7 @@ SplitDBM SplitDBM::operator&(SplitDBM o) {
         meet_pi.emplace_back(0);
         meet_rev.push_back(std::nullopt);
         for (auto [v, n] : vert_map) {
-            vert_id vv = perm_x.size();
+            vert_id vv = static_cast<vert_id>(perm_x.size());
             meet_verts.insert(vmap_elt_t(v, vv));
             meet_rev.push_back(v);
 
@@ -739,7 +739,7 @@ SplitDBM SplitDBM::operator&(SplitDBM o) {
             auto it = meet_verts.find(v);
 
             if (it == meet_verts.end()) {
-                vert_id vv = perm_y.size();
+                vert_id vv = static_cast<vert_id>(perm_y.size());
                 meet_rev.push_back(v);
 
                 perm_y.push_back(n);

--- a/src/crab/thresholds.hpp
+++ b/src/crab/thresholds.hpp
@@ -35,7 +35,7 @@ class thresholds_t final {
         m_thresholds.push_back(bound_t::plus_infinity());
     }
 
-    unsigned size() const { return m_thresholds.size(); }
+    size_t size() const { return m_thresholds.size(); }
 
     void add(bound_t v1);
 

--- a/src/crab_utils/adapt_sgraph.hpp
+++ b/src/crab_utils/adapt_sgraph.hpp
@@ -234,7 +234,7 @@ class AdaptGraph final {
             free_id.pop_back();
             is_free[v] = false;
         } else {
-            v = _succs.size();
+            v = static_cast<vert_id>(_succs.size());
             is_free.push_back(false);
             _succs.emplace_back();
             _preds.emplace_back();
@@ -243,7 +243,7 @@ class AdaptGraph final {
         return v;
     }
 
-    void growTo(vert_id v) {
+    void growTo(size_t v) {
         while (size() < v)
             new_vertex();
     }
@@ -386,7 +386,7 @@ class AdaptGraph final {
     std::vector<smap_t> _succs;
     std::vector<Wt> _ws;
 
-    int edge_count;
+    size_t edge_count;
 
     std::vector<int> is_free;
     std::vector<vert_id> free_id;

--- a/src/crab_utils/graph_ops.hpp
+++ b/src/crab_utils/graph_ops.hpp
@@ -94,11 +94,11 @@ class GraphPerm {
     }
 
     // Number of allocated vertices
-    int size() const { return perm.size(); }
+    size_t size() const { return perm.size(); }
 
     using vert_range = num_range<vert_id>;
     using vert_iterator = typename num_range<vert_id>::value_ref;
-    vert_range verts() const { return vert_range(perm.size()); }
+    vert_range verts() const { return vert_range(static_cast<vert_id>(perm.size())); }
 
     // GKG: Should probably modify this to handle cases where
     // the vertex iterator isn't just a vert_id*.
@@ -257,7 +257,7 @@ class SubGraph {
     void clear() { assert(0 && "SubGraph::clear not implemented."); }
 
     // Number of allocated vertices
-    int size() const { return g.size(); }
+    size_t size() const { return g.size(); }
 
     // Assumption: (x, y) not in mtx
     void add_edge(vert_id x, Wt wt, vert_id y) {
@@ -472,7 +472,7 @@ class GraphOps {
     // Used for Bellman-Ford queueing
     static vert_id* dual_queue;
     static int* vert_marks;
-    static unsigned int scratch_sz;
+    static size_t scratch_sz;
 
     // For locality, should combine dists & dist_ts.
     // Wt must have an empty constructor, but does _not_
@@ -486,14 +486,14 @@ class GraphOps {
     static unsigned int ts;
     static unsigned int ts_idx;
 
-    static void grow_scratch(unsigned int sz) {
+    static void grow_scratch(size_t sz) {
         if (sz <= scratch_sz)
             return;
 
         if (scratch_sz == 0)
             scratch_sz = 10; // Introduce enums for init_sz and growth_factor
         while (scratch_sz < sz)
-            scratch_sz *= 1.5;
+            scratch_sz = static_cast<size_t>(scratch_sz * 1.5);
 
         edge_marks = (char*)realloc(edge_marks, sizeof(char) * scratch_sz * scratch_sz);
         dual_queue = (vert_id*)realloc(dual_queue, sizeof(vert_id) * 2 * scratch_sz);
@@ -512,7 +512,7 @@ class GraphOps {
     static graph_t join(G1& l, G2& r) {
         // For the join, potentials are preserved
         assert(l.size() == r.size());
-        int sz = l.size();
+        size_t sz = l.size();
 
         graph_t g;
         g.growTo(sz);
@@ -628,7 +628,7 @@ class GraphOps {
 
     template <class G>
     static void compute_sccs(G& x, std::vector<std::vector<vert_id>>& out_scc) {
-        int sz = x.size();
+        size_t sz = x.size();
         grow_scratch(sz);
 
         for (vert_id v : x.verts())
@@ -659,7 +659,7 @@ class GraphOps {
     // Returns false if there is some negative cycle.
     template <class G, class P>
     static bool select_potentials(G& g, P& potentials) {
-        int sz = g.size();
+        size_t sz = g.size();
         assert(potentials.size() >= sz);
         grow_scratch(sz);
 
@@ -698,7 +698,7 @@ class GraphOps {
                 qtail++;
             }
 
-            for (int iter = 0; iter < scc.size(); iter++) {
+            for (size_t iter = 0; iter < scc.size(); iter++) {
                 for (; qtail != qhead;) {
                     vert_id s = *(--qtail);
                     // If it _was_ on the queue, it must be in the SCC
@@ -750,7 +750,7 @@ class GraphOps {
         // and potentials have been initialized.
         // We just want to restore closure.
         assert(l.size() == r.size());
-        unsigned int sz = l.size();
+        size_t sz = l.size();
         grow_scratch(sz);
         delta.clear();
 
@@ -805,7 +805,7 @@ class GraphOps {
     // Straight implementation of Dijkstra's algorithm
     template <class G, class P>
     static void dijkstra(G& g, const P& p, vert_id src, std::vector<std::pair<vert_id, Wt>>& out) {
-        unsigned int sz = g.size();
+        size_t sz = g.size();
         if (sz == 0)
             return;
         grow_scratch(sz);
@@ -859,7 +859,7 @@ class GraphOps {
     template <class G, class P>
     static void chrome_dijkstra(G& g, const P& p, std::vector<std::vector<vert_id>>& colour_succs, vert_id src,
                                 std::vector<std::pair<vert_id, Wt>>& out) {
-        unsigned int sz = g.size();
+        size_t sz = g.size();
         if (sz == 0)
             return;
         grow_scratch(sz);
@@ -922,7 +922,7 @@ class GraphOps {
     template <class G, class P, class S>
     static void dijkstra_recover(G& g, const P& p, const S& is_stable, vert_id src,
                                  std::vector<std::pair<vert_id, Wt>>& out) {
-        unsigned int sz = g.size();
+        size_t sz = g.size();
         if (sz == 0)
             return;
         if (is_stable[src])
@@ -986,7 +986,7 @@ class GraphOps {
     template <class G, class P>
     static bool repair_potential(G& g, P& p, vert_id ii, vert_id jj) {
         // Ensure there's enough scratch space.
-        unsigned int sz = g.size();
+        size_t sz = g.size();
         // assert(src < (int) sz && dest < (int) sz);
         grow_scratch(sz);
 
@@ -1035,7 +1035,7 @@ class GraphOps {
 
     template <class G, class P, class V>
     static void close_after_widen(G& g, P& p, const V& is_stable, edge_vector& delta) {
-        unsigned int sz = g.size();
+        size_t sz = g.size();
         grow_scratch(sz);
         //      assert(orig.size() == sz);
 
@@ -1141,7 +1141,7 @@ class GraphOps {
 
     template <class G, class P>
     static void close_after_assign(G& g, P& p, vert_id v, edge_vector& delta) {
-        unsigned int sz = g.size();
+        size_t sz = g.size();
         grow_scratch(sz);
         {
             std::vector<std::pair<vert_id, Wt>> aux;
@@ -1171,7 +1171,7 @@ template <class Wt>
 int* GraphOps<Wt>::vert_marks = nullptr;
 
 template <class Wt>
-unsigned int GraphOps<Wt>::scratch_sz = 0;
+size_t GraphOps<Wt>::scratch_sz = 0;
 
 template <class G>
 std::vector<typename G::Wt> GraphOps<G>::dists;

--- a/src/crab_utils/heap.hpp
+++ b/src/crab_utils/heap.hpp
@@ -87,11 +87,12 @@ class Heap {
     }
 
     void insert(int n) {
-        if (n >= indices.size())
+        assert(n >= 0);
+        if (static_cast<size_t>(n) >= indices.size())
             indices.resize(n + 1, -1);
         assert(!inHeap(n));
 
-        indices[n] = heap.size();
+        indices[n] = static_cast<int>(heap.size());
         heap.push_back(n);
         percolateUp(indices[n]);
     }

--- a/src/crab_utils/safeint.hpp
+++ b/src/crab_utils/safeint.hpp
@@ -9,7 +9,6 @@
 #include <limits>
 
 #include "crab_utils/bignums.hpp"
-#include "crab_utils/safeint.hpp"
 
 namespace crab {
 
@@ -20,7 +19,7 @@ class safe_i64 {
 
     // TODO/FIXME: the current code compiles assuming the type __int128
     // exists. Both clang and gcc supports __int128 if the targeted
-    // architecture is x86/64, but it wont' work with 32 bits.
+    // architecture is x86/64, but it won't work with 32 bits.
     using wideint_t = __int128;
 
     [[nodiscard]] static int64_t get_max() { return std::numeric_limits<int64_t>::max(); }
@@ -28,23 +27,23 @@ class safe_i64 {
 
     static int checked_add(int64_t a, int64_t b, int64_t* rp) {
         wideint_t lr = (wideint_t)a + (wideint_t)b;
-        *rp = lr;
+        *rp = static_cast<int64_t>(lr);
         return lr > get_max() || lr < get_min();
     }
 
     static int checked_sub(int64_t a, int64_t b, int64_t* rp) {
         wideint_t lr = (wideint_t)a - (wideint_t)b;
-        *rp = lr;
+        *rp = static_cast<int64_t>(lr);
         return lr > get_max() || lr < get_min();
     }
     static int checked_mul(int64_t a, int64_t b, int64_t* rp) {
         wideint_t lr = (wideint_t)a * (wideint_t)b;
-        *rp = lr;
+        *rp = static_cast<int64_t>(lr);
         return lr > get_max() || lr < get_min();
     }
     static int checked_div(int64_t a, int64_t b, int64_t* rp) {
         wideint_t lr = (wideint_t)a / (wideint_t)b;
-        *rp = lr;
+        *rp = static_cast<int64_t>(lr);
         return lr > get_max() || lr < get_min();
     }
 


### PR DESCRIPTION
The use of explicit casts removes precision warnings generated by some compilers/analysis tools.

In a couple of places, I changed the type to size_t to avoid having to cast.  For example: in adapt_graph.hpp, I changed the edge_count member to size_t which seems was always intended given that line 228 already returned it as a size_t.

Some of these casts could be avoided if vert_id were changed to be size_t instead of unsigned int, but that could increase the memory requirement on some platforms (since there's various vertices of vert_id so there may be a large number of them) so I didn't do that in this PR.

Signed-off-by: Dave Thaler <dthaler@ntdev.microsoft.com>