### PR TITLE
Use a constant reference instead of by value when the class size is less than a pointer size.

### DIFF
--- a/src/asm_cfg.cpp
+++ b/src/asm_cfg.cpp
@@ -220,7 +220,7 @@ std::map<std::string, int> collect_stats(const cfg_t& cfg) {
                     res["adjust_head"] = 1;
             }
             if (std::holds_alternative<Bin>(ins)) {
-                auto bin = std::get<Bin>(ins);
+                auto const& bin = std::get<Bin>(ins);
                 res[bin.is64 ? "arith64" : "arith32"]++;
             }
             res[instype(ins)]++;

--- a/src/asm_ostream.cpp
+++ b/src/asm_ostream.cpp
@@ -356,7 +356,7 @@ void print(const InstructionSeq& insts, std::ostream& out, std::optional<const l
                 out << std::setw(8) << pc << ":\t";
             }
             if (std::holds_alternative<Jmp>(ins)) {
-                auto jmp = std::get<Jmp>(ins);
+                auto const& jmp = std::get<Jmp>(ins);
                 if (pc_of_label.count(jmp.target) == 0)
                     throw std::runtime_error(string("Cannot find label ") + to_string(jmp.target));
                 pc_t target_pc = pc_of_label.at(jmp.target);

--- a/src/crab/array_domain.cpp
+++ b/src/crab/array_domain.cpp
@@ -284,7 +284,7 @@ array_domain_t::kill_and_find_var(NumAbsDomain& inv, data_kind_t kind, const lin
     }
     if (!cells.empty()) {
         // Forget the scalars from the numerical domain
-        for (auto c : cells) {
+        for (auto const& c : cells) {
             inv -= c.get_scalar(kind);
         }
         // Remove the cells. If needed again they they will be re-created.

--- a/src/crab/array_domain.hpp
+++ b/src/crab/array_domain.hpp
@@ -196,7 +196,7 @@ class offset_map_t final {
     void operator-=(const cell_t& c) { remove_cell(c); }
 
     void operator-=(const std::vector<cell_t>& cells) {
-        for (auto c : cells) {
+        for (auto const& c : cells) {
             this->operator-=(c);
         }
     }

--- a/src/linux/linux_platform.cpp
+++ b/src/linux/linux_platform.cpp
@@ -157,7 +157,7 @@ void parse_maps_section_linux(std::vector<EbpfMapDescriptor>& map_descriptors, c
     }
 
     auto mapdefs = std::vector<bpf_load_map_def>((bpf_load_map_def*)data, (bpf_load_map_def*)(data + size));
-    for (auto s : mapdefs) {
+    for (auto const& s : mapdefs) {
         EbpfMapType type = get_map_type_linux(s.type);
         map_descriptors.emplace_back(EbpfMapDescriptor{
             .original_fd = create_map_linux(s.type, s.key_size, s.value_size, s.max_entries, options),


### PR DESCRIPTION
While running code-analysis tools on the ebpf-verifier code base, it flags two classes of errors:
1) [C26817 Potentially expensive copy of variable name in range-for loop. Consider making it a const reference](https://docs.microsoft.com/en-us/cpp/code-quality/c26817?view=msvc-160)
2) [C26820 Assigning by value when a const-reference would suffice, use const auto& instead](https://docs.microsoft.com/en-us/cpp/code-quality/c26820?view=msvc-160)

Both of these are suggestions to use a constant reference instead of a value semantics to avoid unnecessary copying. Note: I only updated cases where the compile flagged this warning as the others appear to have value sizes approximately the same as pointer size, so switching to a reference wouldn't be a net gain.

Signed-off-by: Alan Jowett <alan.jowett@microsoft.com>