### PR TITLE
Put assumption before the body of basic blocks

### DIFF
--- a/src/asm_cfg.cpp
+++ b/src/asm_cfg.cpp
@@ -113,7 +113,7 @@ static vector<label_t> unique(const std::pair<T, T>& be) {
 
 /// Get a non-deterministic version of a control-flow graph,
 /// i.e., where instead of using if/else, both branches are taken
-/// simultaneously, and are replaced by Assume instructions
+/// simultaneously, and are replaced by Condition
 /// immediately after the branch.
 static cfg_t to_nondet(const cfg_t& cfg) {
     cfg_t res;
@@ -147,7 +147,7 @@ static cfg_t to_nondet(const cfg_t& cfg) {
             for (auto const& [next_label, cond1] : jumps) {
                 label_t jump_label = label_t::make_jump(mid_label, next_label);
                 basic_block_t& jump_bb = res.insert(jump_label);
-                jump_bb.insert<Assume>(cond1);
+                jump_bb.set_assume(cond1);
                 newbb >> jump_bb;
                 jump_bb >> res.insert(next_label);
             }
@@ -188,8 +188,6 @@ static std::string instype(Instruction ins) {
         return "arith";
     } else if (std::holds_alternative<LoadMapFd>(ins)) {
         return "assign";
-    } else if (std::holds_alternative<Assume>(ins)) {
-        return "assume";
     } else {
         return "other";
     }

--- a/src/asm_marshal.cpp
+++ b/src/asm_marshal.cpp
@@ -136,8 +136,6 @@ struct MarshalVisitor {
         return {ebpf_inst{.opcode = INST_OP_EXIT, .dst = 0, .src = 0, .offset = 0, .imm = 0}};
     }
 
-    vector<ebpf_inst> operator()(Assume const& b) { throw std::invalid_argument("Cannot marshal assumptions"); }
-
     vector<ebpf_inst> operator()(Assert const& b) { throw std::invalid_argument("Cannot marshal assertions"); }
 
     vector<ebpf_inst> operator()(Jmp const& b) {

--- a/src/asm_ostream.cpp
+++ b/src/asm_ostream.cpp
@@ -92,6 +92,10 @@ std::ostream& operator<<(std::ostream& os, Condition::Op op) {
     return os;
 }
 
+std::ostream& operator<<(std::ostream& os, Condition const& cond) {
+    return os << cond.left << " " << cond.op << " " << cond.right;
+}
+
 static string size(int w) { return string("u") + std::to_string(w * 8); }
 
 static std::string to_string(TypeGroup ts) {
@@ -240,9 +244,7 @@ struct InstructionPrinterVisitor {
         // A "standalone" jump instruction.
         // Print the label without offset calculations.
         if (b.cond) {
-            os_ << "if ";
-            print(*b.cond);
-            os_ << " ";
+            os_ << "if " << *b.cond << " ";
         }
         os_ << "goto label <" << to_string(b.target) << ">";
     }
@@ -252,9 +254,7 @@ struct InstructionPrinterVisitor {
         string target = sign + std::to_string(offset) + " <" + to_string(b.target) + ">";
 
         if (b.cond) {
-            os_ << "if ";
-            print(*b.cond);
-            os_ << " ";
+            os_ << "if " << *b.cond << " ";
         }
         os_ << "goto " << target;
     }
@@ -282,8 +282,6 @@ struct InstructionPrinterVisitor {
         os_ << "(" << access.basereg << sign << offset << ")";
     }
 
-    void print(Condition const& cond) { os_ << cond.left << " " << cond.op << " " << cond.right; }
-
     void operator()(Mem const& b) {
         if (b.is_load) {
             os_ << b.value << " = ";
@@ -298,11 +296,6 @@ struct InstructionPrinterVisitor {
         os_ << "lock ";
         print(b.access);
         os_ << " += " << b.valreg;
-    }
-
-    void operator()(Assume const& b) {
-        os_ << "assume ";
-        print(b.cond);
     }
 
     void operator()(Assert const& a) {
@@ -432,6 +425,8 @@ void print_dot(const cfg_t& cfg, const std::string& outfile) {
 
 std::ostream& operator<<(std::ostream& o, const basic_block_t& bb) {
     o << bb.label() << ":\n";
+
+    // if (auto condition = bb.get_assume()) { o << "assume " << *condition << "\n"; }
     for (auto const& s : bb) {
         o << "  " << s << ";\n";
     }

--- a/src/asm_ostream.hpp
+++ b/src/asm_ostream.hpp
@@ -24,6 +24,7 @@ std::string to_string(Instruction const& ins);
 
 std::ostream& operator<<(std::ostream& os, Bin::Op op);
 std::ostream& operator<<(std::ostream& os, Condition::Op op);
+std::ostream& operator<<(std::ostream& os, Condition const& cond);
 
 inline std::ostream& operator<<(std::ostream& os, Imm imm) { return os << (int32_t)imm.v; }
 inline std::ostream& operator<<(std::ostream& os, Reg const& a) { return os << "r" << (int)a.v; }
@@ -43,7 +44,6 @@ inline std::ostream& operator<<(std::ostream& os, Jmp const& a) { return os << (
 inline std::ostream& operator<<(std::ostream& os, Packet const& a) { return os << (Instruction)a; }
 inline std::ostream& operator<<(std::ostream& os, Mem const& a) { return os << (Instruction)a; }
 inline std::ostream& operator<<(std::ostream& os, LockAdd const& a) { return os << (Instruction)a; }
-inline std::ostream& operator<<(std::ostream& os, Assume const& a) { return os << (Instruction)a; }
 inline std::ostream& operator<<(std::ostream& os, Assert const& a) { return os << (Instruction)a; }
 std::ostream& operator<<(std::ostream& os, AssertionConstraint const& a);
 std::string to_string(AssertionConstraint const& constraint);

--- a/src/asm_syntax.hpp
+++ b/src/asm_syntax.hpp
@@ -113,6 +113,10 @@ struct LoadMapFd {
     int mapfd{};
 };
 
+
+/// When a CFG is translated to its nondeterministic form, Conditional Jump
+/// instructions are replaced by two conditions, immediately after
+/// the branch and before each jump target.
 struct Condition {
     enum class Op {
         EQ,
@@ -208,13 +212,6 @@ struct Undefined {
     int opcode{};
 };
 
-/// When a CFG is translated to its nondeterministic form, Conditional Jump
-/// instructions are replaced by two Assume instructions, immediately after
-/// the branch and before each jump target.
-struct Assume {
-    Condition cond;
-};
-
 enum class TypeGroup {
     number,
     map_fd,
@@ -300,7 +297,7 @@ struct Assert {
 #define DECLARE_EQ1(T, f1) \
     inline bool operator==(T const& a, T const& b) { return a.f1 == b.f1; }
 
-using Instruction = std::variant<Undefined, Bin, Un, LoadMapFd, Call, Exit, Jmp, Mem, Packet, LockAdd, Assume, Assert>;
+using Instruction = std::variant<Undefined, Bin, Un, LoadMapFd, Call, Exit, Jmp, Mem, Packet, LockAdd, Assert>;
 
 using LabeledInstruction = std::tuple<label_t, Instruction>;
 using InstructionSeq = std::vector<LabeledInstruction>;
@@ -317,7 +314,6 @@ struct InstructionVisitorPrototype {
     void operator()(Call const& a);
     void operator()(Exit const& a);
     void operator()(Jmp const& a);
-    void operator()(Assume const& a);
     void operator()(Assert const& a);
     void operator()(Packet const& a);
     void operator()(Mem const& a);
@@ -348,7 +344,6 @@ inline bool operator==(Mem const& a, Mem const& b) {
     return a.access == b.access && a.value == b.value && a.is_load == b.is_load;
 }
 inline bool operator==(LockAdd const& a, LockAdd const& b) { return a.access == b.access && a.valreg == b.valreg; }
-inline bool operator==(Assume const& a, Assume const& b) { return a.cond == b.cond; }
 bool operator==(Assert const& a, Assert const& b);
 
 DECLARE_EQ2(TypeConstraint, reg, types)

--- a/src/assertions.cpp
+++ b/src/assertions.cpp
@@ -129,8 +129,6 @@ class AssertExtractor {
         return res;
     }
 
-    vector<Assert> operator()(Assume ins) const { return explicate(ins.cond); }
-
     vector<Assert> operator()(Jmp ins) const {
         if (!ins.cond)
             return {};

--- a/src/crab/cfg.hpp
+++ b/src/crab/cfg.hpp
@@ -57,11 +57,19 @@ class basic_block_t final {
     label_t m_label;
     stmt_list_t m_ts;
     label_vec_t m_prev, m_next;
+    std::optional<Condition> assume;
 
   public:
     template <typename T, typename... Args>
     void insert(Args&&... args) {
         m_ts.emplace_back(T{std::forward<Args>(args)...});
+    }
+
+    void set_assume(const Condition& condition) {
+        assume = condition;
+    }
+    const std::optional<Condition>& get_assume() const {
+        return assume;
     }
 
     void insert(const Instruction& arg) {
@@ -155,6 +163,10 @@ class basic_block_rev_t final {
     basic_block_t& _bb;
 
     explicit basic_block_rev_t(basic_block_t& bb) : _bb(bb) {}
+
+    const std::optional<Condition>& get_assume() const {
+        return _bb.get_assume();
+    }
 
     [[nodiscard]] label_t label() const { return _bb.label(); }
 

--- a/src/crab/ebpf_domain.cpp
+++ b/src/crab/ebpf_domain.cpp
@@ -397,9 +397,8 @@ NumAbsDomain ebpf_domain_t::check_access_context(NumAbsDomain inv, const linear_
     return inv;
 }
 
-void ebpf_domain_t::operator()(const Assume& s) {
+void ebpf_domain_t::operator()(const Condition& cond) {
     using namespace crab::dsl_syntax;
-    Condition cond = s.cond;
     auto dst = reg_pack(cond.left);
     if (std::holds_alternative<Reg>(cond.right)) {
         auto src = reg_pack(std::get<Reg>(cond.right));

--- a/src/crab/ebpf_domain.hpp
+++ b/src/crab/ebpf_domain.hpp
@@ -54,7 +54,7 @@ class ebpf_domain_t final {
 
     void operator()(const Addable&);
     void operator()(const Assert&);
-    void operator()(const Assume&);
+    void operator()(const Condition&);
     void operator()(const Bin&);
     void operator()(const Call&);
     void operator()(const Comparable&);

--- a/src/test/test_termination.cpp
+++ b/src/test/test_termination.cpp
@@ -45,7 +45,7 @@ TEST_CASE("Trivial finite loop", "[loop][termination]") {
 
     Reg r{0};
     start.insert(Bin{.op = Bin::Op::MOV, .dst = r, .v = Imm{0}, .is64 = true});
-    middle.insert(Assume{{.op=Condition::Op::GT, .left=r, .right=Imm{10}}});
+    middle.set_assume({.op=Condition::Op::GT, .left=r, .right=Imm{10}});
     middle.insert(Bin{.op = Bin::Op::ADD, .dst = r, .v = Imm{1}, .is64 = true});
 
     entry >> start;
@@ -63,7 +63,7 @@ TEST_CASE("Trivial finite loop", "[loop][termination]") {
     ebpf_verifier_stats_t stats;
     bool pass = run_ebpf_analysis(std::cout, cfg, info, &options, &stats);
     REQUIRE(pass);
-    REQUIRE(stats.max_instruction_count == 3);
+    REQUIRE(stats.max_instruction_count == 2);
     REQUIRE(stats.total_unreachable == 1);
     REQUIRE(stats.total_warnings == 0);
 }


### PR DESCRIPTION
Another PR for demonstration of an idea, not necessarily to be merged.

The `Assume` pseudo-instruction is always the first in a block, and always with a single parent. In this PR it is moved to "just before" the actual basic block, so the invariants are tracked immediately after it. Benefits:
- No need to execute it when checking the assertions
- Less redundancy in the output; the pre-invariant is not exactly the post-invariant of the previous block, even though there's no join operation involved.
- No dedicated `Assume` instruction

It should play well with #258 (#266), so each basic block is a generalized instruction with 3 parts: Assume, Assert, Execute.

Currently (only) the loop test fails, claiming to have a single instruction instead of at least 2, so the implementation of the fixpoint is probably broken.

Signed-off-by: Elazar Gershuni <elazarg@gmail.com>