### PR TITLE
Throw on bad jump instead of continuing to parse

### DIFF
--- a/src/asm_unmarshal.cpp
+++ b/src/asm_unmarshal.cpp
@@ -350,9 +350,9 @@ struct Unmarshaller {
         default: {
             pc_t new_pc = pc + 1 + inst.offset;
             if (new_pc >= insts.size())
-                note("jump out of bounds");
+                throw InvalidInstruction(pc, "jump out of bounds");
             else if (insts[new_pc].opcode == 0)
-                note("jump to middle of lddw");
+                throw InvalidInstruction(pc, "jump to middle of lddw");
 
             auto cond = inst.opcode == INST_OP_JA ? std::optional<Condition>{}
                                                   : Condition{


### PR DESCRIPTION
Immediately fail unmarshaling if jumping to an invalid address.
This fixes a bug where it would continue parsing and have invalid results.

Signed-off-by: Dave Thaler <dthaler@microsoft.com>