### PR TITLE
validate calls to ebpf_map_update_elem()

### DIFF
--- a/src/crab/var_factory.cpp
+++ b/src/crab/var_factory.cpp
@@ -67,5 +67,6 @@ variable_t variable_t::map_key_size() { return make("map_key_size"); }
 variable_t variable_t::meta_offset() { return make("meta_offset"); }
 variable_t variable_t::packet_size() { return make("packet_size"); }
 variable_t variable_t::instruction_count() { return make("instruction_count"); }
+variable_t variable_t::type_sampler() { return make("type_sampler"); }
 
 } // end namespace crab

--- a/src/crab/variable.hpp
+++ b/src/crab/variable.hpp
@@ -57,6 +57,7 @@ class variable_t final {
     static variable_t meta_offset();
     static variable_t packet_size();
     static variable_t instruction_count();
+    static variable_t type_sampler();
 }; // class variable_t
 
 inline size_t hash_value(variable_t v) { return v.hash(); }


### PR DESCRIPTION
Read the type of a single byte from an unknown location within the memory passed to the function, and verify that it holds a numerical value.

We only check for stack addresses, since the packet is assumed only hold numerical values.

Fix #170.

It feels a little bit hacky, and maybe I should not reuse the temporary variable. Also, the check might not be evident from the text of the assertions.

Signed-off-by: Elazar Gershuni <elazarg@gmail.com>