### PR TITLE
Move code from headers to cpp files

### DIFF
--- a/src/asm_syntax.hpp
+++ b/src/asm_syntax.hpp
@@ -215,18 +215,6 @@ struct Assume {
     Condition cond;
 };
 
-// The exact numbers are taken advantage of, in the abstract domain
-enum {
-    T_UNINIT = -7,
-    T_MAP_PROGRAMS = -6,
-    T_MAP = -5,
-    T_NUM = -4,
-    T_CTX = -3,
-    T_STACK = -2,
-    T_PACKET = -1,
-    T_SHARED = 0
-};
-
 enum class TypeGroup {
     number,
     map_fd,

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -22,3 +22,4 @@ struct ebpf_verifier_stats_t {
 };
 
 extern const ebpf_verifier_options_t ebpf_verifier_default_options;
+extern thread_local ebpf_verifier_options_t thread_local_options;

--- a/src/crab/array_domain.hpp
+++ b/src/crab/array_domain.hpp
@@ -23,30 +23,12 @@
 
 #pragma once
 
-#include <algorithm>
-#include <bitset>
 #include <functional>
 #include <optional>
-#include <set>
-#include <unordered_map>
 #include <utility>
-#include <vector>
-
-#include "boost/range/algorithm/set_algorithm.hpp"
 
 #include "crab/variable.hpp"
-#include "crab_utils/debug.hpp"
-#include "crab_utils/stats.hpp"
-
-#include "crab/interval.hpp"
 #include "crab/split_dbm.hpp"
-#include "radix_tree/radix_tree.hpp"
-
-#include "asm_ostream.hpp"
-#include "config.hpp"
-#include "dsl_syntax.hpp"
-#include "helpers.hpp"
-#include "spec_type_descriptors.hpp"
 
 #include "crab/bitset_domain.hpp"
 
@@ -55,288 +37,45 @@ namespace crab::domains {
 // Numerical abstract domain.
 using NumAbsDomain = SplitDBM;
 
-class offset_t final {
-    index_t _index{};
-    int _prefix_length;
-
-public:
-    static constexpr int bitsize = 8 * sizeof(index_t);
-    offset_t() : _prefix_length(bitsize) {}
-    offset_t(index_t index) : _index(index), _prefix_length(bitsize) {}
-    offset_t(index_t index, int prefix_length) : _index(index), _prefix_length(prefix_length) {}
-    explicit operator int() const { return static_cast<int>(_index); }
-    operator index_t() const { return _index; }
-    [[nodiscard]] int prefix_length() const { return _prefix_length; }
-
-    index_t operator[](int n) const { return (_index >> (bitsize - 1 - n)) & 1; }
-};
-
-// Get the length of a key, which is the size usable with the [] operator.
-inline int radix_length(const offset_t& offset) { return offset.prefix_length(); }
-
-offset_t radix_substr(const offset_t& key, int begin, int length);
-offset_t radix_join(const offset_t& entry1, const offset_t& entry2);
-
-/*
-   Conceptually, a cell is tuple of an array, offset, size, and
-   scalar variable such that:
-
-       _scalar = array[_offset, _offset + 1, ..., _offset + _size - 1]
-
-   For simplicity, we don't carry the array inside the cell class.
-   Only, offset_map objects can create cells. They will consider the
-   array when generating the scalar variable.
-*/
-
-class offset_map_t;
-
-class cell_t final {
-  private:
-    friend class offset_map_t;
-
-    offset_t _offset{};
-    unsigned _size{};
-
-    // Only offset_map_t can create cells
-    cell_t() = default;
-
-    cell_t(offset_t offset, unsigned size) : _offset(offset), _size(size) {}
-
-    static interval_t to_interval(const offset_t o, unsigned size) {
-        return {static_cast<int>(o), static_cast<int>(o) + static_cast<int>(size - 1)};
-    }
-
-    [[nodiscard]] interval_t to_interval() const { return to_interval(_offset, _size); }
-
-  public:
-    [[nodiscard]] bool is_null() const { return _offset == 0 && _size == 0; }
-
-    [[nodiscard]] offset_t get_offset() const { return _offset; }
-
-    [[nodiscard]] variable_t get_scalar(data_kind_t kind) const { return variable_t::cell_var(kind, _offset, _size); }
-
-    // ignore the scalar variable
-    bool operator==(const cell_t& o) const { return to_interval() == o.to_interval(); }
-
-    // ignore the scalar variable
-    bool operator<(const cell_t& o) const {
-        if (_offset == o._offset)
-            return _size < o._size;
-        return _offset < o._offset;
-    }
-
-    // Return true if [o, o + size) definitely overlaps with the cell,
-    // where o is a constant expression.
-    bool overlap(const offset_t& o, unsigned size) const {
-        interval_t x = to_interval();
-        interval_t y = to_interval(o, size);
-        bool res = (!(x & y).is_bottom());
-        CRAB_LOG("array-expansion-overlap",
-                 std::cout << "**Checking if " << x << " overlaps with " << y << "=" << res << "\n";);
-        return res;
-    }
-
-    // Return true if [symb_lb, symb_ub] may overlap with the cell,
-    // where symb_lb and symb_ub are not constant expressions.
-    [[nodiscard]]
-    bool symbolic_overlap(const linear_expression_t& symb_lb,
-                          const linear_expression_t& symb_ub,
-                          const NumAbsDomain& dom) const;
-
-    friend std::ostream& operator<<(std::ostream& o, const cell_t& c) { return o << "cell(" << c.to_interval() << ")"; }
-};
-
-// forward declarations
-class array_domain_t;
-
-// Map offsets to cells
-class offset_map_t final {
-  private:
-    friend class array_domain_t;
-
-    using cell_set_t = std::set<cell_t>;
-
-    /*
-      The keys in the patricia tree are processing in big-endian
-      order. This means that the keys are sorted. Sortedness is
-      very important to efficiently perform operations such as
-      checking for overlap cells. Since keys are treated as bit
-      patterns, negative offsets can be used but they are treated
-      as large unsigned numbers.
-    */
-    using patricia_tree_t = radix_tree<offset_t, cell_set_t>;
-
-    patricia_tree_t _map;
-
-    // for algorithm::lower_bound and algorithm::upper_bound
-    struct compare_binding_t {
-        bool operator()(const typename patricia_tree_t::value_type& kv, const offset_t& o) const { return kv.first < o; }
-        bool operator()(const offset_t& o, const typename patricia_tree_t::value_type& kv) const { return o < kv.first; }
-        bool operator()(const typename patricia_tree_t::value_type& kv1,
-                        const typename patricia_tree_t::value_type& kv2) const {
-            return kv1.first < kv2.first;
-        }
-    };
-
-    void remove_cell(const cell_t& c);
-
-    void insert_cell(const cell_t& c);
-
-    [[nodiscard]] std::optional<cell_t> get_cell(offset_t o, unsigned size);
-
-    cell_t mk_cell(offset_t o, unsigned size);
-
-  public:
-    offset_map_t() = default;
-
-    [[nodiscard]] bool empty() const { return _map.empty(); }
-
-    [[nodiscard]] std::size_t size() const { return _map.size(); }
-
-    void operator-=(const cell_t& c) { remove_cell(c); }
-
-    void operator-=(const std::vector<cell_t>& cells) {
-        for (auto const& c : cells) {
-            this->operator-=(c);
-        }
-    }
-
-    // Return in out all cells that might overlap with (o, size).
-    std::vector<cell_t> get_overlap_cells(offset_t o, unsigned size);
-
-    [[nodiscard]] std::vector<cell_t> get_overlap_cells_symbolic_offset(const NumAbsDomain& dom,
-                                                                        const linear_expression_t& symb_lb,
-                                                                        const linear_expression_t& symb_ub);
-
-    friend std::ostream& operator<<(std::ostream& o, offset_map_t& m);
-
-    /* Operations needed if used as value in a separate_domain */
-    [[nodiscard]] bool is_top() const { return empty(); }
-    [[nodiscard]] bool is_bottom() const { return false; }
-    /*
-       We don't distinguish between bottom and top.
-       This is fine because separate_domain only calls bottom if
-       operator[] is called over a bottom state. Thus, we will make
-       sure that we don't call operator[] in that case.
-    */
-    static offset_map_t bottom() { return offset_map_t(); }
-    static offset_map_t top() { return offset_map_t(); }
-};
-
-// We use a global array map
-using array_map_t = std::unordered_map<data_kind_t, offset_map_t>;
-extern thread_local array_map_t global_array_map;
 void clear_global_state();
 
 class array_domain_t final {
     bitset_domain_t num_bytes;
-
-  private:
-    static offset_map_t& lookup_array_map(data_kind_t kind) { return global_array_map[kind]; }
-
-    static std::optional<std::pair<offset_t, unsigned>>
-    kill_and_find_var(NumAbsDomain& inv, data_kind_t kind, const linear_expression_t& i, const linear_expression_t& elem_size);
 
   public:
     array_domain_t() = default;
 
     array_domain_t(const bitset_domain_t& num_bytes) : num_bytes(num_bytes) { }
 
-    void set_to_top() {
-        num_bytes.set_to_top();
-    }
+    void set_to_top();
+    void set_to_bottom();
+    [[nodiscard]] bool is_bottom() const;
+    [[nodiscard]] bool is_top() const;
 
-    void set_to_bottom() { num_bytes.set_to_bottom(); }
+    bool operator<=(const array_domain_t& other) const;
+    bool operator==(const array_domain_t& other) const;
 
-    [[nodiscard]] bool is_bottom() const { return num_bytes.is_bottom(); }
+    void operator|=(const array_domain_t& other);
 
-    [[nodiscard]] bool is_top() const { return num_bytes.is_top(); }
+    array_domain_t operator|(const array_domain_t& other) &;
+    array_domain_t operator|(const array_domain_t& other) &&;
+    array_domain_t operator&(array_domain_t other);
+    array_domain_t widen(const array_domain_t& other);
+    array_domain_t widening_thresholds(const array_domain_t& other, const iterators::thresholds_t& ts);
+    array_domain_t narrow(const array_domain_t& other);
 
-    bool operator<=(const array_domain_t& other) { return num_bytes <= other.num_bytes; }
+    friend std::ostream& operator<<(std::ostream& o, const array_domain_t& dom);
 
-    bool operator==(const array_domain_t& other) {
-        return num_bytes == other.num_bytes;
-    }
-
-    void operator|=(const array_domain_t& other) {
-        if (is_bottom()) {
-            *this = other;
-            return;
-        }
-        num_bytes |= other.num_bytes;
-    }
-
-    array_domain_t operator|(const array_domain_t& other) & {
-        return array_domain_t(num_bytes | other.num_bytes);
-    }
-
-    array_domain_t operator|(const array_domain_t& other) && {
-        return array_domain_t(num_bytes | other.num_bytes);
-    }
-
-    array_domain_t operator&(array_domain_t other) {
-        return array_domain_t(num_bytes & other.num_bytes);
-    }
-
-    array_domain_t widen(const array_domain_t& other) {
-        return array_domain_t(num_bytes | other.num_bytes);
-    }
-
-    array_domain_t widening_thresholds(const array_domain_t& other, const iterators::thresholds_t& ts) {
-        return array_domain_t(num_bytes | other.num_bytes);
-    }
-
-    array_domain_t narrow(const array_domain_t& other) {
-        return array_domain_t(num_bytes & other.num_bytes);
-    }
-
-    friend std::ostream& operator<<(std::ostream& o, const array_domain_t& dom) {
-        return o << dom.num_bytes;
-    }
-
-    std::optional<linear_expression_t> load(NumAbsDomain& inv, data_kind_t kind, const linear_expression_t& i, int width);
     bool all_num(NumAbsDomain& inv, const linear_expression_t& lb, const linear_expression_t& ub);
 
+    std::optional<linear_expression_t> load(NumAbsDomain& inv, data_kind_t kind, const linear_expression_t& i, int width);
     std::optional<variable_t> store(NumAbsDomain& inv, data_kind_t kind, const linear_expression_t& idx, const linear_expression_t& elem_size,
                                     const linear_expression_t& val);
 
-    void havoc(NumAbsDomain& inv, data_kind_t kind, const linear_expression_t& idx, const linear_expression_t& elem_size) {
-        auto maybe_cell = kill_and_find_var(inv, kind, idx, elem_size);
-        if (maybe_cell && kind == data_kind_t::types) {
-            auto [offset, size] = *maybe_cell;
-            num_bytes.havoc(offset, size);
-        }
-    }
+    void havoc(NumAbsDomain& inv, data_kind_t kind, const linear_expression_t& idx, const linear_expression_t& elem_size);
 
     // Perform array stores over an array segment
-    void store_numbers(NumAbsDomain& inv, variable_t _idx, variable_t _width) {
-
-        // TODO: this should be an user parameter.
-        const number_t max_num_elems = EBPF_STACK_SIZE;
-
-        if (is_bottom())
-            return;
-
-        std::optional<number_t> idx_n = inv[_idx].singleton();
-        if (!idx_n) {
-            CRAB_WARN("array expansion store range ignored because ", "lower bound is not constant");
-            return;
-        }
-
-        std::optional<number_t> width = inv[_width].singleton();
-        if (!width) {
-            CRAB_WARN("array expansion store range ignored because ", "upper bound is not constant");
-            return;
-        }
-
-        if (*idx_n + *width > max_num_elems) {
-            CRAB_WARN("array expansion store range ignored because ",
-                      "the number of elements is larger than default limit of ", max_num_elems);
-            return;
-        }
-        num_bytes.reset((int)*idx_n, (int)*width);
-    }
-
+    void store_numbers(NumAbsDomain& inv, variable_t _idx, variable_t _width);
 };
 
 }

--- a/src/crab/array_domain.hpp
+++ b/src/crab/array_domain.hpp
@@ -66,7 +66,7 @@ public:
     offset_t(index_t index, int prefix_length) : _index(index), _prefix_length(prefix_length) {}
     explicit operator int() const { return static_cast<int>(_index); }
     operator index_t() const { return _index; }
-    int prefix_length() const { return _prefix_length; }
+    [[nodiscard]] int prefix_length() const { return _prefix_length; }
 
     index_t operator[](int n) const { return (_index >> (bitsize - 1 - n)) & 1; }
 };

--- a/src/crab/bitset_domain.hpp
+++ b/src/crab/bitset_domain.hpp
@@ -24,35 +24,35 @@ class bitset_domain_t final {
 
     [[nodiscard]] bool is_bottom() const { return false; }
 
-    bool operator<=(const bitset_domain_t& other) {
+    bool operator<=(const bitset_domain_t& other) const {
         return (non_numerical_bytes | other.non_numerical_bytes) == other.non_numerical_bytes;
     }
 
-    bool operator==(const bitset_domain_t& other) { return non_numerical_bytes == other.non_numerical_bytes; }
+    bool operator==(const bitset_domain_t& other) const { return non_numerical_bytes == other.non_numerical_bytes; }
 
     void operator|=(const bitset_domain_t& other) { non_numerical_bytes |= other.non_numerical_bytes; }
 
-    bitset_domain_t operator|(bitset_domain_t&& other) {
+    bitset_domain_t operator|(bitset_domain_t&& other) const {
         return non_numerical_bytes | other.non_numerical_bytes;
     }
 
-    bitset_domain_t operator|(const bitset_domain_t& other) {
+    bitset_domain_t operator|(const bitset_domain_t& other) const {
         return non_numerical_bytes | other.non_numerical_bytes;
     }
 
-    bitset_domain_t operator&(const bitset_domain_t& other) {
+    bitset_domain_t operator&(const bitset_domain_t& other) const {
         return non_numerical_bytes & other.non_numerical_bytes;
     }
 
-    bitset_domain_t widen(const bitset_domain_t& other) {
+    bitset_domain_t widen(const bitset_domain_t& other) const {
         return non_numerical_bytes | other.non_numerical_bytes;
     }
 
-    bitset_domain_t narrow(const bitset_domain_t& other) {
+    bitset_domain_t narrow(const bitset_domain_t& other) const {
         return non_numerical_bytes & other.non_numerical_bytes;
     }
 
-    std::pair<bool, bool> uniformity(size_t lb, int width) {
+    std::pair<bool, bool> uniformity(size_t lb, int width) const {
         bool only_num = true;
         bool only_non_num = true;
         for (int j = 0; j < width; j++) {
@@ -78,7 +78,7 @@ class bitset_domain_t final {
     friend std::ostream& operator<<(std::ostream& o, const bitset_domain_t& array);
 
     // Test whether all values in the range [lb,ub) are numerical.
-    bool all_num(int lb, int ub) {
+    bool all_num(int lb, int ub) const {
         assert(lb < ub);
         if (lb < 0 || ub > (int)non_numerical_bytes.size())
             return false;

--- a/src/crab/ebpf_domain.cpp
+++ b/src/crab/ebpf_domain.cpp
@@ -1,0 +1,1183 @@
+// Copyright (c) Prevail Verifier contributors.
+// SPDX-License-Identifier: MIT
+
+// This file is eBPF-specific, not derived from CRAB.
+
+#include <algorithm>
+#include <bitset>
+#include <functional>
+#include <optional>
+#include <utility>
+#include <vector>
+
+#include "boost/range/algorithm/set_algorithm.hpp"
+
+#include "crab_utils/stats.hpp"
+
+#include "crab/array_domain.hpp"
+#include "crab/ebpf_domain.hpp"
+#include "crab/interval.hpp"
+#include "crab/split_dbm.hpp"
+#include "crab/variable.hpp"
+
+#include "asm_ostream.hpp"
+#include "config.hpp"
+#include "dsl_syntax.hpp"
+#include "platform.hpp"
+#include "string_constraints.hpp"
+
+using crab::domains::NumAbsDomain;
+using crab::data_kind_t;
+
+struct reg_pack_t {
+    variable_t value, offset, type;
+};
+
+reg_pack_t reg_pack(int i) {
+    return {
+        variable_t::reg(data_kind_t::values, i),
+        variable_t::reg(data_kind_t::offsets, i),
+        variable_t::reg(data_kind_t::types, i),
+    };
+}
+reg_pack_t reg_pack(Reg r) { return reg_pack(r.v); }
+
+linear_constraint_t eq(variable_t a, variable_t b) {
+    using namespace crab::dsl_syntax;
+    return {a - b, constraint_kind_t::EQUALS_ZERO};
+}
+
+linear_constraint_t neq(variable_t a, variable_t b) {
+    using namespace crab::dsl_syntax;
+    return {a - b, constraint_kind_t::NOT_ZERO};
+}
+
+constexpr int MAX_PACKET_OFF = 0xffff;
+constexpr int64_t MY_INT_MAX = INT_MAX;
+constexpr int64_t PTR_MAX = MY_INT_MAX - MAX_PACKET_OFF;
+
+/** Linear constraint for a pointer comparison.
+ */
+static linear_constraint_t jmp_to_cst_offsets_reg(Condition::Op op, variable_t dst_offset, variable_t src_offset) {
+    using namespace crab::dsl_syntax;
+    using Op = Condition::Op;
+    switch (op) {
+    case Op::EQ: return eq(dst_offset, src_offset);
+    case Op::NE: return neq(dst_offset, src_offset);
+    case Op::GE: return dst_offset >= src_offset;
+    case Op::SGE: return dst_offset >= src_offset; // pointer comparison is unsigned
+    case Op::LE: return dst_offset <= src_offset;
+    case Op::SLE: return dst_offset <= src_offset; // pointer comparison is unsigned
+    case Op::GT: return dst_offset > src_offset;
+    case Op::SGT: return dst_offset > src_offset; // pointer comparison is unsigned
+    case Op::SLT: return src_offset > dst_offset;
+    // Note: reverse the test as a workaround strange lookup:
+    case Op::LT: return src_offset > dst_offset; // FIX unsigned
+    default: return dst_offset - dst_offset == 0;
+    }
+}
+
+/** Linear constraints for a comparison with a constant.
+ */
+static std::vector<linear_constraint_t> jmp_to_cst_imm(Condition::Op op, variable_t dst_value, int imm) {
+    using namespace crab::dsl_syntax;
+    using Op = Condition::Op;
+    switch (op) {
+    case Op::EQ: return {dst_value == imm};
+    case Op::NE: return {dst_value != imm};
+    case Op::GE: return {dst_value >= (unsigned)imm}; // FIX unsigned
+    case Op::SGE: return {dst_value >= imm};
+    case Op::LE: return {dst_value <= imm, 0 <= dst_value}; // FIX unsigned
+    case Op::SLE: return {dst_value <= imm};
+    case Op::GT: return {dst_value > (unsigned)imm}; // FIX unsigned
+    case Op::SGT: return {dst_value > imm};
+    case Op::LT: return {dst_value < (unsigned)imm}; // FIX unsigned
+    case Op::SLT: return {dst_value < imm};
+    case Op::SET: throw std::exception();
+    case Op::NSET: return {};
+    }
+    return {};
+}
+
+/** Linear constraint for a numerical comparison between registers.
+ */
+static std::vector<linear_constraint_t> jmp_to_cst_reg(Condition::Op op, variable_t dst_value, variable_t src_value) {
+    using namespace crab::dsl_syntax;
+    using Op = Condition::Op;
+    switch (op) {
+    case Op::EQ: return {eq(dst_value, src_value)};
+    case Op::NE: return {neq(dst_value, src_value)};
+    case Op::GE: return {dst_value >= src_value}; // FIX unsigned
+    case Op::SGE: return {dst_value >= src_value};
+    case Op::LE: return {dst_value <= src_value, 0 <= dst_value}; // FIX unsigned
+    case Op::SLE: return {dst_value <= src_value};
+    case Op::GT: return {dst_value > src_value}; // FIX unsigned
+    case Op::SGT: return {dst_value > src_value};
+    // Note: reverse the test as a workaround strange lookup:
+    case Op::LT: return {src_value > dst_value}; // FIX unsigned
+    case Op::SLT: return {src_value > dst_value};
+    case Op::SET: throw std::exception();
+    case Op::NSET: return {};
+    }
+    return {};
+}
+
+static bool is_unsigned_cmp(Condition::Op op) {
+    using Op = Condition::Op;
+    switch (op) {
+    case Op::GE:
+    case Op::LE:
+    case Op::GT:
+    case Op::LT: return true;
+    default: return false;
+    }
+    return {};
+}
+
+void ebpf_domain_t::set_require_check(std::function<check_require_func_t> f) { check_require = std::move(f); }
+
+ebpf_domain_t ebpf_domain_t::top() {
+    ebpf_domain_t abs;
+    abs.set_to_top();
+    return abs;
+}
+
+ebpf_domain_t ebpf_domain_t::bottom() {
+    ebpf_domain_t abs;
+    abs.set_to_bottom();
+    return abs;
+}
+
+ebpf_domain_t::ebpf_domain_t() : m_inv(NumAbsDomain::top()) {}
+
+ebpf_domain_t::ebpf_domain_t(NumAbsDomain inv, crab::domains::array_domain_t stack) : m_inv(std::move(inv)), stack(stack) {}
+
+void ebpf_domain_t::set_to_top() {
+    m_inv.set_to_top();
+    stack.set_to_top();
+}
+
+void ebpf_domain_t::set_to_bottom() { m_inv.set_to_bottom(); }
+
+bool ebpf_domain_t::is_bottom() const { return m_inv.is_bottom(); }
+
+bool ebpf_domain_t::is_top() const { return m_inv.is_top() && stack.is_top(); }
+
+bool ebpf_domain_t::operator<=(const ebpf_domain_t& other) {
+    return m_inv <= other.m_inv && stack <= other.stack;
+}
+
+bool ebpf_domain_t::operator==(ebpf_domain_t other) {
+    return stack == other.stack && m_inv <= other.m_inv && other.m_inv <= m_inv;
+}
+
+void ebpf_domain_t::operator|=(ebpf_domain_t&& other) {
+    if (is_bottom()) {
+        *this = other;
+        return;
+    }
+    m_inv |= other.m_inv;
+    stack |= other.stack;
+}
+
+void ebpf_domain_t::operator|=(const ebpf_domain_t& other) {
+    ebpf_domain_t tmp{other};
+    operator|=(std::move(tmp));
+}
+
+ebpf_domain_t ebpf_domain_t::operator|(ebpf_domain_t&& other) {
+    return ebpf_domain_t(m_inv | other.m_inv, stack | other.stack);
+}
+
+ebpf_domain_t ebpf_domain_t::operator|(const ebpf_domain_t& other) & {
+    return ebpf_domain_t(m_inv | other.m_inv, stack | other.stack);
+}
+
+ebpf_domain_t ebpf_domain_t::operator|(const ebpf_domain_t& other) && {
+    return ebpf_domain_t(m_inv | other.m_inv, stack | other.stack);
+}
+
+ebpf_domain_t ebpf_domain_t::operator&(ebpf_domain_t other) {
+    return ebpf_domain_t(m_inv & std::move(other.m_inv), stack & other.stack);
+}
+
+ebpf_domain_t ebpf_domain_t::widen(const ebpf_domain_t& other) {
+    return ebpf_domain_t(m_inv.widen(other.m_inv), stack | other.stack);
+}
+
+ebpf_domain_t ebpf_domain_t::widening_thresholds(const ebpf_domain_t& other, const crab::iterators::thresholds_t& ts) {
+    return ebpf_domain_t(m_inv.widening_thresholds(other.m_inv, ts), stack | other.stack);
+}
+
+ebpf_domain_t ebpf_domain_t::narrow(const ebpf_domain_t& other) {
+    return ebpf_domain_t(m_inv.narrow(other.m_inv), stack & other.stack);
+}
+
+void ebpf_domain_t::operator+=(const linear_constraint_t& cst) { m_inv += cst; }
+
+void ebpf_domain_t::operator-=(variable_t var) { m_inv -= var; }
+
+void ebpf_domain_t::assign(variable_t x, const linear_expression_t& e) { m_inv.assign(x, e); }
+void ebpf_domain_t::assign(variable_t x, long e) { m_inv.set(x, crab::interval_t(number_t(e))); }
+
+void ebpf_domain_t::apply(crab::arith_binop_t op, variable_t x, variable_t y, const number_t& z) { m_inv.apply(op, x, y, z); }
+
+void ebpf_domain_t::apply(crab::arith_binop_t op, variable_t x, variable_t y, variable_t z) { m_inv.apply(op, x, y, z); }
+
+void ebpf_domain_t::apply(crab::bitwise_binop_t op, variable_t x, variable_t y, variable_t z) { m_inv.apply(op, x, y, z); }
+
+void ebpf_domain_t::apply(crab::bitwise_binop_t op, variable_t x, variable_t y, const number_t& k) { m_inv.apply(op, x, y, k); }
+
+void ebpf_domain_t::apply(crab::binop_t op, variable_t x, variable_t y, const number_t& z) {
+    std::visit([&](auto top) { apply(top, x, y, z); }, op);
+}
+
+void ebpf_domain_t::apply(crab::binop_t op, variable_t x, variable_t y, variable_t z) {
+    std::visit([&](auto top) { apply(top, x, y, z); }, op);
+}
+
+NumAbsDomain ebpf_domain_t::when(const linear_constraint_t& cond) {
+    NumAbsDomain inv = m_inv;
+    inv += cond;
+    return inv;
+}
+
+void ebpf_domain_t::scratch_caller_saved_registers() {
+    for (int i = R1_ARG; i <= R5_ARG; i++) {
+        auto reg = reg_pack(i);
+        havoc(reg.value);
+        havoc(reg.offset);
+        havoc(reg.type);
+    }
+}
+
+void ebpf_domain_t::forget_packet_pointers() {
+    using namespace crab::dsl_syntax;
+
+    initialize_packet(*this);
+
+    for (variable_t v : variable_t::get_type_variables()) {
+        // TODO: this is sufficient, but for clarity it may be useful to forget the offset and value too.
+       if (m_inv.intersect(v == T_PACKET))
+           m_inv -= v;
+    }
+}
+
+void ebpf_domain_t::apply(NumAbsDomain& inv, crab::binop_t op, variable_t x, variable_t y, const number_t& z, bool finite_width) {
+    inv.apply(op, x, y, z);
+    if (finite_width)
+        overflow(x);
+}
+
+void ebpf_domain_t::apply(NumAbsDomain& inv, crab::binop_t op, variable_t x, variable_t y, variable_t z, bool finite_width) {
+    inv.apply(op, x, y, z);
+    if (finite_width)
+        overflow(x);
+}
+
+void ebpf_domain_t::add(variable_t lhs, variable_t op2) { apply(m_inv, crab::arith_binop_t::ADD, lhs, lhs, op2); }
+void ebpf_domain_t::add(variable_t lhs, const number_t& op2) { apply(m_inv, crab::arith_binop_t::ADD, lhs, lhs, op2); }
+void ebpf_domain_t::sub(variable_t lhs, variable_t op2) { apply(m_inv, crab::arith_binop_t::SUB, lhs, lhs, op2); }
+void ebpf_domain_t::sub(variable_t lhs, const number_t& op2) { apply(m_inv, crab::arith_binop_t::SUB, lhs, lhs, op2); }
+void ebpf_domain_t::add_overflow(variable_t lhs, variable_t op2) { apply(m_inv, crab::arith_binop_t::ADD, lhs, lhs, op2, true); }
+void ebpf_domain_t::add_overflow(variable_t lhs, const number_t& op2) { apply(m_inv, crab::arith_binop_t::ADD, lhs, lhs, op2, true); }
+void ebpf_domain_t::sub_overflow(variable_t lhs, variable_t op2) { apply(m_inv, crab::arith_binop_t::SUB, lhs, lhs, op2, true); }
+void ebpf_domain_t::sub_overflow(variable_t lhs, const number_t& op2) { apply(m_inv, crab::arith_binop_t::SUB, lhs, lhs, op2, true); }
+void ebpf_domain_t::neg(variable_t lhs) { apply(m_inv, crab::arith_binop_t::MUL, lhs, lhs, (number_t)-1, true); }
+void ebpf_domain_t::mul(variable_t lhs, variable_t op2) { apply(m_inv, crab::arith_binop_t::MUL, lhs, lhs, op2, true); }
+void ebpf_domain_t::mul(variable_t lhs, const number_t& op2) { apply(m_inv, crab::arith_binop_t::MUL, lhs, lhs, op2, true); }
+void ebpf_domain_t::div(variable_t lhs, variable_t op2) { apply(m_inv, crab::arith_binop_t::SDIV, lhs, lhs, op2, true); }
+void ebpf_domain_t::div(variable_t lhs, const number_t& op2) { apply(m_inv, crab::arith_binop_t::SDIV, lhs, lhs, op2, true); }
+void ebpf_domain_t::udiv(variable_t lhs, variable_t op2) { apply(m_inv, crab::arith_binop_t::UDIV, lhs, lhs, op2, true); }
+void ebpf_domain_t::udiv(variable_t lhs, const number_t& op2) { apply(m_inv, crab::arith_binop_t::UDIV, lhs, lhs, op2, true); }
+void ebpf_domain_t::rem(variable_t lhs, variable_t op2) { apply(m_inv, crab::arith_binop_t::SREM, lhs, lhs, op2, true); }
+void ebpf_domain_t::rem(variable_t lhs, const number_t& op2, bool mod) {
+    apply(m_inv, crab::arith_binop_t::SREM, lhs, lhs, op2, mod);
+}
+void ebpf_domain_t::urem(variable_t lhs, variable_t op2) { apply(m_inv, crab::arith_binop_t::UREM, lhs, lhs, op2, true); }
+void ebpf_domain_t::urem(variable_t lhs, const number_t& op2) { apply(m_inv, crab::arith_binop_t::UREM, lhs, lhs, op2, true); }
+
+void ebpf_domain_t::bitwise_and(variable_t lhs, variable_t op2) { apply(m_inv, crab::bitwise_binop_t::AND, lhs, lhs, op2); }
+void ebpf_domain_t::bitwise_and(variable_t lhs, const number_t& op2) { apply(m_inv, crab::bitwise_binop_t::AND, lhs, lhs, op2); }
+void ebpf_domain_t::bitwise_or(variable_t lhs, variable_t op2) { apply(m_inv, crab::bitwise_binop_t::OR, lhs, lhs, op2); }
+void ebpf_domain_t::bitwise_or(variable_t lhs, const number_t& op2) { apply(m_inv, crab::bitwise_binop_t::OR, lhs, lhs, op2); }
+void ebpf_domain_t::bitwise_xor(variable_t lhs, variable_t op2) { apply(m_inv, crab::bitwise_binop_t::XOR, lhs, lhs, op2); }
+void ebpf_domain_t::bitwise_xor(variable_t lhs, const number_t& op2) { apply(m_inv, crab::bitwise_binop_t::XOR, lhs, lhs, op2); }
+void ebpf_domain_t::shl_overflow(variable_t lhs, variable_t op2) { apply(m_inv, crab::bitwise_binop_t::SHL, lhs, lhs, op2, true); }
+void ebpf_domain_t::shl_overflow(variable_t lhs, const number_t& op2) { apply(m_inv, crab::bitwise_binop_t::SHL, lhs, lhs, op2, true); }
+void ebpf_domain_t::lshr(variable_t lhs, variable_t op2) { apply(m_inv, crab::bitwise_binop_t::LSHR, lhs, lhs, op2); }
+void ebpf_domain_t::lshr(variable_t lhs, const number_t& op2) { apply(m_inv, crab::bitwise_binop_t::LSHR, lhs, lhs, op2); }
+void ebpf_domain_t::ashr(variable_t lhs, variable_t op2) { apply(m_inv, crab::bitwise_binop_t::ASHR, lhs, lhs, op2); }
+void ebpf_domain_t::ashr(variable_t lhs, number_t op2) { apply(m_inv, crab::bitwise_binop_t::ASHR, lhs, lhs, op2); }
+
+
+static void assume(NumAbsDomain& inv, const linear_constraint_t& cst) { inv += cst; }
+void ebpf_domain_t::assume(const linear_constraint_t& cst) { ::assume(m_inv, cst); }
+
+void ebpf_domain_t::require(NumAbsDomain& inv, const linear_constraint_t& cst, const std::string& s) {
+    if (check_require)
+        check_require(inv, cst, std::move(s));
+    ::assume(inv, cst);
+}
+
+/// Forget everything we know about the value of a variable.
+void ebpf_domain_t::havoc(variable_t v) { m_inv -= v; }
+
+void ebpf_domain_t::assign(variable_t lhs, variable_t rhs) { m_inv.assign(lhs, rhs); }
+
+void ebpf_domain_t::assert_no_pointer(const reg_pack_t& reg) {
+    using namespace crab::dsl_syntax;
+    require(m_inv, reg.type == T_NUM, "invalid operation on a non-numerical value");
+    havoc(reg.offset);
+}
+
+static linear_constraint_t is_shared(variable_t v) {
+    using namespace crab::dsl_syntax;
+    return v > T_SHARED;
+}
+
+static linear_constraint_t is_pointer(const reg_pack_t& r) {
+    using namespace crab::dsl_syntax;
+    return r.type >= T_CTX;
+}
+
+void ebpf_domain_t::overflow(variable_t lhs) {
+    using namespace crab::dsl_syntax;
+    auto interval = m_inv[lhs];
+    // handle overflow, assuming 64 bit
+    number_t max(std::numeric_limits<int64_t>::max() / 2);
+    number_t min(std::numeric_limits<int64_t>::min() / 2);
+    if (interval.lb() <= min || interval.ub() >= max)
+        havoc(lhs);
+}
+
+void ebpf_domain_t::operator()(const basic_block_t& bb, bool check_termination) {
+    for (const Instruction& statement : bb) {
+        std::visit(*this, statement);
+    }
+    if (check_termination) {
+        // +1 to avoid being tricked by empty loops
+        add(variable_t::instruction_count(), crab::number_t((unsigned)bb.size() + 1));
+    }
+}
+
+int ebpf_domain_t::get_instruction_count_upper_bound() {
+    const auto& ub = m_inv[variable_t::instruction_count()].ub();
+    return (ub.is_finite() && ub.number().value().fits_sint()) ? (int)ub.number().value() : INT_MAX;
+}
+
+NumAbsDomain ebpf_domain_t::check_access_packet(NumAbsDomain inv, const linear_expression_t& lb, const linear_expression_t& ub, const std::string& s,
+                                                bool is_comparison_check) {
+    using namespace crab::dsl_syntax;
+    require(inv, lb >= variable_t::meta_offset(), std::string("Lower bound must be at least meta_offset") + s);
+    if (is_comparison_check)
+        require(inv, ub <= MAX_PACKET_OFF,
+                std::string("Upper bound must be at most ") + std::to_string(MAX_PACKET_OFF) + s);
+    else
+        require(inv, ub <= variable_t::packet_size(),
+                std::string("Upper bound must be at most packet_size") + s);
+    return inv;
+}
+
+NumAbsDomain ebpf_domain_t::check_access_stack(NumAbsDomain inv, const linear_expression_t& lb, const linear_expression_t& ub, const std::string& s) {
+    using namespace crab::dsl_syntax;
+    require(inv, lb >= 0, std::string("Lower bound must be at least 0") + s);
+    require(inv, ub <= EBPF_STACK_SIZE, std::string("Upper bound must be at most EBPF_STACK_SIZE") + s + std::string(", make sure to bounds check any pointer access"));
+    return inv;
+}
+
+NumAbsDomain ebpf_domain_t::check_access_shared(NumAbsDomain inv, const linear_expression_t& lb, const linear_expression_t& ub, const std::string& s,
+                                        variable_t reg_type) {
+    using namespace crab::dsl_syntax;
+    require(inv, lb >= 0, std::string("Lower bound must be at least 0") + s);
+    require(inv, ub <= reg_type, std::string("Upper bound must be at most ") + reg_type.name() + s);
+    return inv;
+}
+
+NumAbsDomain ebpf_domain_t::check_access_context(NumAbsDomain inv, const linear_expression_t& lb, const linear_expression_t& ub, const std::string& s) {
+    using namespace crab::dsl_syntax;
+    require(inv, lb >= 0, std::string("Lower bound must be at least 0") + s);
+    require(inv, ub <= global_program_info.type.context_descriptor->size,
+            std::string("Upper bound must be at most ") + std::to_string(global_program_info.type.context_descriptor->size) +
+                s);
+    return inv;
+}
+
+void ebpf_domain_t::operator()(const Assume& s) {
+    using namespace crab::dsl_syntax;
+    Condition cond = s.cond;
+    auto dst = reg_pack(cond.left);
+    if (std::holds_alternative<Reg>(cond.right)) {
+        auto src = reg_pack(std::get<Reg>(cond.right));
+        int stype = get_type(src.type);
+        int dtype = get_type(dst.type);
+        if (stype == dtype) {
+            switch (stype) {
+                case T_MAP: break;
+                case T_MAP_PROGRAMS: break;
+                case T_UNINIT: break;
+                case T_NUM: {
+                    if (!is_unsigned_cmp(cond.op))
+                        for (const linear_constraint_t& cst : jmp_to_cst_reg(cond.op, dst.value, src.value))
+                            m_inv += cst;
+                    return;
+                }
+                default: {
+                    m_inv += jmp_to_cst_offsets_reg(cond.op, dst.offset, src.offset);
+                    return;
+                }
+            }
+        }
+        NumAbsDomain different{m_inv};
+        different += neq(dst.type, src.type);
+
+        NumAbsDomain null_src{different};
+        null_src += is_pointer(dst);
+        NumAbsDomain null_dst{different};
+        null_dst += is_pointer(src);
+
+        m_inv += eq(dst.type, src.type);
+
+        NumAbsDomain numbers{m_inv};
+        numbers += dst.type == T_NUM;
+        if (!is_unsigned_cmp(cond.op))
+            for (const linear_constraint_t& cst : jmp_to_cst_reg(cond.op, dst.value, src.value))
+                numbers += cst;
+
+        m_inv += is_pointer(dst);
+        m_inv += jmp_to_cst_offsets_reg(cond.op, dst.offset, src.offset);
+
+        m_inv |= std::move(numbers);
+
+        m_inv |= std::move(null_src);
+        m_inv |= std::move(null_dst);
+    } else {
+        int imm = static_cast<int>(std::get<Imm>(cond.right).v);
+        for (const linear_constraint_t& cst : jmp_to_cst_imm(cond.op, dst.value, imm))
+            assume(cst);
+    }
+}
+
+void ebpf_domain_t::operator()(const Undefined& a) {}
+void ebpf_domain_t::operator()(const Un& stmt) {
+    auto dst = reg_pack(stmt.dst);
+    switch (stmt.op) {
+    case Un::Op::LE16:
+    case Un::Op::LE32:
+    case Un::Op::LE64:
+        havoc(dst.value);
+        assert_no_pointer(dst);
+        break;
+    case Un::Op::NEG:
+        neg(dst.value);
+        assert_no_pointer(dst);
+        break;
+    }
+}
+void ebpf_domain_t::operator()(const Exit& a) {}
+void ebpf_domain_t::operator()(const Jmp& a) {}
+
+void ebpf_domain_t::operator()(const Comparable& s) { require(m_inv, eq(reg_pack(s.r1).type, reg_pack(s.r2).type), to_string(s)); }
+
+void ebpf_domain_t::operator()(const Addable& s) {
+    using namespace crab::dsl_syntax;
+    linear_constraint_t cond = reg_pack(s.ptr).type > T_NUM;
+    NumAbsDomain is_ptr{m_inv};
+    is_ptr += cond;
+    require(is_ptr, reg_pack(s.num).type == T_NUM, "only numbers can be added to pointers (" + to_string(s) + ")");
+
+    m_inv += cond.negate();
+    m_inv |= std::move(is_ptr);
+}
+
+void ebpf_domain_t::operator()(const ValidSize& s) {
+    using namespace crab::dsl_syntax;
+    auto r = reg_pack(s.reg);
+    require(m_inv, s.can_be_zero ? r.value >= 0 : r.value > 0, to_string(s));
+}
+
+void ebpf_domain_t::operator()(const ValidMapKeyValue& s) {
+    using namespace crab::dsl_syntax;
+
+    // Get the actual map_fd value to look up the key size and value size.
+    auto fd_reg = reg_pack(s.map_fd_reg);
+    crab::interval_t fd_interval = m_inv[fd_reg.offset];
+    std::optional<EbpfMapType> map_type;
+    uint32_t max_entries = 0;
+    if (fd_interval.is_bottom()) {
+        m_inv.set(variable_t::map_value_size(), crab::interval_t::bottom());
+        m_inv.set(variable_t::map_key_size(), crab::interval_t::bottom());
+    } else {
+        std::optional<number_t> fd_opt = fd_interval.singleton();
+        if (fd_opt.has_value()) {
+            number_t map_fd = *fd_opt;
+            EbpfMapDescriptor& map_descriptor = global_program_info.platform->get_map_descriptor((int)map_fd);
+            m_inv.assign(variable_t::map_value_size(), (int)map_descriptor.value_size);
+            m_inv.assign(variable_t::map_key_size(), (int)map_descriptor.key_size);
+            map_type = global_program_info.platform->get_map_type(map_descriptor.type);
+            max_entries = map_descriptor.max_entries;
+        } else {
+            m_inv.set(variable_t::map_value_size(), crab::interval_t::top());
+            m_inv.set(variable_t::map_key_size(), crab::interval_t::top());
+        }
+    }
+
+    auto access_reg = reg_pack(s.access_reg);
+
+    variable_t lb = access_reg.offset;
+    variable_t width = s.key ? variable_t::map_key_size() : variable_t::map_value_size();
+    linear_expression_t ub = lb + width;
+    std::string m = std::string(" (") + to_string(s) + ")";
+    require(m_inv, access_reg.type >= T_STACK, "Only stack or packet can be used as a parameter" + m);
+    require(m_inv, access_reg.type <= T_PACKET, "Only stack or packet can be used as a parameter" + m);
+
+    auto when_stack = when(access_reg.type == T_STACK);
+    if (!when_stack.is_bottom()) {
+        if (!stack.all_num(when_stack, lb, ub)) {
+            auto lb_is = when_stack[lb].lb().number();
+            std::string lb_s = lb_is && lb_is->fits_sint() ? std::to_string((int)*lb_is) : "-oo";
+            auto ub_is = when_stack.eval_interval(ub).ub().number();
+            std::string ub_s = ub_is && ub_is->fits_sint() ? std::to_string((int)*ub_is) : "oo";
+            require(when_stack, access_reg.type != T_STACK, "Illegal map update with a non-numerical value [" + lb_s + "-" + ub_s + ")");
+        } else if (thread_local_options.strict && map_type.has_value() && map_type->is_array) {
+            // Get offset value.
+            variable_t key_ptr = access_reg.offset;
+            std::optional<number_t> offset = m_inv[key_ptr].singleton();
+            if (!offset.has_value()) {
+                require(m_inv, linear_constraint_t::FALSE(), "Pointer must be a singleton");
+            } else if (s.key) {
+                // Look up the value pointed to by the key pointer.
+                variable_t key_value =
+                    variable_t::cell_var(data_kind_t::values, (uint64_t)offset.value(), sizeof(uint32_t));
+
+                require(m_inv, key_value < max_entries, "Array index overflow");
+                require(m_inv, key_value >= 0, "Array index underflow");
+            }
+        }
+    }
+
+    m_inv = check_access_packet(when(access_reg.type == T_PACKET), lb, ub, m, false) |
+            check_access_stack(when(access_reg.type == T_STACK), lb, ub, m);
+}
+
+void ebpf_domain_t::operator()(const ValidAccess& s) {
+    using namespace crab::dsl_syntax;
+
+    bool is_comparison_check = s.width == (Value)Imm{0};
+
+    auto reg = reg_pack(s.reg);
+    linear_expression_t lb = reg.offset + s.offset;
+    linear_expression_t ub = std::holds_alternative<Imm>(s.width)
+        ? lb + std::get<Imm>(s.width).v
+        : lb + reg_pack(std::get<Reg>(s.width)).value;
+    std::string m = std::string(" (") + to_string(s) + ")";
+
+    NumAbsDomain assume_ptr =
+        check_access_packet(when(reg.type == T_PACKET), lb, ub, m, is_comparison_check) |
+        check_access_stack(when(reg.type == T_STACK), lb, ub, m) |
+        check_access_shared(when(is_shared(reg.type)), lb, ub, m, reg.type) |
+        check_access_context(when(reg.type == T_CTX), lb, ub, m);
+    if (is_comparison_check) {
+        assume(reg.type <= T_NUM);
+        m_inv |= std::move(assume_ptr);
+        return;
+    } else {
+        if (s.or_null) {
+            require(m_inv, reg.type >= T_NUM, "Must be a pointer or null");
+            assume(reg.type == T_NUM);
+            require(m_inv, reg.value == 0, "Pointers may be compared only to the number 0");
+            m_inv |= std::move(assume_ptr);
+            return;
+        } else {
+            require(m_inv, reg.type > T_NUM, "Only pointers can be dereferenced");
+            require(m_inv, reg.value > 0, "Possible null access");
+            m_inv = std::move(assume_ptr);
+            return;
+        }
+    }
+}
+
+void ebpf_domain_t::operator()(const ValidStore& s) {
+    using namespace crab::dsl_syntax;
+    linear_constraint_t cond = reg_pack(s.mem).type != T_STACK;
+
+    NumAbsDomain non_stack{m_inv};
+    non_stack += cond;
+    require(non_stack, reg_pack(s.val).type == T_NUM, "Only numbers can be stored to externally-visible regions");
+
+    m_inv += cond.negate();
+    m_inv |= std::move(non_stack);
+}
+
+void ebpf_domain_t::operator()(const TypeConstraint& s) {
+    using namespace crab::dsl_syntax;
+    variable_t t = reg_pack(s.reg).type;
+    std::string str = to_string(s);
+    switch (s.types) {
+    case TypeGroup::number: require(m_inv, t == T_NUM, str); break;
+    case TypeGroup::map_fd: require(m_inv, t == T_MAP, str); break;
+    case TypeGroup::map_fd_programs: require(m_inv, t == T_MAP_PROGRAMS, str); break;
+    case TypeGroup::ctx: require(m_inv, t == T_CTX, str); break;
+    case TypeGroup::packet: require(m_inv, t == T_PACKET, str); break;
+    case TypeGroup::stack: require(m_inv, t == T_STACK, str); break;
+    case TypeGroup::shared: require(m_inv, t > T_SHARED, str); break;
+    case TypeGroup::non_map_fd: require(m_inv, t >= T_NUM, str); break;
+    case TypeGroup::mem: require(m_inv, t >= T_STACK, str); break;
+    case TypeGroup::mem_or_num:
+        require(m_inv, t >= T_NUM, str);
+        require(m_inv, t != T_CTX, str);
+        break;
+    case TypeGroup::pointer: require(m_inv, t >= T_CTX, str); break;
+    case TypeGroup::ptr_or_num: require(m_inv, t >= T_NUM, str); break;
+    case TypeGroup::stack_or_packet:
+        require(m_inv, t >= T_STACK, str);
+        require(m_inv, t <= T_PACKET, str);
+        break;
+    }
+}
+
+void ebpf_domain_t::operator()(const ZeroOffset& s) {
+    using namespace crab::dsl_syntax;
+    auto reg = reg_pack(s.reg);
+    require(m_inv, reg.offset == 0, to_string(s));
+}
+
+void ebpf_domain_t::operator()(const Assert& stmt) { std::visit(*this, stmt.cst); };
+
+void ebpf_domain_t::operator()(const Packet& a) {
+    auto reg = reg_pack(R0_RETURN_VALUE);
+    assign(reg.type, T_NUM);
+    havoc(reg.offset);
+    havoc(reg.value);
+    scratch_caller_saved_registers();
+}
+
+NumAbsDomain ebpf_domain_t::do_load_stack(NumAbsDomain inv, const reg_pack_t& target, const linear_expression_t& addr, int width) {
+    if (width == 1 || width == 2 || width == 4 || width == 8) {
+        inv.assign(target.type, stack.load(inv, data_kind_t::types, addr, width));
+        inv.assign(target.value, stack.load(inv,  data_kind_t::values, addr, width));
+        inv.assign(target.offset, stack.load(inv, data_kind_t::offsets, addr, width));
+    } else {
+        inv.assign(target.type, stack.load(inv, data_kind_t::types, addr, width));
+        inv -= target.value;
+        inv -= target.offset;
+    }
+    return inv;
+}
+
+NumAbsDomain ebpf_domain_t::do_load_ctx(NumAbsDomain inv, const reg_pack_t& target, const linear_expression_t& addr_vague, int width) {
+    using namespace crab::dsl_syntax;
+    if (inv.is_bottom())
+        return inv;
+
+    const ebpf_context_descriptor_t* desc = global_program_info.type.context_descriptor;
+
+    inv -= target.value;
+
+    if (desc->end < 0) {
+        inv -= target.offset;
+        inv.assign(target.type, T_NUM);
+        return inv;
+    }
+
+    crab::interval_t interval = inv.eval_interval(addr_vague);
+    std::optional<number_t> maybe_addr = interval.singleton();
+
+    bool may_touch_ptr = interval[desc->data] || interval[desc->end] || interval[desc->end];
+
+    if (!maybe_addr) {
+        inv -= target.offset;
+        if (may_touch_ptr)
+            inv -= target.type;
+        else
+            inv.assign(target.type, T_NUM);
+        return inv;
+    }
+
+    number_t addr = *maybe_addr;
+
+    if (addr == desc->data) {
+        inv.assign(target.offset, 0);
+    } else if (addr == desc->end) {
+        inv.assign(target.offset, variable_t::packet_size());
+    } else if (addr == desc->meta) {
+        inv.assign(target.offset, variable_t::meta_offset());
+    } else {
+        inv -= target.offset;
+        if (may_touch_ptr)
+            inv -= target.type;
+        else
+            inv.assign(target.type, T_NUM);
+        return inv;
+    }
+    inv.assign(target.type, T_PACKET);
+    inv += 4098 <= target.value;
+    inv += target.value <= PTR_MAX;
+    return inv;
+}
+
+NumAbsDomain ebpf_domain_t::do_load_packet_or_shared(NumAbsDomain inv, const reg_pack_t& target, const linear_expression_t& addr, int width) {
+    if (inv.is_bottom())
+        return inv;
+
+    inv.assign(target.type, T_NUM);
+    inv -= target.offset;
+
+    // A 1 or 2 byte copy results in a limited range of values that may be used as array indices.
+    if (width == 1) {
+        inv.set(target.value, crab::interval_t(0, UINT8_MAX));
+    } else if (width == 2) {
+        inv.set(target.value, crab::interval_t(0, UINT16_MAX));
+    } else {
+        inv -= target.value;
+    }
+    return inv;
+}
+
+void ebpf_domain_t::do_load(const Mem& b, const reg_pack_t& target) {
+    using namespace crab::dsl_syntax;
+    auto mem_reg = reg_pack(b.access.basereg);
+    int width = b.access.width;
+    int offset = b.access.offset;
+    linear_expression_t addr = mem_reg.offset + (number_t)offset;
+
+    if (b.access.basereg.v == R10_STACK_POINTER) {
+        m_inv = do_load_stack(std::move(m_inv), target, addr, width);
+        return;
+    }
+
+    int type = get_type(mem_reg.type);
+    if (type == T_UNINIT) {
+        return;
+    }
+
+    switch (type) {
+        case T_UNINIT: {
+            m_inv = do_load_ctx(when(mem_reg.type == T_CTX), target, addr, width) |
+                    do_load_packet_or_shared(when(mem_reg.type >= T_PACKET), target, addr, width) |
+                    do_load_stack(when(mem_reg.type == T_STACK), target, addr, width);
+            return;
+        }
+        case T_MAP: return;
+        case T_MAP_PROGRAMS: return;
+        case T_NUM: return;
+        case T_CTX: m_inv = do_load_ctx(std::move(m_inv), target, addr, width); break;
+        case T_STACK: m_inv = do_load_stack(std::move(m_inv), target, addr, width); break;
+        default: m_inv = do_load_packet_or_shared(std::move(m_inv), target, addr, width); break;
+    }
+}
+
+int ebpf_domain_t::get_type(variable_t v) {
+    auto res = m_inv[v].singleton();
+    if (!res)
+        return T_UNINIT;
+    return (int)*res;
+}
+
+int ebpf_domain_t::get_type(int t) { return t; }
+
+template <typename A, typename X, typename Y, typename Z>
+void ebpf_domain_t::do_store_stack(NumAbsDomain& inv, int width, const A& addr, X val_type, Y val_value,
+                    std::optional<Z> opt_val_offset) {
+    inv.assign(stack.store(inv, data_kind_t::types, addr, width, val_type), val_type);
+    if (width == 8) {
+        inv.assign(stack.store(inv, data_kind_t::values, addr, width, val_value), val_value);
+        if (opt_val_offset && get_type(val_type) != T_NUM)
+            inv.assign(stack.store(inv, data_kind_t::offsets, addr, width, *opt_val_offset), *opt_val_offset);
+        else
+            stack.havoc(inv, data_kind_t::offsets, addr, width);
+    } else if ((width == 1 || width == 2 || width == 4) && get_type(val_type) == T_NUM) {
+        // Keep track of numbers on the stack that might be used as array indices.
+        inv.assign(stack.store(inv, data_kind_t::values, addr, width, val_value), val_value);
+        stack.havoc(inv, data_kind_t::offsets, addr, width);
+    } else {
+        stack.havoc(inv, data_kind_t::values, addr, width);
+        stack.havoc(inv, data_kind_t::offsets, addr, width);
+    }
+}
+
+void ebpf_domain_t::operator()(const Mem& b) {
+    if (m_inv.is_bottom())
+        return;
+    if (std::holds_alternative<Reg>(b.value)) {
+        auto data_reg = reg_pack(std::get<Reg>(b.value));
+        if (b.is_load) {
+            do_load(b, data_reg);
+        } else {
+            do_mem_store(b, data_reg.type, data_reg.value, data_reg.offset);
+        }
+    } else {
+        do_mem_store(b, T_NUM, std::get<Imm>(b.value).v, {});
+    }
+}
+
+template <typename Type, typename Value>
+void ebpf_domain_t::do_mem_store(const Mem& b, Type val_type, Value val_value, std::optional<variable_t> opt_val_offset) {
+    if (m_inv.is_bottom())
+        return;
+    using namespace crab::dsl_syntax;
+    auto mem_reg = reg_pack(b.access.basereg);
+    int width = b.access.width;
+    int offset = b.access.offset;
+    if (b.access.basereg.v == R10_STACK_POINTER) {
+        int addr = EBPF_STACK_SIZE + offset;
+        do_store_stack(m_inv, width, addr, val_type, val_value, opt_val_offset);
+        return;
+    }
+    linear_expression_t addr = linear_expression_t(mem_reg.offset) + offset;
+    switch (get_type(mem_reg.type)) {
+        case T_STACK: do_store_stack(m_inv, width, addr, val_type, val_value, opt_val_offset); return;
+        case T_UNINIT: { //maybe stack
+            NumAbsDomain assume_not_stack(m_inv);
+#ifdef _MSC_VER
+            // MSVC seems to have a harder time coercing the right things, so force
+            // the correct interpretations.
+            assume_not_stack += (linear_constraint_t)(mem_reg.type != T_STACK);
+            m_inv += crab::dsl_syntax::operator==(mem_reg.type, T_STACK);
+#else
+            assume_not_stack += mem_reg.type != T_STACK;
+            m_inv += mem_reg.type == T_STACK;
+#endif
+            if (!m_inv.is_bottom()) {
+                do_store_stack(m_inv, width, addr, val_type, val_value, opt_val_offset);
+            }
+            m_inv |= std::move(assume_not_stack);
+        }
+        default: break;
+    }
+}
+
+void ebpf_domain_t::operator()(const LockAdd& a) {
+    // nothing to do here
+}
+
+void ebpf_domain_t::operator()(const Call& call) {
+    using namespace crab::dsl_syntax;
+    if (m_inv.is_bottom())
+        return;
+    std::optional<Reg> fd_index{};
+    for (ArgSingle param : call.singles) {
+        switch (param.kind) {
+        case ArgSingle::Kind::MAP_FD:
+            fd_index = param.reg;
+            break;
+        case ArgSingle::Kind::ANYTHING:
+        case ArgSingle::Kind::MAP_FD_PROGRAMS:
+        case ArgSingle::Kind::PTR_TO_MAP_KEY:
+        case ArgSingle::Kind::PTR_TO_MAP_VALUE:
+        case ArgSingle::Kind::PTR_TO_CTX:
+            // Do nothing. We don't track the content of relevant memory regions
+            break;
+        }
+    }
+    for (ArgPair param : call.pairs) {
+        switch (param.kind) {
+        case ArgPair::Kind::PTR_TO_MEM_OR_NULL:
+        case ArgPair::Kind::PTR_TO_MEM:
+            // Do nothing. No side effect allowed.
+            break;
+
+        case ArgPair::Kind::PTR_TO_UNINIT_MEM: {
+            // Pointer to a memory region that the called function may change,
+            // so we must havoc.
+            crab::interval_t t = m_inv[reg_pack(param.mem).type];
+            if (t[T_STACK]) {
+                variable_t addr = reg_pack(param.mem).offset;
+                variable_t width = reg_pack(param.size).value;
+                stack.havoc(m_inv, data_kind_t::types, addr, width);
+                stack.havoc(m_inv, data_kind_t::values, addr, width);
+                stack.havoc(m_inv, data_kind_t::offsets, addr, width);
+                if (t.singleton()) {
+                    // Functions are not allowed to write sensitive data,
+                    // and initialization is guaranteed
+                    stack.store_numbers(m_inv, addr, width);
+                }
+            }
+        }
+        }
+    }
+
+    auto r0 = reg_pack(R0_RETURN_VALUE);
+    if (call.is_map_lookup) {
+        // This is the only way to get a null pointer
+        if (fd_index) {
+            if (std::optional<number_t> fd_opt = m_inv[reg_pack(*fd_index).offset].singleton()) {
+                if (fd_opt->fits_sint()) {
+                    const EbpfMapDescriptor& desc = global_program_info.platform->get_map_descriptor((int)*fd_opt);
+                    if (global_program_info.platform->get_map_type(desc.type).value_type == EbpfMapValueType::MAP) {
+                        do_load_mapfd(r0, (int)desc.inner_map_fd, true);
+                        goto out;
+                    }
+                }
+            }
+        }
+        assign_valid_ptr(r0, true);
+        assign(r0.offset, 0);
+        assign(r0.type, variable_t::map_value_size());
+    } else {
+        havoc(r0.value);
+        havoc(r0.offset);
+        assign(r0.type, T_NUM);
+        // assume(r0.value < 0); for INTEGER_OR_NO_RETURN_IF_SUCCEED.
+    }
+out:
+    scratch_caller_saved_registers();
+    if (call.reallocate_packet) {
+        forget_packet_pointers();
+    }
+}
+
+void ebpf_domain_t::do_load_mapfd(const reg_pack_t& dst, int mapfd, bool maybe_null) {
+    const EbpfMapDescriptor& desc = global_program_info.platform->get_map_descriptor(mapfd);
+    const EbpfMapType& type = global_program_info.platform->get_map_type(desc.type);
+    if (type.value_type == EbpfMapValueType::PROGRAM) {
+        assign(dst.type, T_MAP_PROGRAMS);
+    } else {
+        assign(dst.type, T_MAP);
+    }
+    assign(dst.offset, mapfd);
+    assign_valid_ptr(dst, maybe_null);
+}
+
+void ebpf_domain_t::operator()(const LoadMapFd& ins) {
+    do_load_mapfd(reg_pack(ins.dst), ins.mapfd, false);
+}
+
+void ebpf_domain_t::assign_valid_ptr(const reg_pack_t& reg, bool maybe_null) {
+    using namespace crab::dsl_syntax;
+    havoc(reg.value);
+    if (maybe_null) {
+        m_inv += 0 <= reg.value;
+    } else {
+        m_inv += 0 < reg.value;
+    }
+    m_inv += reg.value <= PTR_MAX;
+}
+
+void ebpf_domain_t::operator()(const Bin& bin) {
+    using namespace crab::dsl_syntax;
+
+    auto dst = reg_pack(bin.dst);
+
+    if (std::holds_alternative<Imm>(bin.v)) {
+        // dst += K
+        int imm = static_cast<int>(std::get<Imm>(bin.v).v);
+        switch (bin.op) {
+        case Bin::Op::MOV:
+            assign(dst.value, imm);
+            assign(dst.type, T_NUM);
+            havoc(dst.offset);
+            break;
+        case Bin::Op::ADD:
+            if (imm == 0)
+                return;
+            add_overflow(dst.value, imm);
+            add(dst.offset, imm);
+            break;
+        case Bin::Op::SUB:
+            if (imm == 0)
+                return;
+            sub_overflow(dst.value, imm);
+            sub(dst.offset, imm);
+            break;
+        case Bin::Op::MUL:
+            mul(dst.value, imm);
+            assert_no_pointer(dst);
+            break;
+        case Bin::Op::DIV:
+            div(dst.value, imm);
+            assert_no_pointer(dst);
+            break;
+        case Bin::Op::MOD:
+            rem(dst.value, imm);
+            assert_no_pointer(dst);
+            break;
+        case Bin::Op::OR:
+            bitwise_or(dst.value, imm);
+            assert_no_pointer(dst);
+            break;
+        case Bin::Op::AND:
+            // FIX: what to do with ptr&-8 as in counter/simple_loop_unrolled?
+            bitwise_and(dst.value, imm);
+            if ((int32_t)imm > 0) {
+                assume(dst.value <= imm);
+                assume(0 <= dst.value);
+            }
+            assert_no_pointer(dst);
+            break;
+        case Bin::Op::LSH:
+            // avoid signedness and overflow issues in shl_overflow(dst.value, imm);
+            shl_overflow(dst.value, imm);
+            assert_no_pointer(dst);
+            break;
+        case Bin::Op::RSH:
+            // avoid signedness and overflow issues in lshr(dst.value, imm);
+            havoc(dst.value);
+            assert_no_pointer(dst);
+            break;
+        case Bin::Op::ARSH:
+            // avoid signedness and overflow issues in ashr(dst.value, imm);
+            // = (int64_t)dst >> imm;
+            havoc(dst.value);
+            // assume(dst.value <= (1 << (64 - imm)));
+            // assume(dst.value >= -(1 << (64 - imm)));
+            assert_no_pointer(dst);
+            break;
+        case Bin::Op::XOR:
+            bitwise_xor(dst.value, imm);
+            assert_no_pointer(dst);
+            break;
+        }
+    } else {
+        // dst op= src
+        auto src = reg_pack(std::get<Reg>(bin.v));
+        switch (bin.op) {
+        case Bin::Op::ADD: {
+            auto stype = get_type(src.type);
+            auto dtype = get_type(dst.type);
+            if (stype == T_NUM && dtype == T_NUM) {
+                add_overflow(dst.value, src.value);
+            } else if (dtype == T_NUM) {
+                apply(m_inv, crab::arith_binop_t::ADD, dst.value, src.value, dst.value, true);
+                apply(m_inv, crab::arith_binop_t::ADD, dst.offset, src.offset, dst.value, false);
+                m_inv.assign(dst.type, src.type);
+            } else if (stype == T_NUM) {
+                add_overflow(dst.value, src.value);
+                add(dst.offset, src.value);
+            } else {
+                havoc(dst.type);
+                havoc(dst.value);
+                havoc(dst.offset);
+            }
+            break;
+        }
+        case Bin::Op::SUB: {
+            auto stype = get_type(src.type);
+            auto dtype = get_type(dst.type);
+            if (dtype == T_NUM && stype == T_NUM) {
+                sub_overflow(dst.value, src.value);
+            } else if (stype == T_NUM) {
+                sub_overflow(dst.value, src.value);
+                sub(dst.offset, src.value);
+            } else if (stype == dtype && stype < 0) { // subtracting non-shared pointers
+                apply(m_inv, crab::arith_binop_t::SUB, dst.value, dst.offset, src.offset, true);
+                havoc(dst.offset);
+                assign(dst.type, T_NUM);
+            } else {
+                havoc(dst.type);
+                havoc(dst.value);
+                havoc(dst.offset);
+            }
+            break;
+        }
+        case Bin::Op::MUL:
+            mul(dst.value, src.value);
+            assert_no_pointer(dst);
+            break;
+        case Bin::Op::DIV:
+            // DIV is not checked for zerodiv
+            div(dst.value, src.value);
+            assert_no_pointer(dst);
+            break;
+        case Bin::Op::MOD:
+            // See DIV comment
+            rem(dst.value, src.value);
+            assert_no_pointer(dst);
+            break;
+        case Bin::Op::OR:
+            bitwise_or(dst.value, src.value);
+            assert_no_pointer(dst);
+            break;
+        case Bin::Op::AND:
+            bitwise_and(dst.value, src.value);
+            assert_no_pointer(dst);
+            break;
+        case Bin::Op::LSH:
+            shl_overflow(dst.value, src.value);
+            assert_no_pointer(dst);
+            break;
+        case Bin::Op::RSH:
+            havoc(dst.value);
+            assert_no_pointer(dst);
+            break;
+        case Bin::Op::ARSH:
+            havoc(dst.value);
+            assert_no_pointer(dst);
+            break;
+        case Bin::Op::XOR:
+            bitwise_xor(dst.value, src.value);
+            assert_no_pointer(dst);
+            break;
+        case Bin::Op::MOV:
+            assign(dst.value, src.value);
+            assign(dst.offset, src.offset);
+            assign(dst.type, src.type);
+            break;
+        }
+    }
+    if (!bin.is64) {
+        bitwise_and(dst.value, UINT32_MAX);
+    }
+}
+
+string_invariant ebpf_domain_t::to_set() {
+    return this->m_inv.to_set();
+}
+
+std::ostream& operator<<(std::ostream& o, ebpf_domain_t dom) {
+    if (dom.is_bottom()) {
+        o << "_|_";
+    } else {
+        o << dom.m_inv << "\nStack: " << dom.stack;
+    }
+    return o;
+}
+
+void ebpf_domain_t::initialize_packet(ebpf_domain_t& inv) {
+    using namespace crab::dsl_syntax;
+
+    inv -= variable_t::packet_size();
+    inv -= variable_t::meta_offset();
+
+    inv += 0 <= variable_t::packet_size();
+    inv += variable_t::packet_size() < MAX_PACKET_OFF;
+    auto info = global_program_info;
+    if (info.type.context_descriptor->meta >= 0) {
+        inv += variable_t::meta_offset() <= 0;
+        inv += variable_t::meta_offset() >= -4098;
+    } else {
+        inv.assign(variable_t::meta_offset(), 0);
+    }
+}
+
+ebpf_domain_t ebpf_domain_t::from_constraints(const std::vector<linear_constraint_t>& csts) {
+    ebpf_domain_t inv;
+    for (const auto& cst: csts) {
+        inv += cst;
+    }
+    return inv;
+}
+
+ebpf_domain_t ebpf_domain_t::setup_entry(bool check_termination) {
+    using namespace crab::dsl_syntax;
+
+    ebpf_domain_t inv;
+    auto r10 = reg_pack(R10_STACK_POINTER);
+    inv += EBPF_STACK_SIZE <= r10.value;
+    inv += r10.value <= PTR_MAX;
+    inv.assign(r10.offset, EBPF_STACK_SIZE);
+    inv.assign(r10.type, T_STACK);
+
+    auto r1 = reg_pack(R1_ARG);
+    inv += 1 <= r1.value;
+    inv += r1.value <= PTR_MAX;
+    inv.assign(r1.offset, 0);
+    inv.assign(r1.type, T_CTX);
+
+    initialize_packet(inv);
+
+    if (check_termination) {
+        inv.assign(variable_t::instruction_count(), 0);
+    }
+    return inv;
+}

--- a/src/crab/ebpf_domain.cpp
+++ b/src/crab/ebpf_domain.cpp
@@ -16,9 +16,6 @@
 
 #include "crab/array_domain.hpp"
 #include "crab/ebpf_domain.hpp"
-#include "crab/interval.hpp"
-#include "crab/split_dbm.hpp"
-#include "crab/variable.hpp"
 
 #include "asm_ostream.hpp"
 #include "config.hpp"

--- a/src/crab/ebpf_domain.hpp
+++ b/src/crab/ebpf_domain.hpp
@@ -4,1230 +4,185 @@
 
 // This file is eBPF-specific, not derived from CRAB.
 
-#include <algorithm>
-#include <bitset>
 #include <functional>
 #include <optional>
-#include <set>
-#include <map>
-#include <utility>
 #include <vector>
 
-#include "boost/range/algorithm/set_algorithm.hpp"
-
-#include "crab/variable.hpp"
-#include "crab_utils/debug.hpp"
-#include "crab_utils/stats.hpp"
-
-#include "crab/interval.hpp"
+#include "crab/array_domain.hpp"
 #include "crab/split_dbm.hpp"
-
-#include "asm_ostream.hpp"
-#include "crab_verifier.hpp"
-#include "dsl_syntax.hpp"
-#include "helpers.hpp"
-#include "platform.hpp"
+#include "crab/variable.hpp"
 #include "string_constraints.hpp"
 
-#include "crab/array_domain.hpp"
+struct reg_pack_t;
 
-extern thread_local ebpf_verifier_options_t thread_local_options;
-
-namespace crab::domains {
-
-struct reg_pack_t {
-    variable_t value, offset, type;
-};
-
-inline reg_pack_t reg_pack(int i) {
-    return {
-       variable_t::reg(data_kind_t::values, i),
-       variable_t::reg(data_kind_t::offsets, i),
-       variable_t::reg(data_kind_t::types, i),
-    };
-}
-inline reg_pack_t reg_pack(Reg r) { return reg_pack(r.v); }
-
-inline linear_constraint_t eq(variable_t a, variable_t b) {
-    using namespace dsl_syntax;
-    return {a - b, constraint_kind_t::EQUALS_ZERO};
-}
-
-inline linear_constraint_t neq(variable_t a, variable_t b) {
-    using namespace dsl_syntax;
-    return {a - b, constraint_kind_t::NOT_ZERO};
-}
-
-constexpr int MAX_PACKET_OFF = 0xffff;
-constexpr int64_t MY_INT_MAX = INT_MAX;
-constexpr int64_t PTR_MAX = MY_INT_MAX - MAX_PACKET_OFF;
-
-/** Linear constraint for a pointer comparison.
- */
-inline linear_constraint_t jmp_to_cst_offsets_reg(Condition::Op op, variable_t dst_offset, variable_t src_offset) {
-    using namespace dsl_syntax;
-    using Op = Condition::Op;
-    switch (op) {
-    case Op::EQ: return eq(dst_offset, src_offset);
-    case Op::NE: return neq(dst_offset, src_offset);
-    case Op::GE: return dst_offset >= src_offset;
-    case Op::SGE: return dst_offset >= src_offset; // pointer comparison is unsigned
-    case Op::LE: return dst_offset <= src_offset;
-    case Op::SLE: return dst_offset <= src_offset; // pointer comparison is unsigned
-    case Op::GT: return dst_offset > src_offset;
-    case Op::SGT: return dst_offset > src_offset; // pointer comparison is unsigned
-    case Op::SLT: return src_offset > dst_offset;
-    // Note: reverse the test as a workaround strange lookup:
-    case Op::LT: return src_offset > dst_offset; // FIX unsigned
-    default: return dst_offset - dst_offset == 0;
-    }
-}
-
-/** Linear constraints for a comparison with a constant.
- */
-inline std::vector<linear_constraint_t> jmp_to_cst_imm(Condition::Op op, variable_t dst_value, int imm) {
-    using namespace dsl_syntax;
-    using Op = Condition::Op;
-    switch (op) {
-    case Op::EQ: return {dst_value == imm};
-    case Op::NE: return {dst_value != imm};
-    case Op::GE: return {dst_value >= (unsigned)imm}; // FIX unsigned
-    case Op::SGE: return {dst_value >= imm};
-    case Op::LE: return {dst_value <= imm, 0 <= dst_value}; // FIX unsigned
-    case Op::SLE: return {dst_value <= imm};
-    case Op::GT: return {dst_value > (unsigned)imm}; // FIX unsigned
-    case Op::SGT: return {dst_value > imm};
-    case Op::LT: return {dst_value < (unsigned)imm}; // FIX unsigned
-    case Op::SLT: return {dst_value < imm};
-    case Op::SET: throw std::exception();
-    case Op::NSET: return {};
-    }
-    return {};
-}
-
-/** Linear constraint for a numerical comparison between registers.
- */
-inline std::vector<linear_constraint_t> jmp_to_cst_reg(Condition::Op op, variable_t dst_value, variable_t src_value) {
-    using namespace dsl_syntax;
-    using Op = Condition::Op;
-    switch (op) {
-    case Op::EQ: return {eq(dst_value, src_value)};
-    case Op::NE: return {neq(dst_value, src_value)};
-    case Op::GE: return {dst_value >= src_value}; // FIX unsigned
-    case Op::SGE: return {dst_value >= src_value};
-    case Op::LE: return {dst_value <= src_value, 0 <= dst_value}; // FIX unsigned
-    case Op::SLE: return {dst_value <= src_value};
-    case Op::GT: return {dst_value > src_value}; // FIX unsigned
-    case Op::SGT: return {dst_value > src_value};
-    // Note: reverse the test as a workaround strange lookup:
-    case Op::LT: return {src_value > dst_value}; // FIX unsigned
-    case Op::SLT: return {src_value > dst_value};
-    case Op::SET: throw std::exception();
-    case Op::NSET: return {};
-    }
-    return {};
-}
-
-inline bool is_unsigned_cmp(Condition::Op op) {
-    using Op = Condition::Op;
-    switch (op) {
-    case Op::GE:
-    case Op::LE:
-    case Op::GT:
-    case Op::LT: return true;
-    default: return false;
-    }
-    return {};
-}
+using NumAbsDomain = crab::domains::NumAbsDomain;
 
 class ebpf_domain_t final {
   public:
-    using variable_vector_t = std::vector<variable_t>;
+    ebpf_domain_t();
+    ebpf_domain_t(crab::domains::NumAbsDomain inv, crab::domains::array_domain_t stack);
+
+    // Generic abstract domain operations
+    static ebpf_domain_t top();
+    static ebpf_domain_t bottom();
+    void set_to_top();
+    void set_to_bottom();
+    bool is_bottom() const;
+    bool is_top() const;
+    bool operator<=(const ebpf_domain_t& other);
+    bool operator==(ebpf_domain_t other);
+    void operator|=(ebpf_domain_t&& other);
+    void operator|=(const ebpf_domain_t& other);
+    ebpf_domain_t operator|(ebpf_domain_t&& other);
+    ebpf_domain_t operator|(const ebpf_domain_t& other) &;
+    ebpf_domain_t operator|(const ebpf_domain_t& other) &&;
+    ebpf_domain_t operator&(ebpf_domain_t other);
+    ebpf_domain_t widen(const ebpf_domain_t& other);
+    ebpf_domain_t widening_thresholds(const ebpf_domain_t& other, const crab::iterators::thresholds_t& ts);
+    ebpf_domain_t narrow(const ebpf_domain_t& other);
+
     typedef void check_require_func_t(NumAbsDomain&, const linear_constraint_t&, std::string);
+    void set_require_check(std::function<check_require_func_t> f);
+    int get_instruction_count_upper_bound();
+    static ebpf_domain_t setup_entry(bool check_termination);
+
+    static ebpf_domain_t from_constraints(const std::vector<linear_constraint_t>& csts);
+    string_invariant to_set();
+
+    // abstract transformers
+    void operator()(const basic_block_t& bb, bool check_termination);
+
+    void operator()(const Addable&);
+    void operator()(const Assert&);
+    void operator()(const Assume&);
+    void operator()(const Bin&);
+    void operator()(const Call&);
+    void operator()(const Comparable&);
+    void operator()(const Exit&);
+    void operator()(const Jmp&);
+    void operator()(const LoadMapFd&);
+    void operator()(const LockAdd&);
+    void operator()(const Mem&);
+    void operator()(const Packet&);
+    void operator()(const TypeConstraint&);
+    void operator()(const Un&);
+    void operator()(const Undefined&);
+    void operator()(const ValidAccess&);
+    void operator()(const ValidMapKeyValue&);
+    void operator()(const ValidSize&);
+    void operator()(const ValidStore&);
+    void operator()(const ZeroOffset&);
+
+  private:
+    // private generic domain functions
+    void operator+=(const linear_constraint_t& cst);
+    void operator-=(variable_t var);
+
+    void assign(variable_t lhs, variable_t rhs);
+    void assign(variable_t x, const linear_expression_t& e);
+    void assign(variable_t x, long e);
+
+    void apply(crab::arith_binop_t op, variable_t x, variable_t y, const number_t& z);
+    void apply(crab::arith_binop_t op, variable_t x, variable_t y, variable_t z);
+    void apply(crab::bitwise_binop_t op, variable_t x, variable_t y, variable_t z);
+    void apply(crab::bitwise_binop_t op, variable_t x, variable_t y, const number_t& k);
+    void apply(crab::binop_t op, variable_t x, variable_t y, const number_t& z);
+    void apply(crab::binop_t op, variable_t x, variable_t y, variable_t z);
+
+    void apply(crab::domains::NumAbsDomain& inv, crab::binop_t op, variable_t x, variable_t y, const number_t& z, bool finite_width = false);
+    void apply(crab::domains::NumAbsDomain& inv, crab::binop_t op, variable_t x, variable_t y, variable_t z, bool finite_width = false);
+
+    void add(variable_t lhs, variable_t op2);
+    void add(variable_t lhs, const number_t& op2);
+    void sub(variable_t lhs, variable_t op2);
+    void sub(variable_t lhs, const number_t& op2);
+    void add_overflow(variable_t lhs, variable_t op2);
+    void add_overflow(variable_t lhs, const number_t& op2);
+    void sub_overflow(variable_t lhs, variable_t op2);
+    void sub_overflow(variable_t lhs, const number_t& op2);
+    void neg(variable_t lhs);
+    void mul(variable_t lhs, variable_t op2);
+    void mul(variable_t lhs, const number_t& op2);
+    void div(variable_t lhs, variable_t op2);
+    void div(variable_t lhs, const number_t& op2);
+    void udiv(variable_t lhs, variable_t op2);
+    void udiv(variable_t lhs, const number_t& op2);
+    void rem(variable_t lhs, variable_t op2);
+    void rem(variable_t lhs, const number_t& op2, bool mod = true);
+    void urem(variable_t lhs, variable_t op2);
+    void urem(variable_t lhs, const number_t& op2);
+
+    void bitwise_and(variable_t lhs, variable_t op2);
+    void bitwise_and(variable_t lhs, const number_t& op2);
+    void bitwise_or(variable_t lhs, variable_t op2);
+    void bitwise_or(variable_t lhs, const number_t& op2);
+    void bitwise_xor(variable_t lhs, variable_t op2);
+    void bitwise_xor(variable_t lhs, const number_t& op2);
+    void shl_overflow(variable_t lhs, variable_t op2);
+    void shl_overflow(variable_t lhs, const number_t& op2);
+    void lshr(variable_t lhs, variable_t op2);
+    void lshr(variable_t lhs, const number_t& op2);
+    void ashr(variable_t lhs, variable_t op2);
+    void ashr(variable_t lhs, number_t op2);
+
+    void assume(const linear_constraint_t& cst);
+
+    /// Forget everything we know about the value of a variable.
+    void havoc(variable_t v);
+
+    // shorthand for "m_inv + condition" (since + is not actually overloaded)
+    NumAbsDomain when(const linear_constraint_t& condition);
+
+    void scratch_caller_saved_registers();
+
+    void forget_packet_pointers();
+    void do_load_mapfd(const reg_pack_t& dst, int mapfd, bool maybe_null);
+
+    void overflow(variable_t lhs);
+
+    void assign_valid_ptr(const reg_pack_t& reg, bool maybe_null);
+    void assert_no_pointer(const reg_pack_t& reg);
+
+    void require(crab::domains::NumAbsDomain& inv, const linear_constraint_t& cst, const std::string& s);
+
+    // memory check / load / store
+    NumAbsDomain check_access_stack(NumAbsDomain inv, const linear_expression_t& lb, const linear_expression_t& ub, const std::string& s);
+    NumAbsDomain check_access_packet(NumAbsDomain inv, const linear_expression_t& lb, const linear_expression_t& ub, const std::string& s,
+                                     bool is_comparison_check);
+    NumAbsDomain check_access_shared(NumAbsDomain inv, const linear_expression_t& lb, const linear_expression_t& ub, const std::string& s,
+                                     variable_t reg_type);
+    NumAbsDomain check_access_context(NumAbsDomain inv, const linear_expression_t& lb, const linear_expression_t& ub, const std::string& s);
+
+    NumAbsDomain do_load_stack(NumAbsDomain inv, const reg_pack_t& target, const linear_expression_t& addr, int width);
+    NumAbsDomain do_load_ctx(NumAbsDomain inv, const reg_pack_t& target, const linear_expression_t& addr_vague, int width);
+    NumAbsDomain do_load_packet_or_shared(NumAbsDomain inv, const reg_pack_t& target, const linear_expression_t& addr, int width);
+    void do_load(const Mem& b, const reg_pack_t& target);
+
+    template <typename A, typename X, typename Y, typename Z>
+    void do_store_stack(crab::domains::NumAbsDomain& inv, int width, const A& addr, X val_type, Y val_value,
+                        std::optional<Z> opt_val_offset);
+
+    template <typename Type, typename Value>
+    void do_mem_store(const Mem& b, Type val_type, Value val_value, std::optional<variable_t> opt_val_offset);
+
+    friend std::ostream& operator<<(std::ostream& o, ebpf_domain_t dom);
+
+    static void initialize_packet(ebpf_domain_t& inv);
+
+    int get_type(variable_t v);
+    int get_type(int t);
 
   private:
     /// Mapping from variables (including registers, types, offsets,
     /// memory locations, etc.) to numeric intervals or relationships
     /// to other variables.
-    NumAbsDomain m_inv;
+    crab::domains::NumAbsDomain m_inv;
 
     /// Represents the stack as a memory region, i.e., an array of bytes,
     /// allowing mapping to variable in the m_inv numeric domains
     /// while dealing with overlapping byte ranges.
-    array_domain_t stack;
+    crab::domains::array_domain_t stack;
 
     std::function<check_require_func_t> check_require{};
 
-  public:
-    void set_require_check(std::function<check_require_func_t> f) { check_require = std::move(f); }
-
-    static ebpf_domain_t top() {
-        ebpf_domain_t abs;
-        abs.set_to_top();
-        return abs;
-    }
-
-    static ebpf_domain_t bottom() {
-        ebpf_domain_t abs;
-        abs.set_to_bottom();
-        return abs;
-    }
-
-  public:
-    ebpf_domain_t() : m_inv(NumAbsDomain::top()) {}
-
-    ebpf_domain_t(NumAbsDomain inv, array_domain_t stack) : m_inv(std::move(inv)), stack(stack) {}
-
-    void set_to_top() {
-        m_inv.set_to_top();
-        stack.set_to_top();
-    }
-
-    void set_to_bottom() { m_inv.set_to_bottom(); }
-
-    bool is_bottom() const { return m_inv.is_bottom(); }
-
-    bool is_top() const { return m_inv.is_top() && stack.is_top(); }
-
-    bool operator<=(const ebpf_domain_t& other) {
-        return m_inv <= other.m_inv && stack <= other.stack;
-    }
-
-    bool operator==(ebpf_domain_t other) {
-        return stack == other.stack && m_inv <= other.m_inv && other.m_inv <= m_inv;
-    }
-
-    void operator|=(ebpf_domain_t&& other) {
-        if (is_bottom()) {
-            *this = other;
-            return;
-        }
-        m_inv |= other.m_inv;
-        stack |= other.stack;
-    }
-
-    void operator|=(const ebpf_domain_t& other) {
-        ebpf_domain_t tmp{other};
-        operator|=(std::move(tmp));
-    }
-
-    ebpf_domain_t operator|(ebpf_domain_t&& other) {
-        return ebpf_domain_t(m_inv | other.m_inv, stack | other.stack);
-    }
-
-    ebpf_domain_t operator|(const ebpf_domain_t& other) & {
-        return ebpf_domain_t(m_inv | other.m_inv, stack | other.stack);
-    }
-
-    ebpf_domain_t operator|(const ebpf_domain_t& other) && {
-        return ebpf_domain_t(m_inv | other.m_inv, stack | other.stack);
-    }
-
-    ebpf_domain_t operator&(ebpf_domain_t other) {
-        return ebpf_domain_t(m_inv & std::move(other.m_inv), stack & other.stack);
-    }
-
-    ebpf_domain_t widen(const ebpf_domain_t& other) {
-        return ebpf_domain_t(m_inv.widen(other.m_inv), stack | other.stack);
-    }
-
-    ebpf_domain_t widening_thresholds(const ebpf_domain_t& other, const iterators::thresholds_t& ts) {
-        return ebpf_domain_t(m_inv.widening_thresholds(other.m_inv, ts), stack | other.stack);
-    }
-
-    ebpf_domain_t narrow(const ebpf_domain_t& other) {
-        return ebpf_domain_t(m_inv.narrow(other.m_inv), stack & other.stack);
-    }
-
-    interval_t operator[](variable_t x) { return m_inv[x]; }
-
-    void forget(const variable_vector_t& variables) {
-        // TODO: forget numerical values
-        if (is_bottom() || is_top()) {
-            return;
-        }
-
-        m_inv.forget(variables);
-    }
-
-    void operator+=(const linear_constraint_t& cst) { m_inv += cst; }
-
-    void operator-=(variable_t var) { m_inv -= var; }
-
-    void assign(variable_t x, const linear_expression_t& e) { m_inv.assign(x, e); }
-    void assign(variable_t x, long e) { m_inv.set(x, interval_t(number_t(e))); }
-
-    void apply(arith_binop_t op, variable_t x, variable_t y, const number_t& z) { m_inv.apply(op, x, y, z); }
-
-    void apply(arith_binop_t op, variable_t x, variable_t y, variable_t z) { m_inv.apply(op, x, y, z); }
-
-    void apply(bitwise_binop_t op, variable_t x, variable_t y, variable_t z) { m_inv.apply(op, x, y, z); }
-
-    void apply(bitwise_binop_t op, variable_t x, variable_t y, const number_t& k) { m_inv.apply(op, x, y, k); }
-
-    void apply(binop_t op, variable_t x, variable_t y, const number_t& z) {
-        std::visit([&](auto top) { apply(top, x, y, z); }, op);
-    }
-
-    void apply(binop_t op, variable_t x, variable_t y, variable_t z) {
-        std::visit([&](auto top) { apply(top, x, y, z); }, op);
-    }
-
-  private:
-    static NumAbsDomain when(NumAbsDomain inv, const linear_constraint_t& cond) {
-        inv += cond;
-        return inv;
-    }
-
-    void scratch_caller_saved_registers() {
-        for (int i = R1_ARG; i <= R5_ARG; i++) {
-            auto reg = reg_pack(i);
-            havoc(reg.value);
-            havoc(reg.offset);
-            havoc(reg.type);
-        }
-    }
-
-    void forget_packet_pointers() {
-        using namespace dsl_syntax;
-
-        initialize_packet(*this);
-
-        for (variable_t v : variable_t::get_type_variables()) {
-            // TODO: this is sufficient, but for clarity it may be useful to forget the offset and value too.
-           if (m_inv.intersect(v == T_PACKET))
-               m_inv -= v;
-        }
-    }
-
-    void apply(NumAbsDomain& inv, binop_t op, variable_t x, variable_t y, const number_t& z, bool finite_width = false) {
-        inv.apply(op, x, y, z);
-        if (finite_width)
-            overflow(x);
-    }
-
-    void apply(NumAbsDomain& inv, binop_t op, variable_t x, variable_t y, variable_t z, bool finite_width = false) {
-        inv.apply(op, x, y, z);
-        if (finite_width)
-            overflow(x);
-    }
-
-    void add(variable_t lhs, variable_t op2) { apply(m_inv, crab::arith_binop_t::ADD, lhs, lhs, op2); }
-    void add(variable_t lhs, const number_t& op2) { apply(m_inv, crab::arith_binop_t::ADD, lhs, lhs, op2); }
-    void sub(variable_t lhs, variable_t op2) { apply(m_inv, crab::arith_binop_t::SUB, lhs, lhs, op2); }
-    void sub(variable_t lhs, const number_t& op2) { apply(m_inv, crab::arith_binop_t::SUB, lhs, lhs, op2); }
-    void add_overflow(variable_t lhs, variable_t op2) { apply(m_inv, crab::arith_binop_t::ADD, lhs, lhs, op2, true); }
-    void add_overflow(variable_t lhs, const number_t& op2) { apply(m_inv, crab::arith_binop_t::ADD, lhs, lhs, op2, true); }
-    void sub_overflow(variable_t lhs, variable_t op2) { apply(m_inv, crab::arith_binop_t::SUB, lhs, lhs, op2, true); }
-    void sub_overflow(variable_t lhs, const number_t& op2) { apply(m_inv, crab::arith_binop_t::SUB, lhs, lhs, op2, true); }
-    void neg(variable_t lhs) { apply(m_inv, crab::arith_binop_t::MUL, lhs, lhs, (number_t)-1, true); }
-    void mul(variable_t lhs, variable_t op2) { apply(m_inv, crab::arith_binop_t::MUL, lhs, lhs, op2, true); }
-    void mul(variable_t lhs, const number_t& op2) { apply(m_inv, crab::arith_binop_t::MUL, lhs, lhs, op2, true); }
-    void div(variable_t lhs, variable_t op2) { apply(m_inv, crab::arith_binop_t::SDIV, lhs, lhs, op2, true); }
-    void div(variable_t lhs, const number_t& op2) { apply(m_inv, crab::arith_binop_t::SDIV, lhs, lhs, op2, true); }
-    void udiv(variable_t lhs, variable_t op2) { apply(m_inv, crab::arith_binop_t::UDIV, lhs, lhs, op2, true); }
-    void udiv(variable_t lhs, const number_t& op2) { apply(m_inv, crab::arith_binop_t::UDIV, lhs, lhs, op2, true); }
-    void rem(variable_t lhs, variable_t op2) { apply(m_inv, crab::arith_binop_t::SREM, lhs, lhs, op2, true); }
-    void rem(variable_t lhs, const number_t& op2, bool mod = true) {
-        apply(m_inv, crab::arith_binop_t::SREM, lhs, lhs, op2, mod);
-    }
-    void urem(variable_t lhs, variable_t op2) { apply(m_inv, crab::arith_binop_t::UREM, lhs, lhs, op2, true); }
-    void urem(variable_t lhs, const number_t& op2) { apply(m_inv, crab::arith_binop_t::UREM, lhs, lhs, op2, true); }
-
-    void bitwise_and(variable_t lhs, variable_t op2) { apply(m_inv, crab::bitwise_binop_t::AND, lhs, lhs, op2); }
-    void bitwise_and(variable_t lhs, const number_t& op2) { apply(m_inv, crab::bitwise_binop_t::AND, lhs, lhs, op2); }
-    void bitwise_or(variable_t lhs, variable_t op2) { apply(m_inv, crab::bitwise_binop_t::OR, lhs, lhs, op2); }
-    void bitwise_or(variable_t lhs, const number_t& op2) { apply(m_inv, crab::bitwise_binop_t::OR, lhs, lhs, op2); }
-    void bitwise_xor(variable_t lhs, variable_t op2) { apply(m_inv, crab::bitwise_binop_t::XOR, lhs, lhs, op2); }
-    void bitwise_xor(variable_t lhs, const number_t& op2) { apply(m_inv, crab::bitwise_binop_t::XOR, lhs, lhs, op2); }
-    void shl_overflow(variable_t lhs, variable_t op2) { apply(m_inv, crab::bitwise_binop_t::SHL, lhs, lhs, op2, true); }
-    void shl_overflow(variable_t lhs, const number_t& op2) { apply(m_inv, crab::bitwise_binop_t::SHL, lhs, lhs, op2, true); }
-    void lshr(variable_t lhs, variable_t op2) { apply(m_inv, crab::bitwise_binop_t::LSHR, lhs, lhs, op2); }
-    void lshr(variable_t lhs, const number_t& op2) { apply(m_inv, crab::bitwise_binop_t::LSHR, lhs, lhs, op2); }
-    void ashr(variable_t lhs, variable_t op2) { apply(m_inv, crab::bitwise_binop_t::ASHR, lhs, lhs, op2); }
-    void ashr(variable_t lhs, number_t op2) { apply(m_inv, crab::bitwise_binop_t::ASHR, lhs, lhs, op2); }
-
-    void assume(const linear_constraint_t& cst) { assume(m_inv, cst); }
-    static void assume(NumAbsDomain& inv, const linear_constraint_t& cst) { inv += cst; }
-
-    void require(NumAbsDomain& inv, const linear_constraint_t& cst, std::string s) {
-        if (check_require)
-            check_require(inv, cst, std::move(s));
-        assume(inv, cst);
-    }
-
-    void require_false(NumAbsDomain& inv, std::string s) {
-        using namespace dsl_syntax;
-        require(m_inv, linear_expression_t(0) != 0, s);
-    }
-
-    /// Forget everything we know about the value of a variable.
-    void havoc(variable_t v) { m_inv -= v; }
-
-    void assign(variable_t lhs, variable_t rhs) { m_inv.assign(lhs, rhs); }
-
-    void assert_no_pointer(reg_pack_t reg) {
-        using namespace dsl_syntax;
-        require(m_inv, reg.type == T_NUM, "invalid operation on a non-numerical value");
-        havoc(reg.offset);
-    }
-
-    static linear_constraint_t is_shared(variable_t v) {
-        using namespace dsl_syntax;
-        return v > T_SHARED;
-    }
-
-    static linear_constraint_t is_pointer(reg_pack_t r) {
-        using namespace dsl_syntax;
-        return r.type >= T_CTX;
-    }
-
-    void overflow(variable_t lhs) {
-        using namespace dsl_syntax;
-        auto interval = m_inv[lhs];
-        // handle overflow, assuming 64 bit
-        number_t max(std::numeric_limits<int64_t>::max() / 2);
-        number_t min(std::numeric_limits<int64_t>::min() / 2);
-        if (interval.lb() <= min || interval.ub() >= max)
-            havoc(lhs);
-    }
-
-  public:
-    // All transfer functions are operations on this abstract domain.
-    // It provides the basic operations of setting a variable or adding
-    // a constraint, so all of them would be converted to some kind of
-    // constraint that is added to the domain.
-
-    void operator()(const basic_block_t& bb, bool check_termination) {
-        for (const Instruction& statement : bb) {
-            std::visit(*this, statement);
-        }
-        if (check_termination) {
-            // +1 to avoid being tricked by empty loops
-            add(variable_t::instruction_count(), z_number((unsigned)bb.size() + 1));
-        }
-    }
-
-    int get_instruction_count_upper_bound() {
-        const auto& ub = m_inv[variable_t::instruction_count()].ub();
-        return (ub.is_finite() && ub.number().value().fits_sint()) ? (int)ub.number().value() : INT_MAX;
-    }
-
-    void operator()(Assume const& s) {
-        using namespace dsl_syntax;
-        Condition cond = s.cond;
-        auto dst = reg_pack(cond.left);
-        if (std::holds_alternative<Reg>(cond.right)) {
-            auto src = reg_pack(std::get<Reg>(cond.right));
-            int stype = get_type(src.type);
-            int dtype = get_type(dst.type);
-            if (stype == dtype) {
-                switch (stype) {
-                    case T_MAP: break;
-                    case T_MAP_PROGRAMS: break;
-                    case T_UNINIT: break;
-                    case T_NUM: {
-                        if (!is_unsigned_cmp(cond.op))
-                            for (const linear_constraint_t& cst : jmp_to_cst_reg(cond.op, dst.value, src.value))
-                                m_inv += cst;
-                        return;
-                    }
-                    default: {
-                        m_inv += jmp_to_cst_offsets_reg(cond.op, dst.offset, src.offset);
-                        return;
-                    }
-                }
-            }
-            NumAbsDomain different{m_inv};
-            different += neq(dst.type, src.type);
-
-            NumAbsDomain null_src{different};
-            null_src += is_pointer(dst);
-            NumAbsDomain null_dst{different};
-            null_dst += is_pointer(src);
-
-            m_inv += eq(dst.type, src.type);
-
-            NumAbsDomain numbers{m_inv};
-            numbers += dst.type == T_NUM;
-            if (!is_unsigned_cmp(cond.op))
-                for (const linear_constraint_t& cst : jmp_to_cst_reg(cond.op, dst.value, src.value))
-                    numbers += cst;
-
-            m_inv += is_pointer(dst);
-            m_inv += jmp_to_cst_offsets_reg(cond.op, dst.offset, src.offset);
-
-            m_inv |= std::move(numbers);
-
-            m_inv |= std::move(null_src);
-            m_inv |= std::move(null_dst);
-        } else {
-            int imm = static_cast<int>(std::get<Imm>(cond.right).v);
-            for (const linear_constraint_t& cst : jmp_to_cst_imm(cond.op, dst.value, imm))
-                assume(cst);
-        }
-    }
-
-    void operator()(Undefined const& a) {}
-    void operator()(Un const& stmt) {
-        auto dst = reg_pack(stmt.dst);
-        switch (stmt.op) {
-        case Un::Op::LE16:
-        case Un::Op::LE32:
-        case Un::Op::LE64:
-            havoc(dst.value);
-            assert_no_pointer(dst);
-            break;
-        case Un::Op::NEG:
-            neg(dst.value);
-            assert_no_pointer(dst);
-            break;
-        }
-    }
-    void operator()(Exit const& a) {}
-    void operator()(Jmp const& a) {}
-
-    void operator()(const Comparable& s) { require(m_inv, eq(reg_pack(s.r1).type, reg_pack(s.r2).type), to_string(s)); }
-
-    void operator()(const Addable& s) {
-        using namespace dsl_syntax;
-        linear_constraint_t cond = reg_pack(s.ptr).type > T_NUM;
-        NumAbsDomain is_ptr{m_inv};
-        is_ptr += cond;
-        require(is_ptr, reg_pack(s.num).type == T_NUM, "only numbers can be added to pointers (" + to_string(s) + ")");
-
-        m_inv += cond.negate();
-        m_inv |= std::move(is_ptr);
-    }
-
-    void operator()(const ValidSize& s) {
-        using namespace dsl_syntax;
-        auto r = reg_pack(s.reg);
-        require(m_inv, s.can_be_zero ? r.value >= 0 : r.value > 0, to_string(s));
-    }
-
-    void operator()(const ValidMapKeyValue& s) {
-        using namespace dsl_syntax;
-
-        // Get the actual map_fd value to look up the key size and value size.
-        auto fd_reg = reg_pack(s.map_fd_reg);
-        interval_t fd_interval = operator[](fd_reg.offset);
-        std::optional<EbpfMapType> map_type;
-        uint32_t max_entries = 0;
-        if (fd_interval.is_bottom()) {
-            m_inv.set(variable_t::map_value_size(), interval_t::bottom());
-            m_inv.set(variable_t::map_key_size(), interval_t::bottom());
-        } else {
-            std::optional<number_t> fd_opt = fd_interval.singleton();
-            if (fd_opt.has_value()) {
-                number_t map_fd = *fd_opt;
-                EbpfMapDescriptor& map_descriptor = global_program_info.platform->get_map_descriptor((int)map_fd);
-                m_inv.assign(variable_t::map_value_size(), (int)map_descriptor.value_size);
-                m_inv.assign(variable_t::map_key_size(), (int)map_descriptor.key_size);
-                map_type = global_program_info.platform->get_map_type(map_descriptor.type);
-                max_entries = map_descriptor.max_entries;
-            } else {
-                m_inv.set(variable_t::map_value_size(), interval_t::top());
-                m_inv.set(variable_t::map_key_size(), interval_t::top());
-            }
-        }
-
-        auto access_reg = reg_pack(s.access_reg);
-
-        variable_t lb = access_reg.offset;
-        variable_t width = s.key ? variable_t::map_key_size() : variable_t::map_value_size();
-        linear_expression_t ub = lb + width;
-        std::string m = std::string(" (") + to_string(s) + ")";
-        require(m_inv, access_reg.type >= T_STACK, "Only stack or packet can be used as a parameter" + m);
-        require(m_inv, access_reg.type <= T_PACKET, "Only stack or packet can be used as a parameter" + m);
-
-        auto when_stack = when(m_inv, access_reg.type == T_STACK);
-        if (!when_stack.is_bottom()) {
-            if (!stack.all_num(when_stack, lb, ub)) {
-                auto lb_is = when_stack[lb].lb().number();
-                std::string lb_s = lb_is && lb_is->fits_sint() ? std::to_string((int)*lb_is) : "-oo";
-                auto ub_is = when_stack.eval_interval(ub).ub().number();
-                std::string ub_s = ub_is && ub_is->fits_sint() ? std::to_string((int)*ub_is) : "oo";
-                require(when_stack, access_reg.type != T_STACK, "Illegal map update with a non-numerical value [" + lb_s + "-" + ub_s + ")");
-            } else if (thread_local_options.strict && map_type.has_value() && map_type->is_array) {
-                // Get offset value.
-                variable_t key_ptr = access_reg.offset;
-                std::optional<number_t> offset = m_inv[key_ptr].singleton();
-                if (!offset.has_value()) {
-                    require_false(m_inv, "Pointer must be a singleton");
-                } else if (s.key) {
-                    // Look up the value pointed to by the key pointer.
-                    variable_t key_value =
-                        variable_t::cell_var(data_kind_t::values, (uint64_t)offset.value(), sizeof(uint32_t));
-
-                    require(m_inv, key_value < max_entries, "Array index overflow");
-                    require(m_inv, key_value >= 0, "Array index underflow");
-                }
-            }
-        }
-
-        m_inv = check_access_packet(when(m_inv, access_reg.type == T_PACKET), lb, ub, m, false) |
-                check_access_stack(when(m_inv, access_reg.type == T_STACK), lb, ub, m);
-    }
-
-    void operator()(const ValidAccess& s) {
-        using namespace dsl_syntax;
-
-        bool is_comparison_check = s.width == (Value)Imm{0};
-
-        auto reg = reg_pack(s.reg);
-        linear_expression_t lb = reg.offset + s.offset;
-        linear_expression_t ub = std::holds_alternative<Imm>(s.width)
-            ? lb + std::get<Imm>(s.width).v
-            : lb + reg_pack(std::get<Reg>(s.width)).value;
-        std::string m = std::string(" (") + to_string(s) + ")";
-
-        NumAbsDomain assume_ptr =
-            check_access_packet(when(m_inv, reg.type == T_PACKET), lb, ub, m, is_comparison_check) |
-            check_access_stack(when(m_inv, reg.type == T_STACK), lb, ub, m) |
-            check_access_shared(when(m_inv, is_shared(reg.type)), lb, ub, m, reg.type) |
-            check_access_context(when(m_inv, reg.type == T_CTX), lb, ub, m);
-        if (is_comparison_check) {
-            assume(m_inv, reg.type <= T_NUM);
-            m_inv |= std::move(assume_ptr);
-            return;
-        } else {
-            if (s.or_null) {
-                require(m_inv, reg.type >= T_NUM, "Must be a pointer or null");
-                assume(m_inv, reg.type == T_NUM);
-                require(m_inv, reg.value == 0, "Pointers may be compared only to the number 0");
-                m_inv |= std::move(assume_ptr);
-                return;
-            } else {
-                require(m_inv, reg.type > T_NUM, "Only pointers can be dereferenced");
-                require(m_inv, reg.value > 0, "Possible null access");
-                m_inv = std::move(assume_ptr);
-                return;
-            }
-        }
-    }
-
-    NumAbsDomain check_access_packet(NumAbsDomain inv, const linear_expression_t& lb, const linear_expression_t& ub, const std::string& s,
-                                     bool is_comparison_check) {
-        using namespace dsl_syntax;
-        require(inv, lb >= variable_t::meta_offset(), std::string("Lower bound must be at least meta_offset") + s);
-        if (is_comparison_check)
-            require(inv, ub <= MAX_PACKET_OFF,
-                    std::string("Upper bound must be at most ") + std::to_string(MAX_PACKET_OFF) + s);
-        else
-            require(inv, ub <= variable_t::packet_size(),
-                    std::string("Upper bound must be at most packet_size") + s);
-        return inv;
-    }
-
-    NumAbsDomain check_access_stack(NumAbsDomain inv, const linear_expression_t& lb, const linear_expression_t& ub, const std::string& s) {
-        using namespace dsl_syntax;
-        require(inv, lb >= 0, std::string("Lower bound must be at least 0") + s);
-        require(inv, ub <= EBPF_STACK_SIZE, std::string("Upper bound must be at most EBPF_STACK_SIZE") + s + std::string(", make sure to bounds check any pointer access"));
-        return inv;
-    }
-
-    NumAbsDomain check_access_shared(NumAbsDomain inv, const linear_expression_t& lb, const linear_expression_t& ub, const std::string& s,
-                                     variable_t reg_type) {
-        using namespace dsl_syntax;
-        require(inv, lb >= 0, std::string("Lower bound must be at least 0") + s);
-        require(inv, ub <= reg_type, std::string("Upper bound must be at most ") + reg_type.name() + s);
-        return inv;
-    }
-
-    NumAbsDomain check_access_context(NumAbsDomain inv, const linear_expression_t& lb, const linear_expression_t& ub, const std::string& s) {
-        using namespace dsl_syntax;
-        require(inv, lb >= 0, std::string("Lower bound must be at least 0") + s);
-        require(inv, ub <= global_program_info.type.context_descriptor->size,
-                std::string("Upper bound must be at most ") + std::to_string(global_program_info.type.context_descriptor->size) +
-                    s);
-        return inv;
-    }
-
-    void operator()(const ValidStore& s) {
-        using namespace dsl_syntax;
-        linear_constraint_t cond = reg_pack(s.mem).type != T_STACK;
-
-        NumAbsDomain non_stack{m_inv};
-        non_stack += cond;
-        require(non_stack, reg_pack(s.val).type == T_NUM, "Only numbers can be stored to externally-visible regions");
-
-        m_inv += cond.negate();
-        m_inv |= std::move(non_stack);
-    }
-
-    void operator()(const TypeConstraint& s) {
-        using namespace dsl_syntax;
-        variable_t t = reg_pack(s.reg).type;
-        std::string str = to_string(s);
-        switch (s.types) {
-        case TypeGroup::number: require(m_inv, t == T_NUM, str); break;
-        case TypeGroup::map_fd: require(m_inv, t == T_MAP, str); break;
-        case TypeGroup::map_fd_programs: require(m_inv, t == T_MAP_PROGRAMS, str); break;
-        case TypeGroup::ctx: require(m_inv, t == T_CTX, str); break;
-        case TypeGroup::packet: require(m_inv, t == T_PACKET, str); break;
-        case TypeGroup::stack: require(m_inv, t == T_STACK, str); break;
-        case TypeGroup::shared: require(m_inv, t > T_SHARED, str); break;
-        case TypeGroup::non_map_fd: require(m_inv, t >= T_NUM, str); break;
-        case TypeGroup::mem: require(m_inv, t >= T_STACK, str); break;
-        case TypeGroup::mem_or_num:
-            require(m_inv, t >= T_NUM, str);
-            require(m_inv, t != T_CTX, str);
-            break;
-        case TypeGroup::pointer: require(m_inv, t >= T_CTX, str); break;
-        case TypeGroup::ptr_or_num: require(m_inv, t >= T_NUM, str); break;
-        case TypeGroup::stack_or_packet:
-            require(m_inv, t >= T_STACK, str);
-            require(m_inv, t <= T_PACKET, str);
-            break;
-        }
-    }
-
-    void operator()(const ZeroOffset& s) {
-        using namespace dsl_syntax;
-        auto reg = reg_pack(s.reg);
-        require(m_inv, reg.offset == 0, to_string(s));
-    }
-
-    void operator()(Assert const& stmt) { std::visit(*this, stmt.cst); };
-
-    void operator()(Packet const& a) {
-        auto reg = reg_pack(R0_RETURN_VALUE);
-        assign(reg.type, T_NUM);
-        havoc(reg.offset);
-        havoc(reg.value);
-        scratch_caller_saved_registers();
-    }
-
-    static NumAbsDomain do_load_packet_or_shared(NumAbsDomain inv, reg_pack_t target, const linear_expression_t& addr, int width) {
-        if (inv.is_bottom())
-            return inv;
-
-        inv.assign(target.type, T_NUM);
-        inv -= target.offset;
-
-        // A 1 or 2 byte copy results in a limited range of values that may be used as array indices.
-        if (width == 1) {
-            inv.set(target.value, interval_t(0, UINT8_MAX));
-        } else if (width == 2) {
-            inv.set(target.value, interval_t(0, UINT16_MAX));
-        } else {
-            inv -= target.value;
-        }
-        return inv;
-    }
-
-    static NumAbsDomain do_load_ctx(NumAbsDomain inv, reg_pack_t target, const linear_expression_t& addr_vague, int width) {
-        using namespace dsl_syntax;
-        if (inv.is_bottom())
-            return inv;
-
-        const ebpf_context_descriptor_t* desc = global_program_info.type.context_descriptor;
-
-        inv -= target.value;
-
-        if (desc->end < 0) {
-            inv -= target.offset;
-            inv.assign(target.type, T_NUM);
-            return inv;
-        }
-
-        interval_t interval = inv.eval_interval(addr_vague);
-        std::optional<number_t> maybe_addr = interval.singleton();
-
-        bool may_touch_ptr = interval[desc->data] || interval[desc->end] || interval[desc->end];
-
-        if (!maybe_addr) {
-            inv -= target.offset;
-            if (may_touch_ptr)
-                inv -= target.type;
-            else
-                inv.assign(target.type, T_NUM);
-            return inv;
-        }
-
-        number_t addr = *maybe_addr;
-
-        if (addr == desc->data) {
-            inv.assign(target.offset, 0);
-        } else if (addr == desc->end) {
-            inv.assign(target.offset, variable_t::packet_size());
-        } else if (addr == desc->meta) {
-            inv.assign(target.offset, variable_t::meta_offset());
-        } else {
-            inv -= target.offset;
-            if (may_touch_ptr)
-                inv -= target.type;
-            else
-                inv.assign(target.type, T_NUM);
-            return inv;
-        }
-        inv.assign(target.type, T_PACKET);
-        inv += 4098 <= target.value;
-        inv += target.value <= PTR_MAX;
-        return inv;
-    }
-
-    NumAbsDomain do_load_stack(NumAbsDomain inv, reg_pack_t target, const linear_expression_t& addr, int width) {
-        if (width == 1 || width == 2 || width == 4 || width == 8) {
-            inv.assign(target.type, stack.load(inv, data_kind_t::types, addr, width));
-            inv.assign(target.value, stack.load(inv,  data_kind_t::values, addr, width));
-            inv.assign(target.offset, stack.load(inv, data_kind_t::offsets, addr, width));
-        } else {
-            inv.assign(target.type, stack.load(inv, data_kind_t::types, addr, width));
-            inv -= target.value;
-            inv -= target.offset;
-        }
-        return inv;
-    }
-
-    void do_load(Mem const& b, reg_pack_t target) {
-        if (m_inv.is_bottom())
-            return;
-        using namespace dsl_syntax;
-        auto mem_reg = reg_pack(b.access.basereg);
-        int width = b.access.width;
-        int offset = b.access.offset;
-        linear_expression_t addr = mem_reg.offset + (number_t)offset;
-
-        if (b.access.basereg.v == R10_STACK_POINTER) {
-            m_inv = do_load_stack(std::move(m_inv), target, addr, width);
-            return;
-        }
-
-        int type = get_type(mem_reg.type);
-        if (type == T_UNINIT) {
-            return;
-        }
-
-        switch (type) {
-            case T_UNINIT: {
-                m_inv = do_load_ctx(when(m_inv, mem_reg.type == T_CTX), target, addr, width) |
-                        do_load_packet_or_shared(when(m_inv, mem_reg.type >= T_PACKET), target, addr, width) |
-                        do_load_stack(when(m_inv, mem_reg.type == T_STACK), target, addr, width);
-                return;
-            }
-            case T_MAP: return;
-            case T_MAP_PROGRAMS: return;
-            case T_NUM: return;
-            case T_CTX: m_inv = do_load_ctx(std::move(m_inv), target, addr, width); break;
-            case T_STACK: m_inv = do_load_stack(std::move(m_inv), target, addr, width); break;
-            default: m_inv = do_load_packet_or_shared(std::move(m_inv), target, addr, width); break;
-        }
-    }
-
-    int get_type(variable_t v) {
-        auto res = m_inv[v].singleton();
-        if (!res)
-            return T_UNINIT;
-        return (int)*res;
-    }
-
-    static int get_type(int t) { return t; }
-
-    template <typename A, typename X, typename Y, typename Z>
-    void do_store_stack(NumAbsDomain& inv, int width, const A& addr, X val_type, Y val_value,
-                        std::optional<Z> opt_val_offset) {
-        inv.assign(stack.store(inv, data_kind_t::types, addr, width, val_type), val_type);
-        if (width == 8) {
-            inv.assign(stack.store(inv, data_kind_t::values, addr, width, val_value), val_value);
-            if (opt_val_offset && get_type(val_type) != T_NUM)
-                inv.assign(stack.store(inv, data_kind_t::offsets, addr, width, *opt_val_offset), *opt_val_offset);
-            else
-                stack.havoc(inv, data_kind_t::offsets, addr, width);
-        } else if ((width == 1 || width == 2 || width == 4) && get_type(val_type) == T_NUM) {
-            // Keep track of numbers on the stack that might be used as array indices.
-            inv.assign(stack.store(inv, data_kind_t::values, addr, width, val_value), val_value);
-            stack.havoc(inv, data_kind_t::offsets, addr, width);
-        } else {
-            stack.havoc(inv, data_kind_t::values, addr, width);
-            stack.havoc(inv, data_kind_t::offsets, addr, width);
-        }
-    }
-
-    void operator()(Mem const& b) {
-        if (std::holds_alternative<Reg>(b.value)) {
-            auto data_reg = reg_pack(std::get<Reg>(b.value));
-            if (b.is_load) {
-                do_load(b, data_reg);
-            } else {
-                do_mem_store(b, data_reg.type, data_reg.value, data_reg.offset);
-            }
-        } else {
-            do_mem_store(b, T_NUM, std::get<Imm>(b.value).v, {});
-        }
-    }
-
-    template <typename Type, typename Value>
-    void do_mem_store(Mem const& b, Type val_type, Value val_value, std::optional<variable_t> opt_val_offset) {
-        if (m_inv.is_bottom())
-            return;
-        using namespace dsl_syntax;
-        auto mem_reg = reg_pack(b.access.basereg);
-        int width = b.access.width;
-        int offset = b.access.offset;
-        if (b.access.basereg.v == R10_STACK_POINTER) {
-            int addr = EBPF_STACK_SIZE + offset;
-            do_store_stack(m_inv, width, addr, val_type, val_value, opt_val_offset);
-            return;
-        }
-        linear_expression_t addr = linear_expression_t(mem_reg.offset) + offset;
-        switch (get_type(mem_reg.type)) {
-            case T_STACK: do_store_stack(m_inv, width, addr, val_type, val_value, opt_val_offset); return;
-            case T_UNINIT: { //maybe stack
-                NumAbsDomain assume_not_stack(m_inv);
-#ifdef _MSC_VER
-                // MSVC seems to have a harder time coercing the right things, so force
-                // the correct interpretations.
-                assume_not_stack += (linear_constraint_t)(mem_reg.type != T_STACK);
-                m_inv += crab::dsl_syntax::operator==(mem_reg.type, T_STACK);
-#else
-                assume_not_stack += mem_reg.type != T_STACK;
-                m_inv += mem_reg.type == T_STACK;
-#endif
-                if (!m_inv.is_bottom()) {
-                    do_store_stack(m_inv, width, addr, val_type, val_value, opt_val_offset);
-                }
-                m_inv |= std::move(assume_not_stack);
-            }
-            default: break;
-        }
-    }
-
-    void operator()(LockAdd const& a) {
-        // nothing to do here
-    }
-
-    void operator()(Call const& call) {
-        using namespace dsl_syntax;
-        if (m_inv.is_bottom())
-            return;
-        std::optional<Reg> fd_index{};
-        for (ArgSingle param : call.singles) {
-            switch (param.kind) {
-            case ArgSingle::Kind::MAP_FD:
-                fd_index = param.reg;
-                break;
-            case ArgSingle::Kind::ANYTHING:
-            case ArgSingle::Kind::MAP_FD_PROGRAMS:
-            case ArgSingle::Kind::PTR_TO_MAP_KEY:
-            case ArgSingle::Kind::PTR_TO_MAP_VALUE:
-            case ArgSingle::Kind::PTR_TO_CTX:
-                // Do nothing. We don't track the content of relevant memory regions
-                break;
-            }
-        }
-        for (ArgPair param : call.pairs) {
-            switch (param.kind) {
-            case ArgPair::Kind::PTR_TO_MEM_OR_NULL:
-            case ArgPair::Kind::PTR_TO_MEM:
-                // Do nothing. No side effect allowed.
-                break;
-
-            case ArgPair::Kind::PTR_TO_UNINIT_MEM: {
-                // Pointer to a memory region that the called function may change,
-                // so we must havoc.
-                interval_t t = m_inv[reg_pack(param.mem).type];
-                if (t[T_STACK]) {
-                    variable_t addr = reg_pack(param.mem).offset;
-                    variable_t width = reg_pack(param.size).value;
-                    stack.havoc(m_inv, data_kind_t::types, addr, width);
-                    stack.havoc(m_inv, data_kind_t::values, addr, width);
-                    stack.havoc(m_inv, data_kind_t::offsets, addr, width);
-                    if (t.singleton()) {
-                        // Functions are not allowed to write sensitive data,
-                        // and initialization is guaranteed
-                        stack.store_numbers(m_inv, addr, width);
-                    }
-                }
-            }
-            }
-        }
-
-        auto r0 = reg_pack(R0_RETURN_VALUE);
-        if (call.is_map_lookup) {
-            // This is the only way to get a null pointer
-            if (fd_index) {
-                if (std::optional<number_t> fd_opt = m_inv[reg_pack(*fd_index).offset].singleton()) {
-                    if (fd_opt->fits_sint()) {
-                        const EbpfMapDescriptor& desc = global_program_info.platform->get_map_descriptor((int)*fd_opt);
-                        if (global_program_info.platform->get_map_type(desc.type).value_type == EbpfMapValueType::MAP) {
-                            do_load_mapfd(r0, (int)desc.inner_map_fd, true);
-                            goto out;
-                        }
-                    }
-                }
-            }
-            assign_valid_ptr(r0, true);
-            assign(r0.offset, 0);
-            assign(r0.type, variable_t::map_value_size());
-        } else {
-            havoc(r0.value);
-            havoc(r0.offset);
-            assign(r0.type, T_NUM);
-            // assume(r0.value < 0); for INTEGER_OR_NO_RETURN_IF_SUCCEED.
-        }
-out:
-        scratch_caller_saved_registers();
-        if (call.reallocate_packet) {
-            forget_packet_pointers();
-        }
-    }
-
-    void do_load_mapfd(const reg_pack_t& dst, int mapfd, bool maybe_null) {
-        const EbpfMapDescriptor& desc = global_program_info.platform->get_map_descriptor(mapfd);
-        const EbpfMapType& type = global_program_info.platform->get_map_type(desc.type);
-        if (type.value_type == EbpfMapValueType::PROGRAM) {
-            assign(dst.type, T_MAP_PROGRAMS);
-        } else {
-            assign(dst.type, T_MAP);
-        }
-        assign(dst.offset, mapfd);
-        assign_valid_ptr(dst, maybe_null);
-    }
-
-    void operator()(LoadMapFd const& ins) {
-        do_load_mapfd(reg_pack(ins.dst), ins.mapfd, false);
-    }
-
-    void assign_valid_ptr(const reg_pack_t& reg, bool maybe_null) {
-        using namespace crab::dsl_syntax;
-        havoc(reg.value);
-        if (maybe_null) {
-            m_inv += 0 <= reg.value;
-        } else {
-            m_inv += 0 < reg.value;
-        }
-        m_inv += reg.value <= PTR_MAX;
-    }
-
-    void operator()(Bin const& bin) {
-        using namespace dsl_syntax;
-
-        auto dst = reg_pack(bin.dst);
-
-        if (std::holds_alternative<Imm>(bin.v)) {
-            // dst += K
-            int imm = static_cast<int>(std::get<Imm>(bin.v).v);
-            switch (bin.op) {
-            case Bin::Op::MOV:
-                assign(dst.value, imm);
-                assign(dst.type, T_NUM);
-                havoc(dst.offset);
-                break;
-            case Bin::Op::ADD:
-                if (imm == 0)
-                    return;
-                add_overflow(dst.value, imm);
-                add(dst.offset, imm);
-                break;
-            case Bin::Op::SUB:
-                if (imm == 0)
-                    return;
-                sub_overflow(dst.value, imm);
-                sub(dst.offset, imm);
-                break;
-            case Bin::Op::MUL:
-                mul(dst.value, imm);
-                assert_no_pointer(dst);
-                break;
-            case Bin::Op::DIV:
-                div(dst.value, imm);
-                assert_no_pointer(dst);
-                break;
-            case Bin::Op::MOD:
-                rem(dst.value, imm);
-                assert_no_pointer(dst);
-                break;
-            case Bin::Op::OR:
-                bitwise_or(dst.value, imm);
-                assert_no_pointer(dst);
-                break;
-            case Bin::Op::AND:
-                // FIX: what to do with ptr&-8 as in counter/simple_loop_unrolled?
-                bitwise_and(dst.value, imm);
-                if ((int32_t)imm > 0) {
-                    assume(dst.value <= imm);
-                    assume(0 <= dst.value);
-                }
-                assert_no_pointer(dst);
-                break;
-            case Bin::Op::LSH:
-                // avoid signedness and overflow issues in shl_overflow(dst.value, imm);
-                shl_overflow(dst.value, imm);
-                assert_no_pointer(dst);
-                break;
-            case Bin::Op::RSH:
-                // avoid signedness and overflow issues in lshr(dst.value, imm);
-                havoc(dst.value);
-                assert_no_pointer(dst);
-                break;
-            case Bin::Op::ARSH:
-                // avoid signedness and overflow issues in ashr(dst.value, imm);
-                // = (int64_t)dst >> imm;
-                havoc(dst.value);
-                // assume(dst.value <= (1 << (64 - imm)));
-                // assume(dst.value >= -(1 << (64 - imm)));
-                assert_no_pointer(dst);
-                break;
-            case Bin::Op::XOR:
-                bitwise_xor(dst.value, imm);
-                assert_no_pointer(dst);
-                break;
-            }
-        } else {
-            // dst op= src
-            auto src = reg_pack(std::get<Reg>(bin.v));
-            switch (bin.op) {
-            case Bin::Op::ADD: {
-                auto stype = get_type(src.type);
-                auto dtype = get_type(dst.type);
-                if (stype == T_NUM && dtype == T_NUM) {
-                    add_overflow(dst.value, src.value);
-                } else if (dtype == T_NUM) {
-                    apply(m_inv, crab::arith_binop_t::ADD, dst.value, src.value, dst.value, true);
-                    apply(m_inv, crab::arith_binop_t::ADD, dst.offset, src.offset, dst.value, false);
-                    m_inv.assign(dst.type, src.type);
-                } else if (stype == T_NUM) {
-                    add_overflow(dst.value, src.value);
-                    add(dst.offset, src.value);
-                } else {
-                    havoc(dst.type);
-                    havoc(dst.value);
-                    havoc(dst.offset);
-                }
-                break;
-            }
-            case Bin::Op::SUB: {
-                auto stype = get_type(src.type);
-                auto dtype = get_type(dst.type);
-                if (dtype == T_NUM && stype == T_NUM) {
-                    sub_overflow(dst.value, src.value);
-                } else if (stype == T_NUM) {
-                    sub_overflow(dst.value, src.value);
-                    sub(dst.offset, src.value);
-                } else if (stype == dtype && stype < 0) { // subtracting non-shared pointers
-                    apply(m_inv, crab::arith_binop_t::SUB, dst.value, dst.offset, src.offset, true);
-                    havoc(dst.offset);
-                    assign(dst.type, T_NUM);
-                } else {
-                    havoc(dst.type);
-                    havoc(dst.value);
-                    havoc(dst.offset);
-                }
-                break;
-            }
-            case Bin::Op::MUL:
-                mul(dst.value, src.value);
-                assert_no_pointer(dst);
-                break;
-            case Bin::Op::DIV:
-                // DIV is not checked for zerodiv
-                div(dst.value, src.value);
-                assert_no_pointer(dst);
-                break;
-            case Bin::Op::MOD:
-                // See DIV comment
-                rem(dst.value, src.value);
-                assert_no_pointer(dst);
-                break;
-            case Bin::Op::OR:
-                bitwise_or(dst.value, src.value);
-                assert_no_pointer(dst);
-                break;
-            case Bin::Op::AND:
-                bitwise_and(dst.value, src.value);
-                assert_no_pointer(dst);
-                break;
-            case Bin::Op::LSH:
-                shl_overflow(dst.value, src.value);
-                assert_no_pointer(dst);
-                break;
-            case Bin::Op::RSH:
-                havoc(dst.value);
-                assert_no_pointer(dst);
-                break;
-            case Bin::Op::ARSH:
-                havoc(dst.value);
-                assert_no_pointer(dst);
-                break;
-            case Bin::Op::XOR:
-                bitwise_xor(dst.value, src.value);
-                assert_no_pointer(dst);
-                break;
-            case Bin::Op::MOV:
-                assign(dst.value, src.value);
-                assign(dst.offset, src.offset);
-                assign(dst.type, src.type);
-                break;
-            }
-        }
-        if (!bin.is64) {
-            bitwise_and(dst.value, UINT32_MAX);
-        }
-    }
-
-    string_invariant to_set() {
-        return this->m_inv.to_set();
-    }
-
-    friend std::ostream& operator<<(std::ostream& o, ebpf_domain_t dom) {
-        if (dom.is_bottom()) {
-            o << "_|_";
-        } else {
-            o << dom.m_inv << "\nStack: " << dom.stack;
-        }
-        return o;
-    }
-
-    static void initialize_packet(ebpf_domain_t& inv) {
-        using namespace dsl_syntax;
-
-        inv -= variable_t::packet_size();
-        inv -= variable_t::meta_offset();
-
-        inv += 0 <= variable_t::packet_size();
-        inv += variable_t::packet_size() < MAX_PACKET_OFF;
-        auto info = global_program_info;
-        if (info.type.context_descriptor->meta >= 0) {
-            inv += variable_t::meta_offset() <= 0;
-            inv += variable_t::meta_offset() >= -4098;
-        } else {
-            inv.assign(variable_t::meta_offset(), 0);
-        }
-    }
-
-    static ebpf_domain_t from_constraints(const std::vector<linear_constraint_t>& csts) {
-        ebpf_domain_t inv;
-        for (const auto& cst: csts) {
-            inv += cst;
-        }
-        return inv;
-    }
-
-    static ebpf_domain_t setup_entry(bool check_termination) {
-        using namespace dsl_syntax;
-
-        ebpf_domain_t inv;
-        auto r10 = reg_pack(R10_STACK_POINTER);
-        inv += EBPF_STACK_SIZE <= r10.value;
-        inv += r10.value <= PTR_MAX;
-        inv.assign(r10.offset, EBPF_STACK_SIZE);
-        inv.assign(r10.type, T_STACK);
-
-        auto r1 = reg_pack(R1_ARG);
-        inv += 1 <= r1.value;
-        inv += r1.value <= PTR_MAX;
-        inv.assign(r1.offset, 0);
-        inv.assign(r1.type, T_CTX);
-
-        initialize_packet(inv);
-
-        if (check_termination) {
-            inv.assign(variable_t::instruction_count(), 0);
-        }
-        return inv;
-    }
 }; // end ebpf_domain_t
-
-} // namespace crab

--- a/src/crab/fwd_analyzer.cpp
+++ b/src/crab/fwd_analyzer.cpp
@@ -11,8 +11,6 @@
 
 namespace crab {
 
-using domains::ebpf_domain_t;
-
 // Simple visitor to check if node is a member of the wto component.
 class member_component_visitor final {
     label_t _node;

--- a/src/crab/fwd_analyzer.hpp
+++ b/src/crab/fwd_analyzer.hpp
@@ -11,7 +11,6 @@
 
 namespace crab {
 
-using domains::ebpf_domain_t;
 using invariant_table_t = std::map<label_t, ebpf_domain_t>;
 
 std::pair<invariant_table_t, invariant_table_t> run_forward_analyzer(cfg_t& cfg, const ebpf_domain_t& entry_inv,

--- a/src/crab/linear_constraint.hpp
+++ b/src/crab/linear_constraint.hpp
@@ -14,16 +14,6 @@ enum class constraint_kind_t {
     NOT_ZERO
 };
 
-inline constraint_kind_t negate(constraint_kind_t constraint) {
-    switch (constraint){
-    case constraint_kind_t::NOT_ZERO : return constraint_kind_t::EQUALS_ZERO;
-    case constraint_kind_t::EQUALS_ZERO : return constraint_kind_t::NOT_ZERO;
-    case constraint_kind_t::LESS_THAN_ZERO : return constraint_kind_t::LESS_THAN_OR_EQUALS_ZERO;
-    case constraint_kind_t::LESS_THAN_OR_EQUALS_ZERO : return constraint_kind_t::LESS_THAN_ZERO;
-    default : throw std::exception();
-    }
-}
-
 class linear_constraint_t final {
   private:
     linear_expression_t _expression = linear_expression_t(0);
@@ -60,15 +50,16 @@ class linear_constraint_t final {
 
     // Construct the logical NOT of this constraint.
     [[nodiscard]] linear_constraint_t negate() const {
-        const constraint_kind_t inverse_constraint_kind = ::negate(_constraint_kind);
-        switch (_constraint_kind){
+        switch (_constraint_kind) {
         case constraint_kind_t::NOT_ZERO:
+            return linear_constraint_t(_expression, constraint_kind_t::EQUALS_ZERO);
         case constraint_kind_t::EQUALS_ZERO:
-            return linear_constraint_t{_expression, inverse_constraint_kind};
+            return linear_constraint_t(_expression, constraint_kind_t::NOT_ZERO);
         case constraint_kind_t::LESS_THAN_ZERO:
+            return linear_constraint_t(-_expression, constraint_kind_t::LESS_THAN_OR_EQUALS_ZERO);
         case constraint_kind_t::LESS_THAN_OR_EQUALS_ZERO:
-            return linear_constraint_t{-_expression, inverse_constraint_kind};
-        default : throw std::exception();
+            return linear_constraint_t(-_expression, constraint_kind_t::LESS_THAN_ZERO);
+        default: throw std::exception();
         }
     }
 

--- a/src/crab/linear_expression.hpp
+++ b/src/crab/linear_expression.hpp
@@ -23,7 +23,7 @@ class linear_expression_t final {
     number_t _constant_term;
 
     // Get the coefficient for a given variable, which is 0 if it has no term in the expression.
-    number_t coefficient_of(const variable_t& variable) const {
+    [[nodiscard]] number_t coefficient_of(const variable_t& variable) const {
         auto it = _variable_terms.find(variable);
         if (it == _variable_terms.end()) {
             return 0;
@@ -33,10 +33,12 @@ class linear_expression_t final {
 
   public:
     linear_expression_t(signed long long int coefficient) : _constant_term(coefficient) {}
-    linear_expression_t(const number_t& coefficient) : _constant_term(coefficient) {}
+    linear_expression_t(number_t coefficient) : _constant_term(std::move(coefficient)) {}
     linear_expression_t(const variable_t& variable) { _variable_terms[variable] = 1; }
     linear_expression_t(const number_t& coefficient, const variable_t& variable) { _variable_terms[variable] = coefficient; }
-    linear_expression_t(const variable_terms_t& variable_terms, const number_t& constant_term) : _variable_terms(variable_terms), _constant_term(constant_term) {}
+    linear_expression_t(variable_terms_t variable_terms, number_t constant_term)
+            : _variable_terms(std::move(variable_terms)),
+              _constant_term(std::move(constant_term)) {}
 
     // Allow a caller to access individual terms.
     [[nodiscard]] const variable_terms_t& variable_terms() const { return _variable_terms; }

--- a/src/crab/split_dbm.hpp
+++ b/src/crab/split_dbm.hpp
@@ -390,8 +390,6 @@ class SplitDBM final {
 
     void forget(const variable_vector_t& variables);
 
-    void rename(const variable_vector_t& from, const variable_vector_t& to);
-
     // -- begin array_sgraph_domain_helper_traits
 
     // -- end array_sgraph_domain_helper_traits

--- a/src/crab/split_dbm.hpp
+++ b/src/crab/split_dbm.hpp
@@ -22,9 +22,9 @@
 #include <optional>
 #include <type_traits>
 #include <unordered_set>
+#include <utility>
 
 #include <boost/container/flat_map.hpp>
-#include <utility>
 
 #include "crab/interval.hpp"
 #include "crab/linear_constraint.hpp"
@@ -38,8 +38,20 @@
 #include "crab_utils/stats.hpp"
 
 #include "string_constraints.hpp"
-//#define CHECK_POTENTIAL
-//#define SDBM_NO_NORMALIZE
+
+// These constants are mostly used in ebpf_domain.cpp, but some uses
+// in split_dbm.cpp and array_domain.cpp require them to be declared here.
+// The exact numbers are taken advantage of in ebpf_domain_t
+enum type_encoding_t {
+    T_UNINIT = -7,
+    T_MAP_PROGRAMS = -6,
+    T_MAP = -5,
+    T_NUM = -4,
+    T_CTX = -3,
+    T_STACK = -2,
+    T_PACKET = -1,
+    T_SHARED = 0
+};
 
 namespace crab {
 
@@ -227,7 +239,7 @@ class SplitDBM final {
         return x_out;
     }
 
-    // Resore potential after an edge addition
+    // Restore potential after an edge addition
     bool repair_potential(vert_id src, vert_id dest) { return GrOps::repair_potential(g, potential, src, dest); }
 
     // Restore closure after a single edge addition

--- a/src/crab/variable.hpp
+++ b/src/crab/variable.hpp
@@ -42,12 +42,12 @@ class variable_t final {
 
     [[nodiscard]] std::string name() const { return names.at(_id); }
 
-    bool is_type() { return names.at(_id).find(".type") != std::string::npos; }
+    [[nodiscard]] bool is_type() const { return names.at(_id).find(".type") != std::string::npos; }
 
     friend std::ostream& operator<<(std::ostream& o, variable_t v)  { return o << names.at(v._id); }
 
     // var_factory portion.
-    // This singleton is eBPF-specific, to avoid life time issues and/or passing factory explicitly everywhere:
+    // This singleton is eBPF-specific, to avoid lifetime issues and/or passing factory explicitly everywhere:
   private:
     static variable_t make(const std::string& name);
     static thread_local std::vector<std::string> names;
@@ -64,8 +64,10 @@ class variable_t final {
     static variable_t packet_size();
     static variable_t instruction_count();
     bool is_in_stack();
-}; // class variable_t
 
-inline size_t hash_value(variable_t v) { return v.hash(); }
+    struct Hasher {
+        std::size_t operator()(const variable_t& v) const { return v.hash(); }
+    };
+}; // class variable_t
 
 } // namespace crab

--- a/src/crab_verifier.cpp
+++ b/src/crab_verifier.cpp
@@ -25,10 +25,6 @@ using std::string;
 thread_local program_info global_program_info;
 thread_local ebpf_verifier_options_t thread_local_options;
 
-// Numerical domains over integers
-// using sdbm_domain_t = crab::domains::SplitDBM;
-using crab::domains::ebpf_domain_t;
-
 // Toy database to store invariants.
 struct checks_db final {
     std::map<label_t, std::vector<std::string>> m_db;

--- a/src/string_constraints.cpp
+++ b/src/string_constraints.cpp
@@ -7,6 +7,7 @@
 
 #include "string_constraints.hpp"
 
+#include "crab/split_dbm.hpp"
 #include "crab/variable.hpp"
 #include "crab/linear_constraint.hpp"
 #include "crab/dsl_syntax.hpp"
@@ -45,8 +46,8 @@ static long number(const string& s) {
     }
 }
 
-static int type(const string& s) {
-    static map<string, int> string_to_type{
+static type_encoding_t string_to_type_encoding(const string& s) {
+    static map<string, type_encoding_t> string_to_type{
         {string("uninit"), T_UNINIT},
         {string("map_fd_programs"), T_MAP_PROGRAMS},
         {string("map"), T_MAP},
@@ -76,7 +77,7 @@ std::vector<linear_constraint_t> parse_linear_constraints(const std::set<string>
             res.push_back(equals(d, s));
         } else if (regex_match(cst_text, m, regex(REG DOT "type" "=" TYPE))) {
             variable_t d = variable_t::reg(data_kind_t::types, regnum(m[1]));
-            res.push_back(d == type(m[2]));
+            res.push_back(d == string_to_type_encoding(m[2]));
         } else if (regex_match(cst_text, m, regex(REG DOT KIND "=" IMM))) {
             variable_t d = variable_t::reg(regkind(m[2]), regnum(m[1]));
             res.push_back(d == number(m[3]));


### PR DESCRIPTION
Mostly refactoring: create `ebpf_domain.cpp` file and move all implementation details there. Similarly with `array_domain.cpp` which already existed but much of the details still resided on the hpp file.

Some changes, such as introduction of `std::move` here and there, are more optimization than refactoring; I think this version is slightly faster.

Additionally, some minor changes in split_dbm: use `emplace` instead of `insert(elt_t(...))`, and remove unused function `rename()`.