### PR TITLE
Don't assume assertions

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -5,6 +5,7 @@
 
 const ebpf_verifier_options_t ebpf_verifier_default_options = {
     .check_termination = false,
+    .assume_assertions = false,
     .print_invariants = false,
     .print_failures = false,
     .no_simplify = false,

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -4,6 +4,7 @@
 
 struct ebpf_verifier_options_t {
     bool check_termination;
+    bool assume_assertions;
     bool print_invariants;
     bool print_failures;
     bool no_simplify;

--- a/src/crab/bitset_domain.hpp
+++ b/src/crab/bitset_domain.hpp
@@ -44,15 +44,19 @@ class bitset_domain_t final {
         return non_numerical_bytes & other.non_numerical_bytes;
     }
 
+    [[nodiscard]]
     bitset_domain_t widen(const bitset_domain_t& other) const {
         return non_numerical_bytes | other.non_numerical_bytes;
     }
 
+    [[nodiscard]]
     bitset_domain_t narrow(const bitset_domain_t& other) const {
         return non_numerical_bytes & other.non_numerical_bytes;
     }
 
+    [[nodiscard]]
     std::pair<bool, bool> uniformity(size_t lb, int width) const {
+        width = std::min(width, (int)(EBPF_STACK_SIZE - lb));
         bool only_num = true;
         bool only_non_num = true;
         for (int j = 0; j < width; j++) {
@@ -64,12 +68,14 @@ class bitset_domain_t final {
     }
 
     void reset(size_t lb, int n) {
+        n = std::min(n, (int)(EBPF_STACK_SIZE - lb));
         for (int i = 0; i < n; i++) {
             non_numerical_bytes.reset(lb + i);
         }
     }
 
     void havoc(size_t lb, int width) {
+        width = std::min(width, (int)(EBPF_STACK_SIZE - lb));
         for (int i = 0; i < width; i++) {
             non_numerical_bytes.set(lb + i);
         }
@@ -78,8 +84,11 @@ class bitset_domain_t final {
     friend std::ostream& operator<<(std::ostream& o, const bitset_domain_t& array);
 
     // Test whether all values in the range [lb,ub) are numerical.
+    [[nodiscard]]
     bool all_num(int lb, int ub) const {
         assert(lb < ub);
+        lb = std::max(lb, 0);
+        ub = std::min(ub, EBPF_STACK_SIZE);
         if (lb < 0 || ub > (int)non_numerical_bytes.size())
             return false;
 

--- a/src/crab/ebpf_domain.cpp
+++ b/src/crab/ebpf_domain.cpp
@@ -314,6 +314,10 @@ void ebpf_domain_t::assume(const linear_constraint_t& cst) { ::assume(m_inv, cst
 void ebpf_domain_t::require(NumAbsDomain& inv, const linear_constraint_t& cst, const std::string& s) {
     if (check_require)
         check_require(inv, cst, s);
+    if (thread_local_options.assume_assertions) {
+        // avoid redundant errors
+        ::assume(inv, cst);
+    }
 }
 
 /// Forget everything we know about the value of a variable.

--- a/src/crab/ebpf_domain.cpp
+++ b/src/crab/ebpf_domain.cpp
@@ -313,8 +313,7 @@ void ebpf_domain_t::assume(const linear_constraint_t& cst) { ::assume(m_inv, cst
 
 void ebpf_domain_t::require(NumAbsDomain& inv, const linear_constraint_t& cst, const std::string& s) {
     if (check_require)
-        check_require(inv, cst, std::move(s));
-    ::assume(inv, cst);
+        check_require(inv, cst, s);
 }
 
 /// Forget everything we know about the value of a variable.
@@ -475,13 +474,10 @@ void ebpf_domain_t::operator()(const Comparable& s) { require(m_inv, eq(reg_pack
 
 void ebpf_domain_t::operator()(const Addable& s) {
     using namespace crab::dsl_syntax;
-    linear_constraint_t cond = reg_pack(s.ptr).type > T_NUM;
-    NumAbsDomain is_ptr{m_inv};
-    is_ptr += cond;
-    require(is_ptr, reg_pack(s.num).type == T_NUM, "only numbers can be added to pointers (" + to_string(s) + ")");
-
-    m_inv += cond.negate();
-    m_inv |= std::move(is_ptr);
+    auto is_ptr = when(reg_pack(s.ptr).type > T_NUM);
+    require(is_ptr,
+            reg_pack(s.num).type == T_NUM,
+            "only numbers can be added to pointers (" + to_string(s) + ")");
 }
 
 void ebpf_domain_t::operator()(const ValidSize& s) {

--- a/src/crab/ebpf_domain.hpp
+++ b/src/crab/ebpf_domain.hpp
@@ -41,7 +41,7 @@ class ebpf_domain_t final {
     ebpf_domain_t widening_thresholds(const ebpf_domain_t& other, const crab::iterators::thresholds_t& ts);
     ebpf_domain_t narrow(const ebpf_domain_t& other);
 
-    typedef void check_require_func_t(NumAbsDomain&, const linear_constraint_t&, std::string);
+    typedef bool check_require_func_t(NumAbsDomain&, const linear_constraint_t&, std::string);
     void set_require_check(std::function<check_require_func_t> f);
     int get_instruction_count_upper_bound();
     static ebpf_domain_t setup_entry(bool check_termination);

--- a/src/crab_verifier.cpp
+++ b/src/crab_verifier.cpp
@@ -34,19 +34,22 @@ static checks_db generate_report(cfg_t& cfg,
         ebpf_domain_t from_inv(pre_invariants.at(label));
         from_inv.set_require_check([&m_db, label](auto& inv, const linear_constraint_t& cst, const std::string& s) {
             if (inv.is_bottom())
-                return;
+                return true;
             if (cst.is_contradiction()) {
                 m_db.add_warning(label, std::string("Contradiction: ") + s);
-                return;
+                return false;
             }
 
             if (inv.entail(cst)) {
                 // add_redundant(s);
+                return true;
             } else if (inv.intersect(cst)) {
                 // TODO: add_error() if imply negation
                 m_db.add_warning(label, s);
+                return false;
             } else {
                 m_db.add_warning(label, std::string("assertion failed: ") + s);
+                return false;
             }
         });
 

--- a/src/crab_verifier.hpp
+++ b/src/crab_verifier.hpp
@@ -7,6 +7,36 @@
 #include "spec_type_descriptors.hpp"
 #include "string_constraints.hpp"
 
+// Toy database to store invariants.
+struct checks_db final {
+    std::map<label_t, std::vector<std::string>> m_db;
+    int total_warnings{};
+    int total_unreachable{};
+    int max_instruction_count{};
+    std::set<label_t> maybe_nonterminating;
+
+    void add(const label_t& label, const std::string& msg) {
+        m_db[label].emplace_back(msg);
+    }
+
+    void add_warning(const label_t& label, const std::string& msg) {
+        add(label, msg);
+        total_warnings++;
+    }
+
+    void add_unreachable(const label_t& label, const std::string& msg) {
+        add(label, msg);
+        total_unreachable++;
+    }
+
+    void add_nontermination(const label_t& label) {
+        maybe_nonterminating.insert(label);
+        total_warnings++;
+    }
+
+    checks_db() = default;
+};
+
 bool run_ebpf_analysis(std::ostream& s, cfg_t& cfg, const program_info& info, const ebpf_verifier_options_t* options,
     ebpf_verifier_stats_t* stats);
 
@@ -15,7 +45,7 @@ bool ebpf_verify_program(std::ostream& s, const InstructionSeq& prog, const prog
 
 using string_invariant_map = std::map<crab::label_t, string_invariant>;
 
-std::tuple<ebpf_verifier_stats_t, string_invariant_map, string_invariant_map>
+std::tuple<checks_db, string_invariant_map, string_invariant_map>
 ebpf_analyze_program_for_test(const InstructionSeq& prog, const string_invariant& entry_invariant,
                               const program_info& info,
                               bool no_simplify, bool check_termination);

--- a/src/ebpf_yaml.hpp
+++ b/src/ebpf_yaml.hpp
@@ -19,7 +19,9 @@ bool all_suites(const std::string& path);
 struct Failure {
     string_invariant expected_but_unseen;
     string_invariant seen_but_not_expected;
+    checks_db db;
 };
+
 std::optional<Failure> run_yaml_test_case(const TestCase& test_case);
 
 bool run_yaml(const std::string& path);

--- a/src/main/check.cpp
+++ b/src/main/check.cpp
@@ -47,8 +47,9 @@ int main(int argc, char** argv) {
     std::set<string> doms{"stats", "linux", "zoneCrab", "cfg"};
     app.add_set("-d,--dom,--domain", domain, doms, "Abstract domain")->type_name("DOMAIN");
 
-    ebpf_verifier_options.check_termination = false;
     app.add_flag("--termination", ebpf_verifier_options.check_termination, "Verify termination");
+
+    app.add_flag("--assume-assert", ebpf_verifier_options.assume_assertions, "Assume assertions");
 
     bool verbose = false;
     app.add_flag("-i", ebpf_verifier_options.print_invariants, "Print invariants");

--- a/src/main/run_yaml.cpp
+++ b/src/main/run_yaml.cpp
@@ -35,6 +35,11 @@ int main(int argc, char** argv) {
             std::cout << "Unexpected: " << maybe_failure->seen_but_not_expected << "\n";
             std::cout << "Unseen: " << maybe_failure->expected_but_unseen << "\n";
             res = false;
+            for (const auto& [label, items]: maybe_failure->db.m_db) {
+                std::cout << label << ": ";
+                for (const auto& item : items)
+                    std::cout << item << "\n";
+            }
             std::cout << "failed\n";
         } else {
             std::cout << "pass\n";

--- a/src/string_constraints.cpp
+++ b/src/string_constraints.cpp
@@ -68,7 +68,9 @@ std::vector<linear_constraint_t> parse_linear_constraints(const std::set<string>
     std::vector<linear_constraint_t> res;
     for (const string& cst_text : constraints) {
         std::smatch m;
-        if (regex_match(cst_text, m, regex(REG DOT KIND "=" "packet_size"))) {
+        if (regex_match(cst_text, m, regex("meta_offset" "=" IMM))) {
+            res.push_back(variable_t::meta_offset() == number(m[1]));
+        } else if (regex_match(cst_text, m, regex(REG DOT KIND "=" "packet_size"))) {
             variable_t d = variable_t::reg(regkind(m[2]), regnum(m[1]));
             res.push_back(equals(d, variable_t::packet_size()));
         } else if (regex_match(cst_text, m, regex(REG DOT KIND "=" REG DOT KIND))) {

--- a/test-data/jump.yaml
+++ b/test-data/jump.yaml
@@ -34,7 +34,7 @@ post:
 ---
 test-case: simple conditional jump forward
 
-pre: []
+pre: [r1.type=number]
 
 code:
   <start>: |
@@ -47,3 +47,4 @@ code:
 post:
   - r0.type=number
   - r0.value=[0, 1]
+  - r1.type=number

--- a/test-data/packet.yaml
+++ b/test-data/packet.yaml
@@ -4,6 +4,7 @@
 test-case: simple valid access
 
 pre: [
+    "meta_offset=0",
     "r1.type=packet", "r1.offset=0", "r1.value=[4098, 2147418112]",
     "r2.type=packet", "r2.offset=[0, 65534]", "r2.offset=packet_size"
 ]
@@ -16,16 +17,14 @@ code:
     r4 = 0
     *(u64 *)(r1 + 0) = r4
   <out>: |
-    exit;
+    r5=r5
 
 post: [
+    "meta_offset=0",
     "r1.type=packet", "r1.offset=0", "r1.value=[4098, 2147418112]",
     "r2.type=packet", "r2.offset=[0, 65534]", "r2.offset=packet_size",
     "r3.type=packet", "r3.offset=8", "r3.value=[4106, 2147418120]",
-    "meta_offset=[-oo, 7]", "meta_offset-packet_size<=0", "meta_offset-r1.offset<=7", "meta_offset-r2.offset<=0", "meta_offset-r3.offset<=-1",
     "packet_size-r3.offset<=65526", "packet_size=[0, 65534]",
-    "r0.type=number", "r1.offset-packet_size<=0", "r3.offset-packet_size<=8",
-    "r1.offset-r2.offset<=0", "r1.offset-r3.offset<=65518",
-    "r1.value=r3.value+8",
-    "r2.type=r3.type", "r2.offset-r3.offset<=65526", "r3.offset-r2.offset<=8",
+    "r3.offset-packet_size<=8", "r1.value=r3.value+8",
+    "r2.offset-r3.offset<=65526", "r3.offset-r2.offset<=8",
 ]


### PR DESCRIPTION
Two PRs in one:
- Check for warnings in YAML tests, and fix existing tests accordingly.
- Stop assuming the condition of assertions after the check. This might give redundant warnings when one is found, but there should be cheaper ways to filter them. This results in more than 30% speedup.