### PR TITLE
Use region_size for shared (and packet) instead of encoding into type

### DIFF
--- a/src/crab/ebpf_domain.hpp
+++ b/src/crab/ebpf_domain.hpp
@@ -145,23 +145,26 @@ class ebpf_domain_t final {
 
     // memory check / load / store
     void check_access_stack(NumAbsDomain& inv, const linear_expression_t& lb, const linear_expression_t& ub, const std::string& s);
-    void check_access_packet(NumAbsDomain& inv, const linear_expression_t& lb, const linear_expression_t& ub, const std::string& s,
-                                     bool is_comparison_check);
-    void check_access_shared(NumAbsDomain& inv, const linear_expression_t& lb, const linear_expression_t& ub, const std::string& s,
-                                     variable_t reg_type);
     void check_access_context(NumAbsDomain& inv, const linear_expression_t& lb, const linear_expression_t& ub, const std::string& s);
+    void check_access_packet(NumAbsDomain& inv, const linear_expression_t& lb, const linear_expression_t& ub, const std::string& s,
+                             std::optional<variable_t> region_size);
+    void check_access_shared(NumAbsDomain& inv, const linear_expression_t& lb, const linear_expression_t& ub, const std::string& s,
+                             variable_t region_size);
 
     void do_load_stack(NumAbsDomain& inv, const Reg& target_reg, const linear_expression_t& addr, int width);
     void do_load_ctx(NumAbsDomain& inv, const Reg& target_reg, const linear_expression_t& addr_vague, int width);
     void do_load_packet_or_shared(NumAbsDomain& inv, const Reg& target_reg, const linear_expression_t& addr, int width);
     void do_load(const Mem& b, const Reg& target_reg);
 
-    template <typename A, typename X, typename Y, typename Z>
+    template <typename A, typename X, typename Y>
     void do_store_stack(crab::domains::NumAbsDomain& inv, int width, const A& addr, X val_type, Y val_value,
-                        std::optional<Z> opt_val_offset);
+                        std::optional<variable_t> opt_val_offset,
+                        std::optional<variable_t> opt_val_region_size);
 
     template <typename Type, typename Value>
-    void do_mem_store(const Mem& b, Type val_type, Value val_value, std::optional<variable_t> opt_val_offset);
+    void do_mem_store(const Mem& b, Type val_type, Value val_value,
+                      std::optional<variable_t> opt_val_offset,
+                      std::optional<variable_t> opt_val_region_size);
 
     friend std::ostream& operator<<(std::ostream& o, const ebpf_domain_t& dom);
 

--- a/src/crab/var_factory.cpp
+++ b/src/crab/var_factory.cpp
@@ -22,17 +22,17 @@ thread_local std::vector<std::string> variable_t::names;
 
 void variable_t::clear_thread_local_state() {
     names = std::vector<std::string>{
-        "r0.value",  "r0.offset",  "r0.type",
-        "r1.value",  "r1.offset",  "r1.type",
-        "r2.value",  "r2.offset",  "r2.type",
-        "r3.value",  "r3.offset",  "r3.type",
-        "r4.value",  "r4.offset",  "r4.type",
-        "r5.value",  "r5.offset",  "r5.type",
-        "r6.value",  "r6.offset",  "r6.type",
-        "r7.value",  "r7.offset",  "r7.type",
-        "r8.value",  "r8.offset",  "r8.type",
-        "r9.value",  "r9.offset",  "r9.type",
-        "r10.value", "r10.offset", "r10.type",
+        "r0.value",  "r0.offset",  "r0.type", "r0.region_size",
+        "r1.value",  "r1.offset",  "r1.type", "r1.region_size",
+        "r2.value",  "r2.offset",  "r2.type", "r2.region_size",
+        "r3.value",  "r3.offset",  "r3.type", "r3.region_size",
+        "r4.value",  "r4.offset",  "r4.type", "r4.region_size",
+        "r5.value",  "r5.offset",  "r5.type", "r5.region_size",
+        "r6.value",  "r6.offset",  "r6.type", "r6.region_size",
+        "r7.value",  "r7.offset",  "r7.type", "r7.region_size",
+        "r8.value",  "r8.offset",  "r8.type", "r8.region_size",
+        "r9.value",  "r9.offset",  "r9.type", "r9.region_size",
+        "r10.value", "r10.offset", "r10.type", "r10.region_size",
         "data_size", "meta_size",
     };
 }
@@ -40,6 +40,7 @@ void variable_t::clear_thread_local_state() {
 static std::string name_of(data_kind_t kind) {
     switch (kind) {
     case data_kind_t::offsets: return "offset";
+    case data_kind_t::region_size: return "region_size";
     case data_kind_t::values: return "value";
     case data_kind_t::types: return "type";
     }

--- a/src/crab/variable.hpp
+++ b/src/crab/variable.hpp
@@ -18,7 +18,7 @@ using index_t = uint64_t;
 namespace crab {
 
 // XXX: this is eBPF-specific.
-enum class data_kind_t { types, values, offsets };
+enum class data_kind_t { types, values, offsets, region_size };
 std::ostream& operator<<(std::ostream& o, const data_kind_t& s);
 
 // Wrapper for typed variables used by the crab abstract domains and linear_constraints.

--- a/src/string_constraints.cpp
+++ b/src/string_constraints.cpp
@@ -20,7 +20,7 @@ using std::string;
 using std::map;
 
 #define REG R"_(\s*(r\d\d?)\s*)_"
-#define KIND R"_(\s*(type|value|offset)\s*)_"
+#define KIND R"_(\s*(type|value|offset|region_size)\s*)_"
 #define IMM R"_(\s*\[?([-+]?\d+)\]?\s*)_"
 #define INTERVAL R"_(\s*\[([-+]?\d+),\s*([-+]?\d+)\]?\s*)_"
 
@@ -34,6 +34,7 @@ static uint8_t regnum(const string& s) {
 static crab::data_kind_t regkind(const string& s) {
     if (s == "type") return crab::data_kind_t::types;
     if (s == "offset") return crab::data_kind_t::offsets;
+    if (s == "region_size") return crab::data_kind_t::region_size;
     if (s == "value") return crab::data_kind_t::values;
     throw std::runtime_error(string() + "Bad kind: " + s);
 }
@@ -55,6 +56,7 @@ static type_encoding_t string_to_type_encoding(const string& s) {
         {string("ctx"), T_CTX},
         {string("stack"), T_STACK},
         {string("packet"), T_PACKET},
+        {string("shared"), T_SHARED},
     };
     if (string_to_type.count(s)) {
         return string_to_type[s];

--- a/test-data/packet.yaml
+++ b/test-data/packet.yaml
@@ -50,6 +50,7 @@ post: [
     "packet_size-r3.offset<=65530", "packet_size=[0, 65534]",
     "r3.offset-packet_size<=4", "r1.value=r3.value+4",
     "r2.offset-r3.offset<=65530", "r3.offset-r2.offset<=4",
+    "r1.region_size=r3.region_size"
 ]
 messages:
   - "4: Upper bound must be at most packet_size (valid_access(r1.offset, width=8))"
@@ -60,7 +61,9 @@ test-case: simple valid access
 pre: [
     "meta_offset=0",
     "r1.type=packet", "r1.offset=0", "r1.value=[4098, 2147418112]",
-    "r2.type=packet", "r2.offset=[0, 65534]", "packet_size=r2.offset"
+    "r2.type=packet", "r2.offset=[0, 65534]", "packet_size=r2.offset",
+    "r1.region_size=packet_size",
+    "r2.region_size=packet_size",
 ]
 
 code:
@@ -81,4 +84,11 @@ post: [
     "packet_size-r3.offset<=65526", "packet_size=[0, 65534]",
     "r3.offset-packet_size<=8", "r1.value=r3.value+8",
     "r2.offset-r3.offset<=65526", "r3.offset-r2.offset<=8",
+    "r1.region_size=r3.region_size",
+    "packet_size=r1.region_size", "packet_size=r2.region_size", "packet_size=r3.region_size",
+    "r1.region_size-r3.offset<=65526", "r1.region_size=[0, 65534]", "r1.region_size=r2.offset",
+    "r1.region_size=r2.region_size", "r2.offset=r2.region_size", "r2.offset=r3.region_size",
+    "r2.region_size-r3.offset<=65526", "r2.region_size=[0, 65534]", "r2.region_size=r3.region_size",
+    "r3.offset-r1.region_size<=8", "r3.offset-r2.region_size<=8", "r3.offset-r3.region_size<=8", "r3.region_size-r3.offset<=65526",
+    "r3.region_size=[0, 65534]"
 ]

--- a/test-data/single-instruction-assignment.yaml
+++ b/test-data/single-instruction-assignment.yaml
@@ -25,6 +25,7 @@ post:
   - r1.type=r2.type
   - r1.value=r2.value
   - r1.offset=r2.offset
+  - r1.region_size=r2.region_size
 
 ---
 test-case: re-assign immediate


### PR DESCRIPTION
This should make it easier to use a set domain for the types, and also is more regular - all types are handled in the same way.

On the flip side, the verbose output becomes more, uh, verbose. 

Signed-off-by: Elazar Gershuni <elazarg@gmail.com>