### PR TITLE
validate key in calls to ebpf_map_update_elem()

### DIFF
--- a/src/crab/ebpf_domain.hpp
+++ b/src/crab/ebpf_domain.hpp
@@ -517,12 +517,10 @@ class ebpf_domain_t final {
         require(m_inv, access_reg.type >= T_STACK, "Only stack or packet can be used as a parameter" + m);
         require(m_inv, access_reg.type <= T_PACKET, "Only stack or packet can be used as a parameter" + m);
 
-        if (!s.key) {
-            auto when_stack = when(m_inv, access_reg.type == T_STACK);
-            if (!when_stack.is_bottom()) {
-                if (!stack.all_num(when_stack, lb, ub)) {
-                    require(when_stack, access_reg.type != T_STACK, "Illegal map update with a non-numerical value.");
-                }
+        auto when_stack = when(m_inv, access_reg.type == T_STACK);
+        if (!when_stack.is_bottom()) {
+            if (!stack.all_num(when_stack, lb, ub)) {
+                require(when_stack, access_reg.type != T_STACK, "Illegal map update with a non-numerical value.");
             }
         }
 

--- a/src/test/test_verify.cpp
+++ b/src/test/test_verify.cpp
@@ -324,11 +324,12 @@ TEST_SECTION("suricata", "xdp_filter.o", "xdp")
 // Test some programs that ought to fail verification.
 TEST_SECTION_REJECT("build", "badhelpercall.o", ".text")
 TEST_SECTION_REJECT("build", "exposeptr.o", ".text")
+TEST_SECTION_REJECT("build", "exposeptr2.o", ".text")
 
 // Test some programs that ought to fail verification but
 // are currently allowed through.  These should be changed
 // to TEST_SECTION_REJECT() once fixed.
-TEST_SECTION("build", "exposeptr2.o", ".text")
+
 TEST_SECTION("build", "mapoverflow.o", ".text")
 TEST_SECTION("build", "mapunderflow.o", ".text")
 


### PR DESCRIPTION
Fixes one issue mentioned in #175 by simply not checking whether the argument is key or value before validation.

Signed-off-by: Elazar Gershuni <elazarg@gmail.com>