### PR TITLE
Ignore Debug and Release and fix check-license again

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ check
 logs/*
 build
 html
+Debug/*
+Release/*

--- a/scripts/check-license.sh
+++ b/scripts/check-license.sh
@@ -21,13 +21,12 @@ if [[ $(uname) == MINGW* ]] ; then
 fi
 
 ignore_res=()
-tr -d '\r' < "$root/scripts/.check-license.ignore" | while IFS= read -r i; do
+while IFS=$'\r' read -r i; do
       if [[ $i =~ ^# ]] || [[ -z $i ]]; then # ignore comments
           continue
       fi
       ignore_res+=("$i")
-done
-
+done < "$root/scripts/.check-license.ignore"
 
 should_ignore() {
     for re in "${ignore_res[@]}"; do


### PR DESCRIPTION
Turns out PR #160 was incorrect because pipes run in a subprocess so ignore_res was ignored after set.   This reverts that change and fixes it without using a subprocess.

Also add Debug and Release directories to .gitignore, which directories get used by the cmake commands given in the main README.md file when run on Windows.

Signed-off-by: Dave Thaler <dthaler@ntdev.microsoft.com>