### PR TITLE
Reject ELF files with zero length map section

### DIFF
--- a/src/asm_files.cpp
+++ b/src/asm_files.cpp
@@ -79,7 +79,7 @@ static size_t parse_map_sections(const ebpf_verifier_options_t* options, const e
 
         if (map_count > 0) {
             map_record_size = s->get_size() / map_count;
-            if (s->get_data() == nullptr) {
+            if ((s->get_data() == nullptr) || (s->get_size() == 0)) {
                 throw std::runtime_error(std::string("bad maps section"));
             }
             if (s->get_size() % map_record_size != 0) {


### PR DESCRIPTION
ELFIO can return ELF sections of zero length, but with get_data() != nullptr.

This triggers a division by zero when computing the count of maps.

Resolves: #359 

Signed-off-by: Alan Jowett <alan.jowett@microsoft.com>