### PR TITLE
Throw rather than exiting on crab errors

### DIFF
--- a/src/crab/bitset_domain.hpp
+++ b/src/crab/bitset_domain.hpp
@@ -63,6 +63,9 @@ class bitset_domain_t final {
         bool only_num = true;
         bool only_non_num = true;
         for (int j = 0; j < width; j++) {
+            if (lb + j >= non_numerical_bytes.size()) {
+                throw std::runtime_error("bitset index out of range");
+            }
             bool b = non_numerical_bytes[lb + j];
             only_num &= !b;
             only_non_num &= b;

--- a/src/crab_utils/debug.hpp
+++ b/src/crab_utils/debug.hpp
@@ -47,7 +47,7 @@ inline void ___print___(std::ostream& os, ArgTypes... args) {
     do {                                    \
         std::ostringstream os;              \
         os << "CRAB ERROR: ";               \
-        ___print___(os, __VA_ARGS__);       \
+        crab::___print___(os, __VA_ARGS__); \
         os << "\n";                         \
         throw std::runtime_error(os.str()); \
     } while (0)


### PR DESCRIPTION
Currently when an ELF file is malformed such that a crab error is hit, the entire process exits.
This PR fixes that to instead throw a runtime exception that can be gracefully caught by the verifier code like other parse errors already are.

Also fix a crash on indexing out of range, now converted to throwing gracefully.

Signed-off-by: Dave Thaler <dthaler@microsoft.com>