### PR TITLE
Make Visual Studio use static C runtime libs in Debug configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,6 +52,11 @@ if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" OR
   set(SANITIZE_FLAGS -fsanitize=address -O1 -fno-omit-frame-pointer)
 elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /std:c++latest")
+
+  # Make debug builds use static C runtime libs to avoid having
+  # to install them.  Release builds don't need this because
+  # the release DLLs are included in Windows.
+  set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /MTd")
 endif ()
 
 add_library(ebpfverifier ${LIB_SRC})


### PR DESCRIPTION
Currently it defaults to dynamic (i.e., shared) libs which introduces a dependency to first install them if copying the binaries to another machine.  Hence static libs simplify the developer's life.  This is not needed for the Release configuration since the relevant dynamic libs are already part of Windows itself.

Signed-off-by: Dave Thaler <dthaler@microsoft.com>