### PR TITLE
Use special (empty) entry and exit blocks

### DIFF
--- a/src/asm_syntax.hpp
+++ b/src/asm_syntax.hpp
@@ -13,28 +13,36 @@
 
 namespace crab {
 struct label_t {
-    int from{}; ///< Jump source, or simply index of instruction
-    int to = 0; ///< Jump target or 0
+    int from; ///< Jump source, or simply index of instruction
+    int to; ///< Jump target or 0
 
-    explicit label_t(int index) : from(index) { }
-    label_t(const label_t& src_label, const label_t& target_label) : from(src_label.from), to(target_label.from) {
-        assert(src_label.to == 0);
-        assert(target_label.to == 0);
+    constexpr explicit label_t(int index, int to=-1) noexcept : from(index), to(to) { }
+
+    static constexpr label_t make_jump(const label_t& src_label, const label_t& target_label) {
+        return label_t{src_label.from, target_label.from};
     }
 
-    bool operator==(const label_t& other) const { return from == other.from && to == other.to; }
-    bool operator!=(const label_t& other) const { return !(*this == other); }
-    bool operator<(const label_t& other) const { return from < other.from || (from == other.from && to < other.to); }
+    constexpr bool operator==(const label_t& other) const { return from == other.from && to == other.to; }
+    constexpr bool operator!=(const label_t& other) const { return !(*this == other); }
+    constexpr bool operator<(const label_t& other) const { return from < other.from || (from == other.from && to < other.to); }
 
     // no hash; intended for use in ordered containers.
 
-    [[nodiscard]] bool isjump() const { return to != 0; }
+    [[nodiscard]] constexpr bool isjump() const { return to != -1; }
+
     friend std::ostream& operator<<(std::ostream& os, const label_t& label) {
         if (label.to == 0)
             return os << label.from;
         return os << label.from << ":" << label.to;
     }
+
+    static const label_t entry;
+    static const label_t exit;
 };
+
+inline const label_t label_t::entry{-1};
+inline const label_t label_t::exit{-2};
+
 }
 using crab::label_t;
 


### PR DESCRIPTION
Cherry picked from #13.

This avoids issue with checking for termination in programs that jump to the entry.

Signed-off-by: Elazar Gershuni <elazarg@gmail.com>