### PR TITLE
Fix linux domain

### DIFF
--- a/src/asm_unmarshal.cpp
+++ b/src/asm_unmarshal.cpp
@@ -274,7 +274,7 @@ struct Unmarshaller {
     static ArgSingle::Kind toArgSingleKind(EbpfHelperArgumentType t) {
         switch (t) {
         case EbpfHelperArgumentType::ANYTHING: return ArgSingle::Kind::ANYTHING;
-        case EbpfHelperArgumentType::CONST_SHARED_PTR: return ArgSingle::Kind::MAP_FD;
+        case EbpfHelperArgumentType::PTR_TO_MAP: return ArgSingle::Kind::MAP_FD;
         case EbpfHelperArgumentType::PTR_TO_MAP_KEY: return ArgSingle::Kind::PTR_TO_MAP_KEY;
         case EbpfHelperArgumentType::PTR_TO_MAP_VALUE: return ArgSingle::Kind::PTR_TO_MAP_VALUE;
         case EbpfHelperArgumentType::PTR_TO_CTX: return ArgSingle::Kind::PTR_TO_CTX;
@@ -310,7 +310,7 @@ struct Unmarshaller {
             switch (args[i]) {
             case EbpfHelperArgumentType::DONTCARE: return res;
             case EbpfHelperArgumentType::ANYTHING:
-            case EbpfHelperArgumentType::CONST_SHARED_PTR:
+            case EbpfHelperArgumentType::PTR_TO_MAP:
             case EbpfHelperArgumentType::PTR_TO_MAP_KEY:
             case EbpfHelperArgumentType::PTR_TO_MAP_VALUE:
             case EbpfHelperArgumentType::PTR_TO_CTX: res.singles.push_back({toArgSingleKind(args[i]), Reg{(uint8_t)i}}); break;

--- a/src/helpers.hpp
+++ b/src/helpers.hpp
@@ -10,11 +10,11 @@ enum class EbpfHelperReturnType {
 
 enum class EbpfHelperArgumentType {
     DONTCARE = 0,
-    ANYTHING,
-    CONST_SHARED_PTR,
+    ANYTHING, // All values are valid, e.g., 64-bit flags.
     CONST_SIZE,
     CONST_SIZE_OR_ZERO,
     PTR_TO_CTX,
+    PTR_TO_MAP,
     PTR_TO_MAP_KEY,
     PTR_TO_MAP_VALUE,
     PTR_TO_MEM,

--- a/src/linux/gpl/spec_prototypes.cpp
+++ b/src/linux/gpl/spec_prototypes.cpp
@@ -42,7 +42,7 @@ const struct EbpfHelperPrototype bpf_tail_call_proto = {
     .return_type = EbpfHelperReturnType::VOID,
     .argument_type = {
         EbpfHelperArgumentType::PTR_TO_CTX,
-        EbpfHelperArgumentType::CONST_SHARED_PTR,
+        EbpfHelperArgumentType::PTR_TO_MAP,
         EbpfHelperArgumentType::ANYTHING,
     },
 };
@@ -136,7 +136,7 @@ static const struct EbpfHelperPrototype bpf_perf_event_read_proto = {
     //.gpl_only	= true,
     .return_type = EbpfHelperReturnType::INTEGER,
     .argument_type = {
-        EbpfHelperArgumentType::CONST_SHARED_PTR,
+        EbpfHelperArgumentType::PTR_TO_MAP,
         EbpfHelperArgumentType::ANYTHING,
     },
 };
@@ -156,7 +156,7 @@ static const struct EbpfHelperPrototype bpf_perf_event_read_value_proto = {
     //.gpl_only	= true,
     .return_type = EbpfHelperReturnType::INTEGER,
     .argument_type = {
-        EbpfHelperArgumentType::CONST_SHARED_PTR,
+        EbpfHelperArgumentType::PTR_TO_MAP,
         EbpfHelperArgumentType::ANYTHING,
         EbpfHelperArgumentType::PTR_TO_UNINIT_MEM,
         EbpfHelperArgumentType::CONST_SIZE,
@@ -216,7 +216,7 @@ static const struct EbpfHelperPrototype bpf_perf_event_output_proto = {
     .return_type = EbpfHelperReturnType::INTEGER,
     .argument_type = {
         EbpfHelperArgumentType::PTR_TO_CTX,
-        EbpfHelperArgumentType::CONST_SHARED_PTR,
+        EbpfHelperArgumentType::PTR_TO_MAP,
         EbpfHelperArgumentType::ANYTHING,
         EbpfHelperArgumentType::PTR_TO_MEM,
         EbpfHelperArgumentType::CONST_SIZE_OR_ZERO,
@@ -251,7 +251,7 @@ static const struct EbpfHelperPrototype bpf_current_task_under_cgroup_proto = {
     //.gpl_only   = false,
     .return_type = EbpfHelperReturnType::INTEGER,
     .argument_type = {
-        EbpfHelperArgumentType::CONST_SHARED_PTR,
+        EbpfHelperArgumentType::PTR_TO_MAP,
         EbpfHelperArgumentType::ANYTHING,
     },
 };
@@ -262,7 +262,7 @@ static const struct EbpfHelperPrototype bpf_current_task_under_cgroup_proto = {
 // 	.return_type	= EbpfHelperReturnType::INTEGER,
 // 	.argument_type = {
 // 	    EbpfHelperArgumentType::PTR_TO_CTX,
-// 	    EbpfHelperArgumentType::CONST_SHARED_PTR,
+// 	    EbpfHelperArgumentType::PTR_TO_MAP,
 // 	    EbpfHelperArgumentType::ANYTHING,
 // 	    EbpfHelperArgumentType::PTR_TO_MEM,
 // 	    EbpfHelperArgumentType::CONST_SIZE_OR_ZERO,
@@ -275,7 +275,7 @@ static const struct EbpfHelperPrototype bpf_current_task_under_cgroup_proto = {
 // 	.return_type	= EbpfHelperReturnType::INTEGER,
 // 	.argument_type = {
 // 	    EbpfHelperArgumentType::PTR_TO_CTX,
-// 	    EbpfHelperArgumentType::CONST_SHARED_PTR,
+// 	    EbpfHelperArgumentType::PTR_TO_MAP,
 // 	    EbpfHelperArgumentType::ANYTHING,
 //  },
 // };
@@ -323,7 +323,7 @@ static const struct EbpfHelperPrototype bpf_perf_prog_read_value_proto = {
 // 	.return_type	= EbpfHelperReturnType::INTEGER,
 // 	.argument_type = {
 // 	    EbpfHelperArgumentType::PTR_TO_CTX,
-// 	    EbpfHelperArgumentType::CONST_SHARED_PTR,
+// 	    EbpfHelperArgumentType::PTR_TO_MAP,
 // 	    EbpfHelperArgumentType::ANYTHING,
 // 	    EbpfHelperArgumentType::PTR_TO_MEM,
 // 	    EbpfHelperArgumentType::CONST_SIZE_OR_ZERO,
@@ -336,7 +336,7 @@ static const struct EbpfHelperPrototype bpf_perf_prog_read_value_proto = {
 // 	.return_type	= EbpfHelperReturnType::INTEGER,
 // 	.argument_type = {
 // 	    EbpfHelperArgumentType::PTR_TO_CTX,
-// 	    EbpfHelperArgumentType::CONST_SHARED_PTR,
+// 	    EbpfHelperArgumentType::PTR_TO_MAP,
 // 	    EbpfHelperArgumentType::ANYTHING,
 //   },
 // };
@@ -365,7 +365,7 @@ static const struct EbpfHelperPrototype bpf_map_lookup_elem_proto = {
     //.gpl_only	= false,
     .return_type = EbpfHelperReturnType::PTR_TO_MAP_VALUE_OR_NULL,
     .argument_type = {
-        EbpfHelperArgumentType::CONST_SHARED_PTR,
+        EbpfHelperArgumentType::PTR_TO_MAP,
         EbpfHelperArgumentType::PTR_TO_MAP_KEY,
         EbpfHelperArgumentType::DONTCARE,
         EbpfHelperArgumentType::DONTCARE,
@@ -383,7 +383,7 @@ static const struct EbpfHelperPrototype bpf_map_update_elem_proto = {
     //.gpl_only	= false,
     .return_type = EbpfHelperReturnType::INTEGER,
     .argument_type = {
-        EbpfHelperArgumentType::CONST_SHARED_PTR,
+        EbpfHelperArgumentType::PTR_TO_MAP,
         EbpfHelperArgumentType::PTR_TO_MAP_KEY,
         EbpfHelperArgumentType::PTR_TO_MAP_VALUE,
         EbpfHelperArgumentType::ANYTHING,
@@ -401,7 +401,7 @@ static const struct EbpfHelperPrototype bpf_map_delete_elem_proto = {
     //.gpl_only	= false,
     .return_type = EbpfHelperReturnType::INTEGER,
     .argument_type = {
-        EbpfHelperArgumentType::CONST_SHARED_PTR,
+        EbpfHelperArgumentType::PTR_TO_MAP,
         EbpfHelperArgumentType::PTR_TO_MAP_KEY,
         EbpfHelperArgumentType::DONTCARE,
         EbpfHelperArgumentType::DONTCARE,
@@ -516,7 +516,7 @@ static const struct EbpfHelperPrototype bpf_sock_map_update_proto = {
     .return_type = EbpfHelperReturnType::INTEGER,
     .argument_type = {
         EbpfHelperArgumentType::PTR_TO_CTX,
-        EbpfHelperArgumentType::CONST_SHARED_PTR,
+        EbpfHelperArgumentType::PTR_TO_MAP,
         EbpfHelperArgumentType::PTR_TO_MAP_KEY,
         EbpfHelperArgumentType::ANYTHING,
         EbpfHelperArgumentType::DONTCARE,
@@ -530,7 +530,7 @@ static const struct EbpfHelperPrototype bpf_sock_hash_update_proto = {
     .return_type = EbpfHelperReturnType::INTEGER,
     .argument_type = {
         EbpfHelperArgumentType::PTR_TO_CTX,
-        EbpfHelperArgumentType::CONST_SHARED_PTR,
+        EbpfHelperArgumentType::PTR_TO_MAP,
         EbpfHelperArgumentType::PTR_TO_MAP_KEY,
         EbpfHelperArgumentType::ANYTHING,
         EbpfHelperArgumentType::DONTCARE,
@@ -557,7 +557,7 @@ static const struct EbpfHelperPrototype bpf_get_stackid_proto = {
     .return_type = EbpfHelperReturnType::INTEGER,
     .argument_type = {
         EbpfHelperArgumentType::PTR_TO_CTX,
-        EbpfHelperArgumentType::CONST_SHARED_PTR,
+        EbpfHelperArgumentType::PTR_TO_MAP,
         EbpfHelperArgumentType::ANYTHING,
     },
 };
@@ -848,7 +848,7 @@ static const struct EbpfHelperPrototype bpf_sk_redirect_hash_proto = {
     .return_type = EbpfHelperReturnType::INTEGER,
     .argument_type = {
         EbpfHelperArgumentType::PTR_TO_CTX,
-        EbpfHelperArgumentType::CONST_SHARED_PTR,
+        EbpfHelperArgumentType::PTR_TO_MAP,
         EbpfHelperArgumentType::PTR_TO_MAP_KEY,
         EbpfHelperArgumentType::ANYTHING,
     },
@@ -860,7 +860,7 @@ static const struct EbpfHelperPrototype bpf_sk_redirect_map_proto = {
     .return_type = EbpfHelperReturnType::INTEGER,
     .argument_type = {
         EbpfHelperArgumentType::PTR_TO_CTX,
-        EbpfHelperArgumentType::CONST_SHARED_PTR,
+        EbpfHelperArgumentType::PTR_TO_MAP,
         EbpfHelperArgumentType::ANYTHING,
         EbpfHelperArgumentType::ANYTHING,
     },
@@ -872,7 +872,7 @@ static const struct EbpfHelperPrototype bpf_msg_redirect_hash_proto = {
     .return_type = EbpfHelperReturnType::INTEGER,
     .argument_type = {
         EbpfHelperArgumentType::PTR_TO_CTX,
-        EbpfHelperArgumentType::CONST_SHARED_PTR,
+        EbpfHelperArgumentType::PTR_TO_MAP,
         EbpfHelperArgumentType::PTR_TO_MAP_KEY,
         EbpfHelperArgumentType::ANYTHING,
     },
@@ -884,7 +884,7 @@ static const struct EbpfHelperPrototype bpf_msg_redirect_map_proto = {
     .return_type = EbpfHelperReturnType::INTEGER,
     .argument_type = {
         EbpfHelperArgumentType::PTR_TO_CTX,
-        EbpfHelperArgumentType::CONST_SHARED_PTR,
+        EbpfHelperArgumentType::PTR_TO_MAP,
         EbpfHelperArgumentType::ANYTHING,
         EbpfHelperArgumentType::ANYTHING,
     },
@@ -1173,7 +1173,7 @@ static const struct EbpfHelperPrototype bpf_xdp_adjust_meta_proto = {
 // 	//.gpl_only   = false,
 // 	.return_type   = EbpfHelperReturnType::INTEGER,
 // 	.argument_type = {
-// 	    EbpfHelperArgumentType::CONST_SHARED_PTR,
+// 	    EbpfHelperArgumentType::PTR_TO_MAP,
 // 	    EbpfHelperArgumentType::ANYTHING,
 // 	    EbpfHelperArgumentType::ANYTHING,
 // 	},
@@ -1186,7 +1186,7 @@ static const struct EbpfHelperPrototype bpf_xdp_adjust_meta_proto = {
 // 	.return_type	= EbpfHelperReturnType::INTEGER,
 // 	.argument_type = {
 // 	    EbpfHelperArgumentType::PTR_TO_CTX,
-// 	    EbpfHelperArgumentType::CONST_SHARED_PTR,
+// 	    EbpfHelperArgumentType::PTR_TO_MAP,
 // 	    EbpfHelperArgumentType::ANYTHING,
 // 	    EbpfHelperArgumentType::PTR_TO_MEM,
 // 	    EbpfHelperArgumentType::CONST_SIZE_OR_ZERO,
@@ -1295,7 +1295,7 @@ static const struct EbpfHelperPrototype bpf_skb_under_cgroup_proto = {
     .return_type = EbpfHelperReturnType::INTEGER,
     .argument_type = {
         EbpfHelperArgumentType::PTR_TO_CTX,
-        EbpfHelperArgumentType::CONST_SHARED_PTR,
+        EbpfHelperArgumentType::PTR_TO_MAP,
         EbpfHelperArgumentType::ANYTHING,
     },
 };
@@ -1317,7 +1317,7 @@ static const struct EbpfHelperPrototype bpf_skb_cgroup_id_proto = {
 // 	.return_type	= EbpfHelperReturnType::INTEGER,
 // 	.argument_type = {
 // 	    EbpfHelperArgumentType::PTR_TO_CTX,
-// 	    EbpfHelperArgumentType::CONST_SHARED_PTR,
+// 	    EbpfHelperArgumentType::PTR_TO_MAP,
 // 	    EbpfHelperArgumentType::ANYTHING,
 // 	    EbpfHelperArgumentType::PTR_TO_MEM,
 // 	    EbpfHelperArgumentType::CONST_SIZE_OR_ZERO,
@@ -1650,7 +1650,7 @@ static const struct EbpfHelperPrototype bpf_redirect_map_proto = {
     .name = "redirect_map",
     .return_type = EbpfHelperReturnType::INTEGER,
     .argument_type = {
-        EbpfHelperArgumentType::CONST_SHARED_PTR,
+        EbpfHelperArgumentType::PTR_TO_MAP,
         EbpfHelperArgumentType::ANYTHING,
         EbpfHelperArgumentType::ANYTHING,
     },

--- a/src/linux/linux_platform.cpp
+++ b/src/linux/linux_platform.cpp
@@ -2,28 +2,21 @@
 // SPDX-License-Identifier: MIT
 #if __linux__
 #include <linux/bpf.h>
+#define PTYPE(name, descr, native_type, prefixes) \
+             {name, descr, native_type, prefixes}
+#define PTYPE_PRIVILEGED(name, descr, native_type, prefixes) \
+                        {name, descr, native_type, prefixes, true}
+#else
+#define PTYPE(name, descr, native_type, prefixes) \
+             {name, descr, 0, prefixes}
+#define PTYPE_PRIVILEGED(name, descr, native_type, prefixes) \
+                        {name, descr, 0, prefixes, true}
 #endif
 #include "spec_type_descriptors.hpp"
 #include "helpers.hpp"
 #include "platform.hpp"
 #include "linux_platform.hpp"
 #include "linux/gpl/spec_type_descriptors.hpp"
-
-#ifdef BPF_PROG_TYPE_UNSPEC
-#define PTYPE(name, descr, native_type, prefixes) \
-               {name, descr, native_type, prefixes}
-
-#define PTYPE(name, descr, native_type, prefixes, is_privileged) \
-                       {name, descr, native_type, prefixes, is_privileged}
-
-#else
-
-#define PTYPE(name, descr, native_type, prefixes) \
-                       {name, descr, 0, prefixes}
-
-#define PTYPE_PRIVILEGED(name, descr, native_type, prefixes) \
-                       {name, descr, 0, prefixes, true}
-#endif
 
 // Allow for comma as a separator between multiple prefixes, to make
 // the preprocessor treat a prefix list as one macro argument.


### PR DESCRIPTION
Enum values aren't preprocessor symbols so the ifdef was wrong.
This wasn't caught because the linux domain isn't used in any test.

Also rename CONST_SHARED_PTR to PTR_TO_MAP for better internal consistency and clarity.
Also add a comment on the ANYTHING value definition.

Signed-off-by: Dave Thaler <dthaler@ntdev.microsoft.com>