### PR TITLE
Use structured pairs for labels

### DIFF
--- a/src/asm_marshal.cpp
+++ b/src/asm_marshal.cpp
@@ -1,7 +1,7 @@
 // Copyright (c) Prevail Verifier contributors.
 // SPDX-License-Identifier: MIT
 #include <cassert>
-#include <unordered_map>
+#include <map>
 #include <variant>
 #include <vector>
 
@@ -76,7 +76,7 @@ struct MarshalVisitor {
     }
 
   public:
-    std::function<auto(std::string)->int16_t> label_to_offset;
+    std::function<auto(label_t)->int16_t> label_to_offset;
 
     vector<ebpf_inst> operator()(Undefined const& a) {
         assert(false);
@@ -244,7 +244,7 @@ static int size(Instruction inst) {
 
 static auto get_labels(const InstructionSeq& insts) {
     pc_t pc = 0;
-    std::unordered_map<std::string, pc_t> pc_of_label;
+    std::map<label_t, pc_t> pc_of_label;
     for (auto [label, inst] : insts) {
         pc_of_label[label] = pc;
         pc += size(inst);
@@ -259,7 +259,7 @@ vector<ebpf_inst> marshal(const InstructionSeq& insts) {
     for (auto [label, ins] : insts) {
         if (std::holds_alternative<Jmp>(ins)) {
             Jmp& jmp = std::get<Jmp>(ins);
-            jmp.target = std::to_string(pc_of_label.at(jmp.target));
+            jmp.target = label_t(pc_of_label.at(jmp.target));
         }
         for (auto e : marshal(ins, pc)) {
             pc++;

--- a/src/asm_ostream.hpp
+++ b/src/asm_ostream.hpp
@@ -10,28 +10,18 @@
 #include <boost/lexical_cast.hpp>
 
 #include "asm_syntax.hpp"
-#include "crab/cfg.hpp"
-
-inline pc_t label_to_pc(const label_t& label) {
-    try {
-        return boost::lexical_cast<pc_t>(label);
-    } catch (const boost::bad_lexical_cast&) {
-        throw std::invalid_argument(std::string("Cannot convert ") + label + " to pc_t");
-    }
-}
-
-using LabelTranslator = std::function<std::string(label_t)>;
 
 inline std::function<int16_t(label_t)> label_to_offset(pc_t pc) {
-    return [=](const label_t& label) { return label_to_pc(label) - pc - 1; };
+    return [=](const label_t& label) { return label.from - pc - 1; };
 }
 
 void print(const InstructionSeq& prog, std::ostream& out);
 void print(const InstructionSeq& insts, const std::string& outfile);
 
+std::string to_string(label_t const& label);
+
 std::ostream& operator<<(std::ostream& os, Instruction const& ins);
 std::string to_string(Instruction const& ins);
-std::string to_string(Instruction const& ins, LabelTranslator labeler);
 
 std::ostream& operator<<(std::ostream& os, Bin::Op op);
 std::ostream& operator<<(std::ostream& os, Condition::Op op);
@@ -58,7 +48,3 @@ inline std::ostream& operator<<(std::ostream& os, Assume const& a) { return os <
 inline std::ostream& operator<<(std::ostream& os, Assert const& a) { return os << (Instruction)a; }
 std::ostream& operator<<(std::ostream& os, AssertionConstraint const& a);
 std::string to_string(AssertionConstraint const& constraint);
-
-std::ostream& operator<<(std::ostream& o, const crab::basic_block_t& bb);
-std::ostream& operator<<(std::ostream& o, const crab::basic_block_rev_t& bb);
-std::ostream& operator<<(std::ostream& o, const cfg_t& cfg);

--- a/src/asm_syntax.hpp
+++ b/src/asm_syntax.hpp
@@ -12,7 +12,29 @@
 #include "gpl/spec_type_descriptors.hpp"
 
 namespace crab {
-using label_t = std::string;
+struct label_t {
+    int from{}; ///< Jump source, or simply index of instruction
+    int to = 0; ///< Jump target or 0
+
+    explicit label_t(int index) : from(index) { }
+    label_t(const label_t& src_label, const label_t& target_label) : from(src_label.from), to(target_label.from) {
+        assert(src_label.to == 0);
+        assert(target_label.to == 0);
+    }
+
+    bool operator==(const label_t& other) const { return from == other.from && to == other.to; }
+    bool operator!=(const label_t& other) const { return !(*this == other); }
+    bool operator<(const label_t& other) const { return from < other.from || (from == other.from && to < other.to); }
+
+    // no hash; intended for use in ordered containers.
+
+    [[nodiscard]] bool isjump() const { return to != 0; }
+    friend std::ostream& operator<<(std::ostream& os, const label_t& label) {
+        if (label.to == 0)
+            return os << label.from;
+        return os << label.from << ":" << label.to;
+    }
+};
 }
 using crab::label_t;
 

--- a/src/asm_unmarshal.cpp
+++ b/src/asm_unmarshal.cpp
@@ -347,7 +347,7 @@ struct Unmarshaller {
                                                     };
             return Jmp{
                 .cond = cond,
-                .target = std::to_string(new_pc),
+                .target = label_t{new_pc},
             };
         }
         }
@@ -359,7 +359,7 @@ struct Unmarshaller {
         if (insts.size() == 0) {
             throw std::invalid_argument("Zero length programs are not allowed");
         }
-        for (pc_t pc = 0; pc < insts.size();) {
+        for (size_t pc = 0; pc < insts.size();) {
             ebpf_inst inst = insts[pc];
             Instruction new_ins;
             bool lddw = false;
@@ -410,7 +410,7 @@ struct Unmarshaller {
             */
             if (pc == insts.size() - 1 && fallthrough)
                 note("fallthrough in last instruction");
-            prog.emplace_back(std::to_string(pc), new_ins);
+            prog.emplace_back(label_t{pc}, new_ins);
             pc++;
             note_next_pc();
             if (lddw) {

--- a/src/crab/cfg.hpp
+++ b/src/crab/cfg.hpp
@@ -13,8 +13,8 @@
  *
  */
 #include <memory>
-#include <unordered_map>
-#include <unordered_set>
+#include <map>
+#include <set>
 #include <variant>
 #include <vector>
 
@@ -26,6 +26,7 @@
 #include "crab_utils/debug.hpp"
 
 #include "asm_syntax.hpp"
+#include "asm_ostream.hpp"
 
 namespace crab {
 
@@ -181,7 +182,7 @@ class cfg_t final {
     using const_pred_range = boost::iterator_range<const_pred_iterator>;
 
   private:
-    using basic_block_map_t = std::unordered_map<label_t, basic_block_t>;
+    using basic_block_map_t = std::map<label_t, basic_block_t>;
     using binding_t = typename basic_block_map_t::value_type;
 
     struct get_label {
@@ -199,7 +200,7 @@ class cfg_t final {
     label_t m_exit;
     basic_block_map_t m_blocks;
 
-    using visited_t = std::unordered_set<label_t>;
+    using visited_t = std::set<label_t>;
     template <typename T>
     void dfs_rec(const label_t& curId, visited_t& visited, T f) const {
         if (!visited.insert(curId).second)
@@ -457,7 +458,7 @@ class cfg_rev_t final {
     using const_pred_iterator = typename basic_block_t::const_pred_iterator;
 
   private:
-    using visited_t = std::unordered_set<label_t>;
+    using visited_t = std::set<label_t>;
 
     template <typename T>
     void dfs_rec(const label_t& curId, visited_t& visited, T f) const {
@@ -476,7 +477,7 @@ class cfg_rev_t final {
     }
 
   public:
-    using basic_block_rev_map_t = std::unordered_map<label_t, basic_block_rev_t>;
+    using basic_block_rev_map_t = std::map<label_t, basic_block_rev_t>;
     using iterator = typename basic_block_rev_map_t::iterator;
     using const_iterator = typename basic_block_rev_map_t::const_iterator;
     using label_iterator = typename cfg_t::label_iterator;
@@ -590,3 +591,7 @@ void explicate_assertions(cfg_t& cfg, const program_info& info);
 
 void print_dot(const cfg_t& cfg, std::ostream& out);
 void print_dot(const cfg_t& cfg, const std::string& outfile);
+
+std::ostream& operator<<(std::ostream& o, const crab::basic_block_t& bb);
+std::ostream& operator<<(std::ostream& o, const crab::basic_block_rev_t& bb);
+std::ostream& operator<<(std::ostream& o, const cfg_t& cfg);

--- a/src/crab/cfg_bgl.hpp
+++ b/src/crab/cfg_bgl.hpp
@@ -57,19 +57,6 @@ struct graph_traits<crab::cfg_t> {
     using edges_size_type = size_t;
     using degree_size_type = size_t;
 
-    static vertex_descriptor null_vertex() {
-        if constexpr (std::is_pointer<vertex_descriptor>::value)
-            return nullptr;
-        else {
-            // XXX: if vertex_descriptor is a basic type then
-            // null_vertex will return an undefined value, otherwise it
-            // will return the result of calling the default
-            // constructor.
-            vertex_descriptor n;
-            return n;
-        }
-    }
-
     // iterator of label_t's
     using vertex_iterator = typename graph_t::label_iterator;
     // iterator of pairs of label_t's
@@ -94,19 +81,6 @@ struct graph_traits<crab::cfg_rev_t> {
     using vertices_size_type = size_t;
     using edges_size_type = size_t;
     using degree_size_type = size_t;
-
-    static vertex_descriptor null_vertex() {
-        if constexpr (std::is_pointer<vertex_descriptor>::value)
-            return nullptr;
-        else {
-            // XXX: if vertex_descriptor is a basic type then
-            // null_vertex will return an undefined value, otherwise it
-            // will return the result of calling the default
-            // constructor.
-            vertex_descriptor n;
-            return n;
-        }
-    }
 
     using vertex_iterator = typename graph_t::label_iterator;
     using in_edge_iterator =

--- a/src/crab/ebpf_domain.hpp
+++ b/src/crab/ebpf_domain.hpp
@@ -9,7 +9,7 @@
 #include <functional>
 #include <optional>
 #include <set>
-#include <unordered_map>
+#include <map>
 #include <utility>
 #include <vector>
 

--- a/src/crab/fwd_analyzer.hpp
+++ b/src/crab/fwd_analyzer.hpp
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 
-#include <unordered_map>
+#include <map>
 #include <tuple>
 
 #include "crab/cfg.hpp"
@@ -11,7 +11,7 @@
 namespace crab {
 
 using domains::ebpf_domain_t;
-using invariant_table_t = std::unordered_map<label_t, ebpf_domain_t>;
+using invariant_table_t = std::map<label_t, ebpf_domain_t>;
 
 std::pair<invariant_table_t, invariant_table_t> run_forward_analyzer(cfg_t& cfg);
 

--- a/src/crab/thresholds.hpp
+++ b/src/crab/thresholds.hpp
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 
-#include <unordered_map>
+#include <map>
 #include <algorithm>
 #include <climits>
 
@@ -52,7 +52,7 @@ class wto_thresholds_t final {
     // maximum number of thresholds
     size_t m_max_size;
     // keep a set of thresholds per wto head
-    std::unordered_map<label_t, thresholds_t> m_head_to_thresholds;
+    std::map<label_t, thresholds_t> m_head_to_thresholds;
     // the top of the stack is the current wto head
     std::vector<label_t> m_stack;
 

--- a/src/crab/wto.hpp
+++ b/src/crab/wto.hpp
@@ -50,7 +50,7 @@
 #include <set>
 #include <vector>
 #include <forward_list>
-#include <unordered_map>
+#include <map>
 #include <variant>
 
 #include "crab/cfg.hpp"
@@ -251,9 +251,9 @@ class wto_t final {
   private:
     using wto_component_list_t = std::forward_list<wto_component_t>;
     using dfn_t = bound_t;
-    using dfn_table_t = std::unordered_map<vertex_descriptor_t, dfn_t>;
+    using dfn_table_t = std::map<vertex_descriptor_t, dfn_t>;
     using stack_t = std::vector<vertex_descriptor_t>;
-    using nesting_table_t = std::unordered_map<vertex_descriptor_t, wto_nesting_t>;
+    using nesting_table_t = std::map<vertex_descriptor_t, wto_nesting_t>;
 
     wto_component_list_t _wto_components;
     dfn_table_t _dfn_table;

--- a/src/crab_verifier.cpp
+++ b/src/crab_verifier.cpp
@@ -50,25 +50,9 @@ struct checks_db final {
     checks_db() = default;
 };
 
-inline int first_num(const label_t& s) {
-    try {
-        return boost::lexical_cast<int>(s.substr(0, s.find_first_of(":+")));
-    } catch (...) {
-        std::cout << "bad label:" << s << "\n";
-        throw;
-    }
-}
-
 static std::vector<label_t> sorted_labels(cfg_t& cfg) {
     std::vector<label_t> labels = cfg.labels();
-
-    std::sort(labels.begin(), labels.end(), [](const string& a, const string& b) {
-        if (first_num(a) < first_num(b))
-            return true;
-        if (first_num(a) > first_num(b))
-            return false;
-        return a < b;
-    });
+    std::sort(labels.begin(), labels.end());
     return labels;
 }
 

--- a/src/test/test_marshal.cpp
+++ b/src/test/test_marshal.cpp
@@ -59,13 +59,13 @@ TEST_CASE("disasm_marshal", "[disasm][marshal]") {
         SECTION("Reg right") {
             for (auto op : ops) {
                 Condition cond{.op = op, .left = Reg{1}, .right = Reg{2}};
-                compare_marshal_unmarshal(Jmp{.cond = cond, .target = "1"});
+                compare_marshal_unmarshal(Jmp{.cond = cond, .target = label_t(1)});
             }
         }
         SECTION("Imm right") {
             for (auto op : ops) {
                 Condition cond{.op = op, .left = Reg{1}, .right = Imm{2}};
-                compare_marshal_unmarshal(Jmp{.cond = cond, .target = "1"});
+                compare_marshal_unmarshal(Jmp{.cond = cond, .target = label_t(1)});
             }
         }
     }


### PR DESCRIPTION
Instead of encoding labels as strings (and then parsing those strings), use a dedicated struct.

Signed-off-by: Elazar Gershuni <elazarg@gmail.com>