### PR TITLE
Fix map descriptor lookup

### DIFF
--- a/src/crab/ebpf_domain.cpp
+++ b/src/crab/ebpf_domain.cpp
@@ -608,7 +608,7 @@ std::optional<uint32_t> ebpf_domain_t::get_map_type(const Reg& map_fd_reg) const
 
     std::optional<uint32_t> type;
     for (int map_fd = start_fd; map_fd <= end_fd; map_fd++) {
-        EbpfMapDescriptor* map = find_map_descriptor(map_fd);
+        EbpfMapDescriptor* map = &global_program_info.platform->get_map_descriptor(map_fd);
         if (map == nullptr)
             return std::optional<uint32_t>();
         if (!type.has_value())
@@ -627,7 +627,7 @@ std::optional<uint32_t> ebpf_domain_t::get_map_inner_map_fd(const Reg& map_fd_re
 
     std::optional<uint32_t> inner_map_fd;
     for (int map_fd = start_fd; map_fd <= end_fd; map_fd++) {
-        EbpfMapDescriptor* map = find_map_descriptor(map_fd);
+        EbpfMapDescriptor* map = &global_program_info.platform->get_map_descriptor(map_fd);
         if (map == nullptr)
             return {};
         if (!inner_map_fd.has_value())
@@ -646,7 +646,7 @@ crab::interval_t ebpf_domain_t::get_map_key_size(const Reg& map_fd_reg) const {
 
     crab::interval_t result = crab::interval_t::bottom();
     for (int map_fd = start_fd; map_fd <= end_fd; map_fd++) {
-        if (EbpfMapDescriptor* map = find_map_descriptor(map_fd))
+        if (EbpfMapDescriptor* map = &global_program_info.platform->get_map_descriptor(map_fd))
             result = result | crab::interval_t(number_t(map->key_size));
         else
             return crab::interval_t::top();
@@ -662,7 +662,7 @@ crab::interval_t ebpf_domain_t::get_map_value_size(const Reg& map_fd_reg) const 
 
     crab::interval_t result = crab::interval_t::bottom();
     for (int map_fd = start_fd; map_fd <= end_fd; map_fd++) {
-        if (EbpfMapDescriptor* map = find_map_descriptor(map_fd))
+        if (EbpfMapDescriptor* map = &global_program_info.platform->get_map_descriptor(map_fd))
             result = result | crab::interval_t(number_t(map->value_size));
         else
             return crab::interval_t::top();
@@ -678,7 +678,7 @@ crab::interval_t ebpf_domain_t::get_map_max_entries(const Reg& map_fd_reg) const
 
     crab::interval_t result = crab::interval_t::bottom();
     for (int map_fd = start_fd; map_fd <= end_fd; map_fd++) {
-        if (EbpfMapDescriptor* map = find_map_descriptor(map_fd))
+        if (EbpfMapDescriptor* map = &global_program_info.platform->get_map_descriptor(map_fd))
             result = result | crab::interval_t(number_t(map->max_entries));
         else
             return crab::interval_t::top();


### PR DESCRIPTION
find_map_descriptor() only checks global_program_info.map_descriptors
which is ok for the verifier's own tests, but the platform module may look
in other places.  Previously, the verifier code called
`global_program_info.platform->get_map_descriptor()` which is more
comprehensive but PR #277 recently introduced a regression where it
only called find_map_descriptor() rather than the platform's algorithm.

On Linux, these have the same behavior since get_map_descriptor_linux()
just calls find_map_descriptor(), but on the Windows platform it does
more, so this broke the ebpf-for-windows tests.

This fix restores the call to the platform's function.

Signed-off-by: Dave Thaler <dthaler@microsoft.com>