### PR TITLE
MIT licensed implementation of weak topological ordering

### DIFF
--- a/scripts/.check-license.ignore
+++ b/scripts/.check-license.ignore
@@ -17,7 +17,6 @@ counter
 ebpf-samples
 
 # Files using NASA-1.3 license
-src/crab/wto.hpp
 src/crab_utils/bignums_gmp.hpp
 
 # Files using Apache-2.0 license

--- a/src/crab/fwd_analyzer.cpp
+++ b/src/crab/fwd_analyzer.cpp
@@ -21,20 +21,20 @@ class member_component_visitor final {
   public:
     explicit member_component_visitor(label_t node) : _node(node), _found(false) {}
 
-    void operator()(wto_vertex_t& c) {
+    void operator()(const wto_vertex_t& vertex) {
         if (!_found) {
-            _found = (c.node() == _node);
+            _found = (vertex == _node);
         }
     }
 
-    void operator()(wto_cycle_t& c) {
+    void operator()(std::shared_ptr<wto_cycle_t>& c) {
         if (!_found) {
-            _found = (c.head() == _node);
+            _found = (c->head() == _node);
             if (!_found) {
-                for (auto& x : c) {
+                for (auto it = c->components().rbegin(); it != c->components().rend(); it++) {
                     if (_found)
                         break;
-                    std::visit(*this, x);
+                    std::visit(*this, *it->get());
                 }
             }
         }
@@ -117,9 +117,9 @@ class interleaved_fwd_fixpoint_iterator_t final {
 
     ebpf_domain_t get_post(const label_t& node) { return _post.at(node); }
 
-    void operator()(wto_vertex_t& vertex);
+    void operator()(const wto_vertex_t& vertex);
 
-    void operator()(wto_cycle_t& cycle);
+    void operator()(std::shared_ptr<wto_cycle_t>& cycle);
 
     friend std::pair<invariant_table_t, invariant_table_t> run_forward_analyzer(cfg_t& cfg, bool check_termination);
 };
@@ -128,15 +128,13 @@ std::pair<invariant_table_t, invariant_table_t> run_forward_analyzer(cfg_t& cfg,
     // Go over the CFG in weak topological order (accounting for loops).
     constexpr unsigned int descending_iterations = 2000000;
     interleaved_fwd_fixpoint_iterator_t analyzer(cfg, descending_iterations, check_termination);
-    for (wto_component_t& c : analyzer._wto) {
-        std::visit(analyzer, c);
+    for (auto it = analyzer._wto.components().rbegin(); it != analyzer._wto.components().rend(); it++) {
+        std::visit(analyzer, *it->get());
     }
     return std::make_pair(analyzer._pre, analyzer._post);
 }
 
-void interleaved_fwd_fixpoint_iterator_t::operator()(wto_vertex_t& vertex) {
-    label_t node = vertex.node();
-
+void interleaved_fwd_fixpoint_iterator_t::operator()(const wto_vertex_t& node) {
     /** decide whether skip vertex or not **/
     if (_skip && (node == _cfg.entry_label())) {
         _skip = false;
@@ -151,13 +149,13 @@ void interleaved_fwd_fixpoint_iterator_t::operator()(wto_vertex_t& vertex) {
     transform_to_post(node, pre);
 }
 
-void interleaved_fwd_fixpoint_iterator_t::operator()(wto_cycle_t& cycle) {
-    label_t head = cycle.head();
+void interleaved_fwd_fixpoint_iterator_t::operator()(std::shared_ptr<wto_cycle_t>& cycle) {
+    label_t head = cycle->head();
 
-    /** decide whether skip cycle or not **/
+    /** decide whether to skip cycle or not **/
     bool entry_in_this_cycle = false;
     if (_skip) {
-        // We only skip the analysis of cycle is _entry is not a
+        // We only skip the analysis of cycle if _entry is not a
         // component of it, included nested components.
         member_component_visitor vis(_cfg.entry_label());
         vis(cycle);
@@ -181,14 +179,11 @@ void interleaved_fwd_fixpoint_iterator_t::operator()(wto_cycle_t& cycle) {
     }
 
     for (unsigned int iteration = 1;; ++iteration) {
-        // keep track of how many times the cycle is visited by the fixpoint
-        cycle.increment_fixpo_visits();
-
         // Increasing iteration sequence with widening
         set_pre(head, pre);
         transform_to_post(head, pre);
-        for (auto& x : cycle) {
-            std::visit(*this, x);
+        for (auto it = cycle->components().rbegin(); it != cycle->components().rend(); it++) {
+            std::visit(*this, *it->get());
         }
         ebpf_domain_t new_pre = join_all_prevs(head);
         if (new_pre <= pre) {
@@ -210,8 +205,8 @@ void interleaved_fwd_fixpoint_iterator_t::operator()(wto_cycle_t& cycle) {
         // Decreasing iteration sequence with narrowing
         transform_to_post(head, pre);
 
-        for (auto& x : cycle) {
-            std::visit(*this, x);
+        for (auto it = cycle->components().rbegin(); it != cycle->components().rend(); it++) {
+            std::visit(*this, *it->get());
         }
         ebpf_domain_t new_pre = join_all_prevs(head);
         if (pre <= new_pre) {

--- a/src/crab/thresholds.cpp
+++ b/src/crab/thresholds.cpp
@@ -52,7 +52,7 @@ void wto_thresholds_t::get_thresholds(const basic_block_t& bb, thresholds_t& thr
 
 }
 
-void wto_thresholds_t::operator()(const wto_vertex_t& vertex) {
+void wto_thresholds_t::operator()(const label_t& vertex) {
     if (m_stack.empty())
         return;
 
@@ -83,8 +83,8 @@ void wto_thresholds_t::operator()(std::shared_ptr<wto_cycle_t>& cycle) {
 
     m_head_to_thresholds.insert(std::make_pair(cycle->head(), thresholds));
     m_stack.push_back(cycle->head());
-    for (auto& c : cycle->components()) {
-        std::visit(*this, *c.get());
+    for (auto& component : *cycle) {
+        std::visit(*this, *component);
     }
     m_stack.pop_back();
 }

--- a/src/crab/thresholds.hpp
+++ b/src/crab/thresholds.hpp
@@ -61,7 +61,7 @@ class wto_thresholds_t final {
   public:
     wto_thresholds_t(cfg_t& cfg, size_t max_size) : m_cfg(cfg), m_max_size(max_size) {}
 
-    void operator()(const wto_vertex_t& vertex);
+    void operator()(const label_t& vertex);
 
     void operator()(std::shared_ptr<wto_cycle_t>& cycle);
 

--- a/src/crab/thresholds.hpp
+++ b/src/crab/thresholds.hpp
@@ -61,9 +61,9 @@ class wto_thresholds_t final {
   public:
     wto_thresholds_t(cfg_t& cfg, size_t max_size) : m_cfg(cfg), m_max_size(max_size) {}
 
-    void operator()(wto_vertex_t& vertex);
+    void operator()(const wto_vertex_t& vertex);
 
-    void operator()(wto_cycle_t& cycle);
+    void operator()(std::shared_ptr<wto_cycle_t>& cycle);
 
     friend std::ostream& operator<<(std::ostream& o, const wto_thresholds_t& t);
 

--- a/src/crab/wto.cpp
+++ b/src/crab/wto.cpp
@@ -6,7 +6,7 @@
 #include "wto.hpp"
 
 // This is the Component() function described in figure 4 of the paper.
-void wto_cycle_t::initialize(class wto_t& wto, const wto_vertex_t& vertex, std::shared_ptr<wto_cycle_t>& self)
+void wto_cycle_t::initialize(class wto_t& wto, const label_t& vertex, std::shared_ptr<wto_cycle_t>& self)
 {
     // Walk the control flow graph, adding nodes to this cycle.
     for (const label_t& succ : wto.cfg().next_nodes(vertex)) {

--- a/src/crab/wto.cpp
+++ b/src/crab/wto.cpp
@@ -1,0 +1,21 @@
+// Copyright (c) Prevail Verifier contributors.
+// SPDX-License-Identifier: MIT
+#pragma once
+
+#include "asm_syntax.hpp"
+#include "wto.hpp"
+
+// This is the Component() function described in figure 4 of the paper.
+void wto_cycle_t::initialize(class wto_t& wto, const wto_vertex_t& vertex, std::shared_ptr<wto_cycle_t>& self)
+{
+    // Walk the control flow graph, adding nodes to this cycle.
+    for (const label_t& succ : wto.cfg().next_nodes(vertex)) {
+        if (wto.dfn(succ) == 0) {
+            wto.visit(succ, _components, self);
+        }
+    }
+
+    // Finally, add the vertex at the start of the cycle
+    // (end of the vector which stores the cycle in reverse order).
+    _components.push_back(std::make_shared<wto_component_t>(vertex));
+}

--- a/src/crab/wto.hpp
+++ b/src/crab/wto.hpp
@@ -1,467 +1,180 @@
-// SPDX-License-Identifier: NASA-1.3
-/*******************************************************************************
- *
- * Construction and management of weak topological orderings (WTOs).
- *
- * The construction of weak topological orderings is based on F. Bourdoncle's
- * paper: "Efficient chaotic iteration strategies with widenings", Formal
- * Methods in Programming and Their Applications, 1993, pages 128-141.
- *
- * Author: Arnaud J. Venet (arnaud.j.venet@nasa.gov)
- * Contributors: Jorge A. Navas (jorge.navas@sri.com)
- *
- * Notices:
- *
- * Copyright (c) 2011 United States Government as represented by the
- * Administrator of the National Aeronautics and Space Administration.
- * All Rights Reserved.
- *
- * Disclaimers:
- *
- * No Warranty: THE SUBJECT SOFTWARE IS PROVIDED "AS IS" WITHOUT ANY WARRANTY OF
- * ANY KIND, EITHER EXPRESSED, IMPLIED, OR STATUTORY, INCLUDING, BUT NOT LIMITED
- * TO, ANY WARRANTY THAT THE SUBJECT SOFTWARE WILL CONFORM TO SPECIFICATIONS,
- * ANY IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE,
- * OR FREEDOM FROM INFRINGEMENT, ANY WARRANTY THAT THE SUBJECT SOFTWARE WILL BE
- * ERROR FREE, OR ANY WARRANTY THAT DOCUMENTATION, IF PROVIDED, WILL CONFORM TO
- * THE SUBJECT SOFTWARE. THIS AGREEMENT DOES NOT, IN ANY MANNER, CONSTITUTE AN
- * ENDORSEMENT BY GOVERNMENT AGENCY OR ANY PRIOR RECIPIENT OF ANY RESULTS,
- * RESULTING DESIGNS, HARDWARE, SOFTWARE PRODUCTS OR ANY OTHER APPLICATIONS
- * RESULTING FROM USE OF THE SUBJECT SOFTWARE.  FURTHER, GOVERNMENT AGENCY
- * DISCLAIMS ALL WARRANTIES AND LIABILITIES REGARDING THIRD-PARTY SOFTWARE,
- * IF PRESENT IN THE ORIGINAL SOFTWARE, AND DISTRIBUTES IT "AS IS."
- *
- * Waiver and Indemnity:  RECIPIENT AGREES TO WAIVE ANY AND ALL CLAIMS AGAINST
- * THE UNITED STATES GOVERNMENT, ITS CONTRACTORS AND SUBCONTRACTORS, AS WELL
- * AS ANY PRIOR RECIPIENT.  IF RECIPIENT'S USE OF THE SUBJECT SOFTWARE RESULTS
- * IN ANY LIABILITIES, DEMANDS, DAMAGES, EXPENSES OR LOSSES ARISING FROM SUCH
- * USE, INCLUDING ANY DAMAGES FROM PRODUCTS BASED ON, OR RESULTING FROM,
- * RECIPIENT'S USE OF THE SUBJECT SOFTWARE, RECIPIENT SHALL INDEMNIFY AND HOLD
- * HARMLESS THE UNITED STATES GOVERNMENT, ITS CONTRACTORS AND SUBCONTRACTORS,
- * AS WELL AS ANY PRIOR RECIPIENT, TO THE EXTENT PERMITTED BY LAW.
- * RECIPIENT'S SOLE REMEDY FOR ANY SUCH MATTER SHALL BE THE IMMEDIATE,
- * UNILATERAL TERMINATION OF THIS AGREEMENT.
- *
- ******************************************************************************/
-
+// Copyright (c) Prevail Verifier contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 
-#include <memory>
-#include <set>
+// This file implements Weak Topological Ordering as defined in
+// Bournacle, "Efficient chaotic iteration strategies with widenings", 1993
+// http://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.38.3574
+//
+// Using the example from section 3.1 in the paper, the graph:
+//
+//         4 --> 5 <-> 6
+//         ^ \________ |
+//         |          vv
+//         3 <-------- 7
+//         ^           |
+//         |           v
+//   1 --> 2 --------> 8
+//
+// results in the WTO: 1 2 (3 4 (5 6) 7) 8
+// where a single vertex is represented via wto_vertex_t, and a
+// cycle such as (5 6) is represented via a wto_cycle_t.
+// Each arrow points to a wto_component_t, which can be either a
+// single vertex such as 8, or a cycle such as (5 6).
+
+#include <stack>
 #include <vector>
-#include <forward_list>
-#include <map>
-#include <variant>
+
+using label_t = crab::label_t;
+using wto_component_t = std::variant<std::shared_ptr<class wto_cycle_t>, label_t>;
+using wto_partition_t = std::vector<std::shared_ptr<wto_component_t>>;
 
 #include "crab/cfg.hpp"
-#include "crab/cfg_bgl.hpp"
-#include "crab/interval.hpp"
-#include "crab_utils/debug.hpp"
-
-namespace crab {
-
-
-using vertex_descriptor_t = typename boost::graph_traits<cfg_t>::vertex_descriptor;
-
-
-using out_edge_iterator_t = typename boost::graph_traits<cfg_t>::out_edge_iterator;
-
-
-using edge_descriptor_t = typename boost::graph_traits<cfg_t>::edge_descriptor;
-
-
-class wto_t;
-class wto_vertex_t;
-class wto_cycle_t;
-
-
-class wto_nesting_t final {
-
-    friend class wto_t;
-    friend class wto_vertex_t;
-    friend class wto_cycle_t;
-
-  private:
-    using node_list_t = std::vector<vertex_descriptor_t>;
-    using node_list_ptr = std::shared_ptr<node_list_t>;
-
-    node_list_ptr _nodes;
-
-  public:
-    using iterator = typename node_list_t::iterator;
-    using const_iterator = typename node_list_t::const_iterator;
-
-  private:
-    explicit wto_nesting_t(const node_list_ptr& l) : _nodes(std::make_shared<node_list_t>(*l)) {}
-
-    int compare(wto_nesting_t& other) const {
-        auto this_it = this->begin();
-        auto other_it = other.begin();
-        while (this_it != this->end()) {
-            if (other_it == other.end()) {
-                return 1;
-            } else if (*this_it == *other_it) {
-                ++this_it;
-                ++other_it;
-            } else {
-                return 2; // Nestings are not comparable
-            }
-        }
-        if (other_it == other.end()) {
-            return 0;
-        } else {
-            return -1;
-        }
-    }
-
-  public:
-    wto_nesting_t() : _nodes(std::make_shared<node_list_t>()) {}
-
-    void operator+=(const vertex_descriptor_t& n) {
-        this->_nodes = std::make_shared<node_list_t>(*(this->_nodes));
-        this->_nodes->push_back(n);
-    }
-
-    wto_nesting_t operator+(const vertex_descriptor_t& n) {
-        wto_nesting_t res(this->_nodes);
-        res._nodes->push_back(n);
-        return res;
-    }
-
-    iterator begin() { return _nodes->begin(); }
-
-    iterator end() { return _nodes->end(); }
-
-    const_iterator begin() const { return _nodes->begin(); }
-
-    const_iterator end() const { return _nodes->end(); }
-
-    wto_nesting_t operator^(wto_nesting_t other) const {
-        wto_nesting_t res;
-        for (const_iterator this_it = this->begin(), other_it = other.begin();
-             this_it != this->end() && other_it != other.end(); ++this_it, ++other_it) {
-            if (*this_it == *other_it) {
-                res._nodes->push_back(*this_it);
-            } else {
-                break;
-            }
-        }
-        return res;
-    }
-
-    bool operator<=(wto_nesting_t other) const { return this->compare(other) <= 0; }
-
-    bool operator==(wto_nesting_t other) const { return this->compare(other) == 0; }
-
-    bool operator>(wto_nesting_t other) const { return this->compare(other) == 1; }
-
-    friend std::ostream& operator<<(std::ostream& o, const wto_nesting_t& k) {
-        o << "[";
-        for (auto it = k.begin(); it != k.end();) {
-            vertex_descriptor_t n = *it;
-            o << n;
-            ++it;
-            if (it != k.end()) {
-                o << ", ";
-            }
-        }
-        o << "]";
-        return o;
-    }
-}; // class nesting
-
-using wto_component_t = std::variant<wto_vertex_t, wto_cycle_t>;
-std::ostream& operator<<(std::ostream& o, const wto_component_t& c);
-
-class wto_vertex_t final {
-
-    friend class wto_t;
-
-  private:
-    vertex_descriptor_t _node;
-
-    explicit wto_vertex_t(vertex_descriptor_t node) : _node(std::move(node)) {}
-
-  public:
-    vertex_descriptor_t node() { return this->_node; }
-
-    friend std::ostream& operator<<(std::ostream& o, const wto_vertex_t& vertex);
-
-}; // class wto_vertex
-
-
-class wto_cycle_t final {
-
-    friend class wto_t;
-  private:
-    using wto_component_list_t = std::forward_list<wto_component_t>;
-
-    vertex_descriptor_t _head;
-    wto_component_list_t _wto_components;
-    // number of times the wto cycle is analyzed by the fixpoint iterator
-    unsigned _num_fixpo;
-
-    wto_cycle_t(vertex_descriptor_t head, const wto_component_list_t& wto_components)
-        : _head(head), _wto_components(wto_components), _num_fixpo(0) {}
-
-  public:
-    using iterator = wto_component_list_t::iterator;
-    using const_iterator = wto_component_list_t::const_iterator;
-
-    vertex_descriptor_t head() { return this->_head; }
-
-    iterator begin() { return _wto_components.begin(); }
-
-    iterator end() { return _wto_components.end(); }
-
-    const_iterator begin() const { return _wto_components.begin(); }
-
-    const_iterator end() const { return _wto_components.end(); }
-
-    void increment_fixpo_visits() { _num_fixpo++; }
-
-    friend std::ostream& operator<<(std::ostream& o, const wto_cycle_t& cycle) {
-        o << "(" << cycle._head;
-        if (!cycle._wto_components.empty()) {
-            o << " ";
-            for (const wto_component_t& c : cycle) {
-                o << c << " ";
-            }
-        }
-        o << ")";
-        if (cycle._num_fixpo > 0)
-            o << "^{" << cycle._num_fixpo << "}";
-        return o;
-    }
-
-}; // class wto_cycle
-
-inline std::ostream& operator<<(std::ostream& o, const wto_vertex_t& vertex) {
-    return o << vertex._node;
-}
-
-inline std::ostream& operator<<(std::ostream& o, const wto_component_t& c) {
-    return std::visit(overloaded{
-        [&](const wto_cycle_t& x) -> std::ostream& { return o << x; },
-        [&](const wto_vertex_t& x) -> std::ostream& { return o << x; },
-    }, c);
-}
+#include "crab/wto_cycle.hpp"
+#include "crab/wto_nesting.hpp"
 
 class wto_t final {
-  private:
-    using wto_component_list_t = std::forward_list<wto_component_t>;
-    using dfn_t = bound_t;
-    using dfn_table_t = std::map<vertex_descriptor_t, dfn_t>;
-    using stack_t = std::vector<vertex_descriptor_t>;
-    using nesting_table_t = std::map<vertex_descriptor_t, wto_nesting_t>;
+    // Original control-flow graph.
+    const crab::cfg_t& _cfg;
 
-    wto_component_list_t _wto_components;
-    dfn_table_t _dfn_table;
-    dfn_t _num{0};
-    stack_t _stack;
-    nesting_table_t _nesting_table;
+    std::map<label_t, int> _dfn;
+    int _num;
+    std::stack<label_t> _stack;
 
-    class nesting_builder {
-      private:
-        wto_nesting_t _nesting;
-        nesting_table_t& _nesting_table;
+    // Top level components, in reverse order.
+    wto_partition_t _components;
 
-      public:
-        explicit nesting_builder(nesting_table_t& nesting_table) : _nesting_table(nesting_table) {}
+    // Table mapping label to the cycle containing the label.
+    std::map<label_t, std::weak_ptr<wto_cycle_t>> _containing_cycle;
 
-        void operator()(wto_cycle_t& cycle) {
-            vertex_descriptor_t head = cycle.head();
-            wto_nesting_t previous_nesting = this->_nesting;
-            this->_nesting_table.insert(std::make_pair(head, this->_nesting));
-            this->_nesting += head;
-            for (wto_component_t& c : cycle) {
-                std::visit(*this, c);
+    // Table mapping label to the list of heads of cycles containing the label.
+    // This is an on-demand cache, since for most vertices the nesting is never
+    // looked at so we only create a wto_nesting_t for cases we actually need it.
+    std::map<label_t, wto_nesting_t> _nesting;
+
+    public:
+
+    // Implementation of the Visit() function defined in Figure 4 of the paper.
+    int visit(const wto_vertex_t& vertex, wto_partition_t& partition, std::weak_ptr<wto_cycle_t> containing_cycle) {
+        _stack.push(vertex);
+        _num++;
+        int head = _dfn[vertex] = _num;
+        bool loop = false;
+        int min = INT_MAX;
+        for (const label_t& succ : _cfg.next_nodes(vertex)) {
+            if (_dfn[succ] == 0) {
+                min = visit(succ, partition, containing_cycle);
+            } else {
+                min = _dfn[succ];
             }
-            this->_nesting = previous_nesting;
+            if (min <= head) {
+                head = min;
+                loop = true;
+            }
+        }
+        if (head == _dfn[vertex]) {
+            _dfn[vertex] = INT_MAX;
+            label_t& element = _stack.top();
+            _stack.pop();
+            if (loop) {
+                while (element != vertex) {
+                    _dfn[element] = 0;
+                    element = _stack.top();
+                    _stack.pop();
+                }
+
+                // Create a new cycle component.
+                auto cycle = std::make_shared<wto_cycle_t>(containing_cycle);
+                auto component = std::make_shared<wto_component_t>(cycle);
+                cycle.get()->initialize(*this, vertex, cycle);
+
+                // Insert the component into the current partition.
+                partition.push_back(component);
+
+                // Remember that we put the vertex into the new cycle.
+                _containing_cycle.emplace(vertex, cycle);
+            } else {
+                // Create a new vertex component.
+                auto component = std::make_shared<wto_component_t>(wto_component_t(vertex));
+
+                // Insert the vertex into the current partition.
+                partition.push_back(component);
+
+                // Remember that we put the vertex into the caller's cycle.
+                _containing_cycle.emplace(vertex, containing_cycle);
+            }
+        }
+        return head;
+    }
+
+    [[nodiscard]] const crab::cfg_t& cfg() const { return _cfg; }
+    [[nodiscard]] int dfn(const wto_vertex_t& vertex) const { return _dfn.at(vertex); }
+
+    // Construct a Weak Topological Ordering from a control-flow graph using
+    // the algorithm of figure 4 in the paper, where this constructor matches
+    // what is shown there as the Partition function.
+    wto_t(const cfg_t& cfg) : _cfg(cfg) {
+        for (const label_t& label : cfg.labels()) {
+            _dfn.emplace(label, 0);
+        }
+        _num = 0;
+        visit(cfg.entry_label(), _components, {});
+    }
+
+    [[nodiscard]] wto_partition_t& components() { return _components; }
+
+    // Get the vertex at the head of the component containing a given
+    // label, as discussed in section 4.2 of the paper.  If the label
+    // is itself a head of a component, we want the head of whatever
+    // contains that entire component.  Returns nullopt if the label is
+    // not nested, i.e., the head is logically the entry point of the CFG.
+    std::optional<label_t> head(const label_t& label) {
+        auto it = _containing_cycle.find(label);
+        if (it == _containing_cycle.end()) {
+            // Label is not in any cycle.
+            return {};
+        }
+        std::shared_ptr<wto_cycle_t> cycle = it->second.lock();
+        if (cycle == nullptr) {
+            return {};
+        }
+        const label_t& first = cycle->head();
+        if (first != label) {
+            // Return the head of the cycle the label is inside.
+            return first;
         }
 
-        void operator()(wto_vertex_t& vertex) {
-            this->_nesting_table.insert(std::make_pair(vertex.node(), this->_nesting));
+        // This label is already the head of a cycle, so get the cycle's parent.
+        std::shared_ptr<wto_cycle_t> parent = cycle->containing_cycle().lock();
+        if (parent == nullptr) {
+            return {};
         }
+        return parent->head();
+    }
 
-    }; // class nesting_builder
-
-    dfn_t get_dfn(const vertex_descriptor_t& n) {
-        auto it = this->_dfn_table.find(n);
-        if (it == this->_dfn_table.end()) {
-            return 0;
-        } else {
+    // Compute the set of heads of the nested components containing a given label.
+    // See section 3.1 of the paper for discussion, which uses the notation w(c).
+    const wto_nesting_t& nesting(const label_t& label) {
+        auto it = _nesting.find(label);
+        if (it != _nesting.end()) {
             return it->second;
         }
-    }
 
-    void set_dfn(const vertex_descriptor_t& n, const dfn_t& dfn) {
-        std::pair<typename dfn_table_t::iterator, bool> res = this->_dfn_table.insert(std::make_pair(n, dfn));
-        if (!res.second) {
-            (res.first)->second = dfn;
+        // Not found in the cache yet, so construct the list of heads of the
+        // nested components containing the label, stored in reverse order.
+        std::vector<label_t> heads;
+        for (std::optional<label_t> h = head(label); h.has_value(); h = head(h.value())) {
+            heads.push_back(h.value());
         }
+
+        wto_nesting_t n = wto_nesting_t(heads);
+        _nesting.emplace(label, std::move(n));
+        return _nesting.at(label);
     }
 
-    vertex_descriptor_t pop() {
-        if (this->_stack.empty()) {
-            CRAB_ERROR("WTO computation: empty stack");
-        } else {
-            vertex_descriptor_t top = this->_stack.back();
-            this->_stack.pop_back();
-            return top;
-        }
-    }
+};
 
-    void push(const vertex_descriptor_t& n) { this->_stack.push_back(n); }
-
-    wto_component_t component(cfg_t& g, const vertex_descriptor_t& vertex) {
-        wto_component_list_t partition;
-        std::pair<out_edge_iterator_t, out_edge_iterator_t> succ_edges = out_edges(vertex, g);
-        for (out_edge_iterator_t it = succ_edges.first, et = succ_edges.second; it != et; ++it) {
-            vertex_descriptor_t succ = target(*it, g);
-            if (this->get_dfn(succ) == 0) {
-                this->operator()(g, succ, partition);
-            }
-        }
-        return wto_cycle_t(vertex, partition);
-    }
-
-    struct visit_stack_elem {
-        using succ_iterator = out_edge_iterator_t;
-        vertex_descriptor_t _node;
-        succ_iterator _it; // begin iterator for node's successors
-        succ_iterator _et; // end iterator for node's successors
-        dfn_t _min;        // smallest dfn number of any (direct or
-        // indirect) node's successor through node's
-        // DFS subtree, included node.
-
-        visit_stack_elem(vertex_descriptor_t node, const std::pair<succ_iterator, succ_iterator>& succs, const dfn_t& min)
-            : _node(std::move(node)), _it(succs.first), _et(succs.second), _min(min) {}
-    };
-
-    void operator()(cfg_t& g, const vertex_descriptor_t& vertex, wto_component_list_t& partition) {
-
-        std::vector<visit_stack_elem> visit_stack;
-        std::set<vertex_descriptor_t> loop_nodes;
-
-        /* discover vertex */
-        push(vertex);
-        _num += 1;
-        set_dfn(vertex, _num);
-
-        visit_stack.emplace_back(vertex, out_edges(vertex, g), _num);
-        CRAB_LOG("wto-nonrec", std::cout << "WTO: Node " << vertex << ": dfs num=" << _num << "\n";);
-        while (!visit_stack.empty()) {
-            /*
-             * Perform dfs.
-             *
-             * When this loop terminates, visit_stack.back()_node's children
-             * have been processed.  For each loop iteration we push in
-             * visit_stack one more descendant.
-             */
-            while (visit_stack.back()._it != visit_stack.back()._et) {
-                edge_descriptor_t e = *visit_stack.back()._it++;
-                vertex_descriptor_t child = target(e, g);
-                dfn_t child_dfn = get_dfn(child);
-                if (child_dfn == 0) {
-                    /* discover new vertex */
-                    push(child);
-                    _num += 1;
-                    set_dfn(child, _num);
-                    visit_stack.emplace_back(child, out_edges(child, g), _num);
-                    CRAB_LOG("wto-nonrec", std::cout << "WTO: Node " << child << ": dfs num=" << _num << "\n";);
-                } else {
-                    if (child_dfn <= visit_stack.back()._min) {
-                        visit_stack.back()._min = child_dfn;
-                        CRAB_LOG("wto-nonrec", std::cout << "WTO: loop found " << child << "\n";);
-                        loop_nodes.insert(child);
-                    }
-                }
-            }
-
-            // propagate min from child to parent
-            vertex_descriptor_t visiting_node = visit_stack.back()._node;
-            dfn_t min_visiting_node = visit_stack.back()._min;
-            bool is_loop = loop_nodes.count(visiting_node) > 0;
-            visit_stack.pop_back();
-            if (!visit_stack.empty() && visit_stack.back()._min > min_visiting_node) {
-                visit_stack.back()._min = min_visiting_node;
-            }
-
-            auto dfn_visiting_node = get_dfn(visiting_node);
-            CRAB_LOG("wto-nonrec", std::cout << "WTO: popped node " << visiting_node << " dfs num= "
-                                             << dfn_visiting_node << ": min=" << min_visiting_node << "\n";);
-
-            if (min_visiting_node == get_dfn(visiting_node)) {
-                CRAB_LOG("wto-nonrec",
-                         std::cout << "WTO: BEGIN building partition for node " << visiting_node << "\n";);
-                set_dfn(visiting_node, dfn_t::plus_infinity());
-                vertex_descriptor_t element = pop();
-                if (is_loop) {
-                    while (!(element == visiting_node)) {
-                        set_dfn(element, 0);
-                        CRAB_LOG("wto-nonrec", std::cout << "\tWTO: node " << element << ": dfn num=0\n";);
-                        element = pop();
-                    }
-                    CRAB_LOG("wto-nonrec",
-                             std::cout << "\tWTO: adding component starting from " << visiting_node << "\n";);
-                    partition.push_front(component(g, visiting_node));
-                } else {
-                    CRAB_LOG("wto-nonrec", std::cout << "\tWTO: adding vertex " << visiting_node << "\n";);
-                    partition.push_front(wto_vertex_t(visiting_node));
-                }
-                CRAB_LOG("wto-nonrec", std::cout << "WTO: END building partition\n";);
-            }
-        } // end while (!visit_stack.empty())
-    }
-
-    void build_nesting() {
-        nesting_builder builder(this->_nesting_table);
-        for (wto_component_t& c : *this) {
-            std::visit(builder, c);
-        }
-    }
-
-  public:
-    using iterator = wto_component_list_t::iterator;
-    using const_iterator = wto_component_list_t::const_iterator;
-
-    explicit wto_t(cfg_t& g) {
-        ScopedCrabStats __st__("Fixpo.WTO");
-
-        this->operator()(g, entry(g), this->_wto_components);
-        this->build_nesting();
-    }
-
-    wto_t(const wto_t& other) = delete;
-
-    wto_t(wto_t&& other) = default;
-
-    wto_t& operator=(const wto_t& other) = default;
-
-    iterator begin() { return _wto_components.begin(); }
-
-    iterator end() { return _wto_components.end(); }
-
-    const_iterator begin() const { return _wto_components.begin(); }
-
-    const_iterator end() const { return _wto_components.end(); }
-
-    wto_nesting_t nesting(vertex_descriptor_t n) {
-        auto it = this->_nesting_table.find(n);
-        if (it == this->_nesting_table.end()) {
-            CRAB_ERROR("WTO nesting: node ", n, " not found");
-        } else {
-            return it->second;
-        }
-    }
-
-    friend std::ostream& operator<<(std::ostream& o, const wto_t& wto) {
-        for (const wto_component_t& c : wto) {
-            o << c << " ";
-        }
-        return o;
-    }
-}; // class wto
-
-} // namespace crab
+inline std::ostream& operator<<(std::ostream& o, wto_t& wto) {
+    o << wto.components() << std::endl;
+    return o;
+}

--- a/src/crab/wto_cycle.hpp
+++ b/src/crab/wto_cycle.hpp
@@ -1,8 +1,9 @@
 // Copyright (c) Prevail Verifier contributors.
 // SPDX-License-Identifier: MIT
 #pragma once
-
-using wto_vertex_t = crab::label_t;
+#include <memory>
+#include <ostream>
+#include "wto.hpp"
 
 // Bournacle, "Efficient chaotic iteration strategies with widenings", 1993
 // section 3 uses the term "nested component" to refer to what wto_cycle_t implements.
@@ -18,24 +19,25 @@ class wto_cycle_t final {
 
     // Finish initializing this cycle.  This must be done right after construction, where
     // 'self' is a shared pointer pointing to this instance.
-    void initialize(class wto_t& wto, const wto_vertex_t& vertex, std::shared_ptr<wto_cycle_t>& self);
+    void initialize(class wto_t& wto, const label_t& vertex, std::shared_ptr<wto_cycle_t>& self);
 
     // Get a vertex of an entry point of the cycle.
-    [[nodiscard]] const wto_vertex_t& head() const {
+    [[nodiscard]] const label_t& head() const {
         // Any cycle must start with a vertex, not another cycle,
         // per Definition 1 in the paper.  Since the vector is in reverse
         // order, the head is the last element.
-        return std::get<wto_vertex_t>(*_components.back().get());
+        return std::get<label_t>(*_components.back().get());
     }
 
-    [[nodiscard]] wto_partition_t& components() { return _components; }
+    [[nodiscard]] wto_partition_t::reverse_iterator begin() { return _components.rbegin(); }
+    [[nodiscard]] wto_partition_t::reverse_iterator end() { return _components.rend(); }
+
     [[nodiscard]] std::weak_ptr<wto_cycle_t> containing_cycle() const { return _containing_cycle; }
 };
 
-inline std::ostream& operator<<(std::ostream& o, wto_cycle_t& e) {
+inline std::ostream& operator<<(std::ostream& o, wto_cycle_t& cycle) {
     o << "( ";
-    for (auto it = e.components().rbegin(); it != e.components().rend(); it++) {
-        wto_component_t* component = it->get();
+    for (auto& component : cycle) {
         std::visit([&o](auto& e) -> std::ostream& { return o << e; }, *component);
         o << " ";
     }
@@ -45,7 +47,7 @@ inline std::ostream& operator<<(std::ostream& o, wto_cycle_t& e) {
 
 inline std::ostream& operator<<(std::ostream& o, std::shared_ptr<wto_cycle_t>& e) {
     if (e != nullptr) {
-        o << *e.get();
+        o << *e;
     }
     return o;
 }

--- a/src/crab/wto_cycle.hpp
+++ b/src/crab/wto_cycle.hpp
@@ -1,0 +1,59 @@
+// Copyright (c) Prevail Verifier contributors.
+// SPDX-License-Identifier: MIT
+#pragma once
+
+using wto_vertex_t = crab::label_t;
+
+// Bournacle, "Efficient chaotic iteration strategies with widenings", 1993
+// section 3 uses the term "nested component" to refer to what wto_cycle_t implements.
+class wto_cycle_t final {
+    // The cycle containing this cycle, or null if there is no parent cycle.
+    std::weak_ptr<wto_cycle_t> _containing_cycle;
+
+    // List of subcomponents (i.e., vertices or other cycles) contained in this cycle.
+    wto_partition_t _components;
+
+  public:
+    wto_cycle_t(std::weak_ptr<wto_cycle_t>& containing_cycle) : _containing_cycle(containing_cycle) {}
+
+    // Finish initializing this cycle.  This must be done right after construction, where
+    // 'self' is a shared pointer pointing to this instance.
+    void initialize(class wto_t& wto, const wto_vertex_t& vertex, std::shared_ptr<wto_cycle_t>& self);
+
+    // Get a vertex of an entry point of the cycle.
+    [[nodiscard]] const wto_vertex_t& head() const {
+        // Any cycle must start with a vertex, not another cycle,
+        // per Definition 1 in the paper.  Since the vector is in reverse
+        // order, the head is the last element.
+        return std::get<wto_vertex_t>(*_components.back().get());
+    }
+
+    [[nodiscard]] wto_partition_t& components() { return _components; }
+    [[nodiscard]] std::weak_ptr<wto_cycle_t> containing_cycle() const { return _containing_cycle; }
+};
+
+inline std::ostream& operator<<(std::ostream& o, wto_cycle_t& e) {
+    o << "( ";
+    for (auto it = e.components().rbegin(); it != e.components().rend(); it++) {
+        wto_component_t* component = it->get();
+        std::visit([&o](auto& e) -> std::ostream& { return o << e; }, *component);
+        o << " ";
+    }
+    o << ")";
+    return o;
+}
+
+inline std::ostream& operator<<(std::ostream& o, std::shared_ptr<wto_cycle_t>& e) {
+    if (e != nullptr) {
+        o << *e.get();
+    }
+    return o;
+}
+
+inline std::ostream& operator<<(std::ostream& o, wto_partition_t& partition) {
+    for (auto it = partition.rbegin(); it != partition.rend(); it++) {
+        wto_component_t* component = it->get();
+        std::visit([&o](auto& e) -> std::ostream& { return o << e; }, *component) << " ";
+    }
+    return o;
+}

--- a/src/crab/wto_nesting.hpp
+++ b/src/crab/wto_nesting.hpp
@@ -1,0 +1,43 @@
+// Copyright (c) Prevail Verifier contributors.
+// SPDX-License-Identifier: MIT
+#pragma once
+
+// Bournacle, "Efficient chaotic iteration strategies with widenings", 1993
+// uses the notation w(c) to refer to the set of heads of the nested components
+// containing a vertex c.  This class holds such a set of heads.  The table
+// mapping c to w(c) is stored outside the class, in wto_t._nesting.
+class wto_nesting_t final {
+    // To optimize insertion performance, the list of heads is stored in reverse
+    // order, i.e., from innermost to outermost cycle.
+    std::vector<label_t> _heads;
+
+  public:
+    wto_nesting_t(std::vector<label_t>& heads) : _heads(std::move(heads)) {}
+
+    // Test whether this nesting is a longer subset of another nesting.
+    bool operator>(const wto_nesting_t& nesting) const {
+        size_t this_size = this->_heads.size();
+        size_t other_size = nesting._heads.size();
+        if (this_size <= other_size) {
+            // Can't be a superset.
+            return false;
+        }
+
+        // Compare entries one at a time starting from the outermost
+        // (i.e., end of the vectors).
+        for (int index = 0; index < other_size; index++) {
+            if (this->_heads[this_size - 1 - index] != nesting._heads[other_size - 1 - index]) {
+                return false;
+            }
+        }
+        return true;
+    };
+
+    // Output the nesting in order from outermost to innermost.
+    friend std::ostream& operator<<(std::ostream& o, const wto_nesting_t& nesting) {
+        for (auto it = nesting._heads.rbegin(); it != nesting._heads.rend(); it++) {
+            o << *it << " ";
+        }
+        return o;
+    }
+};

--- a/src/crab/wto_nesting.hpp
+++ b/src/crab/wto_nesting.hpp
@@ -12,7 +12,7 @@ class wto_nesting_t final {
     std::vector<label_t> _heads;
 
   public:
-    wto_nesting_t(std::vector<label_t>&& heads) : _heads(heads) {}
+    wto_nesting_t(std::vector<label_t>&& heads) : _heads(std::move(heads)) {}
 
     // Test whether this nesting is a longer subset of another nesting.
     bool operator>(const wto_nesting_t& nesting) const {

--- a/src/crab/wto_nesting.hpp
+++ b/src/crab/wto_nesting.hpp
@@ -12,7 +12,7 @@ class wto_nesting_t final {
     std::vector<label_t> _heads;
 
   public:
-    wto_nesting_t(std::vector<label_t>& heads) : _heads(std::move(heads)) {}
+    wto_nesting_t(std::vector<label_t>&& heads) : _heads(heads) {}
 
     // Test whether this nesting is a longer subset of another nesting.
     bool operator>(const wto_nesting_t& nesting) const {


### PR DESCRIPTION
Replace the WTO implementation with a new one written entirely based off the specification in the paper.   This is the last piece of issue #149.

Previously the code kept track of how many times the cycle is visited, with:
```
        // keep track of how many times the cycle is visited by the fixpoint
        cycle.increment_fixpo_visits();
```
However, the paper does not mention it, and so the new implementation does not keep track of it. 
 (It turns out that information was not used for anything other than printing with "<<", and even that printing was not actually invoked from any code path.)