### PR TITLE
Add stack numeric bytes info in YAML tests

### DIFF
--- a/src/crab/array_domain.cpp
+++ b/src/crab/array_domain.cpp
@@ -667,5 +667,4 @@ array_domain_t array_domain_t::narrow(const array_domain_t& other) const {
 std::ostream& operator<<(std::ostream& o, const array_domain_t& dom) {
     return o << dom.num_bytes;
 }
-
 } // namespace crab::domains

--- a/src/crab/array_domain.cpp
+++ b/src/crab/array_domain.cpp
@@ -628,6 +628,8 @@ bool array_domain_t::is_bottom() const { return num_bytes.is_bottom(); }
 
 bool array_domain_t::is_top() const { return num_bytes.is_top(); }
 
+string_invariant array_domain_t::to_set() const { return num_bytes.to_set(); }
+
 bool array_domain_t::operator<=(const array_domain_t& other) const { return num_bytes <= other.num_bytes; }
 
 bool array_domain_t::operator==(const array_domain_t& other) const {
@@ -665,4 +667,5 @@ array_domain_t array_domain_t::narrow(const array_domain_t& other) const {
 std::ostream& operator<<(std::ostream& o, const array_domain_t& dom) {
     return o << dom.num_bytes;
 }
+
 } // namespace crab::domains

--- a/src/crab/array_domain.hpp
+++ b/src/crab/array_domain.hpp
@@ -83,6 +83,8 @@ class array_domain_t final {
 
     // Perform array stores over an array segment
     void store_numbers(NumAbsDomain& inv, variable_t _idx, variable_t _width);
+
+    void initialize_numbers(int lb, int width) { num_bytes.reset(lb, width); }
 };
 
 }

--- a/src/crab/array_domain.hpp
+++ b/src/crab/array_domain.hpp
@@ -64,6 +64,7 @@ class array_domain_t final {
     array_domain_t narrow(const array_domain_t& other) const;
 
     friend std::ostream& operator<<(std::ostream& o, const array_domain_t& dom);
+    [[nodiscard]] string_invariant to_set() const;
 
     bool all_num(NumAbsDomain& inv, const linear_expression_t& lb, const linear_expression_t& ub);
 

--- a/src/crab/bitset_domain.cpp
+++ b/src/crab/bitset_domain.cpp
@@ -25,3 +25,32 @@ std::ostream& operator<<(std::ostream& o, const bitset_domain_t& b) {
     o << "}";
     return o;
 }
+
+string_invariant bitset_domain_t::to_set() const
+{
+    if (this->is_bottom()) {
+        return string_invariant::bottom();
+    }
+    if (this->is_top()) {
+        return string_invariant::top();
+    }
+
+    std::set<std::string> result;
+    bool first = true;
+    for (int i = -EBPF_STACK_SIZE; i < 0; i++) {
+        if (non_numerical_bytes[EBPF_STACK_SIZE + i])
+            continue;
+        first = false;
+        std::string value = "s[" + std::to_string(EBPF_STACK_SIZE + i);
+        int j = i + 1;
+        for (; j < 0; j++)
+            if (non_numerical_bytes[EBPF_STACK_SIZE + j])
+                break;
+        if (j > i + 1)
+            value += "..." + std::to_string(EBPF_STACK_SIZE + j - 1);
+        value += "].type=number";
+        result.insert(value);
+        i = j;
+    }
+    return string_invariant{result};
+}

--- a/src/crab/bitset_domain.hpp
+++ b/src/crab/bitset_domain.hpp
@@ -4,6 +4,7 @@
 #include <cassert>
 #include <bitset>
 
+#include "string_constraints.hpp"
 #include "spec_type_descriptors.hpp" // for EBPF_STACK_SIZE
 
 class bitset_domain_t final {
@@ -23,6 +24,8 @@ class bitset_domain_t final {
     [[nodiscard]] bool is_top() const { return non_numerical_bytes.all(); }
 
     [[nodiscard]] bool is_bottom() const { return false; }
+
+    [[nodiscard]] string_invariant to_set() const;
 
     bool operator<=(const bitset_domain_t& other) const {
         return (non_numerical_bytes | other.non_numerical_bytes) == other.non_numerical_bytes;

--- a/src/crab/ebpf_domain.cpp
+++ b/src/crab/ebpf_domain.cpp
@@ -1304,7 +1304,7 @@ void ebpf_domain_t::operator()(const Bin& bin) {
 }
 
 string_invariant ebpf_domain_t::to_set() {
-    return this->m_inv.to_set();
+    return this->m_inv.to_set() + this->stack.to_set();
 }
 
 std::ostream& operator<<(std::ostream& o, const ebpf_domain_t& dom) {

--- a/src/crab/ebpf_domain.cpp
+++ b/src/crab/ebpf_domain.cpp
@@ -1333,12 +1333,18 @@ void ebpf_domain_t::initialize_packet(ebpf_domain_t& inv) {
     }
 }
 
-ebpf_domain_t ebpf_domain_t::from_constraints(const std::vector<linear_constraint_t>& csts) {
-    // TODO: handle type constraints separately
+ebpf_domain_t ebpf_domain_t::from_constraints(const std::set<std::string>& constraints) {
     ebpf_domain_t inv;
-    for (const auto& cst: csts) {
+    auto numeric_ranges = std::vector<crab::interval_t>();
+    for (const auto& cst : parse_linear_constraints(constraints, numeric_ranges)) {
         inv += cst;
     }
+    for (const crab::interval_t& range : numeric_ranges) {
+        int start = (int)range.lb().number().value();
+        int width = 1 + (int)(range.ub() - range.lb()).number().value();
+        inv.stack.initialize_numbers(start, width);
+    }
+    // TODO: handle other stack type constraints
     return inv;
 }
 

--- a/src/crab/ebpf_domain.hpp
+++ b/src/crab/ebpf_domain.hpp
@@ -44,7 +44,7 @@ class ebpf_domain_t final {
     int get_instruction_count_upper_bound();
     static ebpf_domain_t setup_entry(bool check_termination);
 
-    static ebpf_domain_t from_constraints(const std::vector<linear_constraint_t>& csts);
+    static ebpf_domain_t from_constraints(const std::set<std::string>& constraints);
     string_invariant to_set();
 
     // abstract transformers

--- a/src/crab/var_factory.cpp
+++ b/src/crab/var_factory.cpp
@@ -85,7 +85,7 @@ std::vector<variable_t> variable_t::get_type_variables() {
     }
     return res;
 }
-bool variable_t::is_in_stack() {
+bool variable_t::is_in_stack() const {
     return this->name()[0] == 's';
 }
 } // end namespace crab

--- a/src/crab/variable.hpp
+++ b/src/crab/variable.hpp
@@ -60,7 +60,7 @@ class variable_t final {
     static variable_t meta_offset();
     static variable_t packet_size();
     static variable_t instruction_count();
-    bool is_in_stack();
+    [[nodiscard]] bool is_in_stack() const;
 
     struct Hasher {
         std::size_t operator()(const variable_t& v) const { return v.hash(); }

--- a/src/crab_verifier.cpp
+++ b/src/crab_verifier.cpp
@@ -187,7 +187,7 @@ ebpf_analyze_program_for_test(std::ostream& os, const InstructionSeq& prog, cons
                               bool no_simplify, bool check_termination) {
     ebpf_domain_t entry_inv = entry_invariant.is_bottom()
         ? ebpf_domain_t::bottom()
-        : ebpf_domain_t::from_constraints(parse_linear_constraints(entry_invariant.value()));
+        : ebpf_domain_t::from_constraints(entry_invariant.value());
     global_program_info = info;
     cfg_t cfg = prepare_cfg(prog, info, !no_simplify, false);
     auto [pre_invariants, post_invariants] = crab::run_forward_analyzer(cfg, entry_inv, check_termination);

--- a/src/ebpf_yaml.cpp
+++ b/src/ebpf_yaml.cpp
@@ -60,7 +60,7 @@ ebpf_platform_t g_platform_test = {
     .get_map_type = ebpf_get_map_type
 };
 
-static EbpfProgramType make_progran_type(const string& name, ebpf_context_descriptor_t* context_descriptor) {
+static EbpfProgramType make_program_type(const string& name, ebpf_context_descriptor_t* context_descriptor) {
     return EbpfProgramType{
         .name=name,
         .context_descriptor=context_descriptor,
@@ -198,7 +198,7 @@ static Diff<T> make_diff(const T& actual, const T& expected) {
 
 std::optional<Failure> run_yaml_test_case(const TestCase& test_case) {
     ebpf_context_descriptor_t context_descriptor{0, -1, -1, -1};
-    EbpfProgramType program_type = make_progran_type(test_case.name, &context_descriptor);
+    EbpfProgramType program_type = make_program_type(test_case.name, &context_descriptor);
 
     program_info info{&g_platform_test, {}, program_type};
 

--- a/src/string_constraints.cpp
+++ b/src/string_constraints.cpp
@@ -120,6 +120,18 @@ string_invariant string_invariant::operator-(const string_invariant& b) const {
     return res;
 }
 
+// return a+b, taking account potential optional-none
+string_invariant string_invariant::operator+(const string_invariant& b) const {
+    if (this->is_bottom())
+        return b;
+    string_invariant res = *this;
+    for (const std::string& cst : b.value()) {
+        if (res.is_bottom() || !res.contains(cst))
+            res.maybe_inv->insert(cst);
+    }
+    return res;
+}
+
 std::ostream& operator<<(std::ostream& o, const string_invariant& inv) {
     if (inv.is_bottom()) {
         return o << "_|_";

--- a/src/string_constraints.hpp
+++ b/src/string_constraints.hpp
@@ -32,6 +32,7 @@ struct string_invariant {
     }
 
     string_invariant operator-(const string_invariant& b) const;
+    string_invariant operator+(const string_invariant& b) const;
 
     bool operator==(const string_invariant& other) const { return maybe_inv == other.maybe_inv; }
 

--- a/src/string_constraints.hpp
+++ b/src/string_constraints.hpp
@@ -8,6 +8,7 @@
 #include <string>
 #include <vector>
 
+#include "crab/interval.hpp"
 #include "crab/linear_constraint.hpp"
 
 struct string_invariant {
@@ -43,4 +44,4 @@ struct string_invariant {
     friend std::ostream& operator<<(std::ostream&, const string_invariant& inv);
 };
 
-std::vector<linear_constraint_t> parse_linear_constraints(const std::set<std::string>& constraints);
+std::vector<linear_constraint_t> parse_linear_constraints(const std::set<std::string>& constraints, std::vector<crab::interval_t>& numeric_ranges);

--- a/test-data/single-instruction-assignment.yaml
+++ b/test-data/single-instruction-assignment.yaml
@@ -99,3 +99,36 @@ post:
   - r10.offset=512
   - s[504...511].type=packet
   - s[504...511].offset=0
+---
+test-case: stack extend numeric range
+
+pre: ["r10.type=stack", "r10.offset=512", "s[500...507].type=number"]
+
+code:
+  <start>: |
+    *(u64 *)(r10 - 8) = 0
+
+post:
+  - r10.type=stack
+  - r10.offset=512
+  - s[500...511].type=number
+  - s[504...511].value=0
+---
+test-case: stack narrow numeric range
+
+pre: ["r10.type=stack", "r10.offset=512", "r1.type=packet", "r1.offset=0", "s[500...507].type=number"]
+
+code:
+  <start>: |
+    *(u64 *)(r10 - 8) = r1
+
+post:
+  - r1.type=packet
+  - r1.offset=0
+  - r1.value=s[504...511].value
+  - r1.region_size=s[504...511].region_size
+  - r10.type=stack
+  - r10.offset=512
+  - s[500...503].type=number
+  - s[504...511].type=packet
+  - s[504...511].offset=0

--- a/test-data/single-instruction-assignment.yaml
+++ b/test-data/single-instruction-assignment.yaml
@@ -63,6 +63,7 @@ code:
 post:
   - r10.type=stack
   - r10.offset=512
+  - s[504...511].type=number
   - s[504...511].value=0
 ---
 test-case: stack assign number register
@@ -78,6 +79,7 @@ post:
   - r1.value=0
   - r10.type=stack
   - r10.offset=512
+  - s[504...511].type=number
   - s[504...511].value=0
 ---
 test-case: stack assign packet register


### PR DESCRIPTION
For consistency with s[a..b].type=packet etc invariants, this uses
the same string syntax for stack numeric ranges even though they're stored differently

Signed-off-by: Dave Thaler <dthaler@microsoft.com>