### PR TITLE
Add test to verify relocation behavior

### DIFF
--- a/src/test/test_verify.cpp
+++ b/src/test/test_verify.cpp
@@ -454,6 +454,12 @@ TEST_SECTION_REJECT("build", "exposeptr2.o", ".text")
 TEST_SECTION_REJECT("build", "mapvalue-overrun.o", ".text")
 TEST_SECTION_REJECT("build", "nullmapref.o", "test")
 
+// Test some programs that ought to fail verification but
+// are currently allowed through.  These should be changed
+// to TEST_SECTION_REJECT() or FAIL_LOAD_ELF() once fixed.
+
+TEST_SECTION("build", "badrelo.o", ".text")
+
 // The following eBPF programs currently fail verification.
 // If the verifier is later updated to accept them, these should
 // be changed to TEST_SECTION().

--- a/src/test/test_verify.cpp
+++ b/src/test/test_verify.cpp
@@ -454,12 +454,6 @@ TEST_SECTION_REJECT("build", "exposeptr2.o", ".text")
 TEST_SECTION_REJECT("build", "mapvalue-overrun.o", ".text")
 TEST_SECTION_REJECT("build", "nullmapref.o", "test")
 
-// Test some programs that ought to fail verification but
-// are currently allowed through.  These should be changed
-// to TEST_SECTION_REJECT() or FAIL_LOAD_ELF() once fixed.
-
-TEST_SECTION("build", "badrelo.o", ".text")
-
 // The following eBPF programs currently fail verification.
 // If the verifier is later updated to accept them, these should
 // be changed to TEST_SECTION().


### PR DESCRIPTION
This PR illustrates that the verifier incorrectly passes verification as discussed in issue #218.
The fix is in PR #219

Signed-off-by: Dave Thaler <dthaler@ntdev.microsoft.com>