### PR TITLE
ensure libyaml-cpp-dev exists in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:20.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update
-RUN apt-get -yq --no-install-suggests --no-install-recommends install build-essential cmake libboost-dev
+RUN apt-get -yq --no-install-suggests --no-install-recommends install build-essential cmake libboost-dev libyaml-cpp-dev
 
 WORKDIR /verifier
 COPY . /verifier/


### PR DESCRIPTION
The cmake step in the spawned container fails without this.

Signed-off-by: Mihai-Valentin DUMITRU <mihai.dumitru@cs.pub.ro>