### PR TITLE
Use jmp.target to decide how to connect nondeterministic jumps

### DIFF
--- a/src/asm_ostream.cpp
+++ b/src/asm_ostream.cpp
@@ -367,8 +367,7 @@ void print_dot(const cfg_t& cfg, std::ostream& out) {
         }
 
         out << "\"];\n";
-        auto [b, e] = bb.next_blocks();
-        for (const label_t& next : std::vector<label_t>(b, e))
+        for (const label_t& next : bb.next_blocks_set())
             out << "    \"" << label << "\" -> \"" << next << "\";\n";
         out << "\n";
     }
@@ -411,8 +410,8 @@ std::ostream& operator<<(std::ostream& o, const crab::basic_block_rev_t& bb) {
         o << "  " << s << ";\n";
     }
     o << "--> [";
-    for (auto const& n : boost::make_iterator_range(bb.next_blocks())) {
-        o << n << ";";
+    for (const label_t& label : bb.next_blocks_set()) {
+        o << label << ";";
     }
     o << "]\n";
     return o;

--- a/src/asm_unmarshal.cpp
+++ b/src/asm_unmarshal.cpp
@@ -410,7 +410,7 @@ struct Unmarshaller {
             */
             if (pc == insts.size() - 1 && fallthrough)
                 note("fallthrough in last instruction");
-            prog.emplace_back(label_t{pc}, new_ins);
+            prog.emplace_back(label_t(pc), new_ins);
             pc++;
             note_next_pc();
             if (lddw) {

--- a/src/crab/cfg.hpp
+++ b/src/crab/cfg.hpp
@@ -37,12 +37,11 @@ class basic_block_t final {
     friend class cfg_t;
 
   private:
-    using label_vec_t = std::set<label_t>;
 
   public:
     basic_block_t(const basic_block_t&) = delete;
-    // -- iterators
 
+    using label_vec_t = std::set<label_t>;
     using stmt_list_t = std::vector<Instruction>;
     using succ_iterator = label_vec_t::iterator;
     using const_succ_iterator = label_vec_t::const_iterator;
@@ -94,6 +93,14 @@ class basic_block_t final {
 
     [[nodiscard]] std::pair<const_pred_iterator, const_pred_iterator> prev_blocks() const {
         return std::make_pair(m_prev.begin(), m_prev.end());
+    }
+
+    [[nodiscard]] const label_vec_t& next_blocks_set() const {
+        return m_next;
+    }
+
+    [[nodiscard]] const label_vec_t& prev_blocks_set() const {
+        return m_prev;
     }
 
     // Add a cfg_t edge from *this to b
@@ -161,6 +168,15 @@ class basic_block_rev_t final {
     [[nodiscard]] std::pair<const_succ_iterator, const_succ_iterator> next_blocks() const { return _bb.prev_blocks(); }
 
     [[nodiscard]] std::pair<const_pred_iterator, const_pred_iterator> prev_blocks() const { return _bb.next_blocks(); }
+
+
+    [[nodiscard]] const basic_block_t::label_vec_t& next_blocks_set() const {
+        return _bb.prev_blocks_set();
+    }
+
+    [[nodiscard]] const basic_block_t::label_vec_t& prev_blocks_set() const {
+        return _bb.next_blocks_set();
+    }
 };
 
 /// Control-Flow Graph.


### PR DESCRIPTION
Fixes #134.

Instead of relying on the order of the next list in the determinization process, rely on the name of the target label.

I have manually inspected the test results, and they are as they used to be (four failures).

Signed-off-by: Elazar Gershuni <elazarg@gmail.com>