### PR TITLE
Various error message cleanup

### DIFF
--- a/src/crab_verifier.cpp
+++ b/src/crab_verifier.cpp
@@ -120,9 +120,7 @@ static void print_report(std::ostream& s, const checks_db& db) {
             s << "  " << msg << "\n";
     }
     s << "\n";
-    if (db.maybe_nonterminating.empty()) {
-        s << "Always terminates\n";
-    } else {
+    if (!db.maybe_nonterminating.empty()) {
         s << "Could not prove termination on join into: ";
         for (const label_t& label : db.maybe_nonterminating) {
             s << label << ", ";

--- a/src/linux/gpl/spec_prototypes.cpp
+++ b/src/linux/gpl/spec_prototypes.cpp
@@ -1993,10 +1993,10 @@ const struct EbpfHelperPrototype prototypes[81] = {
     FN(get_current_cgroup_id),
 };
 
+bool is_helper_usable_linux(unsigned int n) { return n < sizeof(prototypes) / sizeof(prototypes[0]) && n > 0; }
+
 EbpfHelperPrototype get_helper_prototype_linux(unsigned int n) {
-    if (n >= sizeof(prototypes) / sizeof(prototypes[0]))
-        return bpf_unspec_proto;
+    if (!is_helper_usable_linux(n))
+        throw std::exception();
     return prototypes[n];
 }
-
-bool is_helper_usable_linux(unsigned int n) { return n < sizeof(prototypes) / sizeof(prototypes[0]) && n > 0; }

--- a/src/main/check.cpp
+++ b/src/main/check.cpp
@@ -122,7 +122,7 @@ int main(int argc, char** argv) {
     // Convert the raw program section to a set of instructions.
     std::variant<InstructionSeq, std::string> prog_or_error = unmarshal(raw_prog, &g_ebpf_platform_linux);
     if (std::holds_alternative<string>(prog_or_error)) {
-        std::cout << "trivial verification failure: " << std::get<string>(prog_or_error) << "\n";
+        std::cout << "unmarshaling error at " << std::get<string>(prog_or_error) << "\n";
         return 1;
     }
 


### PR DESCRIPTION
1) Make invalid helper function id be an error instead of silently
   ignoring it.  This means that get_helper_prototype() can safely
   throw since it should never be called when is_helper_usable()
   returns false.

2) When unmarshal hits errors, include the instruction # (pc) in the
   message to help developers.

3) Update ebpf_domain to use register defines instead of just
   numbers, for readability.

4) Remove termination success message ("Always terminates") so
   messages just indicate problems.

Signed-off-by: Dave Thaler <dthaler@ntdev.microsoft.com>