### PR TITLE
Add tail call tests

### DIFF
--- a/src/crab/ebpf_domain.hpp
+++ b/src/crab/ebpf_domain.hpp
@@ -959,7 +959,7 @@ class ebpf_domain_t final {
         } else {
             havoc(r0.offset);
             assign(r0.type, T_NUM);
-            // assume(r0.value < 0); for VOID, which is actually "no return if succeed".
+            // assume(r0.value < 0); for INTEGER_OR_NO_RETURN_IF_SUCCEED.
         }
     }
 

--- a/src/ebpf_base.h
+++ b/src/ebpf_base.h
@@ -9,7 +9,7 @@
 typedef enum _ebpf_return_type {
     EBPF_RETURN_TYPE_INTEGER = 0,
     EBPF_RETURN_TYPE_PTR_TO_MAP_VALUE_OR_NULL,
-    EBPF_RETURN_TYPE_VOID,
+    EBPF_RETURN_TYPE_INTEGER_OR_NO_RETURN_IF_SUCCEED,
 } ebpf_return_type_t;
 
 typedef enum _ebpf_argument_type {

--- a/src/linux/gpl/spec_prototypes.cpp
+++ b/src/linux/gpl/spec_prototypes.cpp
@@ -55,7 +55,7 @@ const struct EbpfHelperPrototype bpf_tail_call_proto = {
     .name = "tail_call",
     //.func		= NULL,
     //.gpl_only	= false,
-    .return_type = EBPF_RETURN_TYPE_VOID,
+    .return_type = EBPF_RETURN_TYPE_INTEGER_OR_NO_RETURN_IF_SUCCEED,
     .argument_type = {
         EBPF_ARGUMENT_TYPE_PTR_TO_CTX,
         EBPF_ARGUMENT_TYPE_PTR_TO_MAP_OF_PROGRAMS,

--- a/src/test/test_verify.cpp
+++ b/src/test/test_verify.cpp
@@ -445,6 +445,7 @@ TEST_SECTION("raw_tracepoint/filler/proc_startupdate_2")
 TEST_SECTION("raw_tracepoint/filler/sys_recvfrom_x")
 */
 TEST_SECTION("build", "packet_start_ok.o", "xdp")
+TEST_SECTION("build", "tail_call.o", "xdp_prog")
 
 // Test some programs that ought to fail verification.
 TEST_SECTION_REJECT("build", "badhelpercall.o", ".text")
@@ -456,6 +457,7 @@ TEST_SECTION_REJECT("build", "mapvalue-overrun.o", ".text")
 TEST_SECTION_REJECT("build", "nullmapref.o", "test")
 TEST_SECTION_REJECT("build", "packet_overflow.o", "xdp")
 TEST_SECTION_REJECT("build", "packet_reallocate.o", "socket_filter")
+TEST_SECTION_REJECT("build", "tail_call_bad.o", "xdp_prog")
 
 // The following eBPF programs currently fail verification.
 // If the verifier is later updated to accept them, these should


### PR DESCRIPTION
Also rename EBPF_RETURN_TYPE_VOID to
EBPF_RETURN_TYPE_INTEGER_OR_NO_RETURN_IF_SUCCEED
since the old name was confusing, as a comment in the code explained.

This depends on https://github.com/vbpf/ebpf-samples/pull/13 being merged first.

Signed-off-by: Dave Thaler <dthaler@microsoft.com>