### PR TITLE
Use explicit equivalent class for map allocation

### DIFF
--- a/src/crab_utils/debug.cpp
+++ b/src/crab_utils/debug.cpp
@@ -8,6 +8,6 @@ std::set<std::string> CrabLog;
 
 unsigned CrabVerbosity = 0;
 
-bool CrabWarningFlag = true;
+bool CrabWarningFlag = false;
 void CrabEnableWarningMsg(bool v) { CrabWarningFlag = v; }
 } // namespace crab


### PR DESCRIPTION
Should be easier to understand and tweak than encoding key and value to the FD - which is also incorrect when taking into account array size.