### PR TITLE
Move maps section parsing to platform-specific code

### DIFF
--- a/src/asm_files.hpp
+++ b/src/asm_files.hpp
@@ -7,13 +7,10 @@
 #include <vector>
 
 #include "asm_syntax.hpp"
-#include "config.hpp"
-#include "spec_type_descriptors.hpp"
-
-using MapFd = auto(uint32_t map_type, uint32_t key_size, uint32_t value_size, uint32_t max_entries, ebpf_verifier_options_t options) -> int;
+#include "platform.hpp"
 
 std::vector<raw_program> read_raw(std::string path, program_info info);
-std::vector<raw_program> read_elf(const std::string& path, const std::string& section, MapFd* allocate_fds, const ebpf_verifier_options_t* options, const ebpf_platform_t* platform);
+std::vector<raw_program> read_elf(const std::string& path, const std::string& section, ebpf_alloc_map_fd_fn alloc_map_fd, const ebpf_verifier_options_t* options, const ebpf_platform_t* platform);
 
 void write_binary_file(std::string path, const char* data, size_t size);
 

--- a/src/main/check.cpp
+++ b/src/main/check.cpp
@@ -89,7 +89,7 @@ int main(int argc, char** argv) {
 
 #if !__linux__
     if (domain == "linux") {
-        std::cerr << "linux domain is unsupported on this machine\n";
+        std::cerr << "error: linux domain is unsupported on this machine\n";
         return 64;
     }
 #endif
@@ -97,7 +97,13 @@ int main(int argc, char** argv) {
     auto create_map = domain == "linux" ? create_map_linux : create_map_crab;
 
     // Read a set of raw program sections from an ELF file.
-    auto raw_progs = read_elf(filename, desired_section, create_map, &ebpf_verifier_options, &g_ebpf_platform_linux);
+    vector<raw_program> raw_progs;
+    try {
+        raw_progs = read_elf(filename, desired_section, create_map, &ebpf_verifier_options, &g_ebpf_platform_linux);
+    } catch (std::runtime_error e) {
+        std::cerr << "error: " << e.what() << std::endl;
+        return 1;
+    }
 
     if (list || raw_progs.size() != 1) {
         if (!list) {

--- a/src/platform.hpp
+++ b/src/platform.hpp
@@ -6,6 +6,7 @@
 // that supports eBPF can have an ebpf_platform_t struct that the verifier
 // can use to call platform-specific functions.
 
+#include "config.hpp"
 #include "spec_type_descriptors.hpp"
 #include "helpers.hpp"
 
@@ -15,10 +16,22 @@ typedef EbpfHelperPrototype (*ebpf_get_helper_prototype_fn)(unsigned int n);
 
 typedef bool (*ebpf_is_helper_usable_fn)(unsigned int n);
 
+// Return an fd for a map created with the given parameters.
+typedef int (*ebpf_alloc_map_fd_fn)(uint32_t map_type, uint32_t key_size, uint32_t value_size, uint32_t max_entries, ebpf_verifier_options_t options);
+
+// Parse map records and allocate map fd's.
+// In the future we may want to move map fd allocation after the verifier step.
+typedef void (*ebpf_parse_maps_section_fn)(std::vector<EbpfMapDescriptor>& map_descriptors, const char* data, size_t size, ebpf_alloc_map_fd_fn fd_alloc, ebpf_verifier_options_t options);
+
 struct ebpf_platform_t {
     ebpf_get_program_type_fn get_program_type;
     ebpf_get_helper_prototype_fn get_helper_prototype;
     ebpf_is_helper_usable_fn is_helper_usable;
+
+    // Size of a record in the "maps" section of an ELF file.
+    size_t map_record_size;
+
+    ebpf_parse_maps_section_fn parse_maps_section;
 };
 
 extern const ebpf_platform_t g_ebpf_platform_linux;


### PR DESCRIPTION
The size of a record in the maps section can vary by platform and even by version of the same platform.  For example, the generic-ebpf project only has 5, not 7, fields in the struct, and even Linux has extended the struct over time it appears.

Also print error on invalid maps section instead of silently crashing due to an exception.

Signed-off-by: Dave Thaler <dthaler@ntdev.microsoft.com>