### PR TITLE
Fix ptype_descr confusion

### DIFF
--- a/src/asm_files.cpp
+++ b/src/asm_files.cpp
@@ -6,7 +6,6 @@
 #include <vector>
 
 #include "asm_files.hpp"
-#include "gpl/spec_type_descriptors.hpp"
 
 #include "elfio/elfio.hpp"
 

--- a/src/asm_files.hpp
+++ b/src/asm_files.hpp
@@ -4,11 +4,11 @@
 
 #include <fstream>
 #include <string>
-#include <tuple>
 #include <vector>
 
 #include "asm_syntax.hpp"
 #include "config.hpp"
+#include "spec_type_descriptors.hpp"
 #include "gpl/spec_type_descriptors.hpp"
 
 using MapFd = auto(uint32_t map_type, uint32_t key_size, uint32_t value_size, uint32_t max_entries, ebpf_verifier_options_t options) -> int;

--- a/src/asm_syntax.hpp
+++ b/src/asm_syntax.hpp
@@ -9,7 +9,6 @@
 #include <vector>
 
 #include "crab/variable.hpp"
-#include "gpl/spec_type_descriptors.hpp"
 
 namespace crab {
 struct label_t {

--- a/src/asm_unmarshal.cpp
+++ b/src/asm_unmarshal.cpp
@@ -11,7 +11,7 @@
 
 #include "gpl/spec_prototypes.hpp"
 
-#include "asm_syntax.hpp"
+#include "asm_unmarshal.hpp"
 
 using std::string;
 using std::vector;
@@ -194,7 +194,7 @@ struct Unmarshaller {
             assert(!(isLoad && isImm));
             uint8_t basereg = isLoad ? inst.src : inst.dst;
 
-            if (basereg == R10_STACK_POINTER && (inst.offset + opcode_to_width(inst.opcode) > 0 || inst.offset < -STACK_SIZE)) {
+            if (basereg == R10_STACK_POINTER && (inst.offset + opcode_to_width(inst.opcode) > 0 || inst.offset < -EBPF_STACK_SIZE)) {
                 note("Stack access out of bounds");
             }
             auto res = Mem{

--- a/src/asm_unmarshal.hpp
+++ b/src/asm_unmarshal.hpp
@@ -9,6 +9,7 @@
 #include <vector>
 
 #include "asm_syntax.hpp"
+#include "spec_type_descriptors.hpp"
 #include "gpl/spec_type_descriptors.hpp"
 
 /** Translate a sequence of eBPF instructions (elf binary format) to a sequence

--- a/src/assertions.cpp
+++ b/src/assertions.cpp
@@ -7,6 +7,7 @@
 
 #include "asm_syntax.hpp"
 #include "crab/cfg.hpp"
+#include "spec_type_descriptors.hpp"
 #include "gpl/spec_type_descriptors.hpp"
 
 using std::string;

--- a/src/crab/array_domain.cpp
+++ b/src/crab/array_domain.cpp
@@ -1,22 +1,5 @@
 // Copyright (c) Prevail Verifier contributors.
 // SPDX-License-Identifier: Apache-2.0
-#include <algorithm>
-#include <bitset>
-#include <optional>
-#include <set>
-#include <utility>
-#include <vector>
-
-#include "boost/range/algorithm/set_algorithm.hpp"
-
-#include "crab/variable.hpp"
-
-#include "crab/interval.hpp"
-#include "crab/split_dbm.hpp"
-#include "crab_utils/patricia_trees.hpp"
-
-#include "dsl_syntax.hpp"
-#include "gpl/spec_type_descriptors.hpp"
 
 #include "crab/array_domain.hpp"
 

--- a/src/crab/array_domain.hpp
+++ b/src/crab/array_domain.hpp
@@ -46,7 +46,7 @@
 #include "config.hpp"
 #include "dsl_syntax.hpp"
 #include "gpl/spec_prototypes.hpp"
-#include "gpl/spec_type_descriptors.hpp"
+#include "spec_type_descriptors.hpp"
 
 #include "crab/bitset_domain.hpp"
 
@@ -313,7 +313,7 @@ class array_domain_t final {
     void store_numbers(NumAbsDomain& inv, variable_t _idx, variable_t _width) {
 
         // TODO: this should be an user parameter.
-        const number_t max_num_elems = STACK_SIZE;
+        const number_t max_num_elems = EBPF_STACK_SIZE;
 
         if (is_bottom())
             return;

--- a/src/crab/bitset_domain.cpp
+++ b/src/crab/bitset_domain.cpp
@@ -6,8 +6,8 @@
 std::ostream& operator<<(std::ostream& o, const bitset_domain_t& b) {
     o << "Numbers -> {";
     bool first = true;
-    for (int i = -STACK_SIZE; i < 0; i++) {
-        if (b.non_numerical_bytes[STACK_SIZE + i])
+    for (int i = -EBPF_STACK_SIZE; i < 0; i++) {
+        if (b.non_numerical_bytes[EBPF_STACK_SIZE + i])
             continue;
         if (!first)
             o << ", ";
@@ -15,7 +15,7 @@ std::ostream& operator<<(std::ostream& o, const bitset_domain_t& b) {
         o << "[" << i;
         int j = i + 1;
         for (; j < 0; j++)
-            if (b.non_numerical_bytes[STACK_SIZE + j])
+            if (b.non_numerical_bytes[EBPF_STACK_SIZE + j])
                 break;
         if (j > i + 1)
             o << "..." << j - 1;

--- a/src/crab/bitset_domain.hpp
+++ b/src/crab/bitset_domain.hpp
@@ -4,11 +4,11 @@
 
 #include <bitset>
 
-#include "gpl/spec_type_descriptors.hpp" // for STACK_SIZE
+#include "spec_type_descriptors.hpp" // for EBPF_STACK_SIZE
 
 class bitset_domain_t final {
   private:
-    using bits_t = std::bitset<STACK_SIZE>;
+    using bits_t = std::bitset<EBPF_STACK_SIZE>;
     bits_t non_numerical_bytes;
 
   public:

--- a/src/crab/cfg.hpp
+++ b/src/crab/cfg.hpp
@@ -28,6 +28,8 @@
 
 #include "asm_syntax.hpp"
 #include "asm_ostream.hpp"
+#include "spec_type_descriptors.hpp"
+#include "gpl/spec_type_descriptors.hpp"
 
 namespace crab {
 

--- a/src/crab/ebpf_domain.hpp
+++ b/src/crab/ebpf_domain.hpp
@@ -26,6 +26,7 @@
 #include "config.hpp"
 #include "dsl_syntax.hpp"
 #include "gpl/spec_prototypes.hpp"
+#include "spec_type_descriptors.hpp"
 #include "gpl/spec_type_descriptors.hpp"
 
 #include "crab/array_domain.hpp"
@@ -559,7 +560,7 @@ class ebpf_domain_t final {
     NumAbsDomain check_access_stack(NumAbsDomain inv, const linear_expression_t& lb, const linear_expression_t& ub, const std::string& s) {
         using namespace dsl_syntax;
         require(inv, lb >= 0, std::string("Lower bound must be higher than 0") + s);
-        require(inv, ub <= STACK_SIZE, std::string("Upper bound must be lower than STACK_SIZE") + s);
+        require(inv, ub <= EBPF_STACK_SIZE, std::string("Upper bound must be lower than EBPF_STACK_SIZE") + s);
         return inv;
     }
 
@@ -643,7 +644,7 @@ class ebpf_domain_t final {
         if (inv.is_bottom())
             return inv;
 
-        ptype_descr desc = global_program_info.descriptor;
+        EbpfContextDescriptor desc = global_program_info.descriptor;
 
         inv -= target.value;
 
@@ -783,7 +784,7 @@ class ebpf_domain_t final {
         int width = b.access.width;
         int offset = b.access.offset;
         if (b.access.basereg.v == 10) {
-            int addr = STACK_SIZE + offset;
+            int addr = EBPF_STACK_SIZE + offset;
             do_store_stack(m_inv, width, addr, val_type, val_value, opt_val_offset);
             return;
         }
@@ -1061,8 +1062,8 @@ class ebpf_domain_t final {
         // intra_abs_transformer<AbsDomain>(inv);
         ebpf_domain_t inv;
         auto r10 = reg_pack(10);
-        inv += STACK_SIZE <= r10.value;
-        inv.assign(r10.offset, STACK_SIZE);
+        inv += EBPF_STACK_SIZE <= r10.value;
+        inv.assign(r10.offset, EBPF_STACK_SIZE);
         inv.assign(r10.type, T_STACK);
 
         auto r1 = reg_pack(1);

--- a/src/crab_verifier.cpp
+++ b/src/crab_verifier.cpp
@@ -11,15 +11,13 @@
 #include <iostream>
 #include <map>
 #include <string>
-#include <tuple>
 #include <vector>
 
-#include "crab/cfg.hpp"
 #include "crab/ebpf_domain.hpp"
 #include "crab/fwd_analyzer.hpp"
 
 #include "asm_syntax.hpp"
-#include "gpl/spec_type_descriptors.hpp"
+#include "crab_verifier.hpp"
 
 using std::string;
 

--- a/src/crab_verifier.hpp
+++ b/src/crab_verifier.hpp
@@ -6,6 +6,7 @@
 
 #include "config.hpp"
 #include "crab/cfg.hpp"
+#include "spec_type_descriptors.hpp"
 #include "gpl/spec_type_descriptors.hpp"
 
 bool run_ebpf_analysis(std::ostream& s, cfg_t& cfg, program_info info, const ebpf_verifier_options_t* options);

--- a/src/gpl/spec_type_descriptors.hpp
+++ b/src/gpl/spec_type_descriptors.hpp
@@ -58,7 +58,6 @@ enum class MapType : unsigned int {
     STACK,
 };
 
-constexpr int STACK_SIZE = 512;
 constexpr int NMAPS = 64;
 constexpr int NONMAPS = 5;
 constexpr int ALL_TYPES = NMAPS + NONMAPS;
@@ -78,13 +77,6 @@ constexpr int cgroup_sock_regions = 12 * 4;
 constexpr int sock_ops_regions = 42 * 4 + 2 * 8;
 constexpr int sk_skb_regions = 36 * 4;
 
-struct ptype_descr {
-    int size{};
-    int data = -1;
-    int end = -1;
-    int meta = -1; // data to meta is like end to data. i.e. meta <= data <= end
-};
-
 struct map_def {
     int original_fd;
     MapType type;
@@ -96,7 +88,7 @@ struct map_def {
 struct program_info {
     BpfProgType program_type;
     std::vector<map_def> map_defs;
-    ptype_descr descriptor;
+    EbpfContextDescriptor descriptor;
 };
 
 extern program_info global_program_info;
@@ -108,24 +100,24 @@ struct raw_program {
     program_info info;
 };
 
-constexpr ptype_descr sk_buff = {sk_skb_regions, 19 * 4, 20 * 4, 35 * 4};
-constexpr ptype_descr xdp_md = {xdp_regions, 0, 1 * 4, 2 * 4};
-constexpr ptype_descr sk_msg_md = {17 * 4, 0, 1 * 8, -1}; // TODO: verify
-constexpr ptype_descr unspec_descr = {0};
-constexpr ptype_descr cgroup_dev_descr = {cgroup_dev_regions};
-constexpr ptype_descr kprobe_descr = {kprobe_regions};
-constexpr ptype_descr tracepoint_descr = {tracepoint_regions};
-constexpr ptype_descr perf_event_descr = {perf_event_regions};
-constexpr ptype_descr socket_filter_descr = sk_buff;
-constexpr ptype_descr sched_descr = sk_buff;
-constexpr ptype_descr xdp_descr = xdp_md;
-constexpr ptype_descr lwt_xmit_descr = sk_buff;
-constexpr ptype_descr lwt_inout_descr = sk_buff;
-constexpr ptype_descr cgroup_sock_descr = {cgroup_sock_regions};
-constexpr ptype_descr sock_ops_descr = {sock_ops_regions};
-constexpr ptype_descr sk_skb_descr = sk_buff;
+constexpr EbpfContextDescriptor sk_buff = {sk_skb_regions, 19 * 4, 20 * 4, 35 * 4};
+constexpr EbpfContextDescriptor xdp_md = {xdp_regions, 0, 1 * 4, 2 * 4};
+constexpr EbpfContextDescriptor sk_msg_md = {17 * 4, 0, 1 * 8, -1}; // TODO: verify
+constexpr EbpfContextDescriptor unspec_descr = {0};
+constexpr EbpfContextDescriptor cgroup_dev_descr = {cgroup_dev_regions};
+constexpr EbpfContextDescriptor kprobe_descr = {kprobe_regions};
+constexpr EbpfContextDescriptor tracepoint_descr = {tracepoint_regions};
+constexpr EbpfContextDescriptor perf_event_descr = {perf_event_regions};
+constexpr EbpfContextDescriptor socket_filter_descr = sk_buff;
+constexpr EbpfContextDescriptor sched_descr = sk_buff;
+constexpr EbpfContextDescriptor xdp_descr = xdp_md;
+constexpr EbpfContextDescriptor lwt_xmit_descr = sk_buff;
+constexpr EbpfContextDescriptor lwt_inout_descr = sk_buff;
+constexpr EbpfContextDescriptor cgroup_sock_descr = {cgroup_sock_regions};
+constexpr EbpfContextDescriptor sock_ops_descr = {sock_ops_regions};
+constexpr EbpfContextDescriptor sk_skb_descr = sk_buff;
 
-inline ptype_descr get_descriptor(BpfProgType t) {
+inline EbpfContextDescriptor get_descriptor(BpfProgType t) {
     switch (t) {
     case BpfProgType::UNSPEC: return unspec_descr;
     case BpfProgType::CGROUP_DEVICE: return cgroup_dev_descr;

--- a/src/main/linux_verifier.cpp
+++ b/src/main/linux_verifier.cpp
@@ -6,13 +6,10 @@
 #include <linux/bpf.h>
 #include <ctime>
 
-#include <iostream>
-
-#include "asm_syntax.hpp"
 #include "config.hpp"
+#include "linux_verifier.hpp"
 #include "utils.hpp"
 
-#include "gpl/spec_type_descriptors.hpp"
 
 static bpf_prog_type to_linuxtype(BpfProgType t) {
     switch (t) {

--- a/src/main/linux_verifier.hpp
+++ b/src/main/linux_verifier.hpp
@@ -9,6 +9,7 @@
 #include <vector>
 
 #include "asm_syntax.hpp"
+#include "spec_type_descriptors.hpp"
 #include "gpl/spec_type_descriptors.hpp"
 #include "linux_ebpf.hpp"
 

--- a/src/spec_type_descriptors.hpp
+++ b/src/spec_type_descriptors.hpp
@@ -1,0 +1,14 @@
+// Copyright (c) Prevail Verifier contributors.
+// SPDX-License-Identifier: MIT
+#pragma once
+
+constexpr int EBPF_STACK_SIZE = 512;
+
+// The following struct describes how to access the layout in
+// memory of the data (e.g., the actual packet).
+struct EbpfContextDescriptor {
+    int size{};     // Size of ctx struct.
+    int data = -1;  // Offset into ctx struct of pointer to data.
+    int end = -1;   // Offset into ctx struct of pointer to end of data.
+    int meta = -1;  // Offset into ctx struct of pointer to metadata.
+};


### PR DESCRIPTION
This PR is the first step in reducing dependencies on files in the gpl
directory.

Replace ptype_descr with the more expressively named EbpfContextDescriptor
and fix comments per email exchange.

Replace STACK_SIZE with the more clear name EBPF_STACK_SIZE for consistency
with generic-ebpf project.

Remove redundant includes, e.g., where a file foo.cpp includes the corresponding foo.hpp and both of them includes bunch of the same headers.

Signed-off-by: Dave Thaler <dthaler@ntdev.microsoft.com>