### PR TITLE
Handle trivial stack access

### DIFF
--- a/src/assertions.cpp
+++ b/src/assertions.cpp
@@ -109,15 +109,17 @@ class AssertExtractor {
         if (info.type.is_privileged)
             return {};
         vector<Assert> res;
-        res.emplace_back(ValidAccess{cond.left});
         if (std::holds_alternative<Imm>(cond.right)) {
             if (imm(cond.right).v != 0) {
+                // no need to check for valid access, it must be a number
                 res.emplace_back(TypeConstraint{cond.left, TypeGroup::number});
             } else {
+                res.emplace_back(ValidAccess{cond.left});
                 // OK - map_fd is just another pointer
                 // Anything can be compared to 0
             }
         } else {
+            res.emplace_back(ValidAccess{cond.left});
             res.emplace_back(ValidAccess{reg(cond.right)});
             if (cond.op != Condition::Op::EQ && cond.op != Condition::Op::NE) {
                 res.emplace_back(TypeConstraint{cond.left, TypeGroup::non_map_fd});

--- a/src/assertions.cpp
+++ b/src/assertions.cpp
@@ -144,7 +144,10 @@ class AssertExtractor {
         int offset = ins.access.offset;
         if (basereg.v == R10_STACK_POINTER) {
             // We know we are accessing the stack.
-            res.emplace_back(ValidAccess{basereg, offset, width, false});
+            if (offset < -EBPF_STACK_SIZE || offset + (int)width.v >= 0) {
+                // This assertion will fail
+                res.emplace_back(ValidAccess{basereg, offset, width, false});
+            }
         } else {
             res.emplace_back(TypeConstraint{basereg, TypeGroup::pointer});
             res.emplace_back(ValidAccess{basereg, offset, width, false});


### PR DESCRIPTION
Avoid adding assertion for trivially-valid stack accesses. Somehow this had slipped away so far, causing ~50% performance penalty.