### PR TITLE
Move map type knowledge to the platform component

### DIFF
--- a/src/crab_verifier.hpp
+++ b/src/crab_verifier.hpp
@@ -10,6 +10,6 @@ bool run_ebpf_analysis(std::ostream& s, cfg_t& cfg, program_info info, const ebp
 
 bool ebpf_verify_program(std::ostream& s, const InstructionSeq& prog, program_info info, const ebpf_verifier_options_t* options);
 
-int create_map_crab(uint32_t map_type, uint32_t key_size, uint32_t value_size, uint32_t max_entries, ebpf_verifier_options_t options);
+int create_map_crab(const EbpfMapType& map_type, uint32_t key_size, uint32_t value_size, uint32_t max_entries, ebpf_verifier_options_t options);
 
 EbpfMapDescriptor* find_map_descriptor(int map_fd);

--- a/src/platform.hpp
+++ b/src/platform.hpp
@@ -12,16 +12,20 @@
 
 typedef EbpfProgramType (*ebpf_get_program_type_fn)(const std::string& section, const std::string& path);
 
+typedef EbpfMapType (*ebpf_get_map_type_fn)(uint32_t platform_specific_type);
+
 typedef EbpfHelperPrototype (*ebpf_get_helper_prototype_fn)(unsigned int n);
 
 typedef bool (*ebpf_is_helper_usable_fn)(unsigned int n);
 
+#if 0
 // Return an fd for a map created with the given parameters.
 typedef int (*ebpf_create_map_fn)(uint32_t map_type, uint32_t key_size, uint32_t value_size, uint32_t max_entries, ebpf_verifier_options_t options);
+#endif
 
 // Parse map records and allocate map fd's.
 // In the future we may want to move map fd allocation after the verifier step.
-typedef void (*ebpf_parse_maps_section_fn)(std::vector<EbpfMapDescriptor>& map_descriptors, const char* data, size_t size, ebpf_create_map_fn create_map, ebpf_verifier_options_t options);
+typedef void (*ebpf_parse_maps_section_fn)(std::vector<EbpfMapDescriptor>& map_descriptors, const char* data, size_t size, const struct ebpf_platform_t* platform, ebpf_verifier_options_t options);
 
 typedef EbpfMapDescriptor& (*ebpf_get_map_descriptor_fn)(int map_fd);
 
@@ -34,8 +38,8 @@ struct ebpf_platform_t {
     size_t map_record_size;
 
     ebpf_parse_maps_section_fn parse_maps_section;
-    ebpf_create_map_fn create_map;
     ebpf_get_map_descriptor_fn get_map_descriptor;
+    ebpf_get_map_type_fn get_map_type;
 };
 
 extern const ebpf_platform_t g_ebpf_platform_linux;

--- a/src/spec_type_descriptors.hpp
+++ b/src/spec_type_descriptors.hpp
@@ -8,11 +8,19 @@
 
 constexpr int EBPF_STACK_SIZE = 512;
 
+struct EbpfMapType {
+    uint32_t platform_specific_type; // EbpfMapDescriptor.type value.
+    std::string name; // For ease of display, not used by the verifier.
+    bool is_array; // True if key is integer in range [0,max_entries-1].
+    bool is_value_map_fd; // True if value is map_fd.
+};
+
 struct EbpfMapDescriptor {
     int original_fd;
     uint32_t type; // Platform-specific type value in ELF file.
     unsigned int key_size;
     unsigned int value_size;
+    unsigned int max_entries;
     unsigned int inner_map_fd;
 };
 


### PR DESCRIPTION
This also exposes max_entries in the map descriptor for potential future use in addressing issues like the map index overflow case of issue #175, which would likely require tracking the values (not just types) of numeric values stored on the stack.

Signed-off-by: Dave Thaler <dthaler@ntdev.microsoft.com>