### PR TITLE
Check entailment using eval_interval first

### DIFF
--- a/src/crab/split_dbm.hpp
+++ b/src/crab/split_dbm.hpp
@@ -437,7 +437,25 @@ class SplitDBM final {
             return true;
         if (rhs.is_contradiction())
             return false;
-
+        interval_t interval = eval_interval(rhs.expression());
+        switch (rhs.kind()) {
+        case constraint_kind_t::EQUALS_ZERO:
+            if (interval.singleton() == std::optional<number_t>(number_t(0)))
+                return true;
+            break;
+        case constraint_kind_t::LESS_THAN_OR_EQUALS_ZERO:
+            if (interval.ub() <= number_t(0))
+                return true;
+            break;
+        case constraint_kind_t::LESS_THAN_ZERO:
+            if (interval.ub() < number_t(0))
+                return true;
+            break;
+        case constraint_kind_t::NOT_ZERO:
+            if (interval.ub() < number_t(0) || interval.lb() > number_t(0))
+                return true;
+            break;
+        }
         if (rhs.kind() == constraint_kind_t::EQUALS_ZERO) {
             // try to convert the equality into inequalities so when it's
             // negated we do not have disequalities.


### PR DESCRIPTION
Standard entailment of a constraint checking involves copying the SplitDBM domain, adding the negation of the constraint, and then checking for bottomness. The copying is quite heavy and incurs large overhead, particularly due to dynamic allocations.

Instead, we now first extract an interval from the expression and return true if it satisfies the constraint, which is a sufficient condition for entailment. We only fallback if that turns out not to be enough. Turns out that the simpler version resolves _all_ the constraints in the largest programs we have, yielding 20% performance improvement.

@caballa can you verify the soundness of this method?

Signed-off-by: Elazar Gershuni <elazarg@gmail.com>