### PR TITLE
Validate calls to ebpf_map_update_elem()

### DIFF
--- a/src/crab/array_domain.cpp
+++ b/src/crab/array_domain.cpp
@@ -291,6 +291,14 @@ array_domain_t::kill_and_find_var(NumAbsDomain& inv, data_kind_t kind, const lin
     return res;
 }
 
+bool array_domain_t::all_num(NumAbsDomain& inv, const linear_expression_t& lb, const linear_expression_t& ub) {
+    auto min_lb = inv.eval_interval(lb).lb().number();
+    auto max_ub = inv.eval_interval(ub).ub().number();
+    if (!min_lb || !max_ub || !min_lb->fits_sint() || !max_ub->fits_sint())
+        return false;
+    return this->num_bytes.all_num((int)*min_lb, (int)*max_ub);
+}
+
 std::optional<linear_expression_t> array_domain_t::load(NumAbsDomain& inv, data_kind_t kind, const linear_expression_t& i, int width) {
     interval_t ii = inv.eval_interval(i);
     if (std::optional<number_t> n = ii.singleton()) {

--- a/src/crab/array_domain.hpp
+++ b/src/crab/array_domain.hpp
@@ -297,6 +297,7 @@ class array_domain_t final {
     }
 
     std::optional<linear_expression_t> load(NumAbsDomain& inv, data_kind_t kind, const linear_expression_t& i, int width);
+    bool all_num(NumAbsDomain& inv, const linear_expression_t& lb, const linear_expression_t& ub);
 
     std::optional<variable_t> store(NumAbsDomain& inv, data_kind_t kind, const linear_expression_t& idx, const linear_expression_t& elem_size,
                                     const linear_expression_t& val);

--- a/src/crab/bitset_domain.hpp
+++ b/src/crab/bitset_domain.hpp
@@ -1,7 +1,7 @@
 // Copyright (c) Prevail Verifier contributors.
 // SPDX-License-Identifier: MIT
 #pragma once
-
+#include <cassert>
 #include <bitset>
 
 #include "spec_type_descriptors.hpp" // for EBPF_STACK_SIZE
@@ -76,4 +76,16 @@ class bitset_domain_t final {
     }
 
     friend std::ostream& operator<<(std::ostream& o, const bitset_domain_t& array);
+
+    // Test whether all values in the range [lb,ub) are numerical.
+    bool all_num(int lb, int ub) {
+        assert(lb < ub);
+        if (lb < 0 || ub > (int)non_numerical_bytes.size())
+            return false;
+
+        for (int i = lb; i < ub; i++)
+            if (non_numerical_bytes[i])
+                return false;
+        return true;
+    }
 };

--- a/src/crab/ebpf_domain.hpp
+++ b/src/crab/ebpf_domain.hpp
@@ -503,6 +503,16 @@ class ebpf_domain_t final {
         std::string m = std::string(" (") + to_string(s) + ")";
         require(m_inv, access_reg.type >= T_STACK, "Only stack or packet can be used as a parameter" + m);
         require(m_inv, access_reg.type <= T_PACKET, "Only stack or packet can be used as a parameter" + m);
+
+        if (!s.key) {
+            auto when_stack = when(m_inv, access_reg.type == T_STACK);
+            if (!when_stack.is_bottom()) {
+                if (!stack.all_num(when_stack, lb, ub)) {
+                    require(when_stack, access_reg.type != T_STACK, "Illegal map update with a non-numerical value.");
+                }
+            }
+        }
+
         m_inv = check_access_packet(when(m_inv, access_reg.type == T_PACKET), lb, ub, m, false) |
                 check_access_stack(when(m_inv, access_reg.type == T_STACK), lb, ub, m);
     }


### PR DESCRIPTION
If the a lower bound on the start address is known, iterate through all bytes and check in the bitmap to see they hold numerical values. Only check for stack, since packet is guaranteed to hold only numerical values.

Fix #170.

Signed-off-by: Elazar Gershuni <elazarg@gmail.com>