### PR TITLE
Add YAML tests for calling helper functions

### DIFF
--- a/src/asm_parse.cpp
+++ b/src/asm_parse.cpp
@@ -9,6 +9,8 @@
 #include <boost/lexical_cast.hpp>
 
 #include "asm_parse.hpp"
+#include "asm_unmarshal.hpp"
+#include "platform.hpp"
 
 using std::regex;
 using std::regex_match;
@@ -104,7 +106,7 @@ Instruction parse_instruction(const std::string& line, const std::map<std::strin
     }
     if (regex_match(text, m, regex("call " FUNC))) {
         int func = boost::lexical_cast<int>(m[1]);
-        return Call{.func = func};
+        return make_call(func, g_ebpf_platform_linux);
     }
     if (regex_match(text, m, regex(REG OPASSIGN REG))) {
         return Bin{.op = str_to_binop.at(m[2]), .dst = reg(m[1]), .v = reg(m[3]), .is64 = true, .lddw = false};

--- a/src/asm_unmarshal.cpp
+++ b/src/asm_unmarshal.cpp
@@ -461,3 +461,10 @@ std::variant<InstructionSeq, std::string> unmarshal(const raw_program& raw_prog)
     vector<vector<string>> notes;
     return unmarshal(raw_prog, notes);
 }
+
+Call make_call(int imm, const ebpf_platform_t& platform)
+{
+    vector<vector<string>> notes;
+    program_info info{.platform = &platform};
+    return Unmarshaller{notes, info}.makeCall(imm);
+}

--- a/src/asm_unmarshal.hpp
+++ b/src/asm_unmarshal.hpp
@@ -21,3 +21,4 @@
  */
 std::variant<InstructionSeq, std::string> unmarshal(const raw_program& raw_prog, std::vector<std::vector<std::string>>& notes);
 std::variant<InstructionSeq, std::string> unmarshal(const raw_program& raw_prog);
+Call make_call(int func, const ebpf_platform_t& platform);

--- a/src/ebpf_yaml.cpp
+++ b/src/ebpf_yaml.cpp
@@ -42,9 +42,9 @@ static void ebpf_parse_maps_section(vector<EbpfMapDescriptor>& map_descriptors, 
 static EbpfMapDescriptor test_map_descriptor = {
     .original_fd=0,
     .type=0,
-    .key_size=0,
-    .value_size=0,
-    .max_entries=0,
+    .key_size=sizeof(uint32_t),
+    .value_size=sizeof(uint32_t),
+    .max_entries=4,
     .inner_map_fd=0
 };
 

--- a/src/string_constraints.cpp
+++ b/src/string_constraints.cpp
@@ -57,7 +57,7 @@ static type_encoding_t string_to_type_encoding(const string& s) {
     static map<string, type_encoding_t> string_to_type{
         {string("uninit"), T_UNINIT},
         {string("map_fd_programs"), T_MAP_PROGRAMS},
-        {string("map"), T_MAP},
+        {string("map_fd"), T_MAP},
         {string("number"), T_NUM},
         {string("ctx"), T_CTX},
         {string("stack"), T_STACK},

--- a/src/test/test_yaml.cpp
+++ b/src/test/test_yaml.cpp
@@ -21,6 +21,7 @@
 
 YAML_CASE("test-data/assign.yaml")
 YAML_CASE("test-data/add.yaml")
+YAML_CASE("test-data/call.yaml")
 YAML_CASE("test-data/subtract.yaml")
 YAML_CASE("test-data/unop.yaml")
 YAML_CASE("test-data/jump.yaml")

--- a/test-data/call.yaml
+++ b/test-data/call.yaml
@@ -1,0 +1,177 @@
+# Copyright (c) Prevail Verifier contributors.
+# SPDX-License-Identifier: MIT
+---
+test-case: bpf_map_lookup_elem
+
+pre: ["r1.type=map_fd", "r1.map_fd=1",
+      "r2.type=stack", "r2.stack_offset=504",
+      "s[504...511].type=number"]
+
+code:
+  <start>: |
+    call 1; bpf_map_lookup_elem
+
+post:
+  - r0.type=shared
+  - r0.shared_offset=0
+  - r0.shared_region_size=4
+  - r0.value=[0, 2147418112]
+  - s[504...511].type=number
+---
+test-case: bpf_map_lookup_elem with non-numeric stack key
+
+pre: ["r1.type=map_fd", "r1.map_fd=1",
+      "r2.type=stack"]
+
+code:
+  <start>: |
+    call 1; bpf_map_lookup_elem
+
+post:
+  - r0.type=shared
+  - r0.shared_offset=0
+  - r0.shared_region_size=4
+  - r0.value=[0, 2147418112]
+
+messages:
+  - "0: Illegal map update with a non-numerical value [-oo-oo) (within stack(r2:key_size(r1)))"
+---
+test-case: bpf_map_update_elem with non-numeric stack value
+
+pre: ["r1.type=map_fd", "r1.map_fd=1",
+      "r2.type=stack", "r2.stack_offset=504",
+      "r3.type=stack", "r3.stack_offset=496",
+      "r4.type=number",
+      "s[504...511].type=number"]
+
+code:
+  <start>: |
+    call 2; bpf_map_update_elem
+
+post:
+  - r0.type=number
+  - s[504...511].type=number
+
+messages:
+  - "0: Illegal map update with a non-numerical value [496-500) (within stack(r3:value_size(r1)))"
+---
+test-case: bpf_map_update_elem with context value
+
+pre: ["r1.type=map_fd", "r1.map_fd=1",
+      "r2.type=stack", "r2.stack_offset=504",
+      "r3.type=ctx", "r3.ctx_offset=0",
+      "r4.type=number",
+      "s[504...511].type=number"]
+
+code:
+  <start>: |
+    call 2; bpf_map_update_elem
+
+post:
+  - r0.type=number
+  - s[504...511].type=number
+
+messages:
+  - "0:  (r3.type in {stack, packet})"
+  - "0: Only stack or packet can be used as a parameter (within stack(r3:value_size(r1)))"
+---
+test-case: bpf_ringbuf_output with numeric stack value
+
+pre: ["r1.type=map_fd", "r1.map_fd=1",
+      "r2.type=stack", "r2.stack_offset=504",
+      "r3.type=number", "r3.value=8",
+      "r4.type=number",
+      "s[504...511].type=number"]
+
+code:
+  <start>: |
+    call 130; bpf_ringbuf_output
+
+post:
+  - r0.type=number
+  - s[504...511].type=number
+---
+test-case: bpf_ringbuf_output with non-numeric stack value
+
+pre: ["r1.type=map_fd", "r1.map_fd=1",
+      "r2.type=stack", "r2.stack_offset=504",
+      "r3.type=number", "r3.value=8",
+      "r4.type=number"]
+
+code:
+  <start>: |
+    call 130; bpf_ringbuf_output
+
+post:
+  - r0.type=number
+
+# The above snippet currently succeeds, but ought to fail with the message below.
+# This is fixed in PR #336.
+#
+#messages:
+#  - "0: Stack content is not numeric (valid_access(r2.offset, width=r3) for read)"
+---
+test-case: bpf_ringbuf_output with context value
+
+pre: ["r1.type=map_fd", "r1.map_fd=1",
+      "r2.type=ctx", "r2.ctx_offset=0",
+      "r3.type=number", "r3.value=8",
+      "r4.type=number",
+      "s[504...511].type=number"]
+
+code:
+  <start>: |
+    call 130; bpf_ringbuf_output
+
+post:
+  - r0.type=number
+  - s[504...511].type=number
+
+messages:
+  - "0:  (r2.type in {stack, packet, shared})"
+---
+test-case: bpf_get_stack
+
+pre: ["r1.type=ctx", "r1.ctx_offset=0",
+      "r2.type=stack", "r2.stack_offset=504",
+      "r3.type=number", "r3.value=8",
+      "r4.type=number"]
+
+code:
+  <start>: |
+    call 67; bpf_get_stack
+
+post:
+  - r0.type=number
+  - s[504...511].type=number
+---
+test-case: bpf_get_stack overwriting ctx
+
+pre: ["r1.type=ctx", "r1.ctx_offset=0",
+      "r2.type=ctx", "r2.ctx_offset=0",
+      "r3.type=number", "r3.value=8",
+      "r4.type=number"]
+
+code:
+  <start>: |
+    call 67; bpf_get_stack
+
+post:
+  - r0.type=number
+
+messages:
+  - "0:  (r2.type in {stack, packet, shared})"
+---
+test-case: bpf_get_stack writing into shared memory
+
+pre: ["r1.type=ctx", "r1.ctx_offset=0",
+      "r2.type=shared", "r2.shared_offset=0", "r2.shared_region_size=64", "r2.value=[1, 2147418112]",
+      "r3.type=number", "r3.value=64",
+      "r4.type=number"]
+
+code:
+  <start>: |
+    call 67; bpf_get_stack, doesn't this leak pointers into the shared memory?
+
+post:
+  - r0.type=number


### PR DESCRIPTION
Add a number of YAML test cases that use the call instruction to test helper function prototype handling.
One of the test cases illustrates the problem that PR #336 fixes.

The last test case in the YAML file is also interesting.  Other code paths enforce that only numbers can be written to shared memory, but the last test shows one way to get non-numeric values written into shared memory today.   I suspect that's another bug.

Signed-off-by: Dave Thaler <dthaler@microsoft.com>