### PR TITLE
More int32 support

### DIFF
--- a/src/asm_ostream.cpp
+++ b/src/asm_ostream.cpp
@@ -185,12 +185,14 @@ struct InstructionPrinterVisitor {
 
     void operator()(LoadMapFd const& b) { os_ << b.dst << " = map_fd " << b.mapfd; }
 
+    // llvm-objdump uses "w<number>" for 32-bit operations and "r<number>" for 64-bit operations.
+    // We use the same convention here for consistency.
+    static std::string reg_name(Reg const& a, bool is64) { return ((is64) ? "r" : "w") + std::to_string(a.v); }
+
     void operator()(Bin const& b) {
-        os_ << b.dst << " " << b.op << "= " << b.v;
+        os_ << reg_name(b.dst, b.is64) << " " << b.op << "= " << b.v;
         if (b.lddw)
             os_ << " ll";
-        if (!b.is64)
-            os_ << " & 0xFFFFFFFF";
     }
 
     void operator()(Un const& b) {

--- a/test-data/jump.yaml
+++ b/test-data/jump.yaml
@@ -340,3 +340,26 @@ post:
 
 messages:
   - "7: Upper bound must be at most packet_size (valid_access(r1.offset-8, width=8))"
+---
+test-case: 32-bit compare
+
+pre: ["r4.type=number", "r4.value=-22"]
+
+code:
+  <start>: |
+    if w4 != 0 goto <good>
+    r0 = 1 ; this should never happen
+  <good>: |
+    r0 = 0
+    goto <out>
+  <out>: |
+    exit
+
+post:
+  - r0.type=number
+  - r0.value=0
+  - r4.type=number
+  - r4.value=-22
+
+messages:
+  - "0:1: Code is unreachable after 0:1"

--- a/test-data/single-instruction-assignment.yaml
+++ b/test-data/single-instruction-assignment.yaml
@@ -7,7 +7,7 @@ pre: []
 
 code:
   <start>: |
-    r1 = 0
+    w1 = 0
 
 post:
   - r1.type=number


### PR DESCRIPTION
llvm-objdump uses "w1" instead of "r1" (for register 1 for example)
for 32-bit operations.  This PR follows that precedent for consistency.

This is another piece of issue #243

Signed-off-by: Dave Thaler <dthaler@microsoft.com>