### PR TITLE
Add more test cases for things that should fail verification

### DIFF
--- a/src/test/test_verify.cpp
+++ b/src/test/test_verify.cpp
@@ -423,6 +423,7 @@ TEST_SECTION("raw_tracepoint/filler/sys_recvfrom_x")
 TEST_SECTION_REJECT("build", "badhelpercall.o", ".text")
 TEST_SECTION_REJECT("build", "exposeptr.o", ".text")
 TEST_SECTION_REJECT("build", "exposeptr2.o", ".text")
+TEST_SECTION_REJECT("build", "mapvalue-overrun.o", ".text")
 TEST_SECTION_REJECT("build", "nullmapref.o", "test")
 
 // Test some programs that ought to fail verification but
@@ -431,7 +432,7 @@ TEST_SECTION_REJECT("build", "nullmapref.o", "test")
 
 TEST_SECTION("build", "mapoverflow.o", ".text")
 TEST_SECTION("build", "mapunderflow.o", ".text")
-
+TEST_SECTION("build", "wronghelper.o", "xdp")
 
 // The following eBPF programs currently fail verification.
 // If the verifier is later updated to accept them, these should


### PR DESCRIPTION
1) Try reading past end of map value (correctly fails)
2) Try passing ctx to a helper that expects a different struct (currently passes, issue #192)

Signed-off-by: Dave Thaler <dthaler@ntdev.microsoft.com>