### PR TITLE
Handle realloc failures

### DIFF
--- a/src/crab_utils/graph_ops.hpp
+++ b/src/crab_utils/graph_ops.hpp
@@ -486,18 +486,27 @@ class GraphOps {
     static unsigned int ts;
     static unsigned int ts_idx;
 
+    static void check_realloc(void** ptr, size_t size) {
+        void* newptr = realloc(*ptr, size);
+        if (newptr == nullptr)
+            throw std::bad_alloc();
+        *ptr = newptr;
+    }
+
     static void grow_scratch(size_t sz) {
         if (sz <= scratch_sz)
             return;
 
-        if (scratch_sz == 0)
-            scratch_sz = 10; // Introduce enums for init_sz and growth_factor
-        while (scratch_sz < sz)
-            scratch_sz = static_cast<size_t>(scratch_sz * 1.5);
+        size_t new_sz = scratch_sz;
+        if (new_sz == 0)
+            new_sz = 10; // TODO: Introduce enums for init_sz and growth_factor
+        while (new_sz < sz)
+            new_sz = static_cast<size_t>(scratch_sz * 1.5);
 
-        edge_marks = (char*)realloc(edge_marks, sizeof(char) * scratch_sz * scratch_sz);
-        dual_queue = (vert_id*)realloc(dual_queue, sizeof(vert_id) * 2 * scratch_sz);
-        vert_marks = (int*)realloc(vert_marks, sizeof(int) * scratch_sz);
+        check_realloc((void**)&edge_marks, sizeof(char) * new_sz * new_sz);
+        check_realloc((void**)&dual_queue, sizeof(vert_id) * 2 * new_sz);
+        check_realloc((void**)&vert_marks, sizeof(int) * new_sz);
+        scratch_sz = new_sz;
 
         // Initialize new elements as necessary.
         while (dists.size() < scratch_sz) {


### PR DESCRIPTION
https://en.cppreference.com/w/cpp/memory/c/realloc explains about `realloc()`:

> On failure, returns a null pointer. The original pointer ptr remains valid and may need to be deallocated with std::free()

and the example there shows:
```
    if(void* mem = std::realloc(p, newSize))
        p = static_cast<char*>(mem);
    else
        throw std::bad_alloc();
```

This PR applies that fix.  Previously the code would leak the old memory, null out the relevant pointer but leave scratch_sz thinking there was actually memory allocated.

Signed-off-by: Dave Thaler <dthaler@ntdev.microsoft.com>