### PR TITLE
Augment LabeledInstruction with source/file/line info from BTF 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ counter/samples/*
 **/#*
 check
 tests
+run_yaml
 ./unit-test
 .vscode/*
 logs/*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,6 +60,7 @@ file(GLOB ALL_TEST
         "./src/test/test.cpp"
         "./src/test/test_loop.cpp"
         "./src/test/test_marshal.cpp"
+        "./src/test/test_print.cpp"
         "./src/test/test_termination.cpp"
         "./src/test/test_verify.cpp"
         "./src/test/test_wto.cpp"

--- a/src/asm_cfg.cpp
+++ b/src/asm_cfg.cpp
@@ -40,7 +40,7 @@ static cfg_t instruction_seq_to_cfg(const InstructionSeq& insts, bool must_have_
     cfg_t cfg;
     std::optional<label_t> falling_from = {};
     bool first = true;
-    for (const auto& [label, inst] : insts) {
+    for (const auto& [label, inst, _] : insts) {
 
         if (std::holds_alternative<Undefined>(inst))
             continue;

--- a/src/asm_cfg.cpp
+++ b/src/asm_cfg.cpp
@@ -40,7 +40,7 @@ static cfg_t instruction_seq_to_cfg(const InstructionSeq& insts, bool must_have_
     cfg_t cfg;
     std::optional<label_t> falling_from = {};
     bool first = true;
-    for (const auto& [label, inst, _] : insts) {
+    for (const auto& [label, inst] : insts) {
 
         if (std::holds_alternative<Undefined>(inst))
             continue;

--- a/src/asm_files.cpp
+++ b/src/asm_files.cpp
@@ -216,7 +216,7 @@ vector<raw_program> read_elf(const std::string& path, const std::string& desired
 
         btf_parse_line_information(vector_of<uint8_t>(*btf), vector_of<uint8_t>(*btf_ext), visitor);
 
-        // BTF doesn't include line info for every instruction, instead sets it only on the first instruction.
+        // BTF doesn't include line info for every instruction, only on the first instruction per source line.
         for (auto& [name, program] : segment_to_program) {
             for (size_t i = 1; i < program.line_info.size(); i++) {
                 // If the previous PC has line info, copy it.

--- a/src/asm_files.cpp
+++ b/src/asm_files.cpp
@@ -220,8 +220,7 @@ vector<raw_program> read_elf(const std::string& path, const std::string& desired
         for (auto& [name, program] : segment_to_program) {
             for (size_t i = 1; i < program.line_info.size(); i++) {
                 // If the previous PC has line info, copy it.
-                if ((std::get<2>(program.line_info[i]) == 0) &&
-                    (std::get<2>(program.line_info[i - 1]) != 0)) {
+                if ((program.line_info[i].line_number == 0) && (program.line_info[i - 1].line_number != 0)) {
                     program.line_info[i] = program.line_info[i - 1];
                 }
             }

--- a/src/asm_marshal.cpp
+++ b/src/asm_marshal.cpp
@@ -259,7 +259,7 @@ static int size(Instruction inst) {
 static auto get_labels(const InstructionSeq& insts) {
     pc_t pc = 0;
     std::map<label_t, pc_t> pc_of_label;
-    for (auto [label, inst, _] : insts) {
+    for (auto [label, inst] : insts) {
         pc_of_label[label] = pc;
         pc += size(inst);
     }
@@ -270,7 +270,7 @@ vector<ebpf_inst> marshal(const InstructionSeq& insts) {
     vector<ebpf_inst> res;
     auto pc_of_label = get_labels(insts);
     pc_t pc = 0;
-    for (auto [label, ins, _] : insts) {
+    for (auto [label, ins] : insts) {
         (void)label; // unused
         if (std::holds_alternative<Jmp>(ins)) {
             Jmp& jmp = std::get<Jmp>(ins);

--- a/src/asm_marshal.cpp
+++ b/src/asm_marshal.cpp
@@ -259,7 +259,7 @@ static int size(Instruction inst) {
 static auto get_labels(const InstructionSeq& insts) {
     pc_t pc = 0;
     std::map<label_t, pc_t> pc_of_label;
-    for (auto [label, inst] : insts) {
+    for (auto [label, inst, _] : insts) {
         pc_of_label[label] = pc;
         pc += size(inst);
     }
@@ -270,7 +270,7 @@ vector<ebpf_inst> marshal(const InstructionSeq& insts) {
     vector<ebpf_inst> res;
     auto pc_of_label = get_labels(insts);
     pc_t pc = 0;
-    for (auto [label, ins] : insts) {
+    for (auto [label, ins, _] : insts) {
         (void)label; // unused
         if (std::holds_alternative<Jmp>(ins)) {
             Jmp& jmp = std::get<Jmp>(ins);

--- a/src/asm_ostream.cpp
+++ b/src/asm_ostream.cpp
@@ -350,7 +350,7 @@ int size(Instruction inst) {
 auto get_labels(const InstructionSeq& insts) {
     pc_t pc = 0;
     std::map<label_t, pc_t> pc_of_label;
-    for (auto [label, inst] : insts) {
+    for (auto [label, inst, _] : insts) {
         pc_of_label[label] = pc;
         pc += size(inst);
     }
@@ -363,13 +363,12 @@ void print(const InstructionSeq& insts, std::ostream& out, std::optional<const l
     std::string previous_source;
     InstructionPrinterVisitor visitor{out};
     for (const LabeledInstruction& labeled_inst : insts) {
-        const auto& [label, ins] = labeled_inst;
+        const auto& [label, ins, line_info] = labeled_inst;
         if (!label_to_print.has_value() || (label == label_to_print)) {
-            if (label.line_info.has_value()) {
-                auto& [file, source, line, column] = label.line_info.value();
+            if (line_info.has_value()) {
+                auto& [file, source, line, column] = line_info.value();
                 // Only decorate the first instruction associated with a source line.
-                if (source != previous_source)
-                {
+                if (source != previous_source) {
                     out << "; " << file.c_str() << ":" << line << "\n";
                     out << "; " << source.c_str() << "\n";
                     previous_source = source;

--- a/src/asm_ostream.cpp
+++ b/src/asm_ostream.cpp
@@ -350,7 +350,7 @@ int size(Instruction inst) {
 auto get_labels(const InstructionSeq& insts) {
     pc_t pc = 0;
     std::map<label_t, pc_t> pc_of_label;
-    for (auto [label, inst, _] : insts) {
+    for (auto [label, inst] : insts) {
         pc_of_label[label] = pc;
         pc += size(inst);
     }
@@ -363,10 +363,10 @@ void print(const InstructionSeq& insts, std::ostream& out, std::optional<const l
     std::string previous_source;
     InstructionPrinterVisitor visitor{out};
     for (const LabeledInstruction& labeled_inst : insts) {
-        const auto& [label, ins, line_info] = labeled_inst;
+        const auto& [label, ins] = labeled_inst;
         if (!label_to_print.has_value() || (label == label_to_print)) {
-            if (line_info.has_value()) {
-                auto& [file, source, line, column] = line_info.value();
+            if (label.line_info.has_value()) {
+                auto& [file, source, line, column] = label.line_info.value();
                 // Only decorate the first instruction associated with a source line.
                 if (source != previous_source)
                 {

--- a/src/asm_parse.cpp
+++ b/src/asm_parse.cpp
@@ -187,7 +187,7 @@ static InstructionSeq parse_program(std::istream& is) {
 
         if (!next_label)
             next_label = label_t(static_cast<int>(labeled_insts.size()));
-        labeled_insts.emplace_back(*next_label, ins);
+        labeled_insts.emplace_back(*next_label, ins, std::optional<btf_line_info_t>());
         next_label = {};
     }
     return labeled_insts;

--- a/src/asm_parse.cpp
+++ b/src/asm_parse.cpp
@@ -187,7 +187,7 @@ static InstructionSeq parse_program(std::istream& is) {
 
         if (!next_label)
             next_label = label_t(static_cast<int>(labeled_insts.size()));
-        labeled_insts.emplace_back(*next_label, ins);
+        labeled_insts.emplace_back(*next_label, ins, std::optional<btf_line_info>());
         next_label = {};
     }
     return labeled_insts;

--- a/src/asm_parse.cpp
+++ b/src/asm_parse.cpp
@@ -187,7 +187,7 @@ static InstructionSeq parse_program(std::istream& is) {
 
         if (!next_label)
             next_label = label_t(static_cast<int>(labeled_insts.size()));
-        labeled_insts.emplace_back(*next_label, ins, std::optional<btf_line_info>());
+        labeled_insts.emplace_back(*next_label, ins);
         next_label = {};
     }
     return labeled_insts;

--- a/src/asm_syntax.hpp
+++ b/src/asm_syntax.hpp
@@ -305,7 +305,13 @@ struct Assert {
 
 using Instruction = std::variant<Undefined, Bin, Un, LoadMapFd, Call, Exit, Jmp, Mem, Packet, LockAdd, Assume, Assert>;
 
-using LabeledInstruction = std::tuple<label_t, Instruction>;
+using btf_line_info = std::tuple<
+    std::string /* File Name */,
+    std::string /* Source Line */,
+    uint32_t    /* Line Number */,
+    uint32_t    /* Column Number */>;
+
+using LabeledInstruction = std::tuple<label_t, Instruction, std::optional<btf_line_info>>;
 using InstructionSeq = std::vector<LabeledInstruction>;
 
 using pc_t = uint16_t;

--- a/src/asm_syntax.hpp
+++ b/src/asm_syntax.hpp
@@ -9,22 +9,17 @@
 #include <vector>
 
 #include "crab/variable.hpp"
-
-using btf_line_info = std::tuple<
-    std::string /* File Name */,
-    std::string /* Source Line */,
-    uint32_t    /* Line Number */,
-    uint32_t    /* Column Number */>;
+#include "spec_type_descriptors.hpp"
 
 namespace crab {
 struct label_t {
     int from; ///< Jump source, or simply index of instruction
     int to; ///< Jump target or -1
 
-    explicit label_t(int index, int to=-1, std::optional<btf_line_info> line_info = {}) noexcept : from(index), to(to), line_info(line_info) { }
+    constexpr explicit label_t(int index, int to = -1) noexcept : from(index), to(to) {}
 
-    static label_t make_jump(const label_t& src_label, const label_t& target_label) {
-        return label_t{src_label.from, target_label.from, target_label.line_info};
+    static constexpr label_t make_jump(const label_t& src_label, const label_t& target_label) {
+        return label_t{src_label.from, target_label.from};
     }
 
     constexpr bool operator==(const label_t& other) const { return from == other.from && to == other.to; }
@@ -52,13 +47,12 @@ struct label_t {
 
     static const label_t entry;
     static const label_t exit;
-    std::optional<btf_line_info> line_info;
 };
 
 inline const label_t label_t::entry{-1};
 inline const label_t label_t::exit{-2};
 
-}
+} // namespace crab
 using crab::label_t;
 
 // Assembly syntax.
@@ -312,7 +306,7 @@ struct Assert {
 
 using Instruction = std::variant<Undefined, Bin, Un, LoadMapFd, Call, Exit, Jmp, Mem, Packet, LockAdd, Assume, Assert>;
 
-using LabeledInstruction = std::tuple<label_t, Instruction>;
+using LabeledInstruction = std::tuple<label_t, Instruction, std::optional<btf_line_info_t>>;
 using InstructionSeq = std::vector<LabeledInstruction>;
 
 using pc_t = uint16_t;

--- a/src/asm_unmarshal.cpp
+++ b/src/asm_unmarshal.cpp
@@ -426,7 +426,7 @@ struct Unmarshaller {
             if (pc == insts.size() - 1 && fallthrough)
                 note("fallthrough in last instruction");
 
-            prog.emplace_back(label_t(static_cast<int>(pc)), new_ins, std::optional<btf_line_info>());
+            prog.emplace_back(label_t(static_cast<int>(pc)), new_ins);
 
             pc++;
             note_next_pc();
@@ -439,7 +439,7 @@ struct Unmarshaller {
             if (i >= line_info.size()) {
                 continue;
             }
-            std::get<2>(prog[i]) = line_info[i];
+            std::get<0>(prog[i]).line_info = line_info[i];
         }
         if (exit_count == 0)
             note("no exit instruction");

--- a/src/asm_unmarshal.cpp
+++ b/src/asm_unmarshal.cpp
@@ -369,7 +369,7 @@ struct Unmarshaller {
         }
     }
 
-    vector<LabeledInstruction> unmarshal(vector<ebpf_inst> const& insts, vector<btf_line_info> const& line_info) {
+    vector<LabeledInstruction> unmarshal(vector<ebpf_inst> const& insts, vector<btf_line_info_t> const& line_info) {
         vector<LabeledInstruction> prog;
         int exit_count = 0;
         if (insts.empty()) {
@@ -426,7 +426,7 @@ struct Unmarshaller {
             if (pc == insts.size() - 1 && fallthrough)
                 note("fallthrough in last instruction");
 
-            prog.emplace_back(label_t(static_cast<int>(pc)), new_ins);
+            prog.emplace_back(label_t(static_cast<int>(pc)), new_ins, std::optional<btf_line_info_t>());
 
             pc++;
             note_next_pc();
@@ -437,9 +437,9 @@ struct Unmarshaller {
         }
         for (size_t i = 0; i < prog.size(); i++) {
             if (i >= line_info.size()) {
-                continue;
+                break;
             }
-            std::get<0>(prog[i]).line_info = line_info[i];
+            std::get<2>(prog[i]) = line_info[i];
         }
         if (exit_count == 0)
             note("no exit instruction");

--- a/src/asm_unmarshal.cpp
+++ b/src/asm_unmarshal.cpp
@@ -436,6 +436,9 @@ struct Unmarshaller {
             }
         }
         for (size_t i = 0; i < prog.size(); i++) {
+            if (i >= line_info.size()) {
+                continue;
+            }
             std::get<2>(prog[i]) = line_info[i];
         }
         if (exit_count == 0)

--- a/src/btf.h
+++ b/src/btf.h
@@ -1,0 +1,151 @@
+// Copyright (c) Prevail Verifier contributors.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+#include <stdint.h>
+// Format of .BTF and .BTF.ext is documented here:
+// https://www.kernel.org/doc/html/latest/bpf/btf.html
+
+#define BTF_KIND_INT 1         /* Integer      */
+#define BTF_KIND_PTR 2         /* Pointer      */
+#define BTF_KIND_ARRAY 3       /* Array        */
+#define BTF_KIND_STRUCT 4      /* Struct       */
+#define BTF_KIND_UNION 5       /* Union        */
+#define BTF_KIND_ENUM 6        /* Enumeration  */
+#define BTF_KIND_FWD 7         /* Forward      */
+#define BTF_KIND_TYPEDEF 8     /* Typedef      */
+#define BTF_KIND_VOLATILE 9    /* Volatile     */
+#define BTF_KIND_CONST 10      /* Const        */
+#define BTF_KIND_RESTRICT 11   /* Restrict     */
+#define BTF_KIND_FUNC 12       /* Function     */
+#define BTF_KIND_FUNC_PROTO 13 /* Function Proto       */
+#define BTF_KIND_VAR 14        /* Variable     */
+#define BTF_KIND_DATASEC 15    /* Section      */
+#define BTF_KIND_FLOAT 16      /* Floating point       */
+#define BTF_KIND_DECL_TAG 17   /* Decl Tag     */
+#define BTF_KIND_TYPE_TAG 18   /* Type Tag     */
+
+#define BTF_INT_ENCODING(VAL) (((VAL)&0x0f000000) >> 24)
+#define BTF_INT_OFFSET(VAL) (((VAL)&0x00ff0000) >> 16)
+#define BTF_INT_BITS(VAL) ((VAL)&0x000000ff)
+
+#define BTF_MEMBER_BITFIELD_SIZE(val) ((val) >> 24)
+#define BTF_MEMBER_BIT_OFFSET(val) ((val)&0xffffff)
+
+#define BTF_MEMBER_BITFIELD_SIZE(val) ((val) >> 24)
+#define BTF_MEMBER_BIT_OFFSET(val) ((val)&0xffffff)
+
+#define BTF_HEADER_MAGIC 0xeB9F
+#define BTF_HEADER_VERSION 1
+
+#define BPF_LINE_INFO_LINE_NUM(line_col) ((line_col) >> 10)
+#define BPF_LINE_INFO_LINE_COL(line_col) ((line_col)&0x3ff)
+
+typedef struct _btf_header
+{
+    uint16_t magic;
+    uint8_t version;
+    uint8_t flags;
+    uint32_t hdr_len;
+
+    /* All offsets are in bytes relative to the end of this header */
+    uint32_t type_off; /* offset of type section       */
+    uint32_t type_len; /* length of type section       */
+    uint32_t str_off;  /* offset of string section     */
+    uint32_t str_len;  /* length of string section     */
+} btf_header_t;
+
+typedef struct _btf_type
+{
+    uint32_t name_off;
+    /* "info" bits arrangement
+     * bits  0-15: vlen (e.g. # of struct's members)
+     * bits 16-23: unused
+     * bits 24-28: kind (e.g. int, ptr, array...etc)
+     * bits 29-30: unused
+     * bit     31: kind_flag, currently used by
+     *             struct, union and fwd
+     */
+    uint32_t info;
+    /* "size" is used by INT, ENUM, STRUCT and UNION.
+     * "size" tells the size of the type it is describing.
+     *
+     * "type" is used by PTR, TYPEDEF, VOLATILE, CONST, RESTRICT,
+     * FUNC, FUNC_PROTO, DECL_TAG and TYPE_TAG.
+     * "type" is a type_id referring to another type.
+     */
+    union
+    {
+        uint32_t size;
+        uint32_t type;
+    };
+} btf_type_t;
+
+typedef struct _btf_array
+{
+    uint32_t type;
+    uint32_t index_type;
+    uint32_t nelems;
+} btf_array_t;
+
+typedef struct _btf_param
+{
+    uint32_t name_off;
+    uint32_t type;
+} btf_param_t;
+
+typedef struct _btf_var
+{
+    uint32_t linkage;
+} btf_var_t;
+
+typedef struct _btf_var_secinfo
+{
+    uint32_t type;
+    uint32_t offset;
+    uint32_t size;
+} btf_var_secinfo_t;
+
+typedef struct _btf_decl_tag
+{
+    uint32_t component_idx;
+} btf_decl_tag_t;
+
+typedef struct _btf_ext_header
+{
+    uint16_t magic;
+    uint8_t version;
+    uint8_t flags;
+    uint32_t hdr_len;
+
+    /* All offsets are in bytes relative to the end of this header */
+    uint32_t func_info_off;
+    uint32_t func_info_len;
+    uint32_t line_info_off;
+    uint32_t line_info_len;
+} btf_ext_header_t;
+
+#pragma warning(push)
+#pragma warning(disable : 4200) // nonstandard extension used: zero-sized array in struct/union
+typedef struct _btf_ext_info_sec
+{
+    uint32_t sec_name_off; /* offset to section name */
+    uint32_t num_info;
+    /* Followed by num_info * record_size number of bytes */
+    uint8_t data[0];
+} btf_ext_info_sec_t;
+#pragma warning(pop)
+
+typedef struct _bpf_func_info
+{
+    uint32_t insn_off; /* [0, insn_cnt - 1] */
+    uint32_t type_id;  /* pointing to a BTF_KIND_FUNC type */
+} bpf_func_info_t;
+
+typedef struct _bpf_line_info
+{
+    uint32_t insn_off;      /* [0, insn_cnt - 1] */
+    uint32_t file_name_off; /* offset to string table for the filename */
+    uint32_t line_off;      /* offset to string table for the source line */
+    uint32_t line_col;      /* line number and column number */
+} bpf_line_info_t;

--- a/src/btf.h
+++ b/src/btf.h
@@ -41,8 +41,7 @@
 #define BPF_LINE_INFO_LINE_NUM(line_col) ((line_col) >> 10)
 #define BPF_LINE_INFO_LINE_COL(line_col) ((line_col)&0x3ff)
 
-typedef struct _btf_header
-{
+typedef struct _btf_header {
     uint16_t magic;
     uint8_t version;
     uint8_t flags;
@@ -55,8 +54,7 @@ typedef struct _btf_header
     uint32_t str_len;  /* length of string section     */
 } btf_header_t;
 
-typedef struct _btf_type
-{
+typedef struct _btf_type {
     uint32_t name_off;
     /* "info" bits arrangement
      * bits  0-15: vlen (e.g. # of struct's members)
@@ -74,45 +72,38 @@ typedef struct _btf_type
      * FUNC, FUNC_PROTO, DECL_TAG and TYPE_TAG.
      * "type" is a type_id referring to another type.
      */
-    union
-    {
+    union {
         uint32_t size;
         uint32_t type;
     };
 } btf_type_t;
 
-typedef struct _btf_array
-{
+typedef struct _btf_array {
     uint32_t type;
     uint32_t index_type;
     uint32_t nelems;
 } btf_array_t;
 
-typedef struct _btf_param
-{
+typedef struct _btf_param {
     uint32_t name_off;
     uint32_t type;
 } btf_param_t;
 
-typedef struct _btf_var
-{
+typedef struct _btf_var {
     uint32_t linkage;
 } btf_var_t;
 
-typedef struct _btf_var_secinfo
-{
+typedef struct _btf_var_secinfo {
     uint32_t type;
     uint32_t offset;
     uint32_t size;
 } btf_var_secinfo_t;
 
-typedef struct _btf_decl_tag
-{
+typedef struct _btf_decl_tag {
     uint32_t component_idx;
 } btf_decl_tag_t;
 
-typedef struct _btf_ext_header
-{
+typedef struct _btf_ext_header {
     uint16_t magic;
     uint8_t version;
     uint8_t flags;
@@ -127,8 +118,7 @@ typedef struct _btf_ext_header
 
 #pragma warning(push)
 #pragma warning(disable : 4200) // nonstandard extension used: zero-sized array in struct/union
-typedef struct _btf_ext_info_sec
-{
+typedef struct _btf_ext_info_sec {
     uint32_t sec_name_off; /* offset to section name */
     uint32_t num_info;
     /* Followed by num_info * record_size number of bytes */
@@ -136,14 +126,12 @@ typedef struct _btf_ext_info_sec
 } btf_ext_info_sec_t;
 #pragma warning(pop)
 
-typedef struct _bpf_func_info
-{
+typedef struct _bpf_func_info {
     uint32_t insn_off; /* [0, insn_cnt - 1] */
     uint32_t type_id;  /* pointing to a BTF_KIND_FUNC type */
 } bpf_func_info_t;
 
-typedef struct _bpf_line_info
-{
+typedef struct _bpf_line_info {
     uint32_t insn_off;      /* [0, insn_cnt - 1] */
     uint32_t file_name_off; /* offset to string table for the filename */
     uint32_t line_off;      /* offset to string table for the source line */

--- a/src/btf_parser.cpp
+++ b/src/btf_parser.cpp
@@ -1,13 +1,12 @@
 // Copyright (c) Prevail Verifier contributors.
 // SPDX-License-Identifier: MIT
 
-#include "btf_parser.h"
-
 #include <map>
 #include <stdexcept>
 #include <string.h>
 
 #include "btf.h"
+#include "btf_parser.h"
 
 void btf_parse_line_information(const std::vector<uint8_t>& btf, const std::vector<uint8_t>& btf_ext,
                                 btf_line_info_visitor visitor) {
@@ -15,29 +14,27 @@ void btf_parse_line_information(const std::vector<uint8_t>& btf, const std::vect
 
     auto btf_header = reinterpret_cast<const btf_header_t*>(btf.data());
     if (btf_header->magic != BTF_HEADER_MAGIC) {
-        throw std::runtime_error("Invalid .btf section - wrong magic");
+        throw std::runtime_error("Invalid .BTF section - wrong magic");
     }
     if (btf_header->version != BTF_HEADER_VERSION) {
-        throw std::runtime_error("Invalid .btf section - wrong version");
+        throw std::runtime_error("Invalid .BTF section - wrong version");
     }
     if (btf_header->hdr_len < sizeof(btf_header_t)) {
-        throw std::runtime_error("Invalid .btf section - wrong size");
+        throw std::runtime_error("Invalid .BTF section - wrong size");
     }
     if (btf_header->hdr_len > btf.size()) {
-        throw std::runtime_error("Invalid .btf section - invalid header length");
+        throw std::runtime_error("Invalid .BTF section - invalid header length");
     }
     if (btf_header->str_off > btf.size()) {
-        throw std::runtime_error("Invalid .btf section - invalid string offest");
+        throw std::runtime_error("Invalid .BTF section - invalid string offest");
     }
     if ((static_cast<size_t>(btf_header->str_off) + static_cast<size_t>(btf_header->str_len) +
          static_cast<size_t>(btf_header->hdr_len)) > btf.size()) {
-        throw std::runtime_error("Invalid .btf section - invalid string length");
+        throw std::runtime_error("Invalid .BTF section - invalid string length");
     }
 
     for (size_t offset = btf_header->str_off + static_cast<size_t>(btf_header->hdr_len);
          offset < static_cast<size_t>(btf_header->str_off) + static_cast<size_t>(btf_header->str_len);) {
-        //size_t remaining_length = btf_header->str_len - offset;
-        //size_t string_length = strlen(reinterpret_cast<const char*>(btf.data()) + offset);
         std::string value(reinterpret_cast<const char*>(btf.data()) + offset);
         size_t string_offset =
             offset - static_cast<size_t>(btf_header->str_off) - static_cast<size_t>(btf_header->hdr_len);
@@ -46,20 +43,20 @@ void btf_parse_line_information(const std::vector<uint8_t>& btf, const std::vect
     }
     auto bpf_ext_header = reinterpret_cast<const btf_ext_header_t*>(btf_ext.data());
     if (bpf_ext_header->magic != BTF_HEADER_MAGIC) {
-        throw std::runtime_error("Invalid .btf.ext section - wrong magic");
+        throw std::runtime_error("Invalid .BTF.ext section - wrong magic");
     }
     if (bpf_ext_header->version != BTF_HEADER_VERSION) {
-        throw std::runtime_error("Invalid .btf.ext section - wrong version");
+        throw std::runtime_error("Invalid .BTF.ext section - wrong version");
     }
     if (bpf_ext_header->hdr_len < sizeof(btf_ext_header_t)) {
-        throw std::runtime_error("Invalid .btf.ext section - wrong size");
+        throw std::runtime_error("Invalid .BTF.ext section - wrong size");
     }
     if (bpf_ext_header->line_info_off > btf_ext.size()) {
-        throw std::runtime_error("Invalid .btf.ex section - invalid line info offest");
+        throw std::runtime_error("Invalid .BTF.ext section - invalid line info offset");
     }
     if ((static_cast<size_t>(bpf_ext_header->line_info_off) + static_cast<size_t>(bpf_ext_header->line_info_len) +
          static_cast<size_t>(bpf_ext_header->hdr_len)) > btf_ext.size()) {
-        throw std::runtime_error("Invalid .btf section - invalid string length");
+        throw std::runtime_error("Invalid .BTF section - invalid string length");
     }
 
     uint32_t line_info_record_size =
@@ -73,7 +70,7 @@ void btf_parse_line_information(const std::vector<uint8_t>& btf, const std::vect
         auto section_info = reinterpret_cast<const btf_ext_info_sec_t*>(btf_ext.data() + offset);
         auto section_name = string_table.find(section_info->sec_name_off);
         if (section_name == string_table.end()) {
-            throw std::runtime_error(std::string("Invalid .btf section - invalid string offset ") +
+            throw std::runtime_error(std::string("Invalid .BTF section - invalid string offset ") +
                                      std::to_string(section_info->sec_name_off));
         }
         for (size_t index = 0; index < section_info->num_info; index++) {

--- a/src/btf_parser.cpp
+++ b/src/btf_parser.cpp
@@ -1,0 +1,98 @@
+// Copyright (c) Prevail Verifier contributors.
+// SPDX-License-Identifier: MIT
+
+#include "btf_parser.h"
+
+#include <map>
+#include <stdexcept>
+#include <string.h>
+
+#include "btf.h"
+
+void btf_parse_line_information(const std::vector<uint8_t>& btf, const std::vector<uint8_t>& btf_ext,
+                                btf_line_info_visitor visitor) {
+    std::map<size_t, std::string> string_table;
+
+    auto btf_header = reinterpret_cast<const btf_header_t*>(btf.data());
+    if (btf_header->magic != BTF_HEADER_MAGIC) {
+        throw std::runtime_error("Invalid .btf section - wrong magic");
+    }
+    if (btf_header->version != BTF_HEADER_VERSION) {
+        throw std::runtime_error("Invalid .btf section - wrong version");
+    }
+    if (btf_header->hdr_len < sizeof(btf_header_t)) {
+        throw std::runtime_error("Invalid .btf section - wrong size");
+    }
+    if (btf_header->hdr_len > btf.size()) {
+        throw std::runtime_error("Invalid .btf section - invalid header length");
+    }
+    if (btf_header->str_off > btf.size()) {
+        throw std::runtime_error("Invalid .btf section - invalid string offest");
+    }
+    if ((static_cast<size_t>(btf_header->str_off) + static_cast<size_t>(btf_header->str_len) +
+         static_cast<size_t>(btf_header->hdr_len)) > btf.size()) {
+        throw std::runtime_error("Invalid .btf section - invalid string length");
+    }
+
+    for (size_t offset = btf_header->str_off + static_cast<size_t>(btf_header->hdr_len);
+         offset < static_cast<size_t>(btf_header->str_off) + static_cast<size_t>(btf_header->str_len);) {
+        size_t remaining_length = btf_header->str_len - offset;
+        size_t string_length = strnlen(reinterpret_cast<const char*>(btf.data()) + offset, remaining_length);
+        std::string value(reinterpret_cast<const char*>(btf.data()) + offset, string_length);
+        size_t string_offset =
+            offset - static_cast<size_t>(btf_header->str_off) - static_cast<size_t>(btf_header->hdr_len);
+        offset += string_length + 1;
+        string_table.insert(std::make_pair(string_offset, value));
+    }
+    auto bpf_ext_header = reinterpret_cast<const btf_ext_header_t*>(btf_ext.data());
+    if (bpf_ext_header->magic != BTF_HEADER_MAGIC) {
+        throw std::runtime_error("Invalid .btf.ext section - wrong magic");
+    }
+    if (bpf_ext_header->version != BTF_HEADER_VERSION) {
+        throw std::runtime_error("Invalid .btf.ext section - wrong version");
+    }
+    if (bpf_ext_header->hdr_len < sizeof(btf_ext_header_t)) {
+        throw std::runtime_error("Invalid .btf.ext section - wrong size");
+    }
+    if (bpf_ext_header->line_info_off > btf_ext.size()) {
+        throw std::runtime_error("Invalid .btf.ex section - invalid line info offest");
+    }
+    if ((static_cast<size_t>(bpf_ext_header->line_info_off) + static_cast<size_t>(bpf_ext_header->line_info_len) +
+         static_cast<size_t>(bpf_ext_header->hdr_len)) > btf_ext.size()) {
+        throw std::runtime_error("Invalid .btf section - invalid string length");
+    }
+
+    uint32_t line_info_record_size =
+        *reinterpret_cast<const uint32_t*>(btf_ext.data() + static_cast<size_t>(bpf_ext_header->hdr_len) +
+                                           static_cast<size_t>(bpf_ext_header->line_info_off));
+
+    for (size_t offset = static_cast<size_t>(bpf_ext_header->hdr_len) +
+                         static_cast<size_t>(bpf_ext_header->line_info_off) + sizeof(uint32_t);
+         offset < static_cast<size_t>(bpf_ext_header->hdr_len) + static_cast<size_t>(bpf_ext_header->line_info_off) +
+                      static_cast<size_t>(bpf_ext_header->line_info_len);) {
+        auto section_info = reinterpret_cast<const btf_ext_info_sec_t*>(btf_ext.data() + offset);
+        auto section_name = string_table.find(section_info->sec_name_off);
+        if (section_name == string_table.end()) {
+            throw std::runtime_error(std::string("Invalid .btf section - invalid string offset ") +
+                                     std::to_string(section_info->sec_name_off));
+        }
+        for (size_t index = 0; index < section_info->num_info; index++) {
+            auto btf_line_info =
+                reinterpret_cast<const bpf_line_info_t*>(section_info->data + index * line_info_record_size);
+            auto file_name = string_table.find(btf_line_info->file_name_off);
+            auto source = string_table.find(btf_line_info->line_off);
+            std::string file_name_string;
+            std::string source_line_string;
+            if (file_name != string_table.end()) {
+                file_name_string = file_name->second;
+            }
+            if (source != string_table.end()) {
+                source_line_string = source->second;
+            }
+            visitor(section_name->second, btf_line_info->insn_off, file_name_string, source_line_string,
+                    BPF_LINE_INFO_LINE_NUM(btf_line_info->line_col), BPF_LINE_INFO_LINE_COL(btf_line_info->line_col));
+        }
+        offset += offsetof(btf_ext_info_sec_t, data) +
+                  static_cast<size_t>(line_info_record_size) * static_cast<size_t>(section_info->num_info);
+    }
+}

--- a/src/btf_parser.cpp
+++ b/src/btf_parser.cpp
@@ -36,12 +36,12 @@ void btf_parse_line_information(const std::vector<uint8_t>& btf, const std::vect
 
     for (size_t offset = btf_header->str_off + static_cast<size_t>(btf_header->hdr_len);
          offset < static_cast<size_t>(btf_header->str_off) + static_cast<size_t>(btf_header->str_len);) {
-        size_t remaining_length = btf_header->str_len - offset;
-        size_t string_length = strnlen(reinterpret_cast<const char*>(btf.data()) + offset, remaining_length);
-        std::string value(reinterpret_cast<const char*>(btf.data()) + offset, string_length);
+        //size_t remaining_length = btf_header->str_len - offset;
+        //size_t string_length = strlen(reinterpret_cast<const char*>(btf.data()) + offset);
+        std::string value(reinterpret_cast<const char*>(btf.data()) + offset);
         size_t string_offset =
             offset - static_cast<size_t>(btf_header->str_off) - static_cast<size_t>(btf_header->hdr_len);
-        offset += string_length + 1;
+        offset += value.size() + 1;
         string_table.insert(std::make_pair(string_offset, value));
     }
     auto bpf_ext_header = reinterpret_cast<const btf_ext_header_t*>(btf_ext.data());

--- a/src/btf_parser.h
+++ b/src/btf_parser.h
@@ -1,0 +1,23 @@
+// Copyright (c) Prevail Verifier contributors.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+#include <functional>
+#include <stdint.h>
+#include <string>
+#include <vector>
+
+typedef std::function<void(const std::string& section, uint32_t instruction_offset, const std::string& file_name,
+                           const std::string& source, uint32_t line_number, uint32_t column_number)>
+    btf_line_info_visitor;
+/**
+ * @brief Parse a .btf and .btf.ext section from an ELF file invoke vistor for
+ * each btf_line_info record.
+ *
+ * @param[in] btf The .btf section (containing type info and strings).
+ * @param[in] btf_ext The .btf.ext section (containing function info and
+ * line info).
+ * @param[in] visitor Function to invoke on each btf_line_info record.
+ */
+void btf_parse_line_information(const std::vector<uint8_t>& btf, const std::vector<uint8_t>& btf_ext,
+                                btf_line_info_visitor visitor);

--- a/src/btf_parser.h
+++ b/src/btf_parser.h
@@ -11,11 +11,11 @@ typedef std::function<void(const std::string& section, uint32_t instruction_offs
                            const std::string& source, uint32_t line_number, uint32_t column_number)>
     btf_line_info_visitor;
 /**
- * @brief Parse a .btf and .btf.ext section from an ELF file invoke vistor for
+ * @brief Parse a .BTF and .BTF.ext section from an ELF file invoke vistor for
  * each btf_line_info record.
  *
- * @param[in] btf The .btf section (containing type info and strings).
- * @param[in] btf_ext The .btf.ext section (containing function info and
+ * @param[in] btf The .BTF section (containing type info and strings).
+ * @param[in] btf_ext The .BTF.ext section (containing function info and
  * line info).
  * @param[in] visitor Function to invoke on each btf_line_info record.
  */

--- a/src/crab/wto.cpp
+++ b/src/crab/wto.cpp
@@ -55,7 +55,7 @@ void wto_t::start_visit(const label_t& vertex, wto_partition_t& partition, std::
 
     if (head_dfn == vertex_data.dfn) {  
         vertex_data.dfn = INT_MAX;
-        label_t& element = _stack.top();
+        label_t element = _stack.top();
         _stack.pop();
         if (loop) {
             while (element != vertex) {

--- a/src/crab_verifier.cpp
+++ b/src/crab_verifier.cpp
@@ -118,7 +118,7 @@ static void print_report(std::ostream& os, const checks_db& db, const Instructio
     for (auto [label, messages] : db.m_db) {
         for (const auto& msg : messages) {
             if (label.line_info.has_value()) {
-                auto& [file, source, line, colum] = label.line_info.value();
+                auto& [file, source, line, _] = label.line_info.value();
                 os << "; " << file.c_str() << ":" << line << "\n";
                 os << "; " << source.c_str() << "\n";
             }

--- a/src/crab_verifier.cpp
+++ b/src/crab_verifier.cpp
@@ -116,8 +116,14 @@ static checks_db generate_report(cfg_t& cfg,
 static void print_report(std::ostream& os, const checks_db& db, const InstructionSeq& prog) {
     os << "\n";
     for (auto [label, messages] : db.m_db) {
-        for (const auto& msg : messages)
+        for (const auto& msg : messages) {
+            if (label.line_info.has_value()) {
+                auto& [file, source, line, colum] = label.line_info.value();
+                os << "; " << file.c_str() << ":" << line << "\n";
+                os << "; " << source.c_str() << "\n";
+            }
             os << label << ": " << msg << "\n";
+        }
     }
     os << "\n";
     if (!db.maybe_nonterminating.empty()) {

--- a/src/crab_verifier.cpp
+++ b/src/crab_verifier.cpp
@@ -117,8 +117,9 @@ static void print_report(std::ostream& os, const checks_db& db, const Instructio
     os << "\n";
     for (auto [label, messages] : db.m_db) {
         for (const auto& msg : messages) {
-            if (label.line_info.has_value()) {
-                auto& [file, source, line, _] = label.line_info.value();
+            auto line_info = std::get<2>(prog[label.from]);
+            if (line_info.has_value()) {
+                auto& [file, source, line, _] = line_info.value();
                 os << "; " << file.c_str() << ":" << line << "\n";
                 os << "; " << source.c_str() << "\n";
             }

--- a/src/ebpf_yaml.cpp
+++ b/src/ebpf_yaml.cpp
@@ -149,7 +149,7 @@ static InstructionSeq raw_cfg_to_instruction_seq(const vector<std::tuple<string,
             const Instruction& ins = parse_instruction(line, label_name_to_label);
             if (std::holds_alternative<Undefined>(ins))
                 std::cout << "text:" << line << "; ins: " << ins << "\n";
-            res.emplace_back(label_index, ins);
+            res.emplace_back(label_index, ins, std::optional<btf_line_info>());
             label_index++;
         }
     }

--- a/src/ebpf_yaml.cpp
+++ b/src/ebpf_yaml.cpp
@@ -145,11 +145,11 @@ static InstructionSeq raw_cfg_to_instruction_seq(const vector<std::tuple<string,
     InstructionSeq res;
     label_index = 0;
     for (const auto& [label_name, raw_block] : raw_blocks) {
-        for (const string& line: raw_block) {
+        for (const string& line : raw_block) {
             const Instruction& ins = parse_instruction(line, label_name_to_label);
             if (std::holds_alternative<Undefined>(ins))
                 std::cout << "text:" << line << "; ins: " << ins << "\n";
-            res.emplace_back(label_index, ins);
+            res.emplace_back(label_index, ins, std::optional<btf_line_info_t>());
             label_index++;
         }
     }

--- a/src/ebpf_yaml.cpp
+++ b/src/ebpf_yaml.cpp
@@ -149,7 +149,7 @@ static InstructionSeq raw_cfg_to_instruction_seq(const vector<std::tuple<string,
             const Instruction& ins = parse_instruction(line, label_name_to_label);
             if (std::holds_alternative<Undefined>(ins))
                 std::cout << "text:" << line << "; ins: " << ins << "\n";
-            res.emplace_back(label_index, ins, std::optional<btf_line_info>());
+            res.emplace_back(label_index, ins);
             label_index++;
         }
     }

--- a/src/spec_type_descriptors.hpp
+++ b/src/spec_type_descriptors.hpp
@@ -52,11 +52,18 @@ struct program_info {
     std::map<EquivalenceKey, int> cache;
 };
 
+using btf_line_info = std::tuple<
+    std::string /* File Name */,
+    std::string /* Source Line */,
+    uint32_t    /* Line Number */,
+    uint32_t    /* Column Number */>;
+
 struct raw_program {
     std::string filename;
     std::string section;
     std::vector<ebpf_inst> prog;
     program_info info;
+    std::vector<btf_line_info> line_info;
 };
 
 extern thread_local program_info global_program_info;

--- a/src/spec_type_descriptors.hpp
+++ b/src/spec_type_descriptors.hpp
@@ -52,18 +52,19 @@ struct program_info {
     std::map<EquivalenceKey, int> cache;
 };
 
-using btf_line_info = std::tuple<
-    std::string /* File Name */,
-    std::string /* Source Line */,
-    uint32_t    /* Line Number */,
-    uint32_t    /* Column Number */>;
+typedef struct _btf_line_info {
+    std::string file_name;
+    std::string source_line;
+    uint32_t line_number;
+    uint32_t column_number;
+} btf_line_info_t;
 
 struct raw_program {
     std::string filename;
     std::string section;
     std::vector<ebpf_inst> prog;
     program_info info;
-    std::vector<btf_line_info> line_info;
+    std::vector<btf_line_info_t> line_info;
 };
 
 extern thread_local program_info global_program_info;

--- a/src/test/test_marshal.cpp
+++ b/src/test/test_marshal.cpp
@@ -11,8 +11,9 @@ static void compare_marshal_unmarshal(const Instruction& ins, bool double_cmd = 
                       .type = g_ebpf_platform_linux.get_program_type("unspec", "unspec")};
     InstructionSeq parsed = std::get<InstructionSeq>(unmarshal(raw_program{"", "", marshal(ins, 0), info}));
     REQUIRE(parsed.size() == 1);
-    auto [_, single] = parsed.back();
-    (void)_; // unused
+    auto [_, single, _2] = parsed.back();
+    (void)_;  // unused
+    (void)_2; // unused
     REQUIRE(single == ins);
 }
 

--- a/src/test/test_marshal.cpp
+++ b/src/test/test_marshal.cpp
@@ -11,9 +11,8 @@ static void compare_marshal_unmarshal(const Instruction& ins, bool double_cmd = 
                       .type = g_ebpf_platform_linux.get_program_type("unspec", "unspec")};
     InstructionSeq parsed = std::get<InstructionSeq>(unmarshal(raw_program{"", "", marshal(ins, 0), info}));
     REQUIRE(parsed.size() == 1);
-    auto [_, single, _2] = parsed.back();
+    auto [_, single] = parsed.back();
     (void)_; // unused
-    (void)_2; // unused
     REQUIRE(single == ins);
 }
 

--- a/src/test/test_marshal.cpp
+++ b/src/test/test_marshal.cpp
@@ -11,8 +11,9 @@ static void compare_marshal_unmarshal(const Instruction& ins, bool double_cmd = 
                       .type = g_ebpf_platform_linux.get_program_type("unspec", "unspec")};
     InstructionSeq parsed = std::get<InstructionSeq>(unmarshal(raw_program{"", "", marshal(ins, 0), info}));
     REQUIRE(parsed.size() == 1);
-    auto [_, single] = parsed.back();
+    auto [_, single, _2] = parsed.back();
     (void)_; // unused
+    (void)_2; // unused
     REQUIRE(single == ins);
 }
 

--- a/src/test/test_print.cpp
+++ b/src/test/test_print.cpp
@@ -1,0 +1,65 @@
+// Copyright (c) Prevail Verifier contributors.
+// SPDX-License-Identifier: MIT
+#include "catch.hpp"
+
+#include <fstream>
+#include <regex>
+#include <string>
+#include <sstream>
+#include <variant>
+
+#include "asm_files.hpp"
+#include "asm_ostream.hpp"
+#include "asm_unmarshal.hpp"
+
+#define TEST_OBJECT_FILE_DIRECTORY "ebpf-samples/build/"
+#define TEST_ASM_FILE_DIRECTORY "ebpf-samples/asm/"
+#define PRINT_CASE(file) \
+    TEST_CASE("Print suite: " #file, "[print]") { \
+        verify_printed_string(#file);\
+    }
+
+void verify_printed_string(const std::string file)
+{
+    std::stringstream generated_output;
+    auto raw_progs = read_elf(std::string(TEST_OBJECT_FILE_DIRECTORY) + file + ".o", "", nullptr, &g_ebpf_platform_linux);
+    raw_program raw_prog = raw_progs.back();
+    std::variant<InstructionSeq, std::string> prog_or_error = unmarshal(raw_prog);
+    REQUIRE(std::holds_alternative<InstructionSeq>(prog_or_error));
+    auto& prog = std::get<InstructionSeq>(prog_or_error);
+    std::string current_directory = get_current_dir_name();
+    print(prog, generated_output, {});
+    std::ifstream input(std::string(TEST_ASM_FILE_DIRECTORY) + file + std::string(".asm"));
+    REQUIRE(input);
+    std::string line;
+    std::string expected_output;
+    std::string output = generated_output.str();
+    while (std::getline(input, line))
+    {
+        expected_output += line;
+        expected_output += "\n";
+    }
+    output = std::regex_replace(output, std::regex(current_directory), ".");
+    REQUIRE(expected_output == output);
+}
+
+
+PRINT_CASE(byteswap)
+PRINT_CASE(ctxoffset)
+PRINT_CASE(exposeptr)
+PRINT_CASE(exposeptr2)
+PRINT_CASE(map_in_map)
+PRINT_CASE(mapoverflow)
+PRINT_CASE(mapunderflow)
+PRINT_CASE(mapvalue-overrun)
+PRINT_CASE(nullmapref)
+PRINT_CASE(packet_access)
+PRINT_CASE(packet_overflow)
+PRINT_CASE(packet_reallocate)
+PRINT_CASE(packet_start_ok)
+PRINT_CASE(stackok)
+PRINT_CASE(tail_call)
+PRINT_CASE(tail_call_bad)
+PRINT_CASE(twomaps)
+PRINT_CASE(twostackvars)
+PRINT_CASE(twotypes)

--- a/src/test/test_print.cpp
+++ b/src/test/test_print.cpp
@@ -2,11 +2,17 @@
 // SPDX-License-Identifier: MIT
 #include "catch.hpp"
 
+#include <filesystem>
 #include <fstream>
 #include <regex>
 #include <string>
 #include <sstream>
 #include <variant>
+
+
+#if !defined(MAX_PATH)
+#define MAX_PATH (256)
+#endif
 
 #include "asm_files.hpp"
 #include "asm_ostream.hpp"
@@ -27,7 +33,7 @@ void verify_printed_string(const std::string file)
     std::variant<InstructionSeq, std::string> prog_or_error = unmarshal(raw_prog);
     REQUIRE(std::holds_alternative<InstructionSeq>(prog_or_error));
     auto& prog = std::get<InstructionSeq>(prog_or_error);
-    std::string current_directory = get_current_dir_name();
+    std::string current_directory = std::filesystem::current_path().generic_string();
     print(prog, generated_output, {});
     std::ifstream input(std::string(TEST_ASM_FILE_DIRECTORY) + file + std::string(".asm"));
     REQUIRE(input);

--- a/src/test/test_print.cpp
+++ b/src/test/test_print.cpp
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MIT
 #include "catch.hpp"
 
-#include <filesystem>
 #include <fstream>
 #include <regex>
 #include <string>
@@ -33,7 +32,6 @@ void verify_printed_string(const std::string file)
     std::variant<InstructionSeq, std::string> prog_or_error = unmarshal(raw_prog);
     REQUIRE(std::holds_alternative<InstructionSeq>(prog_or_error));
     auto& prog = std::get<InstructionSeq>(prog_or_error);
-    std::string current_directory = std::filesystem::current_path().generic_string();
     print(prog, generated_output, {});
     std::ifstream input(std::string(TEST_ASM_FILE_DIRECTORY) + file + std::string(".asm"));
     REQUIRE(input);
@@ -45,7 +43,6 @@ void verify_printed_string(const std::string file)
         expected_output += line;
         expected_output += "\n";
     }
-    output = std::regex_replace(output, std::regex(current_directory), ".");
     REQUIRE(expected_output == output);
 }
 


### PR DESCRIPTION
Parse BTF section of ELF file (if present).
Add btf_line_info to each instruction.
Update "print" to include line number and source.

Resolves: #301
Resolves: #303 
Depends on: https://github.com/vbpf/ebpf-samples/pull/23

Signed-off-by: Alan Jowett <alanjo@microsoft.com>