### PR TITLE
Add naive termination analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Options:
   -l                          List sections
   -d,--dom,--domain DOMAIN:{cfg,linux,stats,zoneCrab}
                               Abstract domain
+  --termination               Verify termination
   -i                          Print invariants
   -f                          Print verifier's failure logs
   -v                          Print both invariants and failures
@@ -179,9 +180,8 @@ counter/objects/simple_loop_ptr_backwards.o
 back-edge from insn 7 to 5
 ```
 
-Using our tool, the safety (but not termination) of some loop-based programs can be verified:
+Using our tool, the safety and termination of some loop-based programs can be verified:
 ```
-$ ./check counter/objects/simple_loop_ptr_backwards.o
-1,0.018346,7900
+$ ./check --termination counter/objects/simple_loop_ptr_backwards.o
 ```
 (not all the programs in the folder are verified)

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: MIT
 #include "config.hpp"
 
-const ebpf_verifier_options_t ebpf_verifier_default_options = 
-{
+const ebpf_verifier_options_t ebpf_verifier_default_options = {
+    .check_termination = false,
     .print_invariants = false,
     .print_failures = false
 };

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -3,6 +3,7 @@
 #pragma once
 
 struct ebpf_verifier_options_t {
+    bool check_termination;
     bool print_invariants;
     bool print_failures;
 };

--- a/src/crab/fwd_analyzer.hpp
+++ b/src/crab/fwd_analyzer.hpp
@@ -5,6 +5,7 @@
 #include <map>
 #include <tuple>
 
+#include "config.hpp"
 #include "crab/cfg.hpp"
 #include "crab/ebpf_domain.hpp"
 
@@ -13,6 +14,6 @@ namespace crab {
 using domains::ebpf_domain_t;
 using invariant_table_t = std::map<label_t, ebpf_domain_t>;
 
-std::pair<invariant_table_t, invariant_table_t> run_forward_analyzer(cfg_t& cfg);
+std::pair<invariant_table_t, invariant_table_t> run_forward_analyzer(cfg_t& cfg, bool check_termination);
 
 } // namespace crab

--- a/src/crab/var_factory.cpp
+++ b/src/crab/var_factory.cpp
@@ -66,5 +66,6 @@ variable_t variable_t::map_value_size() { return make("map_value_size"); }
 variable_t variable_t::map_key_size() { return make("map_key_size"); }
 variable_t variable_t::meta_offset() { return make("meta_offset"); }
 variable_t variable_t::packet_size() { return make("packet_size"); }
+variable_t variable_t::instruction_count() { return make("instruction_count"); }
 
 } // end namespace crab

--- a/src/crab/variable.hpp
+++ b/src/crab/variable.hpp
@@ -56,6 +56,7 @@ class variable_t final {
     static variable_t map_key_size();
     static variable_t meta_offset();
     static variable_t packet_size();
+    static variable_t instruction_count();
 }; // class variable_t
 
 inline size_t hash_value(variable_t v) { return v.hash(); }

--- a/src/main/check.cpp
+++ b/src/main/check.cpp
@@ -47,6 +47,9 @@ int main(int argc, char** argv) {
     std::set<string> doms{"stats", "linux", "zoneCrab", "cfg"};
     app.add_set("-d,--dom,--domain", domain, doms, "Abstract domain")->type_name("DOMAIN");
 
+    ebpf_verifier_options.check_termination = false;
+    app.add_flag("--termination", ebpf_verifier_options.check_termination, "Verify termination");
+
     bool verbose = false;
     app.add_flag("-i", ebpf_verifier_options.print_invariants, "Print invariants");
     app.add_flag("-f", ebpf_verifier_options.print_failures, "Print verifier's failure logs");

--- a/src/test/test_loop.cpp
+++ b/src/test/test_loop.cpp
@@ -21,6 +21,9 @@ TEST_CASE("Trivial loop: middle", "[sanity][loop]") {
     middle >> middle;
     middle >> exit;
 
-    bool pass = run_ebpf_analysis(std::cout, cfg, {}, nullptr);
+    ebpf_verifier_options_t options{
+        .check_termination=false
+    };
+    bool pass = run_ebpf_analysis(std::cout, cfg, {}, &options);
     REQUIRE(pass);
 }

--- a/src/test/test_termination.cpp
+++ b/src/test/test_termination.cpp
@@ -1,0 +1,52 @@
+// Copyright (c) Prevail Verifier contributors.
+// SPDX-License-Identifier: MIT
+#include "catch.hpp"
+
+#include "crab/cfg.hpp"
+#include "crab_verifier.hpp"
+#include "config.hpp"
+
+using namespace crab;
+
+TEST_CASE("Trivial infinite loop", "[loop][termination]") {
+    cfg_t cfg;
+
+    basic_block_t& entry = cfg.get_node(cfg.entry_label());
+    basic_block_t& middle = cfg.insert(label_t(0));
+    basic_block_t& exit = cfg.get_node(cfg.exit_label());
+
+    entry >> middle;
+    middle >> middle;
+    middle >> exit;
+
+    ebpf_verifier_options_t options{
+        .check_termination = true,
+    };
+    bool pass = run_ebpf_analysis(std::cout, cfg, {}, &options);
+    REQUIRE_FALSE(pass);
+}
+
+TEST_CASE("Trivial finite loop", "[loop][termination]") {
+    cfg_t cfg;
+
+    basic_block_t& entry = cfg.get_node(cfg.entry_label());
+    basic_block_t& start = cfg.insert(label_t(0));
+    basic_block_t& middle = cfg.insert(label_t(1));
+    basic_block_t& exit = cfg.get_node(cfg.exit_label());
+
+    Reg r{0};
+    start.insert(Bin{.op = Bin::Op::MOV, .dst = r, .v = Imm{0}, .is64 = true});
+    middle.insert(Assume{{.op=Condition::Op::GT, .left=r, .right=Imm{10}}});
+    middle.insert(Bin{.op = Bin::Op::ADD, .dst = r, .v = Imm{1}, .is64 = true});
+
+    entry >> start;
+    start >> middle;
+    middle >> middle;
+    middle >> exit;
+
+    ebpf_verifier_options_t options{
+        .check_termination = true,
+    };
+    bool pass = run_ebpf_analysis(std::cout, cfg, {}, &options);
+    REQUIRE(pass);
+}


### PR DESCRIPTION
Following Arie's suggestion: add a variable, named `instruction_count`, to be incremented with each basic block. When we generate the report, we verify that it is always lower than some arbitrary constant bound.

We check at join points, since no basic block can cause non-termination by itself.

One (minor) issue is that it pollutes the output with uninteresting correlations with seemingly random program variables. It might be useful at some point, but when you're not interested in termination it might be slightly annoying.

Added a dedicated global option for checking termination. It is not enabled by default. However, being global it preserves its value between tests.

<s>TODO: Figure out why does the analysis diverge without the `_descending_iterations` constant.</s> It does not diverge - only 3 iterations are performed. The reason for the original divergence seems to be the use of loop into the entry (which #141 made impossible).
