### PR TITLE
Reject inconsistent map-to-map values

### DIFF
--- a/src/spec_type_descriptors.hpp
+++ b/src/spec_type_descriptors.hpp
@@ -26,7 +26,7 @@ struct EbpfMapDescriptor {
     unsigned int key_size;
     unsigned int value_size;
     unsigned int max_entries;
-    unsigned int inner_map_fd;
+    int inner_map_fd;
 };
 
 struct EbpfProgramType {

--- a/src/test/test_verify.cpp
+++ b/src/test/test_verify.cpp
@@ -447,7 +447,6 @@ TEST_SECTION("raw_tracepoint/filler/sys_recvfrom_x")
 TEST_SECTION("build", "stackok.o", ".text")
 TEST_SECTION("build", "packet_start_ok.o", "xdp")
 TEST_SECTION("build", "tail_call.o", "xdp_prog")
-TEST_SECTION("build", "map_in_map.o", ".text")
 
 // Test some programs that ought to fail verification.
 TEST_SECTION_REJECT("build", "badhelpercall.o", ".text")
@@ -460,6 +459,7 @@ TEST_SECTION_REJECT("build", "nullmapref.o", "test")
 TEST_SECTION_REJECT("build", "packet_overflow.o", "xdp")
 TEST_SECTION_REJECT("build", "packet_reallocate.o", "socket_filter")
 TEST_SECTION_REJECT("build", "tail_call_bad.o", "xdp_prog")
+TEST_SECTION_REJECT("build", "map_in_map.o", ".text")
 
 // The following eBPF programs currently fail verification.
 // If the verifier is later updated to accept them, these should


### PR DESCRIPTION
Do not allow map-to-map to have value size different from the key size of its inner map.

TODO: change map_in_map test name, and add a test that passes.
Signed-off-by: Elazar Gershuni <elazarg@gmail.com>