### PR TITLE
fix(cmake): support both Clang and AppleClang

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ if (IS_DIRECTORY "${PROJECT_SOURCE_DIR}/.git")
 endif ()
 
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" OR
-    "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+    "${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
   find_package(yaml-cpp REQUIRED)
   find_package(Boost REQUIRED)
   set(CMAKE_CXX_STANDARD 17)


### PR DESCRIPTION
We could add another clause and check that

CMAKE_CXX_COMPILER_ID STREQUAL AppleClang

but I think the fix from
https://stackoverflow.com/questions/10046114/in-cmake-how-can-i-test-if-the-compiler-is-clang
is more robust.

Signed-off-by: Jorge Navas <navasjorgea@gmail.com>