### PR TITLE
Remove pkt_access field

### DIFF
--- a/src/asm_syntax.hpp
+++ b/src/asm_syntax.hpp
@@ -166,7 +166,6 @@ struct ArgPair {
 struct Call {
     int32_t func{};
     std::string name;
-    bool pkt_access{};
     bool returns_map{};
     std::vector<ArgSingle> singles;
     std::vector<ArgPair> pairs;

--- a/src/asm_unmarshal.cpp
+++ b/src/asm_unmarshal.cpp
@@ -299,7 +299,6 @@ struct Unmarshaller {
         Call res;
         res.func = imm;
         res.name = proto.name;
-        res.pkt_access = proto.pkt_access;
         res.returns_map = proto.ret_type == Ret::PTR_TO_MAP_VALUE_OR_NULL;
         std::array<Arg, 7> args = {{Arg::DONTCARE, proto.arg1_type, proto.arg2_type, proto.arg3_type, proto.arg4_type,
                                     proto.arg5_type, Arg::DONTCARE}};

--- a/src/gpl/spec_prototypes.cpp
+++ b/src/gpl/spec_prototypes.cpp
@@ -334,7 +334,6 @@ static const struct bpf_func_proto bpf_map_lookup_elem_proto = {
     .arg3_type = Arg::DONTCARE,
     .arg4_type = Arg::DONTCARE,
     .arg5_type = Arg::DONTCARE,
-    .pkt_access = true,
 };
 
 /*
@@ -351,7 +350,6 @@ static const struct bpf_func_proto bpf_map_update_elem_proto = {
     .arg3_type = Arg::PTR_TO_MAP_VALUE,
     .arg4_type = Arg::ANYTHING,
     .arg5_type = Arg::DONTCARE,
-    .pkt_access = true,
 };
 
 /*
@@ -368,7 +366,6 @@ static const struct bpf_func_proto bpf_map_delete_elem_proto = {
     .arg3_type = Arg::DONTCARE,
     .arg4_type = Arg::DONTCARE,
     .arg5_type = Arg::DONTCARE,
-    .pkt_access = true,
 };
 
 /*
@@ -479,7 +476,6 @@ static const struct bpf_func_proto bpf_sock_map_update_proto = {
     .arg3_type = Arg::PTR_TO_MAP_KEY,
     .arg4_type = Arg::ANYTHING,
     .arg5_type = Arg::DONTCARE,
-    .pkt_access = true,
 };
 
 static const struct bpf_func_proto bpf_sock_hash_update_proto = {
@@ -492,7 +488,6 @@ static const struct bpf_func_proto bpf_sock_hash_update_proto = {
     .arg3_type = Arg::PTR_TO_MAP_KEY,
     .arg4_type = Arg::ANYTHING,
     .arg5_type = Arg::DONTCARE,
-    .pkt_access = true,
 };
 
 /*
@@ -745,7 +740,6 @@ static const struct bpf_func_proto bpf_csum_diff_proto = {
     .arg3_type = Arg::PTR_TO_MEM_OR_NULL,
     .arg4_type = Arg::CONST_SIZE_OR_ZERO,
     .arg5_type = Arg::ANYTHING,
-    .pkt_access = true,
 };
 
 static const struct bpf_func_proto bpf_csum_update_proto = {

--- a/src/gpl/spec_prototypes.hpp
+++ b/src/gpl/spec_prototypes.hpp
@@ -57,7 +57,6 @@ struct bpf_func_proto {
     Arg arg3_type;
     Arg arg4_type;
     Arg arg5_type;
-    bool pkt_access;
 };
 
 bpf_func_proto get_prototype(unsigned int n);


### PR DESCRIPTION
It was set but never used for anything.  If it's needed in the future,
it can be added back in when it's used for something.

Signed-off-by: Dave Thaler <dthaler@ntdev.microsoft.com>