### PR TITLE
Exclude external when computing code coverage numbers

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Generate code coverage report
         run: |
           cd build
-          gcovr -r .. --cobertura ../ebpf-verifier.xml --gcov-ignore-parse-errors
+          gcovr -r .. -e ../external/ --cobertura ../ebpf-verifier.xml --gcov-ignore-parse-errors
 
       - name: Upload Report to Codecov
         uses: codecov/codecov-action@e3c560433a6cc60aec8812599b7844a7b4fa0d71


### PR DESCRIPTION
Code coverage numbers currently include data from the catch2 helper library, which dilutes the code coverage numbers.

This change tells gcovr to exclude files under external/ folder.

Signed-off-by: Alan Jowett <alanjo@microsoft.com>