### PR TITLE
Allow maps section to work independent of Linux kernel version

### DIFF
--- a/src/ebpf_yaml.cpp
+++ b/src/ebpf_yaml.cpp
@@ -35,7 +35,7 @@ static bool ebpf_is_helper_usable(int32_t n){
     return false;
 };
 
-static void ebpf_parse_maps_section(vector<EbpfMapDescriptor>& map_descriptors, const char* data, size_t size,
+static void ebpf_parse_maps_section(vector<EbpfMapDescriptor>& map_descriptors, const char* data, size_t map_record_size, int map_count,
                                     const struct ebpf_platform_t* platform, ebpf_verifier_options_t options) {
 }
 

--- a/src/platform.hpp
+++ b/src/platform.hpp
@@ -25,7 +25,7 @@ typedef int (*ebpf_create_map_fn)(uint32_t map_type, uint32_t key_size, uint32_t
 
 // Parse map records and allocate map fd's.
 // In the future we may want to move map fd allocation after the verifier step.
-typedef void (*ebpf_parse_maps_section_fn)(std::vector<EbpfMapDescriptor>& map_descriptors, const char* data, size_t size, const struct ebpf_platform_t* platform, ebpf_verifier_options_t options);
+typedef void (*ebpf_parse_maps_section_fn)(std::vector<EbpfMapDescriptor>& map_descriptors, const char* data, size_t map_record_size, int map_count, const struct ebpf_platform_t* platform, ebpf_verifier_options_t options);
 
 typedef EbpfMapDescriptor& (*ebpf_get_map_descriptor_fn)(int map_fd);
 

--- a/src/test/test_verify.cpp
+++ b/src/test/test_verify.cpp
@@ -160,6 +160,12 @@ TEST_SECTION("cilium", "bpf_overlay.o", "from-overlay")
 
 TEST_SECTION("cilium", "bpf_xdp.o", "from-netdev")
 
+TEST_SECTION("cilium", "bpf_xdp_dsr_linux.o", "from-netdev")
+TEST_SECTION("cilium", "bpf_xdp_dsr_linux.o", "2/1")
+
+TEST_SECTION("cilium", "bpf_xdp_snat_linux.o", "from-netdev")
+TEST_SECTION("cilium", "bpf_xdp_snat_linux.o", "2/1")
+
 TEST_SECTION("linux", "cpustat_kern.o", "tracepoint/power/cpu_frequency")
 TEST_SECTION("linux", "cpustat_kern.o", "tracepoint/power/cpu_idle")
 TEST_SECTION("linux", "lathist_kern.o", "kprobe/trace_preempt_off")
@@ -474,6 +480,26 @@ TEST_SECTION_FAIL("prototype-kernel", "xdp_ddos01_blacklist_kern.o", ".text")
 
 // False positive: correlated branches
 TEST_SECTION_FAIL("prototype-kernel", "xdp_ddos01_blacklist_kern.o", "xdp_prog")
+
+// Unsupported: offset not tracked separately per pointer type
+TEST_SECTION_FAIL("cilium", "bpf_xdp_dsr_linux.o", "2/7")
+TEST_SECTION_FAIL("cilium", "bpf_xdp_dsr_linux.o", "2/10")
+TEST_SECTION_FAIL("cilium", "bpf_xdp_dsr_linux.o", "2/15")
+TEST_SECTION_FAIL("cilium", "bpf_xdp_dsr_linux.o", "2/16")
+TEST_SECTION_FAIL("cilium", "bpf_xdp_dsr_linux.o", "2/17")
+TEST_SECTION_FAIL("cilium", "bpf_xdp_dsr_linux.o", "2/18")
+TEST_SECTION_FAIL("cilium", "bpf_xdp_dsr_linux.o", "2/19")
+TEST_SECTION_FAIL("cilium", "bpf_xdp_dsr_linux.o", "2/20")
+TEST_SECTION_FAIL("cilium", "bpf_xdp_dsr_linux.o", "2/21")
+TEST_SECTION_FAIL("cilium", "bpf_xdp_dsr_linux.o", "2/24")
+TEST_SECTION_FAIL("cilium", "bpf_xdp_snat_linux.o", "2/7")
+TEST_SECTION_FAIL("cilium", "bpf_xdp_snat_linux.o", "2/10")
+TEST_SECTION_FAIL("cilium", "bpf_xdp_snat_linux.o", "2/15")
+TEST_SECTION_FAIL("cilium", "bpf_xdp_snat_linux.o", "2/16")
+TEST_SECTION_FAIL("cilium", "bpf_xdp_snat_linux.o", "2/17")
+TEST_SECTION_FAIL("cilium", "bpf_xdp_snat_linux.o", "2/18")
+TEST_SECTION_FAIL("cilium", "bpf_xdp_snat_linux.o", "2/19")
+TEST_SECTION_FAIL("cilium", "bpf_xdp_snat_linux.o", "2/24")
 
 // False positive, unknown cause
 TEST_SECTION_FAIL("linux", "test_map_in_map_kern.o", "kprobe/sys_connect")

--- a/src/test/test_verify.cpp
+++ b/src/test/test_verify.cpp
@@ -457,7 +457,6 @@ TEST_SECTION("build", "packet_access.o", "xdp")
 TEST_SECTION("build", "tail_call.o", "xdp_prog")
 TEST_SECTION("build", "map_in_map.o", ".text")
 TEST_SECTION("build", "twomaps.o", ".text");
-TEST_SECTION("build", "twotypes.o", ".text");
 
 // Test some programs that ought to fail verification.
 TEST_SECTION_REJECT("build", "badhelpercall.o", ".text")
@@ -500,6 +499,9 @@ TEST_SECTION_FAIL("cilium", "bpf_xdp_snat_linux.o", "2/17")
 TEST_SECTION_FAIL("cilium", "bpf_xdp_snat_linux.o", "2/18")
 TEST_SECTION_FAIL("cilium", "bpf_xdp_snat_linux.o", "2/19")
 TEST_SECTION_FAIL("cilium", "bpf_xdp_snat_linux.o", "2/24")
+
+// False positive, trying to dereference {shared,stack} pointer
+TEST_SECTION_FAIL("build", "twotypes.o", ".text");
 
 // False positive, unknown cause
 TEST_SECTION_FAIL("linux", "test_map_in_map_kern.o", "kprobe/sys_connect")


### PR DESCRIPTION
This PR uses the same technique as libbpf uses to figure out the
size of the map definition used by the ELF file.

This PR also adds test cases that use cilium programs recently
added to the ebpf-samples repo.  Those samples use map def struct
from a different kernel version, but where the fields used by
the verifier are still consistent.

All of the expected failures added are addressed by other PRs
(PR 289 and PR 292).

 This PR syncs to the latest ebpf-samples branch, and
 https://github.com/vbpf/ebpf-samples/pull/20 modified twotypes.o
 to fail without the verifier fixes, so that sample is also moved to be a false positive.

Signed-off-by: Dave Thaler <dthaler@microsoft.com>