### PR TITLE
Switch codecoverage to use coverals.io coveralls.io

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - name: Install dependencies
         run: |
-          sudo apt install libboost-dev libyaml-cpp-dev
+          sudo apt install libboost-dev libyaml-cpp-dev lcov
           pip install gcovr
 
       - uses: actions/checkout@v3
@@ -33,7 +33,7 @@ jobs:
       - name: Build
         run: |
           mkdir build
-          cmake -B build -DCMAKE_BUILD_TYPE=${{env.BUILD_CONFIGURATION}} -DCMAKE_CXX_FLAGS="--coverage -g -O0"
+          cmake -B build -DCMAKE_BUILD_TYPE=${{env.BUILD_CONFIGURATION}} -DCMAKE_CXX_FLAGS="--coverage -fprofile-arcs -ftest-coverage -g"
           cmake --build build -j $(nproc)
 
       - name: Run unit tests
@@ -42,7 +42,9 @@ jobs:
       - name: Generate code coverage report
         run: |
           cd build
-          gcovr -r .. -e ../external/ --cobertura ../ebpf-verifier.xml --gcov-ignore-parse-errors
+          gcovr -r .. -e '../external/.*' -e '../src/test/.*' --cobertura ../ebpf-verifier.xml --gcov-ignore-parse-errors --exclude-unreachable-branches
+          mkdir ../coverage
+          lcov --capture --directory . --output-file ../coverage/lcov.info
 
       - name: Upload Report to Codecov
         uses: codecov/codecov-action@81cd2dc8148241f03f5839d295e000b8f761e378
@@ -50,3 +52,20 @@ jobs:
           files: ebpf-verifier.xml
           fail_ci_if_error: true
           functionalities: fix
+
+      - name: Coveralls Parallel
+        uses: coverallsapp/github-action@master
+        with:
+          github-token: ${{ secrets.github_token }}
+          flag-name: run-${{ matrix.configurations }}
+          parallel: true
+
+  finish:
+    needs: build_ubuntu
+    runs-on: ubuntu-20.04
+    steps:
+    - name: Coveralls Finished
+      uses: coverallsapp/github-action@master
+      with:
+        github-token: ${{ secrets.github_token }}
+        parallel-finished: true

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ CMakeSettings.json
 cmake-build-debug/
 cmake-build-release/
 cmake-build-sanitize/
+coverage/


### PR DESCRIPTION
Resolves: #339

Codecov.io incorrectly displays code coverage based on gcovr. Switching to coverals.io, which appears to more clearly show the correct results.

See https://coveralls.io/builds/49250468 as an example.

Signed-off-by: Alan Jowett <alanjo@microsoft.com>