### PR TITLE
don't pretend to get optional<cellset_t>

### DIFF
--- a/src/asm_files.cpp
+++ b/src/asm_files.cpp
@@ -5,6 +5,7 @@
 #include <string>
 #include <vector>
 #include <set>
+#include <map>
 #include <sys/stat.h>
 
 #include "asm_files.hpp"

--- a/src/crab/variable.hpp
+++ b/src/crab/variable.hpp
@@ -11,7 +11,6 @@
 
 #include "crab_utils/bignums.hpp"
 #include "crab_utils/debug.hpp"
-#include "radix_tree/radix_tree.hpp"
 using index_t = uint64_t;
 
 /* Basic type definitions */


### PR DESCRIPTION
The explicit use of `std::optional<>` hid the fact that `_map[key]` returns `cellset_t&`, not an optional. This reference can be then mutated directly.

Signed-off-by: Elazar Gershuni <elazarg@gmail.com>