### PR TITLE
Optionally check for indexing outside of map array bounds

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -8,5 +8,6 @@ const ebpf_verifier_options_t ebpf_verifier_default_options = {
     .print_invariants = false,
     .print_failures = false,
     .no_simplify = false,
-    .mock_map_fds = true
+    .mock_map_fds = true,
+    .strict = false
 };

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -10,6 +10,9 @@ struct ebpf_verifier_options_t {
 
     // False to use actual map fd's, true to use mock fd's.
     bool mock_map_fds;
+
+    // True to do additional checks for some things that would fail at runtime.
+    bool strict;
 };
 
 extern const ebpf_verifier_options_t ebpf_verifier_default_options;

--- a/src/main/check.cpp
+++ b/src/main/check.cpp
@@ -53,6 +53,7 @@ int main(int argc, char** argv) {
     bool verbose = false;
     app.add_flag("-i", ebpf_verifier_options.print_invariants, "Print invariants");
     app.add_flag("-f", ebpf_verifier_options.print_failures, "Print verifier's failure logs");
+    app.add_flag("-s", ebpf_verifier_options.strict, "Apply additional checks that would cause runtime failures");
     app.add_flag("-v", verbose, "Print both invariants and failures");
     app.add_flag("--no-simplify", ebpf_verifier_options.no_simplify, "Do not simplify");
 


### PR DESCRIPTION
Provide a "strict" option that is not the default.  If the developer opts in to this flag, the verifier will do some additional checks for things that are potential bugs in the program.   Per comments in #175 from poornagmsft and xfoukas, this can help with preventing failures, improving developer efficient, and even improving program performance compared to other alternatives.

Fixes #175

Signed-off-by: Dave Thaler <dthaler@ntdev.microsoft.com>