### PR TITLE
Convert runtime_error verifier exceptions to failure

### DIFF
--- a/src/test/test_verify.cpp
+++ b/src/test/test_verify.cpp
@@ -424,6 +424,7 @@ TEST_SECTION("raw_tracepoint/filler/sys_recvfrom_x")
 
 // Test some programs that ought to fail verification.
 TEST_SECTION_REJECT("build", "badhelpercall.o", ".text")
+TEST_SECTION_REJECT("build", "badmapptr.o", "test")
 TEST_SECTION_REJECT("build", "exposeptr.o", ".text")
 TEST_SECTION_REJECT("build", "exposeptr2.o", ".text")
 TEST_SECTION_REJECT("build", "mapvalue-overrun.o", ".text")


### PR DESCRIPTION
This is similar to issue #129 except that programs with a valid CFG can still result in the verifier throwing exceptions.
It would be better if each such case could be converted to a normal verifier assertion failure in the future, but in the meantime this PR just covers the catch-all for anything that hasn't been done for so that test cases can be run.

Fixes #209 

Signed-off-by: Dave Thaler <dthaler@ntdev.microsoft.com>