### PR TITLE
ValidAccess: try singleton first

### DIFF
--- a/src/crab/ebpf_domain.cpp
+++ b/src/crab/ebpf_domain.cpp
@@ -581,6 +581,13 @@ void ebpf_domain_t::operator()(const ValidAccess& s) {
                 require(m_inv, linear_constraint_t::FALSE(), "Only pointers can be dereferenced");
                 return;
             }
+        case T_MAP:
+        case T_MAP_PROGRAMS:
+            if (is_comparison_check) {
+                return;
+            } else {
+                require(m_inv, linear_constraint_t::FALSE(), "FDs cannot be dereferenced directly");
+            }
         default:
             if (*type_singleton > T_SHARED) {
                 check_access_shared(m_inv, lb, ub, m, reg.type);

--- a/src/crab/ebpf_domain.hpp
+++ b/src/crab/ebpf_domain.hpp
@@ -145,12 +145,12 @@ class ebpf_domain_t final {
     void require(crab::domains::NumAbsDomain& inv, const linear_constraint_t& cst, const std::string& s);
 
     // memory check / load / store
-    NumAbsDomain check_access_stack(NumAbsDomain inv, const linear_expression_t& lb, const linear_expression_t& ub, const std::string& s);
-    NumAbsDomain check_access_packet(NumAbsDomain inv, const linear_expression_t& lb, const linear_expression_t& ub, const std::string& s,
+    void check_access_stack(NumAbsDomain& inv, const linear_expression_t& lb, const linear_expression_t& ub, const std::string& s);
+    void check_access_packet(NumAbsDomain& inv, const linear_expression_t& lb, const linear_expression_t& ub, const std::string& s,
                                      bool is_comparison_check);
-    NumAbsDomain check_access_shared(NumAbsDomain inv, const linear_expression_t& lb, const linear_expression_t& ub, const std::string& s,
+    void check_access_shared(NumAbsDomain& inv, const linear_expression_t& lb, const linear_expression_t& ub, const std::string& s,
                                      variable_t reg_type);
-    NumAbsDomain check_access_context(NumAbsDomain inv, const linear_expression_t& lb, const linear_expression_t& ub, const std::string& s);
+    void check_access_context(NumAbsDomain& inv, const linear_expression_t& lb, const linear_expression_t& ub, const std::string& s);
 
     NumAbsDomain do_load_stack(NumAbsDomain inv, const reg_pack_t& target, const linear_expression_t& addr, int width);
     NumAbsDomain do_load_ctx(NumAbsDomain inv, const reg_pack_t& target, const linear_expression_t& addr_vague, int width);

--- a/src/crab/split_dbm.hpp
+++ b/src/crab/split_dbm.hpp
@@ -437,7 +437,25 @@ class SplitDBM final {
             return true;
         if (rhs.is_contradiction())
             return false;
-
+        interval_t interval = eval_interval(rhs.expression());
+        switch (rhs.kind()) {
+        case constraint_kind_t::EQUALS_ZERO:
+            if (interval.singleton() == std::optional<number_t>(number_t(0)))
+                return true;
+            break;
+        case constraint_kind_t::LESS_THAN_OR_EQUALS_ZERO:
+            if (interval.ub() <= number_t(0))
+                return true;
+            break;
+        case constraint_kind_t::LESS_THAN_ZERO:
+            if (interval.ub() < number_t(0))
+                return true;
+            break;
+        case constraint_kind_t::NOT_ZERO:
+            if (interval.ub() < number_t(0) || interval.lb() > number_t(0))
+                return true;
+            break;
+        }
         if (rhs.kind() == constraint_kind_t::EQUALS_ZERO) {
             // try to convert the equality into inequalities so when it's
             // negated we do not have disequalities.

--- a/src/crab/split_dbm.hpp
+++ b/src/crab/split_dbm.hpp
@@ -313,6 +313,11 @@ class SplitDBM final {
             return *this;
         return static_cast<SplitDBM&>(*this) | o;
     }
+    SplitDBM operator|(SplitDBM&& o) && {
+        if (o.is_bottom())
+            return *this;
+        return static_cast<SplitDBM&>(*this) | o;
+    }
 
     SplitDBM widen(SplitDBM o);
 


### PR DESCRIPTION
The assertion `ValidAccess` is the heaviest single operation, due to the chain of joins. Checking the common case of a singleton type executes ~25% faster.