### PR TITLE
Add option to read_elf from stream

### DIFF
--- a/src/asm_files.hpp
+++ b/src/asm_files.hpp
@@ -11,6 +11,7 @@
 
 std::vector<raw_program> read_raw(std::string path, program_info info);
 std::vector<raw_program> read_elf(const std::string& path, const std::string& section, const ebpf_verifier_options_t* options, const ebpf_platform_t* platform);
+std::vector<raw_program> read_elf(std::istream& input_stream, const std::string& path, const std::string& section, const ebpf_verifier_options_t* options, const ebpf_platform_t* platform);
 
 void write_binary_file(std::string path, const char* data, size_t size);
 


### PR DESCRIPTION
There is a need to be able to validate an ELF file from an alternative stream, such as a memory stream or an fd. The simplest option is to expose the ability from ELFIO::elfio to parse an ELF from a stream instead of a file path.

Signed-off-by: Alan Jowett <alanjo@microsoft.com>