### PR TITLE
read_elf should reject ELF files that contain references to external functions.

### DIFF
--- a/src/asm_files.cpp
+++ b/src/asm_files.cpp
@@ -126,6 +126,12 @@ vector<raw_program> read_elf(const std::string& path, const std::string& desired
                                                         " at location " + std::to_string(offset / sizeof(ebpf_inst))));
                     }
 
+                    // Only permit loading the address of the map.
+                    if ((inst.opcode & INST_CLS_MASK) != INST_CLS_LD)
+                    {
+                        throw std::runtime_error(string("Illegal operation on symbol " + symbol_name +
+                                                        " at location " + std::to_string(offset / sizeof(ebpf_inst))));
+                    }
                     inst.src = 1; // magic number for LoadFd
 
                     size_t reloc_value = read_reloc_value(symbol);

--- a/src/asm_files.cpp
+++ b/src/asm_files.cpp
@@ -102,10 +102,8 @@ vector<raw_program> read_elf(const std::string& path, const std::string& desired
         if (prelocs) {
             ELFIO::const_relocation_section_accessor reloc{reader, prelocs};
             ELFIO::Elf64_Addr offset;
-            ELFIO::Elf64_Addr value{};
             ELFIO::Elf_Word symbol{};
             ELFIO::Elf_Word type;
-            ELFIO::Elf_Xword size{};
             ELFIO::Elf_Sxword addend;
             for (ELFIO::Elf_Xword i = 0; i < reloc.get_entries_num(); i++) {
                 if (reloc.get_entry(i, offset, symbol, type, addend)) {
@@ -113,12 +111,14 @@ vector<raw_program> read_elf(const std::string& path, const std::string& desired
 
                     if ((inst.opcode & INST_CLS_MASK) == INST_CLS_JMP) {
                         string symbol_name;
+                        ELFIO::Elf64_Addr symbol_value{};
                         unsigned char symbol_bind{};
                         unsigned char symbol_type{};
-                        ELFIO::Elf_Half section_index{};
-                        unsigned char other{};
+                        ELFIO::Elf_Half symbol_section_index{};
+                        unsigned char symbol_other{};
+                        ELFIO::Elf_Xword symbol_size{};
 
-                        symbols.get_symbol(symbol, symbol_name, value, size, symbol_bind, symbol_type, section_index, other);
+                        symbols.get_symbol(symbol, symbol_name, symbol_value, symbol_size, symbol_bind, symbol_type, symbol_section_index, symbol_other);
 
                         throw std::runtime_error(string("Unresolved external function call " + symbol_name
                                                  + " at location " + std::to_string(offset / sizeof(ebpf_inst))));

--- a/src/test/test_verify.cpp
+++ b/src/test/test_verify.cpp
@@ -16,6 +16,7 @@
 // Some intentional failures
 FAIL_LOAD_ELF("cilium", "not-found.o", "2/1")
 FAIL_LOAD_ELF("cilium", "bpf_lxc.o", "not-found")
+FAIL_LOAD_ELF("build", "badrelo.o", ".text")
 
 #define FAIL_UNMARSHAL(dirname, filename, sectionname) \
     TEST_CASE("Try unmarshalling bad program: " dirname "/" filename, "[unmarshal]") { \


### PR DESCRIPTION
read_elf should reject ELF files that contain references to external functions.

Resolves: #218

Signed-off-by: Alan Jowett <alan.jowett@microsoft.com>