### PR TITLE
Add stack variable assignment tests

### DIFF
--- a/src/test/test_yaml.cpp
+++ b/src/test/test_yaml.cpp
@@ -11,6 +11,7 @@
     TEST_CASE("YAML suite: " path, "[yaml]") { \
         foreach_suite(path, [&](const TestCase& test_case){ \
             std::optional<Failure> failure = run_yaml_test_case(test_case); \
+            if (failure) std::cout << "test case: " << test_case.name << "\n"; \
             if (failure) std::cout << "unseen inv: " << failure->invariant.unseen << "\n"; \
             if (failure) std::cout << "unexpected inv: " << failure->invariant.unexpected << "\n";           \
             REQUIRE(!failure); \

--- a/test-data/single-instruction-assignment.yaml
+++ b/test-data/single-instruction-assignment.yaml
@@ -51,3 +51,49 @@ code:
 post:
   - r1.type=number
   - r1.value=0
+---
+test-case: stack assign immediate
+
+pre: ["r10.type=stack", "r10.offset=512"]
+
+code:
+  <start>: |
+    *(u64 *)(r10 - 8) = 0
+
+post:
+  - r10.type=stack
+  - r10.offset=512
+  - s[504...511].value=0
+---
+test-case: stack assign number register
+
+pre: ["r10.type=stack", "r10.offset=512", "r1.type=number", "r1.value=0"]
+
+code:
+  <start>: |
+    *(u64 *)(r10 - 8) = r1
+
+post:
+  - r1.type=number
+  - r1.value=0
+  - r10.type=stack
+  - r10.offset=512
+  - s[504...511].value=0
+---
+test-case: stack assign packet register
+
+pre: ["r10.type=stack", "r10.offset=512", "r1.type=packet", "r1.offset=0"]
+
+code:
+  <start>: |
+    *(u64 *)(r10 - 8) = r1
+
+post:
+  - r1.type=packet
+  - r1.offset=0
+  - r1.value=s[504...511].value
+  - r1.region_size=s[504...511].region_size
+  - r10.type=stack
+  - r10.offset=512
+  - s[504...511].type=packet
+  - s[504...511].offset=0


### PR DESCRIPTION
This PR adds a couple of stack variable assignment YAML tests.
It also adds the test case name to the test output if a test fails.

Currently all these tests pass, though the output looks suspect.
In case they are bugs, this PR at least provides an easy repro.

Signed-off-by: Dave Thaler <dthaler@microsoft.com>