### PR TITLE
Ignore CR if present in .check-license.ignore

### DIFF
--- a/scripts/check-license.sh
+++ b/scripts/check-license.sh
@@ -21,12 +21,12 @@ if [[ $(uname) == MINGW* ]] ; then
 fi
 
 ignore_res=()
-while IFS= read -r i; do
+tr -d '\r' < "$root/scripts/.check-license.ignore" | while IFS= read -r i; do
       if [[ $i =~ ^# ]] || [[ -z $i ]]; then # ignore comments
           continue
       fi
       ignore_res+=("$i")
-done <"$root/scripts/.check-license.ignore"
+done
 
 
 should_ignore() {


### PR DESCRIPTION
Previously the check-license.sh script relied on line endings in
.check-license.ignore to be LF not CRLF.  So if you use an editor
that saves it with CRLF, or git checks out the file using autocrlf,
it might have CRLF on the local system.  This PR updates the script
to accept the file either way.

Signed-off-by: Dave Thaler <dthaler@ntdev.microsoft.com>