### PR TITLE
Switch to the DLL version of the CRT when building on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,11 +56,6 @@ if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" OR
   set(SANITIZE_FLAGS -fsanitize=address -O1 -fno-omit-frame-pointer)
 elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /std:c++latest")
-
-  # Make debug builds use static C runtime libs to avoid having
-  # to install them.  Release builds don't need this because
-  # the release DLLs are included in Windows.
-  set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /MTd")
 endif ()
 
 add_library(ebpfverifier ${LIB_SRC})


### PR DESCRIPTION
Using the static version of the CRT causes issues as file descriptors are then per PE file. File descriptors opened in module A are then not usable in module B, if module A and module B are hosted in different PE files (either DLLs or EXE). 

Signed-off-by: Alan Jowett <alanjo@microsoft.com>