### PR TITLE
Remove check_semantic_reachability from global_options

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -4,7 +4,6 @@
 
 global_options_t global_options{
     .simplify = true,
-    .check_semantic_reachability = false,
     .print_invariants = false,
     .print_failures = false
 };

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -5,7 +5,6 @@
 // defaults are in definition
 struct global_options_t {
     bool simplify;
-    bool check_semantic_reachability;
     bool print_invariants;
     bool print_failures;
 };

--- a/src/crab_verifier.cpp
+++ b/src/crab_verifier.cpp
@@ -93,7 +93,7 @@ static checks_db generate_report(cfg_t& cfg,
         from_inv(bb);
 
         if (!pre_bot && from_inv.is_bottom()) {
-            m_db.add_unreachable(label, std::string("inv became bot after ") + to_string(bb.label()));
+            m_db.add_unreachable(label, std::string("Invariant became _|_ after ") + to_string(bb.label()));
         }
     }
     return m_db;


### PR DESCRIPTION
Fix #151: Reachability is always tracked as a debugging aid, but should not affect verification.

Signed-off-by: Elazar Gershuni <elazarg@gmail.com>