### PR TITLE
Make global_array_map not be global

### DIFF
--- a/src/asm_files.cpp
+++ b/src/asm_files.cpp
@@ -38,8 +38,8 @@ int create_map_crab(const EbpfMapType& map_type, uint32_t key_size, uint32_t val
     return res;
 }
 
-EbpfMapDescriptor* find_map_descriptor(int map_fd) {
-    for (EbpfMapDescriptor& map : global_program_info.map_descriptors) {
+const EbpfMapDescriptor* find_map_descriptor(int map_fd, const program_info& info) {
+    for (const EbpfMapDescriptor& map : info.map_descriptors) {
         if (map.original_fd == map_fd) {
             return &map;
         }

--- a/src/crab/ebpf_domain.cpp
+++ b/src/crab/ebpf_domain.cpp
@@ -1,0 +1,8 @@
+// Copyright (c) Prevail Verifier contributors.
+// SPDX-License-Identifier: MIT
+#pragma once
+
+#include "crab_verifier_job.hpp"
+using crab::domains::ebpf_domain_t;
+
+const program_info& ebpf_domain_t::get_program_info() const { return m_job->get_program_info(); }

--- a/src/crab/fwd_analyzer.cpp
+++ b/src/crab/fwd_analyzer.cpp
@@ -6,8 +6,7 @@
 #include "crab/cfg.hpp"
 #include "crab/wto.hpp"
 
-#include "crab/ebpf_domain.hpp"
-#include "crab/fwd_analyzer.hpp"
+#include "crab_verifier_job.hpp"
 
 namespace crab {
 
@@ -27,11 +26,11 @@ class member_component_visitor final {
         }
     }
 
-    void operator()(std::shared_ptr<wto_cycle_t>& c) {
+    void operator()(const std::shared_ptr<wto_cycle_t>& c) {
         if (!_found) {
             _found = (c->head() == _node);
             if (!_found) {
-                for (auto& component : *c) {
+                for (const auto& component : *c) {
                     if (_found)
                         break;
                     std::visit(*this, *component);
@@ -43,96 +42,12 @@ class member_component_visitor final {
     [[nodiscard]] bool is_member() const { return _found; }
 };
 
-class interleaved_fwd_fixpoint_iterator_t final {
-    using iterator = typename invariant_table_t::iterator;
-
-    program_info& _program_info;
-    cfg_t& _cfg;
-    wto_t _wto;
-    invariant_table_t _pre, _post;
-
-    /// number of iterations until triggering widening
-    const unsigned int _widening_delay{1};
-
-    /// number of narrowing iterations. If the narrowing operator is
-    /// indeed a narrowing operator this parameter is not
-    /// needed. However, there are abstract domains for which an actual
-    /// narrowing operation is not available so we must enforce
-    /// termination.
-    const unsigned int _descending_iterations;
-
-    /// Used to skip the analysis until _entry is found
-    bool _skip{true};
-
-    /// Whether the domain tracks instruction count; the invariants are somewhat easier to read without it
-    /// Generally corresponds to the check_termination flag in ebpf_verifier_options_t
-    const bool check_termination;
-
-  private:
-    inline void set_pre(const label_t& label, const ebpf_domain_t& v) { _pre[label] = v; }
-
-    inline void transform_to_post(const label_t& label, ebpf_domain_t pre) {
-        basic_block_t& bb = _cfg.get_node(label);
-        pre(bb, check_termination);
-        _post[label] = std::move(pre);
+std::pair<invariant_table_t, invariant_table_t> interleaved_fwd_fixpoint_iterator_t::analyze()
+{
+    for (auto& c : _wto) {
+        std::visit(*this, *c);
     }
-
-    [[nodiscard]]
-    ebpf_domain_t extrapolate(const label_t& node, unsigned int iteration, ebpf_domain_t before,
-                              const ebpf_domain_t& after) const {
-        if (iteration <= _widening_delay) {
-            return before | after;
-        } else {
-            return before.widen(after);
-        }
-    }
-
-    static ebpf_domain_t refine(const label_t& node, unsigned int iteration, ebpf_domain_t before,
-                                const ebpf_domain_t& after) {
-        if (iteration == 1) {
-            return before & after;
-        } else {
-            return before.narrow(after);
-        }
-    }
-
-    ebpf_domain_t join_all_prevs(const label_t& node) {
-        ebpf_domain_t res = ebpf_domain_t::bottom();
-        for (const label_t& prev : _cfg.prev_nodes(node)) {
-            res |= get_post(prev);
-        }
-        return res;
-    }
-
-  public:
-    explicit interleaved_fwd_fixpoint_iterator_t(cfg_t& cfg, program_info& info, unsigned int descending_iterations, bool check_termination)
-        : _cfg(cfg), _wto(cfg), _program_info(info), _descending_iterations(descending_iterations), check_termination(check_termination) {
-        for (const auto& label : _cfg.labels()) {
-            _pre.emplace(label, ebpf_domain_t::bottom());
-            _post.emplace(label, ebpf_domain_t::bottom());
-        }
-        _pre[this->_cfg.entry_label()] = ebpf_domain_t::setup_entry(check_termination, info);
-    }
-
-    ebpf_domain_t get_pre(const label_t& node) { return _pre.at(node); }
-
-    ebpf_domain_t get_post(const label_t& node) { return _post.at(node); }
-
-    void operator()(const label_t& vertex);
-
-    void operator()(std::shared_ptr<wto_cycle_t>& cycle);
-
-    friend std::pair<invariant_table_t, invariant_table_t> run_forward_analyzer(cfg_t& cfg, program_info& info, bool check_termination);
-};
-
-std::pair<invariant_table_t, invariant_table_t> run_forward_analyzer(cfg_t& cfg, program_info& info, bool check_termination) {
-    // Go over the CFG in weak topological order (accounting for loops).
-    constexpr unsigned int descending_iterations = 2000000;
-    interleaved_fwd_fixpoint_iterator_t analyzer(cfg, info, descending_iterations, check_termination);
-    for (auto& component : analyzer._wto) {
-        std::visit(analyzer, *component);
-    }
-    return std::make_pair(analyzer._pre, analyzer._post);
+    return std::make_pair(_pre, _post);
 }
 
 void interleaved_fwd_fixpoint_iterator_t::operator()(const label_t& node) {
@@ -150,7 +65,7 @@ void interleaved_fwd_fixpoint_iterator_t::operator()(const label_t& node) {
     transform_to_post(node, pre);
 }
 
-void interleaved_fwd_fixpoint_iterator_t::operator()(std::shared_ptr<wto_cycle_t>& cycle) {
+void interleaved_fwd_fixpoint_iterator_t::operator()(const std::shared_ptr<wto_cycle_t>& cycle) {
     label_t head = cycle->head();
 
     /** decide whether to skip cycle or not **/

--- a/src/crab/fwd_analyzer.hpp
+++ b/src/crab/fwd_analyzer.hpp
@@ -14,6 +14,6 @@ namespace crab {
 using domains::ebpf_domain_t;
 using invariant_table_t = std::map<label_t, ebpf_domain_t>;
 
-std::pair<invariant_table_t, invariant_table_t> run_forward_analyzer(cfg_t& cfg, bool check_termination);
+std::pair<invariant_table_t, invariant_table_t> run_forward_analyzer(cfg_t& cfg, program_info& info, bool check_termination);
 
 } // namespace crab

--- a/src/crab/fwd_analyzer.hpp
+++ b/src/crab/fwd_analyzer.hpp
@@ -14,6 +14,88 @@ namespace crab {
 using domains::ebpf_domain_t;
 using invariant_table_t = std::map<label_t, ebpf_domain_t>;
 
-std::pair<invariant_table_t, invariant_table_t> run_forward_analyzer(cfg_t& cfg, program_info& info, bool check_termination);
+class interleaved_fwd_fixpoint_iterator_t final {
+    using iterator = typename invariant_table_t::iterator;
+    friend crab_verifier_job_t;
+
+    crab_verifier_job_t* _job;
+    cfg_t& _cfg;
+    wto_t _wto;
+    invariant_table_t _pre, _post;
+
+    /// number of iterations until triggering widening
+    const unsigned int _widening_delay{1};
+
+    /// number of narrowing iterations. If the narrowing operator is
+    /// indeed a narrowing operator this parameter is not
+    /// needed. However, there are abstract domains for which an actual
+    /// narrowing operation is not available so we must enforce
+    /// termination.
+    const unsigned int _descending_iterations;
+
+    /// Used to skip the analysis until _entry is found
+    bool _skip{true};
+
+    /// Whether the domain tracks instruction count; the invariants are somewhat easier to read without it
+    /// Generally corresponds to the check_termination flag in ebpf_verifier_options_t
+    const bool check_termination;
+
+  private:
+    inline void set_pre(const label_t& label, const ebpf_domain_t& v) { _pre[label] = v; }
+
+    inline void transform_to_post(const label_t& label, ebpf_domain_t pre) {
+        basic_block_t& bb = _cfg.get_node(label);
+        pre(bb, check_termination);
+        _post[label] = std::move(pre);
+    }
+
+    [[nodiscard]] ebpf_domain_t extrapolate(const label_t& node, unsigned int iteration, ebpf_domain_t before,
+                                            const ebpf_domain_t& after) const {
+        if (iteration <= _widening_delay) {
+            return before | after;
+        } else {
+            return before.widen(after);
+        }
+    }
+
+    static ebpf_domain_t refine(const label_t& node, unsigned int iteration, ebpf_domain_t before,
+                                const ebpf_domain_t& after) {
+        if (iteration == 1) {
+            return before & after;
+        } else {
+            return before.narrow(after);
+        }
+    }
+
+    ebpf_domain_t join_all_prevs(const label_t& node) {
+        ebpf_domain_t res = ebpf_domain_t::bottom();
+        for (const label_t& prev : _cfg.prev_nodes(node)) {
+            res |= get_post(prev);
+        }
+        return res;
+    }
+
+  public:
+    explicit interleaved_fwd_fixpoint_iterator_t(cfg_t& cfg, crab_verifier_job_t* job, unsigned int descending_iterations,
+                                                 bool check_termination)
+        : _cfg(cfg), _wto(cfg), _job(job), _descending_iterations(descending_iterations),
+          check_termination(check_termination) {
+        for (const auto& label : _cfg.labels()) {
+            _pre.emplace(label, ebpf_domain_t::bottom());
+            _post.emplace(label, ebpf_domain_t::bottom());
+        }
+        _pre[this->_cfg.entry_label()] = ebpf_domain_t::setup_entry(check_termination, job);
+    }
+
+    ebpf_domain_t get_pre(const label_t& node) { return _pre.at(node); }
+
+    ebpf_domain_t get_post(const label_t& node) { return _post.at(node); }
+
+    void operator()(const label_t& vertex);
+
+    void operator()(const std::shared_ptr<wto_cycle_t>& cycle);
+
+    std::pair<invariant_table_t, invariant_table_t> analyze();
+};
 
 } // namespace crab

--- a/src/crab_verifier.cpp
+++ b/src/crab_verifier.cpp
@@ -13,8 +13,7 @@
 #include <string>
 #include <vector>
 
-#include "crab/ebpf_domain.hpp"
-#include "crab/fwd_analyzer.hpp"
+#include "crab_verifier_job.hpp"
 
 #include "asm_syntax.hpp"
 #include "crab_verifier.hpp"
@@ -136,11 +135,12 @@ static void print_report(std::ostream& s, const checks_db& db, const Instruction
 }
 
 static checks_db get_ebpf_report(std::ostream& s, cfg_t& cfg, program_info& info, const ebpf_verifier_options_t* options) {
-    crab::domains::clear_global_state();
+    constexpr unsigned int descending_iterations = 2000000;
+    crab::crab_verifier_job_t job(cfg, info, descending_iterations, options->check_termination);
 
     // Get dictionaries of preconditions and postconditions for each
     // basic block.
-    auto [preconditions, postconditions] = crab::run_forward_analyzer(cfg, info, options->check_termination);
+    auto [preconditions, postconditions] = job.analyzer().analyze();
 
     // Analyze the control-flow graph.
     return generate_report(s, cfg, preconditions, postconditions, *options);

--- a/src/crab_verifier.cpp
+++ b/src/crab_verifier.cpp
@@ -21,8 +21,6 @@
 
 using std::string;
 
-program_info global_program_info;
-
 // Numerical domains over integers
 //using sdbm_domain_t = crab::domains::SplitDBM;
 using crab::domains::ebpf_domain_t;
@@ -137,13 +135,12 @@ static void print_report(std::ostream& s, const checks_db& db, const Instruction
     s << db.total_warnings << " errors\n";
 }
 
-static checks_db get_ebpf_report(std::ostream& s, cfg_t& cfg, program_info info, const ebpf_verifier_options_t* options) {
-    global_program_info = std::move(info);
+static checks_db get_ebpf_report(std::ostream& s, cfg_t& cfg, program_info& info, const ebpf_verifier_options_t* options) {
     crab::domains::clear_global_state();
 
     // Get dictionaries of preconditions and postconditions for each
     // basic block.
-    auto [preconditions, postconditions] = crab::run_forward_analyzer(cfg, options->check_termination);
+    auto [preconditions, postconditions] = crab::run_forward_analyzer(cfg, info, options->check_termination);
 
     // Analyze the control-flow graph.
     return generate_report(s, cfg, preconditions, postconditions, *options);
@@ -158,7 +155,7 @@ bool run_ebpf_analysis(std::ostream& s, cfg_t& cfg, program_info info, const ebp
 }
 
 /// Returned value is true if the program passes verification.
-bool ebpf_verify_program(std::ostream& s, const InstructionSeq& prog, program_info info,
+bool ebpf_verify_program(std::ostream& s, const InstructionSeq& prog, program_info& info,
                          const ebpf_verifier_options_t* options) {
     if (options == nullptr)
         options = &ebpf_verifier_default_options;

--- a/src/crab_verifier.hpp
+++ b/src/crab_verifier.hpp
@@ -8,8 +8,8 @@
 
 bool run_ebpf_analysis(std::ostream& s, cfg_t& cfg, program_info info, const ebpf_verifier_options_t* options);
 
-bool ebpf_verify_program(std::ostream& s, const InstructionSeq& prog, program_info info, const ebpf_verifier_options_t* options);
+bool ebpf_verify_program(std::ostream& s, const InstructionSeq& prog, program_info& info, const ebpf_verifier_options_t* options);
 
 int create_map_crab(const EbpfMapType& map_type, uint32_t key_size, uint32_t value_size, uint32_t max_entries, ebpf_verifier_options_t options);
 
-EbpfMapDescriptor* find_map_descriptor(int map_fd);
+const EbpfMapDescriptor* find_map_descriptor(int map_fd, const program_info& info);

--- a/src/crab_verifier_job.hpp
+++ b/src/crab_verifier_job.hpp
@@ -1,0 +1,27 @@
+// Copyright (c) Prevail Verifier contributors.
+// SPDX-License-Identifier: MIT
+#pragma once
+
+#include "crab/fwd_analyzer.hpp"
+#include "crab/array_domain.hpp"
+#include "crab/variable.hpp"
+
+namespace crab {
+
+// This class holds "global" state for a verifier run.
+class crab_verifier_job_t final {
+    crab::domains::array_map_t _array_map;
+    const program_info& _program_info;
+    interleaved_fwd_fixpoint_iterator_t _analyzer;
+
+  public:
+    crab_verifier_job_t(cfg_t& cfg, program_info& info, unsigned int max_instruction_count, bool check_termination)
+        : _program_info(info), _analyzer(cfg, this, max_instruction_count, check_termination) {}
+
+    interleaved_fwd_fixpoint_iterator_t& analyzer() { return _analyzer; }
+    const program_info& get_program_info() const { return _program_info; }
+
+    crab::domains::offset_map_t& lookup_array_map(data_kind_t kind) { return _array_map[kind]; }
+};
+
+} // namespace crab

--- a/src/linux/linux_platform.cpp
+++ b/src/linux/linux_platform.cpp
@@ -219,10 +219,10 @@ static int create_map_linux(uint32_t map_type, uint32_t key_size, uint32_t value
 #endif
 }
 
-EbpfMapDescriptor& get_map_descriptor_linux(int map_fd)
+const EbpfMapDescriptor& get_map_descriptor_linux(int map_fd, const program_info& info)
 {
     // First check if we already have the map descriptor cached.
-    EbpfMapDescriptor* map = find_map_descriptor(map_fd);
+    const EbpfMapDescriptor* map = find_map_descriptor(map_fd, info);
     if (map != nullptr) {
         return *map;
     }

--- a/src/platform.hpp
+++ b/src/platform.hpp
@@ -27,7 +27,7 @@ typedef int (*ebpf_create_map_fn)(uint32_t map_type, uint32_t key_size, uint32_t
 // In the future we may want to move map fd allocation after the verifier step.
 typedef void (*ebpf_parse_maps_section_fn)(std::vector<EbpfMapDescriptor>& map_descriptors, const char* data, size_t size, const struct ebpf_platform_t* platform, ebpf_verifier_options_t options);
 
-typedef EbpfMapDescriptor& (*ebpf_get_map_descriptor_fn)(int map_fd);
+typedef const EbpfMapDescriptor& (*ebpf_get_map_descriptor_fn)(int map_fd, const program_info& info);
 
 struct ebpf_platform_t {
     ebpf_get_program_type_fn get_program_type;

--- a/src/spec_type_descriptors.hpp
+++ b/src/spec_type_descriptors.hpp
@@ -53,5 +53,3 @@ struct raw_program {
     std::vector<ebpf_inst> prog;
     program_info info;
 };
-
-extern program_info global_program_info;


### PR DESCRIPTION
This is part 2 of the changes for issue #113 and the first commit is what is already PR #196 which this builds on.

Added the crab_verifier_job_t class to hold state that was previously global.

Moved interleaved_fwd_fixpoint_iterator_t from fwd_analyzer.cpp to fwd_analyzer.hpp so that it could be referenced from
crab_verifier_job.hpp

Signed-off-by: Dave Thaler <dthaler@ntdev.microsoft.com>