### PR TITLE
Fix Windows CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,10 @@ jobs:
 
       - name: Build
         run: |
-          $env:BOOST_ROOT=$env:BOOST_ROOT_1_72_0
+          $Url = "https://sourceforge.net/projects/boost/files/boost-binaries/1.72.0/boost_1_72_0-msvc-14.2-64.exe"
+          (New-Object System.Net.WebClient).DownloadFile($Url, "$env:TEMP\boost.exe")
+          Start-Process -Wait -FilePath "$env:TEMP\boost.exe" "/SILENT","/SP-","/SUPPRESSMSGBOXES","/DIR=C:\hostedtoolcache\windows\Boost\1.72.0\x86_64"
+          $env:BOOST_ROOT="C:\hostedtoolcache\windows\Boost\1.72.0\x86_64"
           mkdir build
           cmake -B build
           cmake --build build -j $(nproc) --config Release

--- a/src/crab/array_domain.cpp
+++ b/src/crab/array_domain.cpp
@@ -270,9 +270,9 @@ array_domain_t::kill_and_find_var(NumAbsDomain& inv, data_kind_t kind, const lin
         interval_t i_elem_size = inv.eval_interval(elem_size);
         std::optional<number_t> n_bytes = i_elem_size.singleton();
         if (n_bytes) {
-            unsigned size = (long)(*n_bytes);
+            unsigned int size = (unsigned int)(*n_bytes);
             // -- Constant index: kill overlapping cells
-            offset_t o((long)*n);
+            offset_t o((uint64_t)*n);
             cells = offset_map.get_overlap_cells(o, size);
             res = std::make_pair(o, size);
         }
@@ -305,7 +305,7 @@ std::optional<linear_expression_t> array_domain_t::load(NumAbsDomain& inv, data_
     interval_t ii = inv.eval_interval(i);
     if (std::optional<number_t> n = ii.singleton()) {
         offset_map_t& offset_map = lookup_array_map(kind);
-        long k = (long)*n;
+        int64_t k = (int64_t)*n;
         if (kind == data_kind_t::types) {
             auto [only_num, only_non_num] = num_bytes.uniformity(k, width);
             if (only_num) {
@@ -351,7 +351,7 @@ std::optional<variable_t> array_domain_t::store(NumAbsDomain& inv, data_kind_t k
         auto [offset, size] = *maybe_cell;
         if (kind == data_kind_t::types) {
             std::optional<number_t> t = inv.eval_interval(val).singleton();
-            if (t && (long)*t == T_NUM)
+            if (t && (int64_t)*t == T_NUM)
                 num_bytes.reset(offset, size);
             else
                 num_bytes.havoc(offset, size);

--- a/src/crab/split_dbm.hpp
+++ b/src/crab/split_dbm.hpp
@@ -76,7 +76,7 @@ struct SafeInt64DefaultParams {
  **/
 inline SafeInt64DefaultParams::Wt convert_NtoW(const z_number& n, bool& overflow) {
     overflow = false;
-    if (!n.fits_slong()) {
+    if (!n.fits_sint64()) {
         overflow = true;
         return 0;
     }

--- a/src/crab_utils/bignums_boost.hpp
+++ b/src/crab_utils/bignums_boost.hpp
@@ -32,11 +32,19 @@ class z_number final {
     z_number(long n) { _n = n; }
 
     // overloaded typecast operators
-    explicit operator long() const {
-        if (!fits_slong()) {
-            CRAB_ERROR("z_number ", _n.str(), " does not fit into a signed long integer");
+    explicit operator int64_t() const {
+        if (!fits_sint64()) {
+            CRAB_ERROR("z_number ", _n.str(), " does not fit into a signed 64-bit integer");
         } else {
-            return (long)_n;
+            return (int64_t)_n;
+        }
+    }
+
+    explicit operator uint64_t() const {
+        if (!fits_uint64()) {
+            CRAB_ERROR("z_number ", _n.str(), " does not fit into an unsigned 64-bit integer");
+        } else {
+            return (uint64_t)_n;
         }
     }
 
@@ -45,6 +53,14 @@ class z_number final {
             CRAB_ERROR("z_number ", _n.str(), " does not fit into a signed integer");
         } else {
             return (int)_n;
+        }
+    }
+
+    explicit operator unsigned int() const {
+        if (!fits_uint()) {
+            CRAB_ERROR("z_number ", _n.str(), " does not fit into an unsigned integer");
+        } else {
+            return (unsigned int)_n;
         }
     }
 
@@ -59,9 +75,16 @@ class z_number final {
         return ((_n >= INT_MIN) && (_n <= INT_MAX));
     }
 
-    [[nodiscard]] bool fits_slong() const {
-        return ((_n >= LONG_MIN) && (_n <= LONG_MAX));
+    [[nodiscard]] bool fits_uint() const { return ((_n >= 0) && (_n <= UINT_MAX)); }
+
+    [[nodiscard]] bool fits_sint64() const {
+        // "long long" is always 64-bits, whereas "long" varies
+        // (see https://en.cppreference.com/w/cpp/language/types)
+        // so make sure we use 64-bit numbers.
+        return ((_n >= LLONG_MIN) && (_n <= LLONG_MAX));
     }
+
+    [[nodiscard]] bool fits_uint64() const { return ((_n >= 0) && (_n <= ULLONG_MAX)); }
 
     z_number operator+(const z_number& x) const {
         return z_number(_n + x._n);

--- a/src/crab_utils/bignums_gmp.hpp
+++ b/src/crab_utils/bignums_gmp.hpp
@@ -101,11 +101,19 @@ class z_number final {
     }
 
     // overloaded typecast operators
-    explicit operator long() const {
+    explicit operator int64_t() const {
         if (_n.fits_slong_p()) {
             return _n.get_si();
         } else {
-            CRAB_ERROR("mpz_class ", _n.get_str(), " does not fit into a signed long integer");
+            CRAB_ERROR("mpz_class ", _n.get_str(), " does not fit into a signed 64-bit integer");
+        }
+    }
+
+    explicit operator uint64_t() const {
+        if (_n.fits_ulong_p()) {
+            return _n.get_ui();
+        } else {
+            CRAB_ERROR("mpz_class ", _n.get_str(), " does not fit into an unsigned 64-bit integer");
         }
     }
 
@@ -118,6 +126,14 @@ class z_number final {
         }
     }
 
+    explicit operator unsigned int() const {
+        if (_n.fits_uint_p()) {
+            return (unsigned int)_n.get_ui();
+        } else {
+            CRAB_ERROR("mpz_class ", _n.get_str(), " does not fit into an unsigned integer");
+        }
+    }
+
     explicit operator mpz_class() const { return _n; }
 
     [[nodiscard]] std::size_t hash() const {
@@ -127,7 +143,7 @@ class z_number final {
 
     [[nodiscard]] bool fits_sint() const { return _n.fits_sint_p(); }
 
-    [[nodiscard]] bool fits_slong() const { return _n.fits_slong_p(); }
+    [[nodiscard]] bool fits_sint64() const { return _n.fits_slong_p(); }
 
     z_number operator+(const z_number& x) const {
         mpz_class r = _n + x._n;

--- a/src/crab_utils/safeint.hpp
+++ b/src/crab_utils/safeint.hpp
@@ -60,9 +60,9 @@ class safe_i64 {
 
     safe_i64(int64_t num) : m_num(num) {}
 
-    safe_i64(const z_number& n) : m_num((long)n) {}
+    safe_i64(const z_number& n) : m_num((int64_t)n) {}
 
-    operator long() const{ return (long)m_num; }
+    operator int64_t() const{ return (int64_t)m_num; }
 
     // TODO: output parameters whether operation overflows
     safe_i64 operator+(safe_i64 x) const{


### PR DESCRIPTION
This change has two commits.  The first commit fixes the CI problem with boost caused by github making a breaking change to no longer automatically include boost by default.   This fixes issue #190 

The second commit fixes a test failure that was introduced while CI was broken, which is that 2 of the falco tests failed on Windows.   The root cause for that is that they had cases where the upper bound of a variable would fit in 64 bits but not 32 bits.   The code previously used "long", which has a size that varies by platform.  It was 64-bits on Ubuntu and 32-bits on Windows.   The fix was to change it to use int64 explicitly.

I also spotted a couple of places where it had unsafe casts from signed to unsigned (i.e., took the "long" result and passed it to a function that takes an unsigned argument), so fixed those as well by adding explicit unsigned cast operators to number_t.