### PR TITLE
Track offsets and region sizes separately per pointer type

### DIFF
--- a/src/asm_ostream.cpp
+++ b/src/asm_ostream.cpp
@@ -151,7 +151,11 @@ std::ostream& operator<<(std::ostream& os, ValidMapKeyValue const& a) {
 }
 
 std::ostream& operator<<(std::ostream& os, ZeroOffset const& a) {
-    return os << crab::variable_t::reg(crab::data_kind_t::offsets, a.reg.v) << " == 0";
+    return os << crab::variable_t::reg(crab::data_kind_t::ctx_offsets, a.reg.v) << " == 0 and"
+              << crab::variable_t::reg(crab::data_kind_t::map_offsets, a.reg.v) << " == 0 and"
+              << crab::variable_t::reg(crab::data_kind_t::packet_offsets, a.reg.v) << " == 0 and"
+              << crab::variable_t::reg(crab::data_kind_t::shared_offsets, a.reg.v) << " == 0 and"
+              << crab::variable_t::reg(crab::data_kind_t::stack_offsets, a.reg.v) << " == 0";
 }
 
 std::ostream& operator<<(std::ostream& os, Comparable const& a) {

--- a/src/asm_ostream.cpp
+++ b/src/asm_ostream.cpp
@@ -150,12 +150,8 @@ std::ostream& operator<<(std::ostream& os, ValidMapKeyValue const& a) {
     return os << "within stack(" << a.access_reg << ":" << (a.key ? "key_size" : "value_size") << "(" << a.map_fd_reg << "))";
 }
 
-std::ostream& operator<<(std::ostream& os, ZeroOffset const& a) {
-    return os << crab::variable_t::reg(crab::data_kind_t::ctx_offsets, a.reg.v) << " == 0 and"
-              << crab::variable_t::reg(crab::data_kind_t::map_offsets, a.reg.v) << " == 0 and"
-              << crab::variable_t::reg(crab::data_kind_t::packet_offsets, a.reg.v) << " == 0 and"
-              << crab::variable_t::reg(crab::data_kind_t::shared_offsets, a.reg.v) << " == 0 and"
-              << crab::variable_t::reg(crab::data_kind_t::stack_offsets, a.reg.v) << " == 0";
+std::ostream& operator<<(std::ostream& os, ZeroCtxOffset const& a) {
+    return os << crab::variable_t::reg(crab::data_kind_t::ctx_offsets, a.reg.v) << " == 0";
 }
 
 std::ostream& operator<<(std::ostream& os, Comparable const& a) {

--- a/src/asm_syntax.hpp
+++ b/src/asm_syntax.hpp
@@ -281,12 +281,12 @@ struct TypeConstraint {
 };
 
 /// Condition check whether something is a valid size.
-struct ZeroOffset {
+struct ZeroCtxOffset {
     Reg reg;
 };
 
 using AssertionConstraint =
-    std::variant<Comparable, Addable, ValidAccess, ValidStore, ValidSize, ValidMapKeyValue, TypeConstraint, ZeroOffset>;
+    std::variant<Comparable, Addable, ValidAccess, ValidStore, ValidSize, ValidMapKeyValue, TypeConstraint, ZeroCtxOffset>;
 
 struct Assert {
     AssertionConstraint cst;
@@ -362,7 +362,7 @@ DECLARE_EQ2(Addable, ptr, num)
 DECLARE_EQ2(ValidStore, mem, val)
 DECLARE_EQ4(ValidAccess, reg, offset, width, or_null)
 DECLARE_EQ3(ValidMapKeyValue, access_reg, map_fd_reg, key)
-DECLARE_EQ1(ZeroOffset, reg)
+DECLARE_EQ1(ZeroCtxOffset, reg)
 DECLARE_EQ1(Assert, cst)
 
 }

--- a/src/assertions.cpp
+++ b/src/assertions.cpp
@@ -28,7 +28,7 @@ class AssertExtractor {
     static vector<Assert> zero_offset_ctx(Reg reg) {
         vector<Assert> res;
         res.emplace_back(TypeConstraint{reg, TypeGroup::ctx});
-        res.emplace_back(ZeroOffset{reg});
+        res.emplace_back(ZeroCtxOffset{reg});
         return res;
     }
 

--- a/src/crab/ebpf_domain.cpp
+++ b/src/crab/ebpf_domain.cpp
@@ -955,6 +955,7 @@ void ebpf_domain_t::do_load_stack(NumAbsDomain& inv, const Reg& target_reg, cons
     if (width == 1 || width == 2 || width == 4 || width == 8) {
         inv.assign(target.value, stack.load(inv,  data_kind_t::values, addr, width));
         havoc_offsets(target_reg);
+        havoc(target.shared_region_size);
         int type = type_inv.get_type(m_inv, target.type);
         switch (type) {
         case T_CTX: inv.assign(target.ctx_offset, stack.load(inv, data_kind_t::ctx_offsets, addr, width)); break;

--- a/src/crab/ebpf_domain.cpp
+++ b/src/crab/ebpf_domain.cpp
@@ -230,7 +230,9 @@ void ebpf_domain_t::join_inv(NumAbsDomain& dst, NumAbsDomain& src) {
     // Some variables are type-specific.  Type-specific variables
     // for a register can exist in the domain whenever the associated
     // type value is present in the register's types interval (and the
-    // value is not Top), and are absent otherwise.
+    // value is not Top), and are absent otherwise.  That is, we want
+    // to keep track of implications of the form
+    // "if register R has type=T then R.T_offset has value ...".
     //
     // If a type value is legal in exactly one of the two domains, a
     // normal join operation would remove any type-specific variables
@@ -242,6 +244,12 @@ void ebpf_domain_t::join_inv(NumAbsDomain& dst, NumAbsDomain& src) {
     // interpreted as Bottom, so we want to preserve the values of any
     // type-specific variables from the other domain where the type
     // value is legal.
+    //
+    // Example input:
+    //   r1.type=stack, r1.stack_offset=100
+    //   r1.type=packet, r1.packet_offset=4
+    // Output:
+    //   r1.type={stack,packet}, r1.stack_offset=100, r1.packet_offset=4
 
     std::map<crab::variable_t, crab::interval_t> extra_invariants;
     if (!dst.is_bottom()) {

--- a/src/crab/ebpf_domain.cpp
+++ b/src/crab/ebpf_domain.cpp
@@ -1388,8 +1388,8 @@ void ebpf_domain_t::operator()(const Bin& bin) {
                             apply(inv, crab::arith_binop_t::ADD, get_type_offset_variable(bin.dst, inv).value(), dst.value,
                                   get_type_offset_variable(src_reg, inv).value(),
                                   false);
-
-                        inv.assign(dst.shared_region_size, src.shared_region_size);
+                        if (type_inv.get_type(m_inv, src.type) == T_SHARED)
+                            inv.assign(dst.shared_region_size, src.shared_region_size);
                     },
                     [&](NumAbsDomain& inv) {
                         // ptr + num

--- a/src/crab/ebpf_domain.cpp
+++ b/src/crab/ebpf_domain.cpp
@@ -218,6 +218,9 @@ void ebpf_domain_t::operator|=(ebpf_domain_t&& other) {
         *this = other;
         return;
     }
+    if (other.is_bottom()) {
+        return;
+    }
 
     // Some variables are special in that it is ok for them to not exist
     // in one of the two domains and we want to preserve the value in

--- a/src/crab/ebpf_domain.cpp
+++ b/src/crab/ebpf_domain.cpp
@@ -205,8 +205,6 @@ bool ebpf_domain_t::variable_has_type(variable_t type_variable, int type) const 
     crab::interval_t interval = m_inv.eval_interval(type_variable);
     if (interval.is_top())
         return true;
-    if (interval.is_bottom())
-        return false;
     return (interval.lb().number().value_or(INT_MIN) <= type) &&
            (interval.ub().number().value_or(INT_MAX) >= type);
 }
@@ -954,7 +952,6 @@ void ebpf_domain_t::do_load_stack(NumAbsDomain& inv, const Reg& target_reg, cons
     const reg_pack_t& target = reg_pack(target_reg);
     if (width == 1 || width == 2 || width == 4 || width == 8) {
         inv.assign(target.value, stack.load(inv,  data_kind_t::values, addr, width));
-        havoc_offsets(target_reg);
         havoc(target.shared_region_size);
         int type = type_inv.get_type(m_inv, target.type);
         switch (type) {

--- a/src/crab/ebpf_domain.hpp
+++ b/src/crab/ebpf_domain.hpp
@@ -148,6 +148,7 @@ class ebpf_domain_t final {
     crab::interval_t get_map_value_size(const Reg& map_fd_reg) const;
     crab::interval_t get_map_max_entries(const Reg& map_fd_reg) const;
     void forget_packet_pointers();
+    void havoc_register(NumAbsDomain& inv, const Reg& reg);
     void do_load_mapfd(const Reg& dst_reg, int mapfd, bool maybe_null);
 
     void overflow(variable_t lhs);
@@ -218,6 +219,10 @@ class ebpf_domain_t final {
         [[nodiscard]] int get_type(const NumAbsDomain& inv, variable_t v) const;
         [[nodiscard]] int get_type(const NumAbsDomain& inv, const Reg& r) const;
         [[nodiscard]] int get_type(const NumAbsDomain& inv, int t) const;
+
+        [[nodiscard]] bool has_type(const NumAbsDomain& inv, variable_t v, type_encoding_t type) const;
+        [[nodiscard]] bool has_type(const NumAbsDomain& inv, const Reg& r, type_encoding_t type) const;
+        [[nodiscard]] bool has_type(const NumAbsDomain& inv, int t, type_encoding_t type) const;
 
         [[nodiscard]] bool same_type(const NumAbsDomain& inv, const Reg& a, const Reg& b) const;
         [[nodiscard]] bool implies_type(const NumAbsDomain& inv, const linear_constraint_t& a, const linear_constraint_t& b) const;

--- a/src/crab/ebpf_domain.hpp
+++ b/src/crab/ebpf_domain.hpp
@@ -147,9 +147,9 @@ class ebpf_domain_t final {
     void check_access_stack(NumAbsDomain& inv, const linear_expression_t& lb, const linear_expression_t& ub, const std::string& s);
     void check_access_context(NumAbsDomain& inv, const linear_expression_t& lb, const linear_expression_t& ub, const std::string& s);
     void check_access_packet(NumAbsDomain& inv, const linear_expression_t& lb, const linear_expression_t& ub, const std::string& s,
-                             std::optional<variable_t> region_size);
+                             std::optional<variable_t> shared_region_size);
     void check_access_shared(NumAbsDomain& inv, const linear_expression_t& lb, const linear_expression_t& ub, const std::string& s,
-                             variable_t region_size);
+                             variable_t shared_region_size);
 
     void do_load_stack(NumAbsDomain& inv, const Reg& target_reg, const linear_expression_t& addr, int width);
     void do_load_ctx(NumAbsDomain& inv, const Reg& target_reg, const linear_expression_t& addr_vague, int width);
@@ -159,12 +159,12 @@ class ebpf_domain_t final {
     template <typename A, typename X, typename Y>
     void do_store_stack(crab::domains::NumAbsDomain& inv, int width, const A& addr, X val_type, Y val_value,
                         std::optional<variable_t> opt_val_offset,
-                        std::optional<variable_t> opt_val_region_size);
+                        std::optional<variable_t> opt_val_shared_region_size);
 
     template <typename Type, typename Value>
     void do_mem_store(const Mem& b, Type val_type, Value val_value,
                       std::optional<variable_t> opt_val_offset,
-                      std::optional<variable_t> opt_val_region_size);
+                      std::optional<variable_t> opt_val_shared_region_size);
 
     friend std::ostream& operator<<(std::ostream& o, const ebpf_domain_t& dom);
 
@@ -211,6 +211,4 @@ class ebpf_domain_t final {
     };
 
     TypeDomain type_inv;
-
-    void assign_region_size(const Reg& r, const crab::interval_t& size);
 }; // end ebpf_domain_t

--- a/src/crab/ebpf_domain.hpp
+++ b/src/crab/ebpf_domain.hpp
@@ -69,7 +69,7 @@ class ebpf_domain_t final {
     void operator()(const ValidMapKeyValue&);
     void operator()(const ValidSize&);
     void operator()(const ValidStore&);
-    void operator()(const ZeroOffset&);
+    void operator()(const ZeroCtxOffset&);
 
   private:
     // private generic domain functions
@@ -129,6 +129,7 @@ class ebpf_domain_t final {
     void havoc(variable_t v);
     void havoc_offsets(const Reg& reg);
 
+    std::optional<variable_t> get_type_offset_variable(const Reg& reg, const NumAbsDomain& inv) const;
     std::optional<variable_t> get_type_offset_variable(const Reg& reg) const;
     void add_extra_invariant(std::map<crab::variable_t, crab::interval_t>& extra_invariants, variable_t v,
                              ebpf_domain_t& other) const;
@@ -166,7 +167,8 @@ class ebpf_domain_t final {
                         std::optional<variable_t> opt_val_ctx_offset,
                         std::optional<variable_t> opt_val_map_offset,
                         std::optional<variable_t> opt_val_packet_offset,
-                        std::optional<variable_t> opt_val_shared_offset, std::optional<variable_t> opt_val_stack_offset,
+                        std::optional<variable_t> opt_val_shared_offset,
+                        std::optional<variable_t> opt_val_stack_offset,
                         std::optional<variable_t> opt_val_shared_region_size);
 
     template <typename Type, typename Value>

--- a/src/crab/ebpf_domain.hpp
+++ b/src/crab/ebpf_domain.hpp
@@ -16,6 +16,8 @@
 using NumAbsDomain = crab::domains::NumAbsDomain;
 
 class ebpf_domain_t final {
+    struct TypeDomain;
+
   public:
     ebpf_domain_t();
     ebpf_domain_t(crab::domains::NumAbsDomain inv, crab::domains::array_domain_t stack);
@@ -135,12 +137,6 @@ class ebpf_domain_t final {
     static std::optional<variable_t> get_type_offset_variable(const Reg& reg, int type);
     std::optional<variable_t> get_type_offset_variable(const Reg& reg, const NumAbsDomain& inv) const;
     std::optional<variable_t> get_type_offset_variable(const Reg& reg) const;
-    static bool variable_has_type(const NumAbsDomain& inv, variable_t type_variable, type_encoding_t type);
-    static void join_inv(NumAbsDomain& dst, NumAbsDomain& src);
-    static void add_extra_invariant(NumAbsDomain& dst,
-                                     std::map<crab::variable_t, crab::interval_t>& extra_invariants,
-                                     variable_t type_variable, type_encoding_t type, crab::data_kind_t kind,
-                                     const NumAbsDomain& other);
 
     void scratch_caller_saved_registers();
     std::optional<uint32_t> get_map_type(const Reg& map_fd_reg) const;
@@ -233,6 +229,11 @@ class ebpf_domain_t final {
         NumAbsDomain join_by_if_else(const NumAbsDomain& inv, const linear_constraint_t& condition,
                                      const std::function<void(NumAbsDomain&)>& if_true,
                                      const std::function<void(NumAbsDomain&)>& if_false) const;
+        void selectively_join_based_on_type(NumAbsDomain& dst, NumAbsDomain& src) const;
+        void add_extra_invariant(NumAbsDomain& dst,
+                                 std::map<crab::variable_t, crab::interval_t>& extra_invariants,
+                                 variable_t type_variable, type_encoding_t type, crab::data_kind_t kind,
+                                 const NumAbsDomain& other) const;
 
         bool is_in_group(const NumAbsDomain& inv, const Reg& r, TypeGroup group) const;
     };

--- a/src/crab/ebpf_domain.hpp
+++ b/src/crab/ebpf_domain.hpp
@@ -173,7 +173,7 @@ class ebpf_domain_t final {
     template <typename A, typename X, typename Y>
     void do_store_stack(crab::domains::NumAbsDomain& inv, int width, const A& addr, X val_type, Y val_value,
                         std::optional<variable_t> opt_val_ctx_offset,
-                        std::optional<variable_t> opt_val_map_offset,
+                        std::optional<variable_t> opt_val_map_fd,
                         std::optional<variable_t> opt_val_packet_offset,
                         std::optional<variable_t> opt_val_shared_offset,
                         std::optional<variable_t> opt_val_stack_offset,
@@ -182,7 +182,7 @@ class ebpf_domain_t final {
     template <typename Type, typename Value>
     void do_mem_store(const Mem& b, Type val_type, Value val_value,
                       std::optional<variable_t> opt_val_ctx_offset,
-                      std::optional<variable_t> opt_val_map_offset,
+                      std::optional<variable_t> opt_val_map_fd,
                       std::optional<variable_t> opt_val_packet_offset,
                       std::optional<variable_t> opt_val_shared_offset,
                       std::optional<variable_t> opt_val_stack_offset,

--- a/src/crab/ebpf_domain.hpp
+++ b/src/crab/ebpf_domain.hpp
@@ -138,7 +138,7 @@ class ebpf_domain_t final {
     static void join_inv(NumAbsDomain& dst, NumAbsDomain& src);
     static void add_extra_invariant(NumAbsDomain& dst,
                                      std::map<crab::variable_t, crab::interval_t>& extra_invariants,
-                                     variable_t type_variable, type_encoding_t type, variable_t v,
+                                     variable_t type_variable, type_encoding_t type, crab::data_kind_t kind,
                                      const NumAbsDomain& other);
 
     void scratch_caller_saved_registers();

--- a/src/crab/ebpf_domain.hpp
+++ b/src/crab/ebpf_domain.hpp
@@ -127,6 +127,11 @@ class ebpf_domain_t final {
 
     /// Forget everything we know about the value of a variable.
     void havoc(variable_t v);
+    void havoc_offsets(const Reg& reg);
+
+    std::optional<variable_t> get_type_offset_variable(const Reg& reg) const;
+    void add_extra_invariant(std::map<crab::variable_t, crab::interval_t>& extra_invariants, variable_t v,
+                             ebpf_domain_t& other) const;
 
     void scratch_caller_saved_registers();
     std::optional<uint32_t> get_map_type(const Reg& map_fd_reg) const;
@@ -158,12 +163,19 @@ class ebpf_domain_t final {
 
     template <typename A, typename X, typename Y>
     void do_store_stack(crab::domains::NumAbsDomain& inv, int width, const A& addr, X val_type, Y val_value,
-                        std::optional<variable_t> opt_val_offset,
+                        std::optional<variable_t> opt_val_ctx_offset,
+                        std::optional<variable_t> opt_val_map_offset,
+                        std::optional<variable_t> opt_val_packet_offset,
+                        std::optional<variable_t> opt_val_shared_offset, std::optional<variable_t> opt_val_stack_offset,
                         std::optional<variable_t> opt_val_shared_region_size);
 
     template <typename Type, typename Value>
     void do_mem_store(const Mem& b, Type val_type, Value val_value,
-                      std::optional<variable_t> opt_val_offset,
+                      std::optional<variable_t> opt_val_ctx_offset,
+                      std::optional<variable_t> opt_val_map_offset,
+                      std::optional<variable_t> opt_val_packet_offset,
+                      std::optional<variable_t> opt_val_shared_offset,
+                      std::optional<variable_t> opt_val_stack_offset,
                       std::optional<variable_t> opt_val_shared_region_size);
 
     friend std::ostream& operator<<(std::ostream& o, const ebpf_domain_t& dom);

--- a/src/crab/ebpf_domain.hpp
+++ b/src/crab/ebpf_domain.hpp
@@ -127,6 +127,8 @@ class ebpf_domain_t final {
 
     /// Forget everything we know about the value of a variable.
     void havoc(variable_t v);
+
+    /// Forget everything about all offset variables for a given register.
     void havoc_offsets(const Reg& reg);
 
     std::optional<variable_t> get_type_offset_variable(const Reg& reg, const NumAbsDomain& inv) const;

--- a/src/crab/ebpf_domain.hpp
+++ b/src/crab/ebpf_domain.hpp
@@ -131,10 +131,12 @@ class ebpf_domain_t final {
     /// Forget everything about all offset variables for a given register.
     void havoc_offsets(const Reg& reg);
 
+    static std::optional<variable_t> get_type_offset_variable(const Reg& reg, int type);
     std::optional<variable_t> get_type_offset_variable(const Reg& reg, const NumAbsDomain& inv) const;
     std::optional<variable_t> get_type_offset_variable(const Reg& reg) const;
-    void add_extra_invariant(std::map<crab::variable_t, crab::interval_t>& extra_invariants, variable_t v,
-                             ebpf_domain_t& other) const;
+    bool variable_has_type(variable_t type_variable, int type) const;
+    void add_extra_invariant(std::map<crab::variable_t, crab::interval_t>& extra_invariants,
+                             variable_t type_variable, int type, variable_t v, ebpf_domain_t& other) const;
 
     void scratch_caller_saved_registers();
     std::optional<uint32_t> get_map_type(const Reg& map_fd_reg) const;

--- a/src/crab/ebpf_domain.hpp
+++ b/src/crab/ebpf_domain.hpp
@@ -130,6 +130,7 @@ class ebpf_domain_t final {
 
     /// Forget everything about all offset variables for a given register.
     void havoc_offsets(const Reg& reg);
+    void havoc_offsets(NumAbsDomain& inv, const Reg& reg);
 
     static std::optional<variable_t> get_type_offset_variable(const Reg& reg, int type);
     std::optional<variable_t> get_type_offset_variable(const Reg& reg, const NumAbsDomain& inv) const;

--- a/src/crab/ebpf_domain.hpp
+++ b/src/crab/ebpf_domain.hpp
@@ -134,9 +134,12 @@ class ebpf_domain_t final {
     static std::optional<variable_t> get_type_offset_variable(const Reg& reg, int type);
     std::optional<variable_t> get_type_offset_variable(const Reg& reg, const NumAbsDomain& inv) const;
     std::optional<variable_t> get_type_offset_variable(const Reg& reg) const;
-    bool variable_has_type(variable_t type_variable, int type) const;
-    void add_extra_invariant(std::map<crab::variable_t, crab::interval_t>& extra_invariants,
-                             variable_t type_variable, int type, variable_t v, ebpf_domain_t& other) const;
+    static bool variable_has_type(const NumAbsDomain& inv, variable_t type_variable, type_encoding_t type);
+    static void join_inv(NumAbsDomain& dst, NumAbsDomain& src);
+    static void add_extra_invariant(NumAbsDomain& dst,
+                                     std::map<crab::variable_t, crab::interval_t>& extra_invariants,
+                                     variable_t type_variable, type_encoding_t type, variable_t v,
+                                     const NumAbsDomain& other);
 
     void scratch_caller_saved_registers();
     std::optional<uint32_t> get_map_type(const Reg& map_fd_reg) const;

--- a/src/crab/var_factory.cpp
+++ b/src/crab/var_factory.cpp
@@ -22,25 +22,29 @@ thread_local std::vector<std::string> variable_t::names;
 
 void variable_t::clear_thread_local_state() {
     names = std::vector<std::string>{
-        "r0.value",  "r0.offset",  "r0.type", "r0.shared_region_size",
-        "r1.value",  "r1.offset",  "r1.type", "r1.shared_region_size",
-        "r2.value",  "r2.offset",  "r2.type", "r2.shared_region_size",
-        "r3.value",  "r3.offset",  "r3.type", "r3.shared_region_size",
-        "r4.value",  "r4.offset",  "r4.type", "r4.shared_region_size",
-        "r5.value",  "r5.offset",  "r5.type", "r5.shared_region_size",
-        "r6.value",  "r6.offset",  "r6.type", "r6.shared_region_size",
-        "r7.value",  "r7.offset",  "r7.type", "r7.shared_region_size",
-        "r8.value",  "r8.offset",  "r8.type", "r8.shared_region_size",
-        "r9.value",  "r9.offset",  "r9.type", "r9.shared_region_size",
-        "r10.value", "r10.offset", "r10.type", "r10.shared_region_size",
+        "r0.value", "r0.ctx_offset", "r0.map_offset", "r0.packet_offset", "r0.shared_offset", "r0.stack_offset", "r0.type", "r0.shared_region_size",
+        "r1.value", "r1.ctx_offset", "r1.map_offset", "r1.packet_offset", "r1.shared_offset", "r1.stack_offset", "r1.type", "r1.shared_region_size",
+        "r2.value", "r2.ctx_offset", "r2.map_offset", "r2.packet_offset", "r2.shared_offset", "r2.stack_offset", "r2.type", "r2.shared_region_size",
+        "r3.value", "r3.ctx_offset", "r3.map_offset", "r3.packet_offset", "r3.shared_offset", "r3.stack_offset", "r3.type", "r3.shared_region_size",
+        "r4.value", "r4.ctx_offset", "r4.map_offset", "r4.packet_offset", "r4.shared_offset", "r4.stack_offset", "r4.type", "r4.shared_region_size",
+        "r5.value", "r5.ctx_offset", "r5.map_offset", "r5.packet_offset", "r5.shared_offset", "r5.stack_offset", "r5.type", "r5.shared_region_size",
+        "r6.value", "r6.ctx_offset", "r6.map_offset", "r6.packet_offset", "r6.shared_offset", "r6.stack_offset", "r6.type", "r6.shared_region_size",
+        "r7.value", "r7.ctx_offset", "r7.map_offset", "r7.packet_offset", "r7.shared_offset", "r7.stack_offset", "r7.type", "r7.shared_region_size",
+        "r8.value", "r8.ctx_offset", "r8.map_offset", "r8.packet_offset", "r8.shared_offset", "r8.stack_offset", "r8.type", "r8.shared_region_size",
+        "r9.value", "r9.ctx_offset", "r9.map_offset", "r9.packet_offset", "r9.shared_offset", "r9.stack_offset", "r9.type", "r9.shared_region_size",
+        "r10.value", "r10.ctx_offset", "r10.map_offset", "r10.packet_offset", "r10.shared_offset", "r10.stack_offset", "r10.type", "r10.shared_region_size",
         "data_size", "meta_size",
     };
 }
 
 static std::string name_of(data_kind_t kind) {
     switch (kind) {
-    case data_kind_t::offsets: return "offset";
-    case data_kind_t::shared_region_size: return "shared_region_size";
+    case data_kind_t::ctx_offsets: return "ctx_offset";
+    case data_kind_t::map_offsets: return "map_offset";
+    case data_kind_t::packet_offsets: return "packet_offset";
+    case data_kind_t::shared_offsets: return "shared_offset";
+    case data_kind_t::stack_offsets: return "stack_offset";
+    case data_kind_t::shared_region_sizes: return "shared_region_size";
     case data_kind_t::values: return "value";
     case data_kind_t::types: return "type";
     }

--- a/src/crab/var_factory.cpp
+++ b/src/crab/var_factory.cpp
@@ -72,6 +72,12 @@ variable_t variable_t::cell_var(data_kind_t array, index_t offset, unsigned size
     return make(mk_scalar_name(array, (int)offset, (int)size));
 }
 
+// Given a type variable, get the associated variable of a given kind.
+variable_t variable_t::kind_var(data_kind_t kind, variable_t type_variable) {
+    std::string name = type_variable.name();
+    return make(name.substr(0, name.rfind('.') + 1) + name_of(kind));
+}
+
 variable_t variable_t::meta_offset() { return make("meta_offset"); }
 variable_t variable_t::packet_size() { return make("packet_size"); }
 variable_t variable_t::instruction_count() { return make("instruction_count"); }

--- a/src/crab/var_factory.cpp
+++ b/src/crab/var_factory.cpp
@@ -22,17 +22,17 @@ thread_local std::vector<std::string> variable_t::names;
 
 void variable_t::clear_thread_local_state() {
     names = std::vector<std::string>{
-        "r0.value", "r0.ctx_offset", "r0.map_offset", "r0.packet_offset", "r0.shared_offset", "r0.stack_offset", "r0.type", "r0.shared_region_size",
-        "r1.value", "r1.ctx_offset", "r1.map_offset", "r1.packet_offset", "r1.shared_offset", "r1.stack_offset", "r1.type", "r1.shared_region_size",
-        "r2.value", "r2.ctx_offset", "r2.map_offset", "r2.packet_offset", "r2.shared_offset", "r2.stack_offset", "r2.type", "r2.shared_region_size",
-        "r3.value", "r3.ctx_offset", "r3.map_offset", "r3.packet_offset", "r3.shared_offset", "r3.stack_offset", "r3.type", "r3.shared_region_size",
-        "r4.value", "r4.ctx_offset", "r4.map_offset", "r4.packet_offset", "r4.shared_offset", "r4.stack_offset", "r4.type", "r4.shared_region_size",
-        "r5.value", "r5.ctx_offset", "r5.map_offset", "r5.packet_offset", "r5.shared_offset", "r5.stack_offset", "r5.type", "r5.shared_region_size",
-        "r6.value", "r6.ctx_offset", "r6.map_offset", "r6.packet_offset", "r6.shared_offset", "r6.stack_offset", "r6.type", "r6.shared_region_size",
-        "r7.value", "r7.ctx_offset", "r7.map_offset", "r7.packet_offset", "r7.shared_offset", "r7.stack_offset", "r7.type", "r7.shared_region_size",
-        "r8.value", "r8.ctx_offset", "r8.map_offset", "r8.packet_offset", "r8.shared_offset", "r8.stack_offset", "r8.type", "r8.shared_region_size",
-        "r9.value", "r9.ctx_offset", "r9.map_offset", "r9.packet_offset", "r9.shared_offset", "r9.stack_offset", "r9.type", "r9.shared_region_size",
-        "r10.value", "r10.ctx_offset", "r10.map_offset", "r10.packet_offset", "r10.shared_offset", "r10.stack_offset", "r10.type", "r10.shared_region_size",
+        "r0.value", "r0.ctx_offset", "r0.map_fd", "r0.packet_offset", "r0.shared_offset", "r0.stack_offset", "r0.type", "r0.shared_region_size",
+        "r1.value", "r1.ctx_offset", "r1.map_fd", "r1.packet_offset", "r1.shared_offset", "r1.stack_offset", "r1.type", "r1.shared_region_size",
+        "r2.value", "r2.ctx_offset", "r2.map_fd", "r2.packet_offset", "r2.shared_offset", "r2.stack_offset", "r2.type", "r2.shared_region_size",
+        "r3.value", "r3.ctx_offset", "r3.map_fd", "r3.packet_offset", "r3.shared_offset", "r3.stack_offset", "r3.type", "r3.shared_region_size",
+        "r4.value", "r4.ctx_offset", "r4.map_fd", "r4.packet_offset", "r4.shared_offset", "r4.stack_offset", "r4.type", "r4.shared_region_size",
+        "r5.value", "r5.ctx_offset", "r5.map_fd", "r5.packet_offset", "r5.shared_offset", "r5.stack_offset", "r5.type", "r5.shared_region_size",
+        "r6.value", "r6.ctx_offset", "r6.map_fd", "r6.packet_offset", "r6.shared_offset", "r6.stack_offset", "r6.type", "r6.shared_region_size",
+        "r7.value", "r7.ctx_offset", "r7.map_fd", "r7.packet_offset", "r7.shared_offset", "r7.stack_offset", "r7.type", "r7.shared_region_size",
+        "r8.value", "r8.ctx_offset", "r8.map_fd", "r8.packet_offset", "r8.shared_offset", "r8.stack_offset", "r8.type", "r8.shared_region_size",
+        "r9.value", "r9.ctx_offset", "r9.map_fd", "r9.packet_offset", "r9.shared_offset", "r9.stack_offset", "r9.type", "r9.shared_region_size",
+        "r10.value", "r10.ctx_offset", "r10.map_fd", "r10.packet_offset", "r10.shared_offset", "r10.stack_offset", "r10.type", "r10.shared_region_size",
         "data_size", "meta_size",
     };
 }
@@ -40,7 +40,7 @@ void variable_t::clear_thread_local_state() {
 static std::string name_of(data_kind_t kind) {
     switch (kind) {
     case data_kind_t::ctx_offsets: return "ctx_offset";
-    case data_kind_t::map_offsets: return "map_offset";
+    case data_kind_t::map_fds: return "map_fd";
     case data_kind_t::packet_offsets: return "packet_offset";
     case data_kind_t::shared_offsets: return "shared_offset";
     case data_kind_t::stack_offsets: return "stack_offset";

--- a/src/crab/var_factory.cpp
+++ b/src/crab/var_factory.cpp
@@ -22,17 +22,17 @@ thread_local std::vector<std::string> variable_t::names;
 
 void variable_t::clear_thread_local_state() {
     names = std::vector<std::string>{
-        "r0.value",  "r0.offset",  "r0.type", "r0.region_size",
-        "r1.value",  "r1.offset",  "r1.type", "r1.region_size",
-        "r2.value",  "r2.offset",  "r2.type", "r2.region_size",
-        "r3.value",  "r3.offset",  "r3.type", "r3.region_size",
-        "r4.value",  "r4.offset",  "r4.type", "r4.region_size",
-        "r5.value",  "r5.offset",  "r5.type", "r5.region_size",
-        "r6.value",  "r6.offset",  "r6.type", "r6.region_size",
-        "r7.value",  "r7.offset",  "r7.type", "r7.region_size",
-        "r8.value",  "r8.offset",  "r8.type", "r8.region_size",
-        "r9.value",  "r9.offset",  "r9.type", "r9.region_size",
-        "r10.value", "r10.offset", "r10.type", "r10.region_size",
+        "r0.value",  "r0.offset",  "r0.type", "r0.shared_region_size",
+        "r1.value",  "r1.offset",  "r1.type", "r1.shared_region_size",
+        "r2.value",  "r2.offset",  "r2.type", "r2.shared_region_size",
+        "r3.value",  "r3.offset",  "r3.type", "r3.shared_region_size",
+        "r4.value",  "r4.offset",  "r4.type", "r4.shared_region_size",
+        "r5.value",  "r5.offset",  "r5.type", "r5.shared_region_size",
+        "r6.value",  "r6.offset",  "r6.type", "r6.shared_region_size",
+        "r7.value",  "r7.offset",  "r7.type", "r7.shared_region_size",
+        "r8.value",  "r8.offset",  "r8.type", "r8.shared_region_size",
+        "r9.value",  "r9.offset",  "r9.type", "r9.shared_region_size",
+        "r10.value", "r10.offset", "r10.type", "r10.shared_region_size",
         "data_size", "meta_size",
     };
 }
@@ -40,7 +40,7 @@ void variable_t::clear_thread_local_state() {
 static std::string name_of(data_kind_t kind) {
     switch (kind) {
     case data_kind_t::offsets: return "offset";
-    case data_kind_t::region_size: return "region_size";
+    case data_kind_t::shared_region_size: return "shared_region_size";
     case data_kind_t::values: return "value";
     case data_kind_t::types: return "type";
     }

--- a/src/crab/variable.hpp
+++ b/src/crab/variable.hpp
@@ -18,7 +18,7 @@ using index_t = uint64_t;
 namespace crab {
 
 // data_kind_t is eBPF-specific.
-enum class data_kind_t { types, values, ctx_offsets, map_offsets, packet_offsets, stack_offsets, shared_offsets, shared_region_sizes };
+enum class data_kind_t { types, values, ctx_offsets, map_offsets, packet_offsets, shared_offsets, stack_offsets, shared_region_sizes };
 std::ostream& operator<<(std::ostream& o, const data_kind_t& s);
 
 // Wrapper for typed variables used by the crab abstract domains and linear_constraints.

--- a/src/crab/variable.hpp
+++ b/src/crab/variable.hpp
@@ -18,7 +18,7 @@ using index_t = uint64_t;
 namespace crab {
 
 // XXX: this is eBPF-specific.
-enum class data_kind_t { types, values, offsets, region_size };
+enum class data_kind_t { types, values, offsets, shared_region_size };
 std::ostream& operator<<(std::ostream& o, const data_kind_t& s);
 
 // Wrapper for typed variables used by the crab abstract domains and linear_constraints.

--- a/src/crab/variable.hpp
+++ b/src/crab/variable.hpp
@@ -57,6 +57,7 @@ class variable_t final {
     static std::vector<variable_t> get_type_variables();
     static variable_t reg(data_kind_t, int);
     static variable_t cell_var(data_kind_t array, index_t offset, unsigned size);
+    static variable_t kind_var(data_kind_t kind, variable_t type_variable);
     static variable_t meta_offset();
     static variable_t packet_size();
     static variable_t instruction_count();

--- a/src/crab/variable.hpp
+++ b/src/crab/variable.hpp
@@ -18,7 +18,7 @@ using index_t = uint64_t;
 namespace crab {
 
 // data_kind_t is eBPF-specific.
-enum class data_kind_t { types, values, ctx_offsets, map_offsets, packet_offsets, shared_offsets, stack_offsets, shared_region_sizes };
+enum class data_kind_t { types, values, ctx_offsets, map_fds, packet_offsets, shared_offsets, stack_offsets, shared_region_sizes };
 std::ostream& operator<<(std::ostream& o, const data_kind_t& s);
 
 // Wrapper for typed variables used by the crab abstract domains and linear_constraints.

--- a/src/crab/variable.hpp
+++ b/src/crab/variable.hpp
@@ -17,8 +17,8 @@ using index_t = uint64_t;
 
 namespace crab {
 
-// XXX: this is eBPF-specific.
-enum class data_kind_t { types, values, offsets, shared_region_size };
+// data_kind_t is eBPF-specific.
+enum class data_kind_t { types, values, ctx_offsets, map_offsets, packet_offsets, stack_offsets, shared_offsets, shared_region_sizes };
 std::ostream& operator<<(std::ostream& o, const data_kind_t& s);
 
 // Wrapper for typed variables used by the crab abstract domains and linear_constraints.

--- a/src/string_constraints.cpp
+++ b/src/string_constraints.cpp
@@ -34,8 +34,10 @@ static uint8_t regnum(const string& s) {
 
 static crab::data_kind_t regkind(const string& s) {
     if (s == "type") return crab::data_kind_t::types;
-    if (s == "offset") return crab::data_kind_t::offsets;
-    if (s == "shared_region_size") return crab::data_kind_t::shared_region_size;
+    if (s == "packet_offset") return crab::data_kind_t::packet_offsets;
+    if (s == "shared_offset") return crab::data_kind_t::shared_offsets;
+    if (s == "stack_offset") return crab::data_kind_t::stack_offsets;
+    if (s == "shared_region_size") return crab::data_kind_t::shared_region_sizes;
     if (s == "value") return crab::data_kind_t::values;
     throw std::runtime_error(string() + "Bad kind: " + s);
 }

--- a/src/string_constraints.cpp
+++ b/src/string_constraints.cpp
@@ -20,7 +20,7 @@ using std::string;
 using std::map;
 
 #define REG R"_(\s*(r\d\d?)\s*)_"
-#define KIND R"_(\s*(type|value|offset|shared_region_size)\s*)_"
+#define KIND R"_(\s*(type|value|ctx_offset|map_offset|packet_offset|shared_offset|stack_offset|shared_region_size)\s*)_"
 #define IMM R"_(\s*\[?([-+]?\d+)\]?\s*)_"
 #define INTERVAL R"_(\s*\[([-+]?\d+),\s*([-+]?\d+)\]?\s*)_"
 #define ARRAY_RANGE R"_(\s*\[([-+]?\d+)\.\.\.\s*([-+]?\d+)\]?\s*)_"

--- a/src/string_constraints.cpp
+++ b/src/string_constraints.cpp
@@ -20,7 +20,7 @@ using std::string;
 using std::map;
 
 #define REG R"_(\s*(r\d\d?)\s*)_"
-#define KIND R"_(\s*(type|value|offset|region_size)\s*)_"
+#define KIND R"_(\s*(type|value|offset|shared_region_size)\s*)_"
 #define IMM R"_(\s*\[?([-+]?\d+)\]?\s*)_"
 #define INTERVAL R"_(\s*\[([-+]?\d+),\s*([-+]?\d+)\]?\s*)_"
 #define ARRAY_RANGE R"_(\s*\[([-+]?\d+)\.\.\.\s*([-+]?\d+)\]?\s*)_"
@@ -35,7 +35,7 @@ static uint8_t regnum(const string& s) {
 static crab::data_kind_t regkind(const string& s) {
     if (s == "type") return crab::data_kind_t::types;
     if (s == "offset") return crab::data_kind_t::offsets;
-    if (s == "region_size") return crab::data_kind_t::region_size;
+    if (s == "shared_region_size") return crab::data_kind_t::shared_region_size;
     if (s == "value") return crab::data_kind_t::values;
     throw std::runtime_error(string() + "Bad kind: " + s);
 }

--- a/src/string_constraints.cpp
+++ b/src/string_constraints.cpp
@@ -34,6 +34,8 @@ static uint8_t regnum(const string& s) {
 
 static crab::data_kind_t regkind(const string& s) {
     if (s == "type") return crab::data_kind_t::types;
+    if (s == "ctx_offset") return crab::data_kind_t::ctx_offsets;
+    if (s == "map_offset") return crab::data_kind_t::map_offsets;
     if (s == "packet_offset") return crab::data_kind_t::packet_offsets;
     if (s == "shared_offset") return crab::data_kind_t::shared_offsets;
     if (s == "stack_offset") return crab::data_kind_t::stack_offsets;

--- a/src/string_constraints.cpp
+++ b/src/string_constraints.cpp
@@ -20,7 +20,7 @@ using std::string;
 using std::map;
 
 #define REG R"_(\s*(r\d\d?)\s*)_"
-#define KIND R"_(\s*(type|value|ctx_offset|map_offset|packet_offset|shared_offset|stack_offset|shared_region_size)\s*)_"
+#define KIND R"_(\s*(type|value|ctx_offset|map_fd|packet_offset|shared_offset|stack_offset|shared_region_size)\s*)_"
 #define IMM R"_(\s*\[?([-+]?\d+)\]?\s*)_"
 #define INTERVAL R"_(\s*\[([-+]?\d+),\s*([-+]?\d+)\]?\s*)_"
 #define ARRAY_RANGE R"_(\s*\[([-+]?\d+)\.\.\.\s*([-+]?\d+)\]?\s*)_"
@@ -35,7 +35,7 @@ static uint8_t regnum(const string& s) {
 static crab::data_kind_t regkind(const string& s) {
     if (s == "type") return crab::data_kind_t::types;
     if (s == "ctx_offset") return crab::data_kind_t::ctx_offsets;
-    if (s == "map_offset") return crab::data_kind_t::map_offsets;
+    if (s == "map_fd") return crab::data_kind_t::map_fds;
     if (s == "packet_offset") return crab::data_kind_t::packet_offsets;
     if (s == "shared_offset") return crab::data_kind_t::shared_offsets;
     if (s == "stack_offset") return crab::data_kind_t::stack_offsets;

--- a/src/test/test_verify.cpp
+++ b/src/test/test_verify.cpp
@@ -297,6 +297,7 @@ TEST_SECTION("prototype-kernel", "napi_monitor_kern.o", "tracepoint/napi/napi_po
 TEST_SECTION("prototype-kernel", "tc_bench01_redirect_kern.o", "ingress_redirect")
 TEST_SECTION("prototype-kernel", "xdp_bench01_mem_access_cost_kern.o", "xdp_bench01")
 TEST_SECTION("prototype-kernel", "xdp_bench02_drop_pattern_kern.o", "xdp_bench02")
+TEST_SECTION("prototype-kernel", "xdp_ddos01_blacklist_kern.o", "xdp_prog")
 TEST_SECTION("prototype-kernel", "xdp_monitor_kern.o", "tracepoint/xdp/xdp_redirect")
 TEST_SECTION("prototype-kernel", "xdp_monitor_kern.o", "tracepoint/xdp/xdp_redirect_err")
 TEST_SECTION("prototype-kernel", "xdp_monitor_kern.o", "tracepoint/xdp/xdp_redirect_map_err")

--- a/src/test/test_verify.cpp
+++ b/src/test/test_verify.cpp
@@ -458,6 +458,7 @@ TEST_SECTION("build", "packet_access.o", "xdp")
 TEST_SECTION("build", "tail_call.o", "xdp_prog")
 TEST_SECTION("build", "map_in_map.o", ".text")
 TEST_SECTION("build", "twomaps.o", ".text");
+TEST_SECTION("build", "twotypes.o", ".text");
 
 // Test some programs that ought to fail verification.
 TEST_SECTION_REJECT("build", "badhelpercall.o", ".text")
@@ -478,9 +479,6 @@ TEST_SECTION_REJECT("build", "tail_call_bad.o", "xdp_prog")
 // Unsupported: ebpf-function
 TEST_SECTION_FAIL("prototype-kernel", "xdp_ddos01_blacklist_kern.o", ".text")
 
-// False positive: correlated branches
-TEST_SECTION_FAIL("prototype-kernel", "xdp_ddos01_blacklist_kern.o", "xdp_prog")
-
 // Unsupported: offset not tracked separately per pointer type
 TEST_SECTION_FAIL("cilium", "bpf_xdp_dsr_linux.o", "2/7")
 TEST_SECTION_FAIL("cilium", "bpf_xdp_dsr_linux.o", "2/10")
@@ -500,9 +498,6 @@ TEST_SECTION_FAIL("cilium", "bpf_xdp_snat_linux.o", "2/17")
 TEST_SECTION_FAIL("cilium", "bpf_xdp_snat_linux.o", "2/18")
 TEST_SECTION_FAIL("cilium", "bpf_xdp_snat_linux.o", "2/19")
 TEST_SECTION_FAIL("cilium", "bpf_xdp_snat_linux.o", "2/24")
-
-// False positive, trying to dereference {shared,stack} pointer
-TEST_SECTION_FAIL("build", "twotypes.o", ".text");
 
 // False positive, unknown cause
 TEST_SECTION_FAIL("linux", "test_map_in_map_kern.o", "kprobe/sys_connect")

--- a/test-data/jump.yaml
+++ b/test-data/jump.yaml
@@ -77,3 +77,74 @@ post:
   - s[504...511].type in {packet, stack}
   - s[504...511].packet_offset=8
   - s[504...511].stack_offset=4
+---
+test-case: same_type
+
+pre: ["r0.type=number",
+      "r8.type=ctx", "r8.ctx_offset=4",
+      "r9.type=ctx", "r9.ctx_offset=0"]
+
+code:
+  <start>: |
+    if r0 == 0 goto <stack>
+  <number>: |
+    r1 = 1
+    r2 = r0
+    goto <out>
+  <stack>: |
+    r1 = r8
+    r2 = r9
+    goto <out>
+  <out>: |
+    r3 = r2
+    r3 -= r1; trigger same_type(r2, r1)
+
+post:
+  - r1.type=r2.type
+  - r0.type=number
+  - r1.ctx_offset=4
+  - r1.type in {number, ctx}
+  - r2.ctx_offset=0
+  - r2.type in {number, ctx}
+  - r3.type=number
+  - r8.ctx_offset=4
+  - r8.type=ctx
+  - r9.ctx_offset=0
+  - r9.type=ctx
+
+---
+test-case: not same_type
+
+pre: ["r0.type=number",
+      "r8.type=ctx", "r8.ctx_offset=4",
+      "r9.type=ctx", "r9.ctx_offset=0"]
+
+code:
+  <start>: |
+    if r0 == 0 goto <stack>
+  <number>: |
+    r1 = 1
+    r2 = r9
+    goto <out>
+  <stack>: |
+    r1 = r8
+    r2 = r0
+    goto <out>
+  <out>: |
+    r3 = r2
+    r3 -= r1; trigger same_type(r2, r1)
+
+
+post:
+  - r0.type=number
+  - r1.type in {number, ctx}
+  - r1.ctx_offset=4
+  - r2.type in {number, ctx}
+  - r2.ctx_offset=0
+  - r8.type=ctx
+  - r8.ctx_offset=4
+  - r9.type=ctx
+  - r9.ctx_offset=0
+
+messages:
+  - "8: r1.type == r3.type"

--- a/test-data/jump.yaml
+++ b/test-data/jump.yaml
@@ -48,3 +48,32 @@ code:
 post:
   - r0.type=number
   - r0.value=0
+---
+test-case: join stack
+
+pre: ["r0.type=number",
+      "r1.type=packet", "r1.packet_offset=8",
+      "r2.type=stack", "r2.stack_offset=4",
+      "r10.type=stack", "r10.stack_offset=512"]
+
+code:
+  <start>: |
+    if r0 == 0 goto <mid>
+    *(u64 *)(r10 - 8) = r1
+    goto <out>
+  <mid>: |
+    *(u64 *)(r10 - 8) = r2
+  <out>: |
+    exit
+
+post:
+  - r0.type=number
+  - r1.type=packet
+  - r1.packet_offset=8
+  - r2.type=stack
+  - r2.stack_offset=4
+  - r10.type=stack
+  - r10.stack_offset=512
+  - s[504...511].type in {packet, stack}
+  - s[504...511].packet_offset=8
+  - s[504...511].stack_offset=4

--- a/test-data/jump.yaml
+++ b/test-data/jump.yaml
@@ -148,3 +148,129 @@ post:
 
 messages:
   - "8: r1.type == r3.type"
+---
+test-case: multiple types add ok
+
+pre: ["r0.type=number",
+      "r8.type=ctx", "r8.ctx_offset=0",
+      "r9.type=packet", "r9.packet_offset=0"]
+
+code:
+  <start>: |
+    r1 = 4
+    if r0 == 0 goto <ctxnum>
+  <numctx>: |
+    r2 = r8
+    goto <out>
+  <ctxnum>: |
+    r2 = r9
+    goto <out>
+  <out>: |
+    r3 = r1
+    r3 += r2
+    r4 = r2
+    r4 += r1
+
+post:
+  - r0.type=number
+  - r1.type=number
+  - r1.value=4
+  - r2.ctx_offset=0
+  - r2.packet_offset=0
+  - r2.type in {ctx, packet}
+  - r3.ctx_offset=4
+  - r3.packet_offset=4
+  - r3.type in {ctx, packet}
+  - r4.ctx_offset=4
+  - r4.packet_offset=4
+  - r4.type in {ctx, packet}
+  - r8.ctx_offset=0
+  - r8.type=ctx
+  - r9.packet_offset=0
+  - r9.type=packet
+---
+test-case: multiple types add fail
+
+pre: ["r0.type=number",
+      "r8.type=ctx", "r8.ctx_offset=0"]
+
+code:
+  <start>: |
+    if r0 == 0 goto <ctxnum>
+  <numctx>: |
+    r1 = 4
+    r2 = r8
+    goto <out>
+  <ctxnum>: |
+    r1 = r8
+    r2 = 4
+    goto <out>
+  <out>: |
+    r3 = r1
+    r3 += r2; the domain does not currently store inequalities so we can't yet tell that this is safe
+
+post:
+  - r0.type=number
+  - r1.ctx_offset=0
+  - r1.type in {number, ctx}
+  - r1.value=4
+  - r2.ctx_offset=0
+  - r2.type in {number, ctx}
+  - r2.value=4
+  - r3.ctx_offset=4
+  - r3.type=ctx
+  - r8.ctx_offset=0
+  - r8.type=ctx
+
+messages:
+  - "8: only numbers can be added to pointers (r2.type = ptr -> r3.type = number)"
+  - "8: only numbers can be added to pointers (r3.type = ptr -> r2.type = number)"
+---
+test-case: multiple types compare
+
+pre: ["r0.type=number",
+      "r6.type=stack", "r6.stack_offset=4",
+      "r7.type=stack", "r7.stack_offset=0",
+      "r8.type=packet", "r8.packet_offset=4",
+      "r9.type=packet", "r9.packet_offset=0",
+      "meta_offset=0"]
+
+code:
+  <start>: |
+    if r0 == 0 goto <packet>
+  <stack>: |
+    r1 = r6
+    r2 = r7
+    goto <join>
+  <packet>: |
+    r1 = r8
+    r2 = r9
+    goto <join>
+  <join>: |
+    if r1 == r2 goto <out> ; trigger same_type(r1, r2)
+    r0 = 42
+  <out>: |
+    exit
+
+post:
+  - meta_offset=0
+  - r0.type=number
+  - r0.value=42
+  - r1.stack_offset=4
+  - r1.packet_offset=4
+  - r1.type in {packet, stack}
+  - r1.type=r2.type
+  - r2.stack_offset=0
+  - r2.packet_offset=0
+  - r2.type in {packet, stack}
+  - r6.type=stack
+  - r6.stack_offset=4
+  - r7.type=stack
+  - r7.stack_offset=0
+  - r8.type=packet
+  - r8.packet_offset=4
+  - r9.type=packet
+  - r9.packet_offset=0
+
+messages:
+  - "7:9: Code is unreachable after 7:9"

--- a/test-data/jump.yaml
+++ b/test-data/jump.yaml
@@ -78,7 +78,7 @@ post:
   - s[504...511].packet_offset=8
   - s[504...511].stack_offset=4
 ---
-test-case: same_type
+test-case: same_type subtract
 
 pre: ["r0.type=number",
       "r8.type=ctx", "r8.ctx_offset=4",
@@ -86,12 +86,12 @@ pre: ["r0.type=number",
 
 code:
   <start>: |
-    if r0 == 0 goto <stack>
+    if r0 == 0 goto <ctx>
   <number>: |
     r1 = 1
     r2 = r0
     goto <out>
-  <stack>: |
+  <ctx>: |
     r1 = r8
     r2 = r9
     goto <out>
@@ -100,10 +100,10 @@ code:
     r3 -= r1; trigger same_type(r2, r1)
 
 post:
-  - r1.type=r2.type
   - r0.type=number
   - r1.ctx_offset=4
   - r1.type in {number, ctx}
+  - r1.type=r2.type
   - r2.ctx_offset=0
   - r2.type in {number, ctx}
   - r3.type=number
@@ -121,12 +121,12 @@ pre: ["r0.type=number",
 
 code:
   <start>: |
-    if r0 == 0 goto <stack>
+    if r0 == 0 goto <ctx>
   <number>: |
     r1 = 1
     r2 = r9
     goto <out>
-  <stack>: |
+  <ctx>: |
     r1 = r8
     r2 = r0
     goto <out>
@@ -137,14 +137,14 @@ code:
 
 post:
   - r0.type=number
-  - r1.type in {number, ctx}
   - r1.ctx_offset=4
-  - r2.type in {number, ctx}
+  - r1.type in {number, ctx}
   - r2.ctx_offset=0
-  - r8.type=ctx
+  - r2.type in {number, ctx}
   - r8.ctx_offset=4
-  - r9.type=ctx
+  - r8.type=ctx
   - r9.ctx_offset=0
+  - r9.type=ctx
 
 messages:
   - "8: r1.type == r3.type"
@@ -192,7 +192,7 @@ post:
 test-case: multiple types add fail
 
 pre: ["r0.type=number",
-      "r8.type=ctx", "r8.ctx_offset=0"]
+      "r8.type=ctx", "r8.ctx_offset=0", "r8.value=1024"]
 
 code:
   <start>: |
@@ -213,14 +213,36 @@ post:
   - r0.type=number
   - r1.ctx_offset=0
   - r1.type in {number, ctx}
-  - r1.value=4
+  - r1.type-r1.value<=-8
+  - r1.type-r3.ctx_offset<=-7
+  - r1.type-r3.value<=-12
+  - r1.value-r1.type<=1027
+  - r1.value-r3.ctx_offset<=1020
+  - r1.value-r3.value<=-4
+  - r1.value=[4, 1024]
   - r2.ctx_offset=0
   - r2.type in {number, ctx}
-  - r2.value=4
-  - r3.ctx_offset=4
+  - r2.ctx_offset-r3.ctx_offset<=-4
+  - r2.type-r2.value<=-8
+  - r2.type-r3.value<=-12
+  - r2.value-r2.type<=1027
+  - r2.value-r3.value<=-4
+  - r2.value=[4, 1024]
   - r3.type=ctx
+  - r3.ctx_offset-r1.type<=1028
+  - r3.ctx_offset-r1.value<=1020
+  - r3.ctx_offset-r2.ctx_offset<=1024
+  - r3.ctx_offset-r3.value<=1016
+  - r3.ctx_offset=[4, 1024]
+  - r3.value-r1.type<=2051
+  - r3.value-r1.value<=1024
+  - r3.value-r2.type<=2051
+  - r3.value-r2.value<=1024
+  - r3.value-r3.ctx_offset<=2044
+  - r3.value=[8, 2048]
   - r8.ctx_offset=0
   - r8.type=ctx
+  - r8.value=1024
 
 messages:
   - "8: only numbers can be added to pointers (r2.type = ptr -> r3.type = number)"

--- a/test-data/packet.yaml
+++ b/test-data/packet.yaml
@@ -5,8 +5,8 @@ test-case: simple invalid access
 
 pre: [
     "meta_offset=0",
-    "r1.type=packet", "r1.offset=0", "r1.value=[4098, 2147418112]",
-    "r2.type=packet", "r2.offset=[0, 65534]", "packet_size=r2.offset", "packet_size=[0, 65534]"
+    "r1.type=packet", "r1.packet_offset=0", "r1.value=[4098, 2147418112]",
+    "r2.type=packet", "r2.packet_offset=[0, 65534]", "packet_size=r2.packet_offset", "packet_size=[0, 65534]"
 ]
 
 code:
@@ -16,8 +16,8 @@ code:
 
 post: [
     "meta_offset=0",
-    "r1.type=packet", "r1.offset=0", "r1.value=[4098, 2147418112]",
-    "r2.type=packet", "r2.offset=[0, 65534]", "packet_size=r2.offset",
+    "r1.type=packet", "r1.packet_offset=0", "r1.value=[4098, 2147418112]",
+    "r2.type=packet", "r2.packet_offset=[0, 65534]", "packet_size=r2.packet_offset",
     "packet_size=[0, 65534]", "r4.type=number", "r4.value=0"
 ]
 messages:
@@ -28,8 +28,8 @@ test-case: writing 8 bytes when packet size is 4
 
 pre: [
     "meta_offset=0",
-    "r1.type=packet", "r1.offset=0", "r1.value=[4098, 2147418112]",
-    "r2.type=packet", "r2.offset=[0, 65534]", "packet_size=r2.offset"
+    "r1.type=packet", "r1.packet_offset=0", "r1.value=[4098, 2147418112]",
+    "r2.type=packet", "r2.packet_offset=[0, 65534]", "packet_size=r2.packet_offset"
 ]
 
 code:
@@ -44,13 +44,12 @@ code:
 
 post: [
     "meta_offset=0",
-    "r1.type=packet", "r1.offset=0", "r1.value=[4098, 2147418112]",
-    "r2.type=packet", "r2.offset=[0, 65534]", "packet_size=r2.offset",
-    "r3.type=packet", "r3.offset=4", "r3.value=[4102, 2147418116]",
-    "packet_size-r3.offset<=65530", "packet_size=[0, 65534]",
-    "r3.offset-packet_size<=4", "r1.value=r3.value+4",
-    "r2.offset-r3.offset<=65530", "r3.offset-r2.offset<=4",
-    "r1.region_size=r3.region_size"
+    "r1.type=packet", "r1.packet_offset=0", "r1.value=[4098, 2147418112]",
+    "r2.type=packet", "r2.packet_offset=[0, 65534]", "packet_size=r2.packet_offset",
+    "r3.type=packet", "r3.packet_offset=4", "r3.value=[4102, 2147418116]",
+    "packet_size-r3.packet_offset<=65530", "packet_size=[0, 65534]",
+    "r3.packet_offset-packet_size<=4", "r1.value=r3.value+4",
+    "r2.packet_offset-r3.packet_offset<=65530", "r3.packet_offset-r2.packet_offset<=4",
 ]
 messages:
   - "4: Upper bound must be at most packet_size (valid_access(r1.offset, width=8))"
@@ -60,10 +59,8 @@ test-case: simple valid access
 
 pre: [
     "meta_offset=0",
-    "r1.type=packet", "r1.offset=0", "r1.value=[4098, 2147418112]",
-    "r2.type=packet", "r2.offset=[0, 65534]", "packet_size=r2.offset",
-    "r1.region_size=packet_size",
-    "r2.region_size=packet_size",
+    "r1.type=packet", "r1.packet_offset=0", "r1.value=[4098, 2147418112]",
+    "r2.type=packet", "r2.packet_offset=[0, 65534]", "packet_size=r2.packet_offset",
 ]
 
 code:
@@ -78,17 +75,10 @@ code:
 
 post: [
     "meta_offset=0",
-    "r1.type=packet", "r1.offset=0", "r1.value=[4098, 2147418112]",
-    "r2.type=packet", "r2.offset=[0, 65534]", "packet_size=r2.offset",
-    "r3.type=packet", "r3.offset=8", "r3.value=[4106, 2147418120]",
-    "packet_size-r3.offset<=65526", "packet_size=[0, 65534]",
-    "r3.offset-packet_size<=8", "r1.value=r3.value+8",
-    "r2.offset-r3.offset<=65526", "r3.offset-r2.offset<=8",
-    "r1.region_size=r3.region_size",
-    "packet_size=r1.region_size", "packet_size=r2.region_size", "packet_size=r3.region_size",
-    "r1.region_size-r3.offset<=65526", "r1.region_size=[0, 65534]", "r1.region_size=r2.offset",
-    "r1.region_size=r2.region_size", "r2.offset=r2.region_size", "r2.offset=r3.region_size",
-    "r2.region_size-r3.offset<=65526", "r2.region_size=[0, 65534]", "r2.region_size=r3.region_size",
-    "r3.offset-r1.region_size<=8", "r3.offset-r2.region_size<=8", "r3.offset-r3.region_size<=8", "r3.region_size-r3.offset<=65526",
-    "r3.region_size=[0, 65534]"
+    "r1.type=packet", "r1.packet_offset=0", "r1.value=[4098, 2147418112]",
+    "r2.type=packet", "r2.packet_offset=[0, 65534]", "packet_size=r2.packet_offset",
+    "r3.type=packet", "r3.packet_offset=8", "r3.value=[4106, 2147418120]",
+    "packet_size-r3.packet_offset<=65526", "packet_size=[0, 65534]",
+    "r3.packet_offset-packet_size<=8", "r1.value=r3.value+8",
+    "r2.packet_offset-r3.packet_offset<=65526", "r3.packet_offset-r2.packet_offset<=8"
 ]

--- a/test-data/single-instruction-assignment.yaml
+++ b/test-data/single-instruction-assignment.yaml
@@ -24,8 +24,6 @@ code:
 post:
   - r1.type=r2.type
   - r1.value=r2.value
-  - r1.offset=r2.offset
-  - r1.region_size=r2.region_size
 
 ---
 test-case: re-assign immediate

--- a/test-data/single-instruction-assignment.yaml
+++ b/test-data/single-instruction-assignment.yaml
@@ -130,3 +130,69 @@ post:
   - s[500...503].type=number
   - s[504...511].type=packet
   - s[504...511].offset=0
+---
+test-case: assign register number value
+
+pre: ["r1.value=0", "r1.type=number"]
+
+code:
+  <start>: |
+    r2 = r1
+
+post:
+  - r1.type=number
+  - r1.value=0
+  - r2.type=number
+  - r2.value=0
+---
+test-case: assign register stack value
+
+pre: ["r1.type=stack", "r1.stack_offset=0"]
+
+code:
+  <start>: |
+    r2 = r1
+
+post:
+  - r1.type=stack
+  - r1.stack_offset=0
+  - r2.type=stack
+  - r2.stack_offset=0
+  - r1.value=r2.value
+---
+test-case: assign register shared value
+
+pre: ["r1.type=shared", "r1.shared_offset=0", "r1.shared_region_size=16"]
+
+code:
+  <start>: |
+    r2 = r1
+
+post:
+  - r1.type=shared
+  - r1.shared_offset=0
+  - r1.shared_region_size=16
+  - r2.type=shared
+  - r2.shared_offset=0
+  - r2.shared_region_size=16
+  - r1.value=r2.value
+---
+test-case: assign register combination value
+
+pre: ["r1.type=[-1,0]", "r1.shared_offset=0", "r1.shared_region_size=16", "r1.stack_offset=500"]
+
+code:
+  <start>: |
+    r2 = r1
+
+post:
+  - r1.type in {stack, shared}
+  - r1.shared_offset=0
+  - r1.shared_region_size=16
+  - r1.stack_offset=500
+  - r2.type in {stack, shared}
+  - r2.shared_offset=0
+  - r2.shared_region_size=16
+  - r2.stack_offset=500
+  - r1.type=r2.type
+  - r1.value=r2.value

--- a/test-data/single-instruction-assignment.yaml
+++ b/test-data/single-instruction-assignment.yaml
@@ -52,7 +52,7 @@ post:
 ---
 test-case: stack assign immediate
 
-pre: ["r10.type=stack", "r10.offset=512"]
+pre: ["r10.type=stack", "r10.stack_offset=512"]
 
 code:
   <start>: |
@@ -60,13 +60,13 @@ code:
 
 post:
   - r10.type=stack
-  - r10.offset=512
+  - r10.stack_offset=512
   - s[504...511].type=number
   - s[504...511].value=0
 ---
 test-case: stack assign number register
 
-pre: ["r10.type=stack", "r10.offset=512", "r1.type=number", "r1.value=0"]
+pre: ["r10.type=stack", "r10.stack_offset=512", "r1.type=number", "r1.value=0"]
 
 code:
   <start>: |
@@ -76,13 +76,13 @@ post:
   - r1.type=number
   - r1.value=0
   - r10.type=stack
-  - r10.offset=512
+  - r10.stack_offset=512
   - s[504...511].type=number
   - s[504...511].value=0
 ---
 test-case: stack assign packet register
 
-pre: ["r10.type=stack", "r10.offset=512", "r1.type=packet", "r1.offset=0"]
+pre: ["r10.type=stack", "r10.stack_offset=512", "r1.type=packet", "r1.packet_offset=0"]
 
 code:
   <start>: |
@@ -90,17 +90,16 @@ code:
 
 post:
   - r1.type=packet
-  - r1.offset=0
+  - r1.packet_offset=0
   - r1.value=s[504...511].value
-  - r1.region_size=s[504...511].region_size
   - r10.type=stack
-  - r10.offset=512
+  - r10.stack_offset=512
   - s[504...511].type=packet
-  - s[504...511].offset=0
+  - s[504...511].packet_offset=0
 ---
 test-case: stack extend numeric range
 
-pre: ["r10.type=stack", "r10.offset=512", "s[500...507].type=number"]
+pre: ["r10.type=stack", "r10.stack_offset=512", "s[500...507].type=number"]
 
 code:
   <start>: |
@@ -108,13 +107,13 @@ code:
 
 post:
   - r10.type=stack
-  - r10.offset=512
+  - r10.stack_offset=512
   - s[500...511].type=number
   - s[504...511].value=0
 ---
 test-case: stack narrow numeric range
 
-pre: ["r10.type=stack", "r10.offset=512", "r1.type=packet", "r1.offset=0", "s[500...507].type=number"]
+pre: ["r10.type=stack", "r10.stack_offset=512", "r1.type=packet", "r1.packet_offset=0", "s[500...507].type=number"]
 
 code:
   <start>: |
@@ -122,14 +121,13 @@ code:
 
 post:
   - r1.type=packet
-  - r1.offset=0
+  - r1.packet_offset=0
   - r1.value=s[504...511].value
-  - r1.region_size=s[504...511].region_size
   - r10.type=stack
-  - r10.offset=512
+  - r10.stack_offset=512
   - s[500...503].type=number
   - s[504...511].type=packet
-  - s[504...511].offset=0
+  - s[504...511].packet_offset=0
 ---
 test-case: assign register number value
 

--- a/test-data/single-instruction-binop.yaml
+++ b/test-data/single-instruction-binop.yaml
@@ -122,3 +122,21 @@ post:
   - r7.packet_offset-r2.packet_offset<=5
   - r7.packet_offset-r7.value<=-7
   - r7.value-r7.packet_offset<=11
+
+---
+test-case: subtract dual-typed pointers
+
+pre: ["r2.type=[-2, -1]", "r2.packet_offset=4", "r2.stack_offset=4",
+      "r3.type=[-2, -1]", "r3.packet_offset=8", "r3.stack_offset=8"]
+
+code:
+  <start>: |
+    r3 -= r2
+
+post:
+  - r2.type in {packet, stack}
+  - r2.packet_offset=4
+  - r2.stack_offset=4
+
+messages:
+  - "0: r2.type == r3.type"

--- a/test-data/single-instruction-binop.yaml
+++ b/test-data/single-instruction-binop.yaml
@@ -80,7 +80,7 @@ post:
 ---
 test-case: add interval number register to constant register pointer
 
-pre: ["r2.type=packet", "r2.offset=0", "r2.value=[7, 11]", "r2.region_size=packet_size",
+pre: ["r2.type=packet", "r2.packet_offset=0", "r2.value=[7, 11]",
       "r7.type=number", "r7.value=[3, 5]"]
 
 code:
@@ -89,21 +89,20 @@ code:
 
 post:
   - r2.type=packet
-  - r2.offset=[3, 5]
+  - r2.packet_offset=[3, 5]
   - r2.value=[10, 16]
   - r7.type=number
   - r7.value=[3, 5]
   - r7.value-r2.value<=-7
   - r2.value-r7.value<=11
-  - r2.offset-r2.value<=-7
-  - r2.value-r2.offset<=11
-  - r2.offset=r7.value
-  - packet_size=r2.region_size
+  - r2.packet_offset-r2.value<=-7
+  - r2.value-r2.packet_offset<=11
+  - r2.packet_offset=r7.value
 
 ---
 test-case: add constant register pointer to interval number
 
-pre: ["r2.type=packet", "r2.offset=0", "r2.value=[7, 11]", "r2.region_size=packet_size",
+pre: ["r2.type=packet", "r2.packet_offset=0", "r2.value=[7, 11]",
       "r7.type=number", "r7.value=[3, 5]"]
 
 code:
@@ -112,17 +111,14 @@ code:
 
 post:
   - r7.type=packet
-  - r7.offset=[3, 5]
+  - r7.packet_offset=[3, 5]
   - r7.value=[10, 16]
   - r2.type=packet
-  - r2.offset=0
+  - r2.packet_offset=0
   - r2.value=[7, 11]
   - r2.value-r7.value<=-3
   - r7.value-r2.value<=5
-  - r2.offset-r7.offset<=-3
-  - r7.offset-r2.offset<=5
-  - r7.offset-r7.value<=-7
-  - r7.value-r7.offset<=11
-  - packet_size=r2.region_size
-  - packet_size=r7.region_size
-  - r2.region_size=r7.region_size
+  - r2.packet_offset-r7.packet_offset<=-3
+  - r7.packet_offset-r2.packet_offset<=5
+  - r7.packet_offset-r7.value<=-7
+  - r7.value-r7.packet_offset<=11


### PR DESCRIPTION
This approach allows verifying the sample in https://github.com/vbpf/ebpf-samples/pull/20

* r#.region_size is replaced with r#.shared_region_size since the other region sizes are per-type not per register.
* r#.offset is replaced with four separate r#.packet_offset, r#.stack_offset, etc. which if present holds the offset when r#.type is packet, stack, etc. respectively.  If r#.type contains multiple values, the multiple offsets can be present to track the offsets separately per type.