### PR TITLE
Capture count of relocation entries locally to permit static analysis

### DIFF
--- a/src/asm_files.cpp
+++ b/src/asm_files.cpp
@@ -105,14 +105,17 @@ vector<raw_program> read_elf(const std::string& path, const std::string& desired
             ELFIO::Elf_Word symbol{};
             ELFIO::Elf_Word type;
             ELFIO::Elf_Sxword addend;
+            // Fetch and store relocation count locally to permit static
+            // analysis tools to correctly reason about the code below.
+            ELFIO::Elf_Xword relocation_count = reloc.get_entries_num();
 
             // Below, only relocations of symbols located in the maps section are allowed,
             // so if there are relocations there needs to be a "maps" section.
-            if (reloc.get_entries_num() && !maps_section) {
+            if (relocation_count && !maps_section) {
                 throw std::runtime_error(string("Can't find any maps sections in file ") + path);
             }
 
-            for (ELFIO::Elf_Xword i = 0; i < reloc.get_entries_num(); i++) {
+            for (ELFIO::Elf_Xword i = 0; i < relocation_count; i++) {
                 if (reloc.get_entry(i, offset, symbol, type, addend)) {
                     ebpf_inst& inst = prog.prog[offset / sizeof(ebpf_inst)];
 


### PR DESCRIPTION
Static analysis tools assume that the reloc.get_entries_num() can change between:
https://github.com/vbpf/ebpf-verifier/blob/124e0281bc68b128090fa3c1c0adf65111e696d1/src/asm_files.cpp#L111

And:
https://github.com/vbpf/ebpf-verifier/blob/124e0281bc68b128090fa3c1c0adf65111e696d1/src/asm_files.cpp#L115

Which then would result in a NULL dereference on line:
https://github.com/vbpf/ebpf-verifier/blob/124e0281bc68b128090fa3c1c0adf65111e696d1/src/asm_files.cpp#L131

This appears to be a false positive, but this change captures the value of reloc.get_entries_num() locally so that the static analysis tools can reason correctly about the code.

Signed-off-by: Alan Jowett <alan.jowett@microsoft.com>