### PR TITLE
Test both Debug and Release configurations in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,14 @@ on:
 
 jobs:
   build_ubuntu:
+    strategy:
+      matrix:
+        configurations: [Debug, Release]
     runs-on: ubuntu-20.04
+    env:
+      # Configuration type to build.  For documentation on how build matrices work, see
+      # https://docs.github.com/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
+      BUILD_CONFIGURATION: ${{matrix.configurations}}
 
     steps:
       - name: Install dependencies
@@ -19,14 +26,21 @@ jobs:
       - name: Build
         run: |
           mkdir build
-          cmake -B build -DCMAKE_BUILD_TYPE=Debug
+          cmake -B build -DCMAKE_BUILD_TYPE=${{env.BUILD_CONFIGURATION}}
           cmake --build build -j $(nproc)
 
       - name: Run unit tests
         run: ./tests -d yes
 
   build_windows:
+    strategy:
+      matrix:
+        configurations: [Debug, Release]
     runs-on: windows-latest
+    env:
+      # Configuration type to build.  For documentation on how build matrices work, see
+      # https://docs.github.com/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
+      BUILD_CONFIGURATION: ${{matrix.configurations}}
 
     steps:
       - uses: actions/checkout@v2
@@ -37,7 +51,7 @@ jobs:
         run: |
           mkdir build
           cmake -B build
-          cmake --build build -j $(nproc) --config Release
+          cmake --build build -j $(nproc) --config ${{env.BUILD_CONFIGURATION}}
 
       - name: Run unit tests
-        run: ./Release/tests -d yes
+        run: ./${{env.BUILD_CONFIGURATION}}/tests -d yes


### PR DESCRIPTION
Update the github workflows configuration to run both configurations for both Ubuntu and Windows.
Previously, only Debug was built/tested for Ubuntu, and only Release was built/tested for Windows.

Signed-off-by: Dave Thaler <dthaler@microsoft.com>