### PR TITLE
Return verifier stats to the calling application

### DIFF
--- a/src/config.hpp
+++ b/src/config.hpp
@@ -15,4 +15,10 @@ struct ebpf_verifier_options_t {
     bool strict;
 };
 
+struct ebpf_verifier_stats_t {
+    int total_unreachable;
+    int total_warnings;
+    int max_instruction_count;
+};
+
 extern const ebpf_verifier_options_t ebpf_verifier_default_options;

--- a/src/crab/ebpf_domain.hpp
+++ b/src/crab/ebpf_domain.hpp
@@ -395,10 +395,9 @@ class ebpf_domain_t final {
         }
     }
 
-    bool terminates() {
-        using namespace crab::dsl_syntax;
-        constexpr int max_instructions = 100000;
-        return m_inv.entail(variable_t::instruction_count() <= max_instructions);
+    int get_instruction_count_upper_bound() {
+        const auto& ub = m_inv[variable_t::instruction_count()].ub();
+        return (ub.is_finite() && ub.number().value().fits_sint()) ? (int)ub.number().value() : INT_MAX;
     }
 
     void operator()(Assume const& s) {

--- a/src/crab_verifier.cpp
+++ b/src/crab_verifier.cpp
@@ -168,10 +168,16 @@ static checks_db get_ebpf_report(std::ostream& s, cfg_t& cfg, program_info info,
 }
 
 /// Returned value is true if the program passes verification.
-bool run_ebpf_analysis(std::ostream& s, cfg_t& cfg, program_info info, const ebpf_verifier_options_t* options) {
+bool run_ebpf_analysis(std::ostream& s, cfg_t& cfg, program_info info, const ebpf_verifier_options_t* options,
+                       ebpf_verifier_stats_t* stats) {
     if (options == nullptr)
         options = &ebpf_verifier_default_options;
     checks_db report = get_ebpf_report(s, cfg, info, options);
+    if (stats) {
+        stats->total_unreachable = report.total_unreachable;
+        stats->total_warnings = report.total_warnings;
+        stats->max_instruction_count = report.max_instruction_count;
+    }
     return (report.total_warnings == 0);
 }
 

--- a/src/crab_verifier.hpp
+++ b/src/crab_verifier.hpp
@@ -8,7 +8,8 @@
 
 bool run_ebpf_analysis(std::ostream& s, cfg_t& cfg, program_info info, const ebpf_verifier_options_t* options);
 
-bool ebpf_verify_program(std::ostream& s, const InstructionSeq& prog, program_info info, const ebpf_verifier_options_t* options);
+bool ebpf_verify_program(std::ostream& s, const InstructionSeq& prog, program_info info, const ebpf_verifier_options_t* options,
+    ebpf_verifier_stats_t* stats);
 
 int create_map_crab(const EbpfMapType& map_type, uint32_t key_size, uint32_t value_size, uint32_t max_entries, ebpf_verifier_options_t options);
 

--- a/src/crab_verifier.hpp
+++ b/src/crab_verifier.hpp
@@ -6,7 +6,8 @@
 #include "crab/cfg.hpp"
 #include "spec_type_descriptors.hpp"
 
-bool run_ebpf_analysis(std::ostream& s, cfg_t& cfg, program_info info, const ebpf_verifier_options_t* options);
+bool run_ebpf_analysis(std::ostream& s, cfg_t& cfg, program_info info, const ebpf_verifier_options_t* options,
+    ebpf_verifier_stats_t* stats);
 
 bool ebpf_verify_program(std::ostream& s, const InstructionSeq& prog, program_info info, const ebpf_verifier_options_t* options,
     ebpf_verifier_stats_t* stats);

--- a/src/main/check.cpp
+++ b/src/main/check.cpp
@@ -139,9 +139,13 @@ int main(int argc, char** argv) {
     }
 
     if (domain == "zoneCrab") {
+        ebpf_verifier_stats_t verifier_stats;
         const auto [res, seconds] = timed_execution([&] {
-            return ebpf_verify_program(std::cout, prog, raw_prog.info, &ebpf_verifier_options);
+            return ebpf_verify_program(std::cout, prog, raw_prog.info, &ebpf_verifier_options, &verifier_stats);
         });
+        if (ebpf_verifier_options.check_termination && (ebpf_verifier_options.print_failures || ebpf_verifier_options.print_invariants)) {
+            std::cout << "Program terminates within " << verifier_stats.max_instruction_count << " instructions\n";
+        }
         std::cout << res << "," << seconds << "," << resident_set_size_kb() << "\n";
         return !res;
     } else if (domain == "linux") {

--- a/src/test/test_loop.cpp
+++ b/src/test/test_loop.cpp
@@ -28,6 +28,6 @@ TEST_CASE("Trivial loop: middle", "[sanity][loop]") {
         .platform = &g_ebpf_platform_linux,
         .type = g_ebpf_platform_linux.get_program_type("unspec", "unspec")
     };
-    bool pass = run_ebpf_analysis(std::cout, cfg, info, &options);
+    bool pass = run_ebpf_analysis(std::cout, cfg, info, &options, nullptr);
     REQUIRE(pass);
 }

--- a/src/test/test_termination.cpp
+++ b/src/test/test_termination.cpp
@@ -27,8 +27,12 @@ TEST_CASE("Trivial infinite loop", "[loop][termination]") {
         .platform = &g_ebpf_platform_linux,
         .type = g_ebpf_platform_linux.get_program_type("unspec", "unspec")
     };
-    bool pass = run_ebpf_analysis(std::cout, cfg, info, &options);
+    ebpf_verifier_stats_t stats;
+    bool pass = run_ebpf_analysis(std::cout, cfg, info, &options, &stats);
     REQUIRE_FALSE(pass);
+    REQUIRE(stats.max_instruction_count == INT_MAX);
+    REQUIRE(stats.total_unreachable == 0);
+    REQUIRE(stats.total_warnings == 1);
 }
 
 TEST_CASE("Trivial finite loop", "[loop][termination]") {
@@ -56,6 +60,10 @@ TEST_CASE("Trivial finite loop", "[loop][termination]") {
         .platform = &g_ebpf_platform_linux,
         .type = g_ebpf_platform_linux.get_program_type("unspec", "unspec")
     };
-    bool pass = run_ebpf_analysis(std::cout, cfg, info, &options);
+    ebpf_verifier_stats_t stats;
+    bool pass = run_ebpf_analysis(std::cout, cfg, info, &options, &stats);
     REQUIRE(pass);
+    REQUIRE(stats.max_instruction_count == 3);
+    REQUIRE(stats.total_unreachable == 1);
+    REQUIRE(stats.total_warnings == 0);
 }

--- a/src/test/test_verify.cpp
+++ b/src/test/test_verify.cpp
@@ -38,8 +38,7 @@ FAIL_UNMARSHAL("build", "wronghelper.o", "xdp")
         std::variant<InstructionSeq, std::string> prog_or_error = unmarshal(raw_prog); \
         REQUIRE(std::holds_alternative<InstructionSeq>(prog_or_error)); \
         auto& prog = std::get<InstructionSeq>(prog_or_error); \
-        cfg_t cfg = prepare_cfg(prog, raw_prog.info, true); \
-        bool res = run_ebpf_analysis(std::cout, cfg, raw_prog.info, options); \
+        bool res = ebpf_verify_program(std::cout, prog, raw_prog.info, options, nullptr); \
         if (pass)                                            \
             REQUIRE(res);                                    \
         else                                                 \
@@ -470,7 +469,7 @@ TEST_SECTION_FAIL("prototype-kernel", "xdp_ddos01_blacklist_kern.o", ".text")
 TEST_SECTION_FAIL("prototype-kernel", "xdp_ddos01_blacklist_kern.o", "xdp_prog")
 
 void test_analyze_thread(cfg_t* cfg, program_info* info, bool* res) {
-    *res = run_ebpf_analysis(std::cout, *cfg, *info, nullptr);
+    *res = run_ebpf_analysis(std::cout, *cfg, *info, nullptr, nullptr);
 }
 
 // Test multithreading


### PR DESCRIPTION
For example so the caller of ebpf_verify_program() can impose its own limit on max instructions to complete within.

Signed-off-by: Dave Thaler <dthaler@ntdev.microsoft.com>