### PR TITLE
Replace map_def with EbpfMapDescriptor

### DIFF
--- a/src/crab/ebpf_domain.hpp
+++ b/src/crab/ebpf_domain.hpp
@@ -575,8 +575,8 @@ class ebpf_domain_t final {
     NumAbsDomain check_access_context(NumAbsDomain inv, const linear_expression_t& lb, const linear_expression_t& ub, const std::string& s) {
         using namespace dsl_syntax;
         require(inv, lb >= 0, std::string("Lower bound must be higher than 0") + s);
-        require(inv, ub <= global_program_info.descriptor.size,
-                std::string("Upper bound must be lower than ") + std::to_string(global_program_info.descriptor.size) +
+        require(inv, ub <= global_program_info.context_descriptor.size,
+                std::string("Upper bound must be lower than ") + std::to_string(global_program_info.context_descriptor.size) +
                     s);
         return inv;
     }
@@ -644,7 +644,7 @@ class ebpf_domain_t final {
         if (inv.is_bottom())
             return inv;
 
-        EbpfContextDescriptor desc = global_program_info.descriptor;
+        EbpfContextDescriptor desc = global_program_info.context_descriptor;
 
         inv -= target.value;
 
@@ -1074,7 +1074,7 @@ class ebpf_domain_t final {
 
         inv += 0 <= variable_t::packet_size();
         inv += variable_t::packet_size() < MAX_PACKET_OFF;
-        if (global_program_info.descriptor.meta >= 0) {
+        if (global_program_info.context_descriptor.meta >= 0) {
             inv += variable_t::meta_offset() <= 0;
             inv += variable_t::meta_offset() >= -4098;
         } else {

--- a/src/gpl/spec_type_descriptors.hpp
+++ b/src/gpl/spec_type_descriptors.hpp
@@ -77,18 +77,10 @@ constexpr int cgroup_sock_regions = 12 * 4;
 constexpr int sock_ops_regions = 42 * 4 + 2 * 8;
 constexpr int sk_skb_regions = 36 * 4;
 
-struct map_def {
-    int original_fd;
-    MapType type;
-    unsigned int key_size;
-    unsigned int value_size;
-    unsigned int inner_map_fd;
-};
-
 struct program_info {
     BpfProgType program_type;
-    std::vector<map_def> map_defs;
-    EbpfContextDescriptor descriptor;
+    std::vector<EbpfMapDescriptor> map_descriptors;
+    EbpfContextDescriptor context_descriptor;
 };
 
 extern program_info global_program_info;
@@ -117,7 +109,7 @@ constexpr EbpfContextDescriptor cgroup_sock_descr = {cgroup_sock_regions};
 constexpr EbpfContextDescriptor sock_ops_descr = {sock_ops_regions};
 constexpr EbpfContextDescriptor sk_skb_descr = sk_buff;
 
-inline EbpfContextDescriptor get_descriptor(BpfProgType t) {
+inline EbpfContextDescriptor get_context_descriptor(BpfProgType t) {
     switch (t) {
     case BpfProgType::UNSPEC: return unspec_descr;
     case BpfProgType::CGROUP_DEVICE: return cgroup_dev_descr;

--- a/src/spec_type_descriptors.hpp
+++ b/src/spec_type_descriptors.hpp
@@ -4,6 +4,14 @@
 
 constexpr int EBPF_STACK_SIZE = 512;
 
+struct EbpfMapDescriptor {
+    int original_fd;
+    uint32_t type; // Platform-specific type value in ELF file.
+    unsigned int key_size;
+    unsigned int value_size;
+    unsigned int inner_map_fd;
+};
+
 // The following struct describes how to access the layout in
 // memory of the data (e.g., the actual packet).
 struct EbpfContextDescriptor {


### PR DESCRIPTION
This is the next step in reducing dependency on code in the gpl subdirectory.

The verifier today never uses MapType for anything, so leave it raw like in bpf_load_map_def in asm_files.cpp.  Once the verifier does need to use it, we can reintroduce a platform-agnostic type.  (MapType today has linux-specific values and issue #110 should eventually result in multiple platforms supported.)

program_info and raw_program will move in a later PR since they require BpfProgType to be handled first.

Signed-off-by: Dave Thaler <dthaler@ntdev.microsoft.com>