### PR TITLE
Non-recursive simplification

### DIFF
--- a/src/asm_ostream.cpp
+++ b/src/asm_ostream.cpp
@@ -419,6 +419,8 @@ std::ostream& operator<<(std::ostream& o, const crab::basic_block_rev_t& bb) {
 }
 
 std::ostream& operator<<(std::ostream& o, const cfg_t& cfg) {
-    cfg.dfs([&](const auto& bb) { o << bb; });
+    for (const label_t& label : cfg.sorted_labels()) {
+        o << cfg.get_node(label);
+    }
     return o;
 }

--- a/src/crab/cfg.hpp
+++ b/src/crab/cfg.hpp
@@ -66,33 +66,33 @@ class basic_block_t final {
 
     void insert(const Instruction& arg) { m_ts.push_back(arg); }
 
-    explicit basic_block_t(label_t _label) : m_label(std::move(_label)) {}
+    explicit basic_block_t(label_t _label) : m_label(_label) {}
 
     ~basic_block_t() = default;
 
-    label_t label() const { return m_label; }
+    [[nodiscard]] label_t label() const { return m_label; }
 
     iterator begin() { return (m_ts.begin()); }
     iterator end() { return (m_ts.end()); }
-    const_iterator begin() const { return (m_ts.begin()); }
-    const_iterator end() const { return (m_ts.end()); }
+    [[nodiscard]] const_iterator begin() const { return (m_ts.begin()); }
+    [[nodiscard]] const_iterator end() const { return (m_ts.end()); }
 
     reverse_iterator rbegin() { return (m_ts.rbegin()); }
     reverse_iterator rend() { return (m_ts.rend()); }
-    const_reverse_iterator rbegin() const { return (m_ts.rbegin()); }
-    const_reverse_iterator rend() const { return (m_ts.rend()); }
+    [[nodiscard]] const_reverse_iterator rbegin() const { return (m_ts.rbegin()); }
+    [[nodiscard]] const_reverse_iterator rend() const { return (m_ts.rend()); }
 
-    size_t size() const { return static_cast<size_t>(std::distance(begin(), end())); }
+    [[nodiscard]] size_t size() const { return static_cast<size_t>(std::distance(begin(), end())); }
 
     std::pair<succ_iterator, succ_iterator> next_blocks() { return std::make_pair(m_next.begin(), m_next.end()); }
 
     std::pair<pred_iterator, pred_iterator> prev_blocks() { return std::make_pair(m_prev.begin(), m_prev.end()); }
 
-    std::pair<const_succ_iterator, const_succ_iterator> next_blocks() const {
+    [[nodiscard]] std::pair<const_succ_iterator, const_succ_iterator> next_blocks() const {
         return std::make_pair(m_next.begin(), m_next.end());
     }
 
-    std::pair<const_pred_iterator, const_pred_iterator> prev_blocks() const {
+    [[nodiscard]] std::pair<const_pred_iterator, const_pred_iterator> prev_blocks() const {
         return std::make_pair(m_prev.begin(), m_prev.end());
     }
 
@@ -114,11 +114,11 @@ class basic_block_t final {
         std::move(other.m_ts.begin(), other.m_ts.end(), std::back_inserter(m_ts));
     }
 
-    size_t in_degree() {
+    [[nodiscard]] size_t in_degree() const {
         return m_prev.size();
     }
 
-    size_t out_degree() {
+    [[nodiscard]] size_t out_degree() const {
         return m_next.size();
     }
 
@@ -142,25 +142,25 @@ class basic_block_rev_t final {
 
     explicit basic_block_rev_t(basic_block_t& bb) : _bb(bb) {}
 
-    label_t label() const { return _bb.label(); }
+    [[nodiscard]] label_t label() const { return _bb.label(); }
 
     iterator begin() { return _bb.rbegin(); }
 
     iterator end() { return _bb.rend(); }
 
-    const_iterator begin() const { return _bb.rbegin(); }
+    [[nodiscard]] const_iterator begin() const { return _bb.rbegin(); }
 
-    const_iterator end() const { return _bb.rend(); }
+    [[nodiscard]] const_iterator end() const { return _bb.rend(); }
 
-    std::size_t size() const { return static_cast<size_t>(std::distance(begin(), end())); }
+    [[nodiscard]] std::size_t size() const { return static_cast<size_t>(std::distance(begin(), end())); }
 
     std::pair<succ_iterator, succ_iterator> next_blocks() { return _bb.prev_blocks(); }
 
     std::pair<pred_iterator, pred_iterator> prev_blocks() { return _bb.next_blocks(); }
 
-    std::pair<const_succ_iterator, const_succ_iterator> next_blocks() const { return _bb.prev_blocks(); }
+    [[nodiscard]] std::pair<const_succ_iterator, const_succ_iterator> next_blocks() const { return _bb.prev_blocks(); }
 
-    std::pair<const_pred_iterator, const_pred_iterator> prev_blocks() const { return _bb.next_blocks(); }
+    [[nodiscard]] std::pair<const_pred_iterator, const_pred_iterator> prev_blocks() const { return _bb.next_blocks(); }
 };
 
 /// Control-Flow Graph.

--- a/src/crab/cfg.hpp
+++ b/src/crab/cfg.hpp
@@ -342,7 +342,7 @@ class cfg_t final {
     size_t size() const { return static_cast<size_t>(std::distance(begin(), end())); }
 
     void simplify() {
-        std::unordered_set<label_t> worklist(this->label_begin(), this->label_end());
+        std::set<label_t> worklist(this->label_begin(), this->label_end());
         while (!worklist.empty()) {
             label_t label = *worklist.begin();
             worklist.erase(label);
@@ -376,6 +376,12 @@ class cfg_t final {
                 remove(next_bb.label());
             }
         }
+    }
+
+    [[nodiscard]] std::vector<label_t> sorted_labels() const {
+        std::vector<label_t> labels = this->labels();
+        std::sort(labels.begin(), labels.end());
+        return labels;
     }
 
   private:

--- a/src/crab_verifier.cpp
+++ b/src/crab_verifier.cpp
@@ -50,17 +50,11 @@ struct checks_db final {
     checks_db() = default;
 };
 
-static std::vector<label_t> sorted_labels(cfg_t& cfg) {
-    std::vector<label_t> labels = cfg.labels();
-    std::sort(labels.begin(), labels.end());
-    return labels;
-}
-
 static checks_db generate_report(cfg_t& cfg,
                                  crab::invariant_table_t& preconditions,
                                  crab::invariant_table_t& postconditions) {
     checks_db m_db;
-    for (const label_t& label : sorted_labels(cfg)) {
+    for (const label_t& label : cfg.sorted_labels()) {
         basic_block_t& bb = cfg.get_node(label);
 
         if (global_options.print_invariants) {

--- a/src/crab_verifier.cpp
+++ b/src/crab_verifier.cpp
@@ -12,10 +12,7 @@
 #include <map>
 #include <string>
 #include <tuple>
-#include <utility>
 #include <vector>
-
-#include <boost/lexical_cast.hpp>
 
 #include "crab/cfg.hpp"
 #include "crab/ebpf_domain.hpp"

--- a/src/main/check.cpp
+++ b/src/main/check.cpp
@@ -43,7 +43,7 @@ int main(int argc, char** argv) {
     app.add_flag("-l", list, "List sections");
 
     std::string domain = "zoneCrab";
-    std::set<string> doms{"stats", "linux", "zoneCrab"};
+    std::set<string> doms{"stats", "linux", "zoneCrab", "cfg"};
     app.add_set("-d,--dom,--domain", domain, doms, "Abstract domain")->type_name("DOMAIN");
 
     bool verbose = false;
@@ -155,6 +155,11 @@ int main(int argc, char** argv) {
         for (const string& h : stats_headers()) {
             std::cout << "," << stats.at(h);
         }
+        std::cout << "\n";
+    } else if (domain == "cfg") {
+        // Convert the instruction sequence to a control-flow graph.
+        cfg_t cfg = prepare_cfg(prog, raw_prog.info, global_options.simplify);
+        std::cout << cfg;
         std::cout << "\n";
     } else {
         assert(false);


### PR DESCRIPTION
Fixes #112: iterative simplification of CFG

The resulting graph is different. The recursive algorithm seems to retain basic blocks with more than one outgoing edges (conditional jumps). I see no reason to keep them. The recursive algorithm also keeps the exit as an independent basic block.

Also added a pseudo-domain `cfg` (similar to `stats`) to allow printing of CFG without performing the analysis.

One issue with the new implementation is that the order of children is changed, so the output is less similar to the original assembly code.

The differences from the recursive algorithm make it harder to verify the correctness using the benchmark. I guess the right answer is to add unit tests - a general issue in this codebase.

Signed-off-by: Elazar Gershuni <elazarg@gmail.com>