### PR TITLE
Gracefully handle malformed ELF file with no .symtab section

### DIFF
--- a/src/asm_files.cpp
+++ b/src/asm_files.cpp
@@ -111,7 +111,7 @@ vector<raw_program> read_elf(std::istream& input_stream, const std::string& path
     program_info info{platform};
     std::set<ELFIO::Elf_Half> map_section_indices;
 
-    auto symbol_section = reader.sections["symtab"];
+    auto symbol_section = reader.sections[".symtab"];
     if (!symbol_section) {
         throw std::runtime_error(string("No symbol section found in ELF file ") + path);
     }


### PR DESCRIPTION
Verifier crashed (rather than throwing an exception that could be caught by try/catch)
if handed an ELF file with no .symtab section.  Found via fuzz testing.

Signed-off-by: Dave Thaler <dthaler@microsoft.com>