### PR TITLE
Display stack indices as positive to match offset values

### DIFF
--- a/src/crab/bitset_domain.cpp
+++ b/src/crab/bitset_domain.cpp
@@ -12,13 +12,13 @@ std::ostream& operator<<(std::ostream& o, const bitset_domain_t& b) {
         if (!first)
             o << ", ";
         first = false;
-        o << "[" << i;
+        o << "[" << EBPF_STACK_SIZE + i;
         int j = i + 1;
         for (; j < 0; j++)
             if (b.non_numerical_bytes[EBPF_STACK_SIZE + j])
                 break;
         if (j > i + 1)
-            o << "..." << j - 1;
+            o << "..." << EBPF_STACK_SIZE + j - 1;
         o << "]";
         i = j;
     }

--- a/src/crab/var_factory.cpp
+++ b/src/crab/var_factory.cpp
@@ -65,7 +65,7 @@ static std::string mk_scalar_name(data_kind_t kind, int o, int size) {
 }
 
 variable_t variable_t::cell_var(data_kind_t array, index_t offset, unsigned size) {
-    return make(mk_scalar_name(array, - (512 - (int)offset), (int)size));
+    return make(mk_scalar_name(array, (int)offset, (int)size));
 }
 
 variable_t variable_t::meta_offset() { return make("meta_offset"); }


### PR DESCRIPTION
Currently in the verbose output, stack indices are displayed as negative, like

>               S.type[-4...-1]=number, S.value[-4...-1]=[0], S.value[-8...-5]=[0], S.type[-8...-5]=number,
>               Stack: Numbers -> {[-8...-1]}

Etc. but register offset values are displayed as positive, like

>               r2.type=stack_pointer, r2.offset=[504]

This makes it visually difficult to match up what r2 points to.

This PR updates the output to look like:

>               S.type[508...511]=number, S.value[508...511]=[0], S.value[504...507]=[0], S.type[504...507]=number,
>               Stack: Numbers -> {[504...-511]}

to ease visually matching an r.offset with the associated stack variables.

Signed-off-by: Dave Thaler <dthaler@microsoft.com>