### PR TITLE
Check for null access even for type != num

### DIFF
--- a/src/crab/ebpf_domain.hpp
+++ b/src/crab/ebpf_domain.hpp
@@ -558,6 +558,7 @@ class ebpf_domain_t final {
                 return;
             } else {
                 require(m_inv, reg.type > T_NUM, "Only pointers can be dereferenced");
+                require(m_inv, reg.value > 0, "Possible null access");
                 m_inv = std::move(assume_ptr);
                 return;
             }
@@ -1082,6 +1083,7 @@ class ebpf_domain_t final {
         ebpf_domain_t inv;
         auto r10 = reg_pack(R10_STACK_POINTER);
         inv += EBPF_STACK_SIZE <= r10.value;
+        inv += r10.value <= PTR_MAX;
         inv.assign(r10.offset, EBPF_STACK_SIZE);
         inv.assign(r10.type, T_STACK);
 

--- a/src/test/test_verify.cpp
+++ b/src/test/test_verify.cpp
@@ -423,6 +423,7 @@ TEST_SECTION("raw_tracepoint/filler/sys_recvfrom_x")
 TEST_SECTION_REJECT("build", "badhelpercall.o", ".text")
 TEST_SECTION_REJECT("build", "exposeptr.o", ".text")
 TEST_SECTION_REJECT("build", "exposeptr2.o", ".text")
+TEST_SECTION_REJECT("build", "nullmapref.o", "test")
 
 // Test some programs that ought to fail verification but
 // are currently allowed through.  These should be changed
@@ -430,7 +431,7 @@ TEST_SECTION_REJECT("build", "exposeptr2.o", ".text")
 
 TEST_SECTION("build", "mapoverflow.o", ".text")
 TEST_SECTION("build", "mapunderflow.o", ".text")
-TEST_SECTION("build", "nullmapref.o", "test")
+
 
 // The following eBPF programs currently fail verification.
 // If the verifier is later updated to accept them, these should


### PR DESCRIPTION
Fix #183: add a check for null access that work for shared-or-null.

Also initialize r10.value upper bound to PTR_MAX.

Signed-off-by: Elazar Gershuni <elazarg@gmail.com>