### PR TITLE
SplitDBM: Keep it normalized

### DIFF
--- a/src/crab/array_domain.cpp
+++ b/src/crab/array_domain.cpp
@@ -615,27 +615,23 @@ void array_domain_t::operator|=(const array_domain_t& other) {
     num_bytes |= other.num_bytes;
 }
 
-array_domain_t array_domain_t::operator|(const array_domain_t& other) & {
+array_domain_t array_domain_t::operator|(const array_domain_t& other) const {
     return array_domain_t(num_bytes | other.num_bytes);
 }
 
-array_domain_t array_domain_t::operator|(const array_domain_t& other) && {
-    return array_domain_t(num_bytes | other.num_bytes);
-}
-
-array_domain_t array_domain_t::operator&(array_domain_t other) {
+array_domain_t array_domain_t::operator&(const array_domain_t& other) const {
     return array_domain_t(num_bytes & other.num_bytes);
 }
 
-array_domain_t array_domain_t::widen(const array_domain_t& other) {
+array_domain_t array_domain_t::widen(const array_domain_t& other) const {
     return array_domain_t(num_bytes | other.num_bytes);
 }
 
-array_domain_t array_domain_t::widening_thresholds(const array_domain_t& other, const iterators::thresholds_t& ts) {
+array_domain_t array_domain_t::widening_thresholds(const array_domain_t& other, const iterators::thresholds_t& ts) const {
     return array_domain_t(num_bytes | other.num_bytes);
 }
 
-array_domain_t array_domain_t::narrow(const array_domain_t& other) {
+array_domain_t array_domain_t::narrow(const array_domain_t& other) const {
     return array_domain_t(num_bytes & other.num_bytes);
 }
 

--- a/src/crab/array_domain.hpp
+++ b/src/crab/array_domain.hpp
@@ -57,12 +57,11 @@ class array_domain_t final {
 
     void operator|=(const array_domain_t& other);
 
-    array_domain_t operator|(const array_domain_t& other) &;
-    array_domain_t operator|(const array_domain_t& other) &&;
-    array_domain_t operator&(array_domain_t other);
-    array_domain_t widen(const array_domain_t& other);
-    array_domain_t widening_thresholds(const array_domain_t& other, const iterators::thresholds_t& ts);
-    array_domain_t narrow(const array_domain_t& other);
+    array_domain_t operator|(const array_domain_t& other) const;
+    array_domain_t operator&(const array_domain_t& other) const;
+    array_domain_t widen(const array_domain_t& other) const;
+    array_domain_t widening_thresholds(const array_domain_t& other, const iterators::thresholds_t& ts) const;
+    array_domain_t narrow(const array_domain_t& other) const;
 
     friend std::ostream& operator<<(std::ostream& o, const array_domain_t& dom);
 

--- a/src/crab/cfg.hpp
+++ b/src/crab/cfg.hpp
@@ -44,10 +44,7 @@ class basic_block_t final {
 
     using label_vec_t = std::set<label_t>;
     using stmt_list_t = std::vector<Instruction>;
-    using succ_iterator = label_vec_t::iterator;
-    using const_succ_iterator = label_vec_t::const_iterator;
-    using pred_iterator = succ_iterator;
-    using const_pred_iterator = const_succ_iterator;
+    using neighbour_const_iterator = label_vec_t::const_iterator;
     using iterator = typename stmt_list_t::iterator;
     using const_iterator = typename stmt_list_t::const_iterator;
     using reverse_iterator = typename stmt_list_t::reverse_iterator;
@@ -88,17 +85,9 @@ class basic_block_t final {
 
     [[nodiscard]] size_t size() const { return static_cast<size_t>(std::distance(begin(), end())); }
 
-    std::pair<succ_iterator, succ_iterator> next_blocks() { return std::make_pair(m_next.begin(), m_next.end()); }
+    std::pair<neighbour_const_iterator, neighbour_const_iterator> next_blocks() const { return std::make_pair(m_next.begin(), m_next.end()); }
 
-    std::pair<pred_iterator, pred_iterator> prev_blocks() { return std::make_pair(m_prev.begin(), m_prev.end()); }
-
-    [[nodiscard]] std::pair<const_succ_iterator, const_succ_iterator> next_blocks() const {
-        return std::make_pair(m_next.begin(), m_next.end());
-    }
-
-    [[nodiscard]] std::pair<const_pred_iterator, const_pred_iterator> prev_blocks() const {
-        return std::make_pair(m_prev.begin(), m_prev.end());
-    }
+    std::pair<neighbour_const_iterator, neighbour_const_iterator> prev_blocks() const { return std::make_pair(m_prev.begin(), m_prev.end()); }
 
     [[nodiscard]] const label_vec_t& next_blocks_set() const {
         return m_next;
@@ -143,10 +132,7 @@ class basic_block_t final {
 // backward analysis.
 class basic_block_rev_t final {
   public:
-    using succ_iterator = typename basic_block_t::succ_iterator;
-    using const_succ_iterator = typename basic_block_t::const_succ_iterator;
-    using pred_iterator = succ_iterator;
-    using const_pred_iterator = const_succ_iterator;
+    using neighbour_const_iterator = typename basic_block_t::neighbour_const_iterator;
 
     using iterator = typename basic_block_t::reverse_iterator;
     using const_iterator = typename basic_block_t::const_reverse_iterator;
@@ -168,13 +154,13 @@ class basic_block_rev_t final {
 
     [[nodiscard]] std::size_t size() const { return static_cast<size_t>(std::distance(begin(), end())); }
 
-    std::pair<succ_iterator, succ_iterator> next_blocks() { return _bb.prev_blocks(); }
+    std::pair<neighbour_const_iterator, neighbour_const_iterator> next_blocks() { return _bb.prev_blocks(); }
 
-    std::pair<pred_iterator, pred_iterator> prev_blocks() { return _bb.next_blocks(); }
+    std::pair<neighbour_const_iterator, neighbour_const_iterator> prev_blocks() { return _bb.next_blocks(); }
 
-    [[nodiscard]] std::pair<const_succ_iterator, const_succ_iterator> next_blocks() const { return _bb.prev_blocks(); }
+    [[nodiscard]] std::pair<neighbour_const_iterator, neighbour_const_iterator> next_blocks() const { return _bb.prev_blocks(); }
 
-    [[nodiscard]] std::pair<const_pred_iterator, const_pred_iterator> prev_blocks() const { return _bb.next_blocks(); }
+    [[nodiscard]] std::pair<neighbour_const_iterator, neighbour_const_iterator> prev_blocks() const { return _bb.next_blocks(); }
 
 
     [[nodiscard]] const basic_block_t::label_vec_t& next_blocks_set() const {
@@ -191,15 +177,9 @@ class cfg_t final {
   public:
     using node_t = label_t; // for Bgl graphs
 
-    using succ_iterator = typename basic_block_t::succ_iterator;
-    using pred_iterator = typename basic_block_t::pred_iterator;
-    using const_succ_iterator = typename basic_block_t::const_succ_iterator;
-    using const_pred_iterator = typename basic_block_t::const_pred_iterator;
+    using neighbour_const_iterator = typename basic_block_t::neighbour_const_iterator;
 
-    using succ_range = boost::iterator_range<succ_iterator>;
-    using pred_range = boost::iterator_range<pred_iterator>;
-    using const_succ_range = boost::iterator_range<const_succ_iterator>;
-    using const_pred_range = boost::iterator_range<const_pred_iterator>;
+    using neighbour_const_range = boost::iterator_range<neighbour_const_iterator>;
 
   private:
     using basic_block_map_t = std::map<label_t, basic_block_t>;
@@ -238,17 +218,13 @@ class cfg_t final {
 
     [[nodiscard]] label_t entry_label() const { return label_t::entry; }
 
-    [[nodiscard]] const_succ_range next_nodes(const label_t& _label) const {
+    [[nodiscard]] neighbour_const_range next_nodes(const label_t& _label) const {
         return boost::make_iterator_range(get_node(_label).next_blocks());
     }
 
-    [[nodiscard]] const_pred_range prev_nodes(const label_t& _label) const {
+    [[nodiscard]] neighbour_const_range prev_nodes(const label_t& _label) const {
         return boost::make_iterator_range(get_node(_label).prev_blocks());
     }
-
-    succ_range next_nodes(const label_t& _label) { return boost::make_iterator_range(get_node(_label).next_blocks()); }
-
-    pred_range prev_nodes(const label_t& _label) { return boost::make_iterator_range(get_node(_label).prev_blocks()); }
 
     basic_block_t& get_node(const label_t& _label) {
         auto it = m_blocks.find(_label);
@@ -420,16 +396,10 @@ class cfg_rev_t final {
   public:
     using node_t = label_t; // for Bgl graphs
 
-    using pred_range = typename cfg_t::succ_range;
-    using succ_range = typename cfg_t::pred_range;
-    using const_pred_range = typename cfg_t::const_succ_range;
-    using const_succ_range = typename cfg_t::const_pred_range;
+    using neighbour_const_range = typename cfg_t::neighbour_const_range;
 
     // For BGL
-    using succ_iterator = typename basic_block_t::succ_iterator;
-    using pred_iterator = typename basic_block_t::pred_iterator;
-    using const_succ_iterator = typename basic_block_t::const_succ_iterator;
-    using const_pred_iterator = typename basic_block_t::const_pred_iterator;
+    using neighbour_const_iterator = typename basic_block_t::neighbour_const_iterator;
 
   public:
     using basic_block_rev_map_t = std::map<label_t, basic_block_rev_t>;
@@ -458,13 +428,13 @@ class cfg_rev_t final {
 
     [[nodiscard]] label_t entry_label() const { return _cfg.exit_label(); }
 
-    [[nodiscard]] const_succ_range next_nodes(const label_t& bb) const { return _cfg.prev_nodes(bb); }
+    [[nodiscard]] neighbour_const_range next_nodes(const label_t& bb) const { return _cfg.prev_nodes(bb); }
 
-    [[nodiscard]] const_pred_range prev_nodes(const label_t& bb) const { return _cfg.next_nodes(bb); }
+    [[nodiscard]] neighbour_const_range prev_nodes(const label_t& bb) const { return _cfg.next_nodes(bb); }
 
-    succ_range next_nodes(const label_t& bb) { return _cfg.prev_nodes(bb); }
+    neighbour_const_range next_nodes(const label_t& bb) { return _cfg.prev_nodes(bb); }
 
-    pred_range prev_nodes(const label_t& bb) { return _cfg.next_nodes(bb); }
+    neighbour_const_range prev_nodes(const label_t& bb) { return _cfg.next_nodes(bb); }
 
     basic_block_rev_t& get_node(const label_t& _label) {
         auto it = _rev_bbs.find(_label);

--- a/src/crab/cfg.hpp
+++ b/src/crab/cfg.hpp
@@ -85,9 +85,9 @@ class basic_block_t final {
 
     [[nodiscard]] size_t size() const { return static_cast<size_t>(std::distance(begin(), end())); }
 
-    std::pair<neighbour_const_iterator, neighbour_const_iterator> next_blocks() const { return std::make_pair(m_next.begin(), m_next.end()); }
+    [[nodiscard]] std::pair<neighbour_const_iterator, neighbour_const_iterator> next_blocks() const { return std::make_pair(m_next.begin(), m_next.end()); }
 
-    std::pair<neighbour_const_iterator, neighbour_const_iterator> prev_blocks() const { return std::make_pair(m_prev.begin(), m_prev.end()); }
+    [[nodiscard]] std::pair<neighbour_const_iterator, neighbour_const_iterator> prev_blocks() const { return std::make_pair(m_prev.begin(), m_prev.end()); }
 
     [[nodiscard]] const label_vec_t& next_blocks_set() const {
         return m_next;
@@ -153,10 +153,6 @@ class basic_block_rev_t final {
     [[nodiscard]] const_iterator end() const { return _bb.rend(); }
 
     [[nodiscard]] std::size_t size() const { return static_cast<size_t>(std::distance(begin(), end())); }
-
-    std::pair<neighbour_const_iterator, neighbour_const_iterator> next_blocks() { return _bb.prev_blocks(); }
-
-    std::pair<neighbour_const_iterator, neighbour_const_iterator> prev_blocks() { return _bb.next_blocks(); }
 
     [[nodiscard]] std::pair<neighbour_const_iterator, neighbour_const_iterator> next_blocks() const { return _bb.prev_blocks(); }
 

--- a/src/crab/cfg_bgl.hpp
+++ b/src/crab/cfg_bgl.hpp
@@ -60,9 +60,9 @@ struct graph_traits<crab::cfg_t> {
     // iterator of label_t's
     using vertex_iterator = typename graph_t::label_iterator;
     // iterator of pairs of label_t's
-    using in_edge_iterator = transform_iterator<crab::graph::mk_in_edge<graph_t>, typename graph_t::pred_iterator>;
+    using in_edge_iterator = transform_iterator<crab::graph::mk_in_edge<graph_t>, typename graph_t::neighbour_iterator>;
     // iterator of pairs of label_t's
-    using out_edge_iterator = transform_iterator<crab::graph::mk_out_edge<graph_t>, typename graph_t::succ_iterator>;
+    using out_edge_iterator = transform_iterator<crab::graph::mk_out_edge<graph_t>, typename graph_t::neighbour_iterator>;
 }; // end class graph_traits
 
 // cfg_rev
@@ -84,9 +84,9 @@ struct graph_traits<crab::cfg_rev_t> {
 
     using vertex_iterator = typename graph_t::label_iterator;
     using in_edge_iterator =
-        boost::transform_iterator<crab::graph::mk_in_edge<graph_t>, typename graph_t::pred_iterator>;
+        boost::transform_iterator<crab::graph::mk_in_edge<graph_t>, typename graph_t::neighbour_iterator>;
     using out_edge_iterator =
-        boost::transform_iterator<crab::graph::mk_out_edge<graph_t>, typename graph_t::succ_iterator>;
+        boost::transform_iterator<crab::graph::mk_out_edge<graph_t>, typename graph_t::neighbour_iterator>;
 }; // end class graph_traits
 } // namespace boost
 

--- a/src/crab/ebpf_domain.cpp
+++ b/src/crab/ebpf_domain.cpp
@@ -182,16 +182,16 @@ void ebpf_domain_t::operator|=(const ebpf_domain_t& other) {
     operator|=(std::move(tmp));
 }
 
-ebpf_domain_t ebpf_domain_t::operator|(ebpf_domain_t&& other) {
+ebpf_domain_t ebpf_domain_t::operator|(ebpf_domain_t&& other) const {
     return ebpf_domain_t(m_inv | std::move(other.m_inv), stack | other.stack);
 }
 
-ebpf_domain_t ebpf_domain_t::operator|(const ebpf_domain_t& other) & {
+ebpf_domain_t ebpf_domain_t::operator|(const ebpf_domain_t& other) const& {
     return ebpf_domain_t(m_inv | other.m_inv, stack | other.stack);
 }
 
 ebpf_domain_t ebpf_domain_t::operator|(const ebpf_domain_t& other) && {
-    return ebpf_domain_t(m_inv | other.m_inv, stack | other.stack);
+    return ebpf_domain_t(other.m_inv | std::move(m_inv), other.stack | std::move(stack));
 }
 
 ebpf_domain_t ebpf_domain_t::operator&(const ebpf_domain_t& other) const {

--- a/src/crab/ebpf_domain.cpp
+++ b/src/crab/ebpf_domain.cpp
@@ -164,7 +164,7 @@ bool ebpf_domain_t::operator<=(const ebpf_domain_t& other) {
     return m_inv <= other.m_inv && stack <= other.stack;
 }
 
-bool ebpf_domain_t::operator==(ebpf_domain_t other) {
+bool ebpf_domain_t::operator==(const ebpf_domain_t& other) const {
     return stack == other.stack && m_inv <= other.m_inv && other.m_inv <= m_inv;
 }
 
@@ -194,8 +194,8 @@ ebpf_domain_t ebpf_domain_t::operator|(const ebpf_domain_t& other) && {
     return ebpf_domain_t(m_inv | other.m_inv, stack | other.stack);
 }
 
-ebpf_domain_t ebpf_domain_t::operator&(ebpf_domain_t other) {
-    return ebpf_domain_t(m_inv & std::move(other.m_inv), stack & other.stack);
+ebpf_domain_t ebpf_domain_t::operator&(const ebpf_domain_t& other) const {
+    return ebpf_domain_t(m_inv & other.m_inv, stack & other.stack);
 }
 
 ebpf_domain_t ebpf_domain_t::widen(const ebpf_domain_t& other) {
@@ -305,7 +305,7 @@ void ebpf_domain_t::shl_overflow(variable_t lhs, const number_t& op2) { apply(m_
 void ebpf_domain_t::lshr(variable_t lhs, variable_t op2) { apply(m_inv, crab::bitwise_binop_t::LSHR, lhs, lhs, op2); }
 void ebpf_domain_t::lshr(variable_t lhs, const number_t& op2) { apply(m_inv, crab::bitwise_binop_t::LSHR, lhs, lhs, op2); }
 void ebpf_domain_t::ashr(variable_t lhs, variable_t op2) { apply(m_inv, crab::bitwise_binop_t::ASHR, lhs, lhs, op2); }
-void ebpf_domain_t::ashr(variable_t lhs, number_t op2) { apply(m_inv, crab::bitwise_binop_t::ASHR, lhs, lhs, op2); }
+void ebpf_domain_t::ashr(variable_t lhs, const number_t& op2) { apply(m_inv, crab::bitwise_binop_t::ASHR, lhs, lhs, op2); }
 
 
 static void assume(NumAbsDomain& inv, const linear_constraint_t& cst) { inv += cst; }
@@ -1155,7 +1155,7 @@ string_invariant ebpf_domain_t::to_set() {
     return this->m_inv.to_set();
 }
 
-std::ostream& operator<<(std::ostream& o, ebpf_domain_t dom) {
+std::ostream& operator<<(std::ostream& o, const ebpf_domain_t& dom) {
     if (dom.is_bottom()) {
         o << "_|_";
     } else {

--- a/src/crab/ebpf_domain.hpp
+++ b/src/crab/ebpf_domain.hpp
@@ -30,13 +30,13 @@ class ebpf_domain_t final {
     bool is_bottom() const;
     bool is_top() const;
     bool operator<=(const ebpf_domain_t& other);
-    bool operator==(ebpf_domain_t other);
+    bool operator==(const ebpf_domain_t& other) const;
     void operator|=(ebpf_domain_t&& other);
     void operator|=(const ebpf_domain_t& other);
     ebpf_domain_t operator|(ebpf_domain_t&& other);
     ebpf_domain_t operator|(const ebpf_domain_t& other) &;
     ebpf_domain_t operator|(const ebpf_domain_t& other) &&;
-    ebpf_domain_t operator&(ebpf_domain_t other);
+    ebpf_domain_t operator&(const ebpf_domain_t& other) const;
     ebpf_domain_t widen(const ebpf_domain_t& other);
     ebpf_domain_t widening_thresholds(const ebpf_domain_t& other, const crab::iterators::thresholds_t& ts);
     ebpf_domain_t narrow(const ebpf_domain_t& other);
@@ -123,7 +123,7 @@ class ebpf_domain_t final {
     void lshr(variable_t lhs, variable_t op2);
     void lshr(variable_t lhs, const number_t& op2);
     void ashr(variable_t lhs, variable_t op2);
-    void ashr(variable_t lhs, number_t op2);
+    void ashr(variable_t lhs, const number_t& op2);
 
     void assume(const linear_constraint_t& cst);
 
@@ -164,7 +164,7 @@ class ebpf_domain_t final {
     template <typename Type, typename Value>
     void do_mem_store(const Mem& b, Type val_type, Value val_value, std::optional<variable_t> opt_val_offset);
 
-    friend std::ostream& operator<<(std::ostream& o, ebpf_domain_t dom);
+    friend std::ostream& operator<<(std::ostream& o, const ebpf_domain_t& dom);
 
     static void initialize_packet(ebpf_domain_t& inv);
 

--- a/src/crab/ebpf_domain.hpp
+++ b/src/crab/ebpf_domain.hpp
@@ -33,8 +33,8 @@ class ebpf_domain_t final {
     bool operator==(const ebpf_domain_t& other) const;
     void operator|=(ebpf_domain_t&& other);
     void operator|=(const ebpf_domain_t& other);
-    ebpf_domain_t operator|(ebpf_domain_t&& other);
-    ebpf_domain_t operator|(const ebpf_domain_t& other) &;
+    ebpf_domain_t operator|(ebpf_domain_t&& other) const;
+    ebpf_domain_t operator|(const ebpf_domain_t& other) const&;
     ebpf_domain_t operator|(const ebpf_domain_t& other) &&;
     ebpf_domain_t operator&(const ebpf_domain_t& other) const;
     ebpf_domain_t widen(const ebpf_domain_t& other);

--- a/src/crab/split_dbm.cpp
+++ b/src/crab/split_dbm.cpp
@@ -456,7 +456,7 @@ bool SplitDBM::operator<=(const SplitDBM& o) const {
     }
 }
 
-SplitDBM SplitDBM::operator|(const SplitDBM& o) const {
+SplitDBM SplitDBM::operator|(const SplitDBM& o) const& {
     CrabStats::count("SplitDBM.count.join");
     ScopedCrabStats __st__("SplitDBM.join");
 

--- a/src/crab/split_dbm.hpp
+++ b/src/crab/split_dbm.hpp
@@ -309,7 +309,27 @@ class SplitDBM final {
         }
     }
 
-    SplitDBM operator|(const SplitDBM& o) const;
+    SplitDBM operator|(const SplitDBM& o) const&;
+
+    SplitDBM operator|(SplitDBM&& o) && {
+        if (is_bottom() || o.is_top())
+            return std::move(o);
+        if (is_top() || o.is_bottom())
+            return std::move(*this);
+        return ((const SplitDBM&)*this) | (const SplitDBM&)o;
+    }
+
+    SplitDBM operator|(const SplitDBM& o) && {
+        if (is_top() || o.is_bottom())
+            return std::move(*this);
+        return ((const SplitDBM&)*this) | o;
+    }
+
+    SplitDBM operator|(SplitDBM&& o) const& {
+        if (is_bottom() || o.is_top())
+            return std::move(o);
+        return (*this) | (const SplitDBM&)o;
+    }
 
     SplitDBM widen(const SplitDBM& o) const;
 

--- a/src/crab/split_dbm.hpp
+++ b/src/crab/split_dbm.hpp
@@ -161,7 +161,7 @@ class SplitDBM final {
         return res;
     }
 
-    interval_t compute_residual(const linear_expression_t& e, variable_t pivot) {
+    interval_t compute_residual(const linear_expression_t& e, variable_t pivot) const {
         interval_t residual(-e.constant_term());
         for (const auto& [variable, coefficient] : e.variable_terms()) {
             if (variable != pivot) {

--- a/src/crab/split_dbm.hpp
+++ b/src/crab/split_dbm.hpp
@@ -137,7 +137,7 @@ class SplitDBM final {
     };
 
     // Evaluate the potential value of a variable.
-    Weight pot_value(variable_t v) {
+    Weight pot_value(variable_t v) const {
         auto it = vert_map.find(v);
         if (it != vert_map.end())
             return potential[(*it).second];
@@ -145,7 +145,7 @@ class SplitDBM final {
     }
 
     // Evaluate an expression under the chosen potentials
-    Weight eval_expression(const linear_expression_t& e, bool overflow) {
+    Weight eval_expression(const linear_expression_t& e, bool overflow) const {
         Weight res(convert_NtoW(e.constant_term(), overflow));
         if (overflow) {
             return Weight(0);
@@ -190,7 +190,7 @@ class SplitDBM final {
                             bool extract_upper_bounds,
                             /* foreach {v, k} \in diff_csts we have
                                the difference constraint v - k <= k */
-                            std::vector<std::pair<variable_t, Weight>>& diff_csts);
+                            std::vector<std::pair<variable_t, Weight>>& diff_csts) const;
 
     // Turn an assignment into a set of difference constraints.
     void diffcsts_of_assign(variable_t x, const linear_expression_t& exp, std::vector<std::pair<variable_t, Weight>>& lb,
@@ -209,7 +209,7 @@ class SplitDBM final {
                              /* x >= lb for each {x,lb} in lbs */
                              std::vector<std::pair<variable_t, Weight>>& lbs,
                              /* x <= ub for each {x,ub} in ubs */
-                             std::vector<std::pair<variable_t, Weight>>& ubs);
+                             std::vector<std::pair<variable_t, Weight>>& ubs) const;
 
     bool add_linear_leq(const linear_expression_t& exp);
 
@@ -224,11 +224,12 @@ class SplitDBM final {
                 add_univar_disequation(variable, *k);
             }
         }
+        normalize();
     }
 
-    interval_t get_interval(variable_t x) { return get_interval(vert_map, g, x); }
+    interval_t get_interval(variable_t x) const { return get_interval(vert_map, g, x); }
 
-    static interval_t get_interval(vert_map_t& m, graph_t& r, variable_t x) {
+    static interval_t get_interval(const vert_map_t& m, const graph_t& r, variable_t x) {
         auto it = m.find(x);
         if (it == m.end()) {
             return interval_t::top();
@@ -265,6 +266,7 @@ class SplitDBM final {
                  std::cout << "#nodes = " << p.first << " #edges=" << p.second << "\n";);
 
         assert(g.size() > 0);
+        normalize();
     }
 
     SplitDBM(const SplitDBM& o) = default;
@@ -295,7 +297,7 @@ class SplitDBM final {
         return g.is_empty();
     }
 
-    bool operator<=(SplitDBM o);
+    bool operator<=(const SplitDBM& o) const;
 
     // FIXME: can be done more efficient
     void operator|=(const SplitDBM& o) { *this = *this | o; }
@@ -307,28 +309,18 @@ class SplitDBM final {
         }
     }
 
-    SplitDBM operator|(const SplitDBM& o) &;
-    SplitDBM operator|(const SplitDBM& o) && {
-        if (o.is_bottom())
-            return *this;
-        return static_cast<SplitDBM&>(*this) | o;
-    }
-    SplitDBM operator|(SplitDBM&& o) && {
-        if (o.is_bottom())
-            return *this;
-        return static_cast<SplitDBM&>(*this) | o;
-    }
+    SplitDBM operator|(const SplitDBM& o) const;
 
-    SplitDBM widen(SplitDBM o);
+    SplitDBM widen(const SplitDBM& o) const;
 
-    SplitDBM widening_thresholds(SplitDBM o, const iterators::thresholds_t& ts) {
+    SplitDBM widening_thresholds(const SplitDBM& o, const iterators::thresholds_t& ts) const {
         // TODO: use thresholds
-        return ((*this).widen(std::move(o)));
+        return this->widen(o);
     }
 
-    SplitDBM operator&(SplitDBM o);
+    SplitDBM operator&(const SplitDBM& o) const;
 
-    SplitDBM narrow(SplitDBM o);
+    SplitDBM narrow(const SplitDBM& o) const;
 
     void normalize();
 
@@ -373,17 +365,14 @@ class SplitDBM final {
 
     void operator+=(const linear_constraint_t& cst);
 
-    interval_t eval_interval(const linear_expression_t& e) {
+    interval_t eval_interval(const linear_expression_t& e) const {
         interval_t r{e.constant_term()};
         for (const auto& [variable, coefficient] : e.variable_terms())
             r += coefficient * operator[](variable);
         return r;
     }
 
-    interval_t operator[](variable_t x) {
-        CrabStats::count("SplitDBM.count.to_intervals");
-        ScopedCrabStats __st__("SplitDBM.to_intervals");
-
+    interval_t operator[](variable_t x) const {
         if (is_bottom()) {
             return interval_t::bottom();
         } else {
@@ -403,13 +392,13 @@ class SplitDBM final {
     std::pair<std::size_t, std::size_t> size() const { return {g.size(), g.num_edges()}; }
 
   private:
-    bool entail_aux(const linear_constraint_t& cst) {
+    bool entail_aux(const linear_constraint_t& cst) const {
         SplitDBM dom(*this); // copy is necessary
         dom += cst.negate();
         return dom.is_bottom();
     }
 
-    bool intersect_aux(const linear_constraint_t& cst) {
+    bool intersect_aux(const linear_constraint_t& cst) const {
         SplitDBM dom(*this); // copy is necessary
         dom += cst;
         return !dom.is_bottom();
@@ -426,7 +415,7 @@ class SplitDBM final {
 
 
     // Return true if inv intersects with cst.
-    bool intersect(const linear_constraint_t& cst) {
+    bool intersect(const linear_constraint_t& cst) const {
         if (is_bottom() || cst.is_contradiction())
             return false;
         if (is_top() || cst.is_tautology())
@@ -435,7 +424,7 @@ class SplitDBM final {
     }
 
     // Return true if entails rhs.
-    bool entail(const linear_constraint_t& rhs) {
+    bool entail(const linear_constraint_t& rhs) const {
         if (is_bottom())
             return true;
         if (rhs.is_tautology())
@@ -480,8 +469,8 @@ class SplitDBM final {
         //       if (dom.is_top()) { ... }
     }
 
-    friend std::ostream& operator<<(std::ostream& o, SplitDBM& dom);
-    string_invariant to_set();
+    friend std::ostream& operator<<(std::ostream& o, const SplitDBM& dom);
+    string_invariant to_set() const;
 }; // class SplitDBM
 
 } // namespace domains

--- a/src/crab_utils/adapt_sgraph.hpp
+++ b/src/crab_utils/adapt_sgraph.hpp
@@ -221,8 +221,8 @@ class AdaptGraph final {
     using neighbour_range = adj_range_t;
     using neighbour_const_range = adj_const_range_t;
 
-    adj_const_range_t succs(vert_id v) const { return _succs[v].keys(); }
-    adj_const_range_t preds(vert_id v) const { return _preds[v].keys(); }
+    [[nodiscard]] adj_const_range_t succs(vert_id v) const { return _succs[v].keys(); }
+    [[nodiscard]] adj_const_range_t preds(vert_id v) const { return _preds[v].keys(); }
 
     using fwd_edge_range = edge_const_range_t;
     using rev_edge_range = edge_const_range_t;
@@ -334,7 +334,7 @@ class AdaptGraph final {
         return false;
     }
 
-    std::optional<Weight> lookup(vert_id s, vert_id d) const {
+    [[nodiscard]] std::optional<Weight> lookup(vert_id s, vert_id d) const {
         if (auto idx = _succs[s].lookup(d)) {
             return _ws[*idx];
         }

--- a/src/crab_utils/adapt_sgraph.hpp
+++ b/src/crab_utils/adapt_sgraph.hpp
@@ -29,7 +29,7 @@ class TreeSMap final {
     class key_iter_t {
       public:
         key_iter_t() = default;
-        explicit key_iter_t(col::const_iterator _e) : e(_e) {}
+        explicit key_iter_t(const col::const_iterator& _e) : e(_e) {}
 
         // XXX: to make sure that we always return the same address
         // for the "empty" iterator, otherwise we can trigger
@@ -49,15 +49,15 @@ class TreeSMap final {
         col::const_iterator e;
     };
 
-    class key_range_t {
+    class key_const_range_t {
       public:
         using iterator = key_iter_t;
 
-        explicit key_range_t(const col& c) : c{c} {}
+        explicit key_const_range_t(const col& c) : c{c} {}
         [[nodiscard]] size_t size() const { return c.size(); }
 
-        [[nodiscard]] key_iter_t begin() const { return key_iter_t(c.begin()); }
-        [[nodiscard]] key_iter_t end() const { return key_iter_t(c.end()); }
+        [[nodiscard]] key_iter_t begin() const { return key_iter_t(c.cbegin()); }
+        [[nodiscard]] key_iter_t end() const { return key_iter_t(c.cend()); }
 
         const col& c;
     };
@@ -73,8 +73,19 @@ class TreeSMap final {
         const col& c;
     };
 
+    class elt_const_range_t {
+      public:
+        elt_const_range_t(const col& c) : c{c} {}
+        [[nodiscard]] size_t size() const { return c.size(); }
+
+        [[nodiscard]] auto begin() const { return c.cbegin(); }
+        [[nodiscard]] auto end() const { return c.cend(); }
+
+        const col& c;
+    };
+
     [[nodiscard]] elt_range_t elts() const { return elt_range_t(map); }
-    [[nodiscard]] key_range_t keys() const { return key_range_t(map); }
+    [[nodiscard]] key_const_range_t keys() const { return key_const_range_t(map); }
 
     [[nodiscard]] bool contains(key_t k) const {
         return map.count(k);
@@ -130,36 +141,36 @@ class AdaptGraph final {
         return g;
     }
 
-    struct vert_iterator {
+    struct vert_const_iterator {
         vert_id v;
         const std::vector<int>& is_free;
 
         vert_id operator*() const { return v; }
 
-        bool operator!=(const vert_iterator& o) {
+        bool operator!=(const vert_const_iterator& o) {
             while (v < o.v && is_free[v])
                 ++v;
             return v < o.v;
         }
 
-        vert_iterator& operator++() {
+        vert_const_iterator& operator++() {
             ++v;
             return *this;
         }
     };
-    struct vert_range {
+    struct vert_const_range {
         const std::vector<int>& is_free;
 
-        explicit vert_range(const std::vector<int>& _is_free) : is_free(_is_free) {}
+        explicit vert_const_range(const std::vector<int>& _is_free) : is_free(_is_free) {}
 
-        [[nodiscard]] vert_iterator begin() const { return vert_iterator{0, is_free}; }
-        [[nodiscard]] vert_iterator end() const { return vert_iterator{static_cast<vert_id>(is_free.size()), is_free}; }
+        [[nodiscard]] vert_const_iterator begin() const { return vert_const_iterator{0, is_free}; }
+        [[nodiscard]] vert_const_iterator end() const { return vert_const_iterator{static_cast<vert_id>(is_free.size()), is_free}; }
 
         [[nodiscard]] size_t size() const { return is_free.size(); }
     };
-    [[nodiscard]] vert_range verts() const { return vert_range{is_free}; }
+    [[nodiscard]] vert_const_range verts() const { return vert_const_range{is_free}; }
 
-    struct edge_iter {
+    struct edge_const_iter {
         struct edge_ref {
             vert_id vert{};
             Weight val;
@@ -168,58 +179,58 @@ class AdaptGraph final {
         smap_t::elt_iter_t it{};
         const std::vector<Weight>* ws{};
 
-        edge_iter(const smap_t::elt_iter_t& _it, const std::vector<Weight>& _ws) : it(_it), ws(&_ws) {}
-        edge_iter(const edge_iter& o) = default;
-        edge_iter& operator=(const edge_iter& o) = default;
-        edge_iter() = default;
+        edge_const_iter(const smap_t::elt_iter_t& _it, const std::vector<Weight>& _ws) : it(_it), ws(&_ws) {}
+        edge_const_iter(const edge_const_iter& o) = default;
+        edge_const_iter& operator=(const edge_const_iter& o) = default;
+        edge_const_iter() = default;
 
         // XXX: to make sure that we always return the same address
         // for the "empty" iterator, otherwise we can trigger
         // undefined behavior.
-        inline static std::unique_ptr<edge_iter> _empty_iter = std::make_unique<edge_iter>();
-        static edge_iter empty_iterator() {
+        inline static std::unique_ptr<edge_const_iter> _empty_iter = std::make_unique<edge_const_iter>();
+        static edge_const_iter empty_iterator() {
             return *_empty_iter;
         }
 
         edge_ref operator*() const { return edge_ref{it->first, (*ws)[it->second]}; }
-        edge_iter operator++() {
+        edge_const_iter operator++() {
             ++it;
             return *this;
         }
-        bool operator!=(const edge_iter& o) const { return it != o.it; }
+        bool operator!=(const edge_const_iter& o) const { return it != o.it; }
     };
 
-    using adj_range_t = typename smap_t::key_range_t;
 
-    struct edge_range_t {
+    struct edge_const_range_t {
         using elt_range_t = typename smap_t::elt_range_t;
-        using iterator = edge_iter;
+        using iterator = edge_const_iter;
 
         elt_range_t r;
         const std::vector<Weight>& ws;
 
-        [[nodiscard]] edge_iter begin() const { return edge_iter(r.begin(), ws); }
-        [[nodiscard]] edge_iter end() const { return edge_iter(r.end(), ws); }
+        [[nodiscard]] edge_const_iter begin() const { return edge_const_iter(r.begin(), ws); }
+        [[nodiscard]] edge_const_iter end() const { return edge_const_iter(r.end(), ws); }
         [[nodiscard]] size_t size() const { return r.size(); }
     };
 
-    using fwd_edge_iter = edge_iter;
-    using rev_edge_iter = edge_iter;
+    using fwd_edge_const_iter = edge_const_iter;
+    using rev_edge_const_iter = edge_const_iter;
 
-    using pred_range = adj_range_t;
-    using succ_range = adj_range_t;
+    using adj_range_t = typename smap_t::key_const_range_t;
+    using adj_const_range_t = typename smap_t::key_const_range_t;
+    using neighbour_range = adj_range_t;
+    using neighbour_const_range = adj_const_range_t;
 
-    adj_range_t succs(vert_id v) { return _succs[v].keys(); }
-    adj_range_t preds(vert_id v) { return _preds[v].keys(); }
+    adj_const_range_t succs(vert_id v) const { return _succs[v].keys(); }
+    adj_const_range_t preds(vert_id v) const { return _preds[v].keys(); }
 
-    using fwd_edge_range = edge_range_t;
-    using rev_edge_range = edge_range_t;
+    using fwd_edge_range = edge_const_range_t;
+    using rev_edge_range = edge_const_range_t;
 
-    [[nodiscard]] edge_range_t e_succs(vert_id v) const { return {_succs[v].elts(), _ws}; }
-    [[nodiscard]] edge_range_t e_preds(vert_id v) const { return {_preds[v].elts(), _ws}; }
+    [[nodiscard]] edge_const_range_t e_succs(vert_id v) const { return {_succs[v].elts(), _ws}; }
+    [[nodiscard]] edge_const_range_t e_preds(vert_id v) const { return {_preds[v].elts(), _ws}; }
 
-    using e_pred_range = edge_range_t;
-    using e_succ_range = edge_range_t;
+    using e_neighbour_const_range = edge_const_range_t;
 
     // Management
     [[nodiscard]] bool is_empty() const { return edge_count == 0; }
@@ -286,9 +297,11 @@ class AdaptGraph final {
         edge_count = 0;
     }
 
-    bool elem(vert_id s, vert_id d) { return _succs[s].contains(d); }
+    [[nodiscard]] bool elem(vert_id s, vert_id d) const {
+        return _succs[s].contains(d);
+    }
 
-    Weight& edge_val(vert_id s, vert_id d) {
+    const Weight& edge_val(vert_id s, vert_id d) const {
         return _ws[*_succs[s].lookup(d)];
     }
 
@@ -319,6 +332,13 @@ class AdaptGraph final {
             return true;
         }
         return false;
+    }
+
+    std::optional<Weight> lookup(vert_id s, vert_id d) const {
+        if (auto idx = _succs[s].lookup(d)) {
+            return _ws[*idx];
+        }
+        return {};
     }
 
     void add_edge(vert_id s, Weight w, vert_id d) {


### PR DESCRIPTION
Constness is an issue in SplitDBM; this PR attempts to fix it, by moving the normalization step to the end of mutating operations, and by making graph_ops more const friendly.