### PR TITLE
Fix output regression from PR #257

### DIFF
--- a/src/asm_ostream.cpp
+++ b/src/asm_ostream.cpp
@@ -124,7 +124,7 @@ std::ostream& operator<<(std::ostream& os, ValidStore const& a) {
 
 std::ostream& operator<<(std::ostream& os, ValidAccess const& a) {
     if (a.or_null)
-        os << a.reg << ".type == number and " << a.reg << ".value == 0";
+        os << "(" << a.reg << ".type == number and " << a.reg << ".value == 0) or ";
     os << "valid_access(" << a.reg << ".offset";
     if (a.offset > 0)
         os << "+" << a.offset;


### PR DESCRIPTION
An "or" was output before PR #257 but it got lost in that PR, along
with the space before "valid_access", resulting in output like:

> Lower bound must be at least 0 (r3.type == number and r3.value == 0valid_access(r3.offset, width=r4))

Signed-off-by: Dave Thaler <dthaler@microsoft.com>