### PR TITLE
Fix disassembly output for calls with pairs

### DIFF
--- a/src/asm_ostream.cpp
+++ b/src/asm_ostream.cpp
@@ -203,6 +203,7 @@ struct InstructionPrinterVisitor {
                 if (r > 1)
                     os_ << ", ";
                 os_ << *pair;
+                r++;
                 continue;
             }
 


### PR DESCRIPTION
Bug was that no argument after a pair would be shown because the
register for the 2nd half of the pair wasn't being found.

This affected all calls that actually had one or more arguments after a pair,
such as bpf_skb_store_bytes, bpf_csum_diff, bpf_skb_set_tunnel_key, etc.

Signed-off-by: Dave Thaler <dthaler@microsoft.com>