### PR TITLE
API cleanup

### DIFF
--- a/src/asm_files.hpp
+++ b/src/asm_files.hpp
@@ -8,12 +8,13 @@
 #include <vector>
 
 #include "asm_syntax.hpp"
+#include "config.hpp"
 #include "gpl/spec_type_descriptors.hpp"
 
-using MapFd = auto(uint32_t map_type, uint32_t key_size, uint32_t value_size, uint32_t max_entries) -> int;
+using MapFd = auto(uint32_t map_type, uint32_t key_size, uint32_t value_size, uint32_t max_entries, ebpf_verifier_options_t options) -> int;
 
 std::vector<raw_program> read_raw(std::string path, program_info info);
-std::vector<raw_program> read_elf(const std::string& path, const std::string& section, MapFd* allocate_fds);
+std::vector<raw_program> read_elf(const std::string& path, const std::string& section, MapFd* allocate_fds, const ebpf_verifier_options_t* options);
 
 void write_binary_file(std::string path, const char* data, size_t size);
 

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: MIT
 #include "config.hpp"
 
-global_options_t global_options{
+const ebpf_verifier_options_t ebpf_verifier_default_options = 
+{
     .print_invariants = false,
     .print_failures = false
 };

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -2,10 +2,9 @@
 // SPDX-License-Identifier: MIT
 #pragma once
 
-// defaults are in definition
-struct global_options_t {
+struct ebpf_verifier_options_t {
     bool print_invariants;
     bool print_failures;
 };
 
-extern global_options_t global_options;
+extern const ebpf_verifier_options_t ebpf_verifier_default_options;

--- a/src/crab_verifier.hpp
+++ b/src/crab_verifier.hpp
@@ -4,9 +4,10 @@
 
 #include <tuple>
 
+#include "config.hpp"
 #include "crab/cfg.hpp"
 #include "gpl/spec_type_descriptors.hpp"
 
-std::tuple<bool, double> run_ebpf_analysis(cfg_t& cfg, program_info info);
+bool run_ebpf_analysis(std::ostream& s, cfg_t& cfg, program_info info, const ebpf_verifier_options_t* options);
 
-int create_map_crab(uint32_t map_type, uint32_t key_size, uint32_t value_size, uint32_t max_entries);
+int create_map_crab(uint32_t map_type, uint32_t key_size, uint32_t value_size, uint32_t max_entries, ebpf_verifier_options_t options);

--- a/src/ebpf_verifier.hpp
+++ b/src/ebpf_verifier.hpp
@@ -1,0 +1,9 @@
+// Copyright (c) Prevail Verifier contributors.
+// SPDX-License-Identifier: MIT
+#pragma once
+
+#include "asm_files.hpp"
+#include "asm_unmarshal.hpp"
+#include "config.hpp"
+#include "crab/cfg.hpp"
+#include "crab_verifier.hpp"

--- a/src/main/linux_verifier.hpp
+++ b/src/main/linux_verifier.hpp
@@ -12,14 +12,14 @@
 #include "gpl/spec_type_descriptors.hpp"
 #include "linux_ebpf.hpp"
 
-int create_map_linux(uint32_t map_type, uint32_t key_size, uint32_t value_size, uint32_t max_entries);
-std::tuple<bool, double> bpf_verify_program(BpfProgType type, const std::vector<ebpf_inst>& raw_prog);
+int create_map_linux(uint32_t map_type, uint32_t key_size, uint32_t value_size, uint32_t max_entries, ebpf_verifier_options_t options);
+std::tuple<bool, double> bpf_verify_program(BpfProgType type, const std::vector<ebpf_inst>& raw_prog, ebpf_verifier_options_t* options);
 
 #else
 
 #define create_map_linux (nullptr)
 
-std::tuple<bool, double> bpf_verify_program(BpfProgType type, const std::vector<ebpf_inst>& raw_prog) {
+std::tuple<bool, double> bpf_verify_program(BpfProgType type, const std::vector<ebpf_inst>& raw_prog, ebpf_verifier_options_t* options) {
     std::cerr << "linux domain is unsupported on this machine\n";
     exit(64);
     return {{}, {}};

--- a/src/main/utils.hpp
+++ b/src/main/utils.hpp
@@ -1,0 +1,14 @@
+// Copyright (c) Prevail Verifier contributors.
+// SPDX-License-Identifier: MIT
+
+template<typename F>
+auto timed_execution(F f) {
+    clock_t begin = clock();
+
+    const auto& res = f();
+
+    clock_t end = clock();
+
+    double elapsed_secs = double(end - begin) / CLOCKS_PER_SEC;
+    return std::make_tuple(res, elapsed_secs);
+}

--- a/src/test/test_loop.cpp
+++ b/src/test/test_loop.cpp
@@ -2,8 +2,7 @@
 // SPDX-License-Identifier: MIT
 #include "catch.hpp"
 
-#include "crab/cfg.hpp"
-#include "crab_verifier.hpp"
+#include "ebpf_verifier.hpp"
 
 using namespace crab;
 
@@ -22,6 +21,6 @@ TEST_CASE("Trivial loop: middle", "[sanity][loop]") {
     middle >> middle;
     middle >> exit;
 
-    auto [pass, time] = run_ebpf_analysis(cfg, {});
+    bool pass = run_ebpf_analysis(std::cout, cfg, {}, nullptr);
     REQUIRE(pass);
 }


### PR DESCRIPTION
1. Move timed_execution() into the subdirectory for the check command.

2. Clean up global_options_t by making options be passed in as a parameter, rather than relying on a global variable, and rename the type accordingly. Allow passing NULL (for C compatibility) as a shortcut to just use the default options.

3. Rather than always writing to std::cout, allow the output stream to be passed in as an argument. (This PR currently doesn't affect CRAB_LOG.)

4. Add ebpf_verifier.hpp to simplify writing apps, so one only can just include the master header to use the static lib, instead of having to keep track of what header goes with what API.