### PR TITLE
Return error on invalid LDDW instead of parsing it incorrectly

### DIFF
--- a/src/asm_unmarshal.cpp
+++ b/src/asm_unmarshal.cpp
@@ -248,7 +248,7 @@ struct Unmarshaller {
 
     auto makeLddw(ebpf_inst inst, int32_t next_imm, const vector<ebpf_inst>& insts, pc_t pc) -> Instruction {
         if (pc >= insts.size() - 1)
-            note("incomplete LDDW");
+            throw InvalidInstruction(pc, "incomplete LDDW");
         if (inst.src > 1 || inst.dst > R10_STACK_POINTER || inst.offset != 0)
             note("LDDW uses reserved fields");
 

--- a/src/test/test_verify.cpp
+++ b/src/test/test_verify.cpp
@@ -29,6 +29,7 @@ FAIL_LOAD_ELF("build", "badrelo.o", ".text")
 
 // Some intentional unmarshal failures
 FAIL_UNMARSHAL("build", "wronghelper.o", "xdp")
+FAIL_UNMARSHAL("invalid", "invalid-lddw.o", ".text")
 
 #define VERIFY_SECTION(dirname, filename, sectionname, options, pass) \
     do { \


### PR DESCRIPTION
And potentially reading past end of buffer if the invalid LDDW is at the end.

Signed-off-by: Dave Thaler <dthaler@microsoft.com>