### PR TITLE
Simplify linear_constraint_t and linear_expression_t

### DIFF
--- a/src/crab/linear_constraints.hpp
+++ b/src/crab/linear_constraints.hpp
@@ -42,11 +42,11 @@
 
 #pragma once
 
+#include <map>
 #include <optional>
 #include <utility>
 #include <vector>
 
-#include <boost/container/flat_map.hpp>
 #include <boost/functional/hash.hpp>
 
 #include "crab/variable.hpp"
@@ -56,10 +56,10 @@ namespace crab {
 
 class linear_expression_t final {
   private:
-    using map_t = boost::container::flat_map<variable_t, number_t>;
+    using map_t = std::map<variable_t, number_t>;
 
-    const map_t _map;
-    const number_t _cst = 0;
+    map_t _map;
+    number_t _cst = 0;
 
     linear_expression_t(map_t map, number_t cst) : _map(std::move(map)), _cst(std::move(cst)) {}
 

--- a/src/crab/split_dbm.cpp
+++ b/src/crab/split_dbm.cpp
@@ -807,12 +807,6 @@ void SplitDBM::operator+=(const linear_constraint_t& cst) {
     CrabStats::count("SplitDBM.count.add_constraints");
     ScopedCrabStats __st__("SplitDBM.add_constraints");
 
-    // XXX: we do nothing with unsigned linear inequalities
-    if (cst.is_inequality() && cst.is_unsigned()) {
-        CRAB_WARN("unsigned inequality ", cst, " skipped by split_dbm domain");
-        return;
-    }
-
     if (is_bottom())
         return;
     normalize();
@@ -839,7 +833,7 @@ void SplitDBM::operator+=(const linear_constraint_t& cst) {
     if (cst.is_strict_inequality()) {
         // We try to convert a strict to non-strict.
         // e < 0 --> e <= -1
-        auto nc = linear_constraint_t(cst.expression() + 1, cst_kind::INEQUALITY, cst.is_signed());
+        auto nc = linear_constraint_t(cst.expression() + 1, cst_kind::INEQUALITY);
         if (nc.is_inequality()) {
             // here we succeed
             if (!add_linear_leq(nc.expression())) {


### PR DESCRIPTION
Probably not very useful, in light of #149, but I did that anyway, and maybe it is now more obvious what is the actual interface. Also, I guess removing ~100 NASA-licensed LOCs is a good thing, even if it's still derivative work.

I don't see any use of the signedness of linear constraints, so I removed it. Whether we want to introduce such distinction is a different question.

`boost::flat_map` is replaced with `std::map` since it seems to not hurt performance.

Signed-off-by: Elazar Gershuni <elazarg@gmail.com>