### PR TITLE
Add codecov.yml to control codecov.io behavior

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,14 @@
+# Copyright (c) Prevail Verifier contributors.
+# SPDX-License-Identifier: MIT
+
+codecov:
+  notify:
+    wait_for_ci: yes
+    after_n_builds: 2 # (CPP Code Coverage) * (Debug, Release)
+comment:
+    after_n_builds: 2 # (CPP Code Coverage) * (Debug, Release)
+coverage:
+  status:
+    project:
+      default:
+        threshold: 0.5%


### PR DESCRIPTION
Codecov.io uses a file called codecov.yml to control various behavior. 

Add an initial version of this file with reasonable defaults.

Signed-off-by: Alan Jowett <alanjo@microsoft.com>