### PR TITLE
Ignore whitespace at the end of lines in test_print.cpp

### DIFF
--- a/src/crab/ebpf_domain.cpp
+++ b/src/crab/ebpf_domain.cpp
@@ -1226,7 +1226,6 @@ void ebpf_domain_t::do_mem_store(const Mem& b, Type val_type, Value val_value,
     if (m_inv.is_bottom())
         return;
     using namespace crab::dsl_syntax;
-    auto mem_reg = reg_pack(b.access.basereg);
     int width = b.access.width;
     int offset = b.access.offset;
     if (b.access.basereg.v == R10_STACK_POINTER) {


### PR DESCRIPTION
Also remove unused variable.

Signed-off-by: Elazar Gershuni <elazarg@gmail.com>