### PR TITLE
Fixes for modulo and division by zero

### DIFF
--- a/src/asm_ostream.cpp
+++ b/src/asm_ostream.cpp
@@ -174,7 +174,7 @@ std::ostream& operator<<(std::ostream& os, Addable const& a) {
     return os << TypeConstraint{a.ptr, TypeGroup::pointer} << " -> " << TypeConstraint{a.num, TypeGroup::number};
 }
 
-std::ostream& operator<<(std::ostream& os, NonZeroNumber const& a) {
+std::ostream& operator<<(std::ostream& os, ValidDivisor const& a) {
     return os << a.reg << " != 0";
 }
 

--- a/src/asm_ostream.cpp
+++ b/src/asm_ostream.cpp
@@ -174,6 +174,10 @@ std::ostream& operator<<(std::ostream& os, Addable const& a) {
     return os << TypeConstraint{a.ptr, TypeGroup::pointer} << " -> " << TypeConstraint{a.num, TypeGroup::number};
 }
 
+std::ostream& operator<<(std::ostream& os, NonZeroNumber const& a) {
+    return os << a.reg << " != 0";
+}
+
 std::ostream& operator<<(std::ostream& os, TypeConstraint const& tc) {
     string types = to_string(tc.types);
     string cmp_op = types[0] == '{' ? "in" : "==";

--- a/src/asm_syntax.hpp
+++ b/src/asm_syntax.hpp
@@ -258,7 +258,7 @@ struct Addable {
 };
 
 // Condition check whether a register contains a non-zero number.
-struct NonZeroNumber {
+struct ValidDivisor {
     Reg reg;
 };
 
@@ -300,7 +300,7 @@ struct ZeroCtxOffset {
 };
 
 using AssertionConstraint =
-    std::variant<Comparable, Addable, NonZeroNumber, ValidAccess, ValidStore, ValidSize, ValidMapKeyValue, TypeConstraint, ZeroCtxOffset>;
+    std::variant<Comparable, Addable, ValidDivisor, ValidAccess, ValidStore, ValidSize, ValidMapKeyValue, TypeConstraint, ZeroCtxOffset>;
 
 struct Assert {
     AssertionConstraint cst;
@@ -373,7 +373,7 @@ DECLARE_EQ2(TypeConstraint, reg, types)
 DECLARE_EQ2(ValidSize, reg, can_be_zero)
 DECLARE_EQ2(Comparable, r1, r2)
 DECLARE_EQ2(Addable, ptr, num)
-DECLARE_EQ1(NonZeroNumber, reg)
+DECLARE_EQ1(ValidDivisor, reg)
 DECLARE_EQ2(ValidStore, mem, val)
 DECLARE_EQ5(ValidAccess, reg, offset, width, or_null, access_type)
 DECLARE_EQ3(ValidMapKeyValue, access_reg, map_fd_reg, key)

--- a/src/asm_syntax.hpp
+++ b/src/asm_syntax.hpp
@@ -257,6 +257,11 @@ struct Addable {
     Reg num;
 };
 
+// Condition check whether a register contains a non-zero number.
+struct NonZeroNumber {
+    Reg reg;
+};
+
 enum class AccessType {
     compare,
     read,  // Memory pointed to must be initialized.
@@ -295,7 +300,7 @@ struct ZeroCtxOffset {
 };
 
 using AssertionConstraint =
-    std::variant<Comparable, Addable, ValidAccess, ValidStore, ValidSize, ValidMapKeyValue, TypeConstraint, ZeroCtxOffset>;
+    std::variant<Comparable, Addable, NonZeroNumber, ValidAccess, ValidStore, ValidSize, ValidMapKeyValue, TypeConstraint, ZeroCtxOffset>;
 
 struct Assert {
     AssertionConstraint cst;
@@ -368,6 +373,7 @@ DECLARE_EQ2(TypeConstraint, reg, types)
 DECLARE_EQ2(ValidSize, reg, can_be_zero)
 DECLARE_EQ2(Comparable, r1, r2)
 DECLARE_EQ2(Addable, ptr, num)
+DECLARE_EQ1(NonZeroNumber, reg)
 DECLARE_EQ2(ValidStore, mem, val)
 DECLARE_EQ5(ValidAccess, reg, offset, width, or_null, access_type)
 DECLARE_EQ3(ValidMapKeyValue, access_reg, map_fd_reg, key)

--- a/src/asm_unmarshal.cpp
+++ b/src/asm_unmarshal.cpp
@@ -238,7 +238,7 @@ struct Unmarshaller {
                                              .v = getBinValue(inst),
                                              .is64 = (inst.opcode & INST_CLS_MASK) == INST_CLS_ALU64,
                                          };
-                                         if (op == Bin::Op::DIV || op == Bin::Op::MOD)
+                                         if (!thread_local_options.allow_division_by_zero && (op == Bin::Op::DIV || op == Bin::Op::MOD))
                                              if (std::holds_alternative<Imm>(res.v) && std::get<Imm>(res.v).v == 0)
                                                  note("division by zero");
                                          return res;

--- a/src/assertions.cpp
+++ b/src/assertions.cpp
@@ -206,6 +206,14 @@ class AssertExtractor {
                     Assert{TypeConstraint{ins.dst, TypeGroup::ptr_or_num}}
                 };
             }
+        case Bin::Op::DIV:
+        case Bin::Op::MOD:
+            if (std::holds_alternative<Reg>(ins.v)) {
+                auto src = reg(ins.v);
+                return {Assert{TypeConstraint{ins.dst, TypeGroup::number}}, Assert{NonZeroNumber{src}}};
+            } else {
+                return {Assert{TypeConstraint{ins.dst, TypeGroup::number}}};
+            }
         default:
             return { Assert{TypeConstraint{ins.dst, TypeGroup::number}} };
         }

--- a/src/assertions.cpp
+++ b/src/assertions.cpp
@@ -210,7 +210,7 @@ class AssertExtractor {
         case Bin::Op::MOD:
             if (std::holds_alternative<Reg>(ins.v)) {
                 auto src = reg(ins.v);
-                return {Assert{TypeConstraint{ins.dst, TypeGroup::number}}, Assert{NonZeroNumber{src}}};
+                return {Assert{TypeConstraint{ins.dst, TypeGroup::number}}, Assert{ValidDivisor{src}}};
             } else {
                 return {Assert{TypeConstraint{ins.dst, TypeGroup::number}}};
             }

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -12,5 +12,5 @@ const ebpf_verifier_options_t ebpf_verifier_default_options = {
     .mock_map_fds = true,
     .strict = false,
     .print_line_info = false,
-    .allow_division_by_zero = false,
+    .allow_division_by_zero = true,
 };

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -12,4 +12,5 @@ const ebpf_verifier_options_t ebpf_verifier_default_options = {
     .mock_map_fds = true,
     .strict = false,
     .print_line_info = false,
+    .allow_division_by_zero = false,
 };

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -16,6 +16,7 @@ struct ebpf_verifier_options_t {
     bool strict;
 
     bool print_line_info;
+    bool allow_division_by_zero;
 };
 
 struct ebpf_verifier_stats_t {

--- a/src/crab/ebpf_domain.cpp
+++ b/src/crab/ebpf_domain.cpp
@@ -717,12 +717,13 @@ void ebpf_domain_t::operator()(const Addable& s) {
         require(m_inv, linear_constraint_t::FALSE(), "Only numbers can be added to pointers");
 }
 
-void ebpf_domain_t::operator()(const NonZeroNumber& s) {
+void ebpf_domain_t::operator()(const ValidDivisor& s) {
     using namespace crab::dsl_syntax;
     auto reg = reg_pack(s.reg);
     if (!type_inv.implies_type(m_inv, type_is_pointer(reg), type_is_number(s.reg)))
         require(m_inv, linear_constraint_t::FALSE(), "Only numbers can be used as divisors");
-    require(m_inv, reg.value != 0, "Possible division by zero");
+    if (!thread_local_options.allow_division_by_zero)
+        require(m_inv, reg.value != 0, "Possible division by zero");
 }
 
 void ebpf_domain_t::operator()(const ValidStore& s) {

--- a/src/crab/ebpf_domain.cpp
+++ b/src/crab/ebpf_domain.cpp
@@ -717,6 +717,14 @@ void ebpf_domain_t::operator()(const Addable& s) {
         require(m_inv, linear_constraint_t::FALSE(), "Only numbers can be added to pointers");
 }
 
+void ebpf_domain_t::operator()(const NonZeroNumber& s) {
+    using namespace crab::dsl_syntax;
+    auto reg = reg_pack(s.reg);
+    if (!type_inv.implies_type(m_inv, type_is_pointer(reg), type_is_number(s.reg)))
+        require(m_inv, linear_constraint_t::FALSE(), "Only numbers can be used as divisors");
+    require(m_inv, reg.value != 0, "Possible division by zero");
+}
+
 void ebpf_domain_t::operator()(const ValidStore& s) {
     if (!type_inv.implies_type(m_inv, type_is_not_stack(reg_pack(s.mem)), type_is_number(s.val)))
         require(m_inv, linear_constraint_t::FALSE(), "Only numbers can be stored to externally-visible regions");

--- a/src/crab/ebpf_domain.hpp
+++ b/src/crab/ebpf_domain.hpp
@@ -65,6 +65,7 @@ class ebpf_domain_t final {
     void operator()(const LoadMapFd&);
     void operator()(const LockAdd&);
     void operator()(const Mem&);
+    void operator()(const NonZeroNumber&);
     void operator()(const Packet&);
     void operator()(const TypeConstraint&);
     void operator()(const Un&);

--- a/src/crab/ebpf_domain.hpp
+++ b/src/crab/ebpf_domain.hpp
@@ -65,7 +65,7 @@ class ebpf_domain_t final {
     void operator()(const LoadMapFd&);
     void operator()(const LockAdd&);
     void operator()(const Mem&);
-    void operator()(const NonZeroNumber&);
+    void operator()(const ValidDivisor&);
     void operator()(const Packet&);
     void operator()(const TypeConstraint&);
     void operator()(const Un&);

--- a/src/crab/interval.cpp
+++ b/src/crab/interval.cpp
@@ -19,15 +19,20 @@ interval_t interval_t::operator/(const interval_t& x) const {
                 return interval_t(_lb / bound_t{c}, _ub / bound_t{c});
             } else if (c < 0) {
                 return interval_t(_ub / bound_t{c}, _lb / bound_t{c});
+            } else {
+                // The eBPF ISA defines division by 0 as resulting in 0.
+                return interval_t(number_t(0));
             }
         }
         // Divisor is not a singleton
         using z_interval = interval_t;
         if (x[0]) {
+            // The divisor contains 0.
             z_interval l(x._lb, z_bound(-1));
             z_interval u(z_bound(1), x._ub);
-            return (operator/(l) | operator/(u));
+            return (operator/(l) | operator/(u) | z_interval(number_t(0)));
         } else if (operator[](0)) {
+            // The dividend contains 0.
             z_interval l(_lb, z_bound(-1));
             z_interval u(z_bound(1), _ub);
             return ((l / x) | (u / x) | z_interval(number_t(0)));
@@ -55,15 +60,22 @@ interval_t interval_t::SRem(const interval_t& x) const {
         number_t divisor = *x.singleton();
 
         if (divisor == 0) {
-            return bottom();
+            return interval_t(dividend);
         }
 
         return interval_t(dividend % divisor);
+    } else if (x[0]) {
+        // The divisor contains 0.
+        interval_t l(x._lb, z_bound(-1));
+        interval_t u(z_bound(1), x._ub);
+        return SRem(l) | SRem(u) | *this;
     } else if (x.ub().is_finite() && x.lb().is_finite()) {
+        number_t min_divisor = min(abs(*x.lb().number()), abs(*x.ub().number()));
         number_t max_divisor = max(abs(*x.lb().number()), abs(*x.ub().number()));
 
-        if (max_divisor == 0) {
-            return bottom();
+        if (ub() < min_divisor && -lb() < min_divisor) {
+            // The modulo operation won't change the destination register.
+            return *this;
         }
 
         if (lb() < 0) {
@@ -76,7 +88,8 @@ interval_t interval_t::SRem(const interval_t& x) const {
             return interval_t(0, max_divisor - 1);
         }
     } else {
-        return top();
+        // Divisor has infinite range, so result can be anything between the dividend and zero.
+        return *this | interval_t(number_t(0));
     }
 }
 

--- a/src/crab_verifier.cpp
+++ b/src/crab_verifier.cpp
@@ -199,15 +199,15 @@ static string_invariant_map to_string_invariant_map(crab::invariant_table_t& inv
 
 std::tuple<string_invariant_map, string_invariant_map>
 ebpf_analyze_program_for_test(std::ostream& os, const InstructionSeq& prog, const string_invariant& entry_invariant,
-                              const program_info& info,
-                              bool no_simplify, bool check_termination) {
+                              const program_info& info, const ebpf_verifier_options_t& options) {
+    thread_local_options = options;
     ebpf_domain_t entry_inv = entry_invariant.is_bottom()
         ? ebpf_domain_t::bottom()
         : ebpf_domain_t::from_constraints(entry_invariant.value());
     assert(!entry_inv.is_bottom());
     global_program_info = info;
-    cfg_t cfg = prepare_cfg(prog, info, !no_simplify, false);
-    auto [pre_invariants, post_invariants] = crab::run_forward_analyzer(cfg, entry_inv, check_termination);
+    cfg_t cfg = prepare_cfg(prog, info, !options.no_simplify, false);
+    auto [pre_invariants, post_invariants] = crab::run_forward_analyzer(cfg, entry_inv, options.check_termination);
     checks_db report = generate_report(cfg, pre_invariants, post_invariants);
     print_report(os, report, prog, false);
 

--- a/src/crab_verifier.hpp
+++ b/src/crab_verifier.hpp
@@ -25,8 +25,7 @@ ebpf_analyze_program_for_test(
     const InstructionSeq& prog,
     const string_invariant& entry_invariant,
     const program_info& info,
-    bool no_simplify,
-    bool check_termination);
+    const ebpf_verifier_options_t& options);
 
 int create_map_crab(const EbpfMapType& map_type, uint32_t key_size, uint32_t value_size, uint32_t max_entries, ebpf_verifier_options_t options);
 

--- a/src/ebpf_yaml.cpp
+++ b/src/ebpf_yaml.cpp
@@ -165,8 +165,8 @@ static ebpf_verifier_options_t raw_options_to_options(const std::set<string>& ra
     options.no_simplify = true;
 
     for (string name : raw_options) {
-        if (name == "allow_division_by_zero") {
-            options.allow_division_by_zero = true;
+        if (name == "!allow_division_by_zero") {
+            options.allow_division_by_zero = false;
         }
     }
     return options;

--- a/src/ebpf_yaml.cpp
+++ b/src/ebpf_yaml.cpp
@@ -93,6 +93,7 @@ static string_invariant read_invariant(const vector<string>& raw_invariant) {
 
 struct RawTestCase {
     string test_case;
+    std::set<string> options;
     vector<string> pre;
     vector<std::tuple<string, vector<string>>> raw_blocks;
     vector<string> post;
@@ -125,6 +126,7 @@ static std::set<string> as_set_empty_default(const YAML::Node& optional_node) {
 static RawTestCase parse_case(const YAML::Node& case_node) {
     return RawTestCase {
         .test_case = case_node["test-case"].as<string>(),
+        .options = as_set_empty_default(case_node["options"]),
         .pre = case_node["pre"].as<vector<string>>(),
         .raw_blocks = parse_code(case_node["code"]),
         .post = case_node["post"].as<vector<string>>(),
@@ -156,9 +158,24 @@ static InstructionSeq raw_cfg_to_instruction_seq(const vector<std::tuple<string,
     return res;
 }
 
+static ebpf_verifier_options_t raw_options_to_options(const std::set<string>& raw_options) {
+    ebpf_verifier_options_t options = ebpf_verifier_default_options;
+
+    // All YAML tests use no_simplify.
+    options.no_simplify = true;
+
+    for (string name : raw_options) {
+        if (name == "allow_division_by_zero") {
+            options.allow_division_by_zero = true;
+        }
+    }
+    return options;
+}
+
 static TestCase read_case(const RawTestCase& raw_case) {
     return TestCase{
         .name = raw_case.test_case,
+        .options = raw_options_to_options(raw_case.options),
         .assumed_pre_invariant = read_invariant(raw_case.pre),
         .instruction_seq = raw_cfg_to_instruction_seq(raw_case.raw_blocks),
         .expected_post_invariant = read_invariant(raw_case.post),
@@ -205,7 +222,7 @@ std::optional<Failure> run_yaml_test_case(const TestCase& test_case) {
     std::ostringstream ss;
     const auto& [pre_invs, post_invs] = ebpf_analyze_program_for_test(ss, test_case.instruction_seq,
                                                                       test_case.assumed_pre_invariant,
-                                                                      info, true, false);
+                                                                      info, test_case.options);
     std::set<string> actual_messages = extract_messages(ss.str());
 
     const auto& actual_last_invariant = pre_invs.at(label_t::exit);

--- a/src/ebpf_yaml.hpp
+++ b/src/ebpf_yaml.hpp
@@ -9,6 +9,7 @@
 
 struct TestCase {
     std::string name;
+    ebpf_verifier_options_t options;
     string_invariant assumed_pre_invariant;
     InstructionSeq instruction_seq;
     string_invariant expected_post_invariant;

--- a/src/main/check.cpp
+++ b/src/main/check.cpp
@@ -56,6 +56,8 @@ int main(int argc, char** argv) {
     app.add_flag("-f", ebpf_verifier_options.print_failures, "Print verifier's failure logs");
     app.add_flag("-s", ebpf_verifier_options.strict, "Apply additional checks that would cause runtime failures");
     app.add_flag("-v", verbose, "Print both invariants and failures");
+    bool no_division_by_zero = false;
+    app.add_flag("--no-division-by-zero", no_division_by_zero, "Do not allow division by zero");
     app.add_flag("--no-simplify", ebpf_verifier_options.no_simplify, "Do not simplify");
     app.add_flag("--line-info", ebpf_verifier_options.print_line_info, "Print line information");
 
@@ -69,6 +71,7 @@ int main(int argc, char** argv) {
     CLI11_PARSE(app, argc, argv);
     if (verbose)
         ebpf_verifier_options.print_invariants = ebpf_verifier_options.print_failures = true;
+    ebpf_verifier_options.allow_division_by_zero = !no_division_by_zero;
 
     // Main program
 

--- a/src/test/test_yaml.cpp
+++ b/src/test/test_yaml.cpp
@@ -22,6 +22,7 @@
 YAML_CASE("test-data/assign.yaml")
 YAML_CASE("test-data/add.yaml")
 YAML_CASE("test-data/call.yaml")
+YAML_CASE("test-data/divmod.yaml")
 YAML_CASE("test-data/subtract.yaml")
 YAML_CASE("test-data/unop.yaml")
 YAML_CASE("test-data/jump.yaml")

--- a/test-data/divmod.yaml
+++ b/test-data/divmod.yaml
@@ -81,6 +81,34 @@ post:
   - r2.type=number
   - r2.value=[-5, 5]
 ---
+test-case: non-zero divided by possibly zero register 2
+
+pre: ["r1.type=number", "r1.value=6", "r2.type=number", "r2.value=[-5, 0]"]
+
+code:
+  <start>: |
+    r1 /= r2  ; this could divide by 0
+
+post:
+  - r1.type=number
+  - r1.value=[-6, -1]
+  - r2.type=number
+  - r2.value=[-5, 0]
+---
+test-case: zero divided by possibly zero register 2
+
+pre: ["r1.type=number", "r1.value=0", "r2.type=number", "r2.value=[-5, 0]"]
+
+code:
+  <start>: |
+    r1 /= r2 ; this could divide by 0 but ok to set to 0
+
+post:
+  - r1.type=number
+  - r1.value=0
+  - r2.type=number
+  - r2.value=[-5, 0]
+---
 test-case: non-zero divided by undefined value register
 
 pre: ["r1.type=number", "r1.value=6", "r2.type=number"]
@@ -185,6 +213,34 @@ post:
   - r1.value=[0, 4]
   - r2.type=number
   - r2.value=[-5, 5]
+---
+test-case: non-zero modulo possibly zero register 2
+
+pre: ["r1.type=number", "r1.value=6", "r2.type=number", "r2.value=[-5, 0]"]
+
+code:
+  <start>: |
+    r1 %= r2 ; this could do modulo 0 so could set r1 = r2
+
+post:
+  - r1.type=number
+  - r1.value=[0, 4]
+  - r2.type=number
+  - r2.value=[-5, 0]
+---
+test-case: zero modulo possibly zero register 2
+
+pre: ["r1.type=number", "r1.value=0", "r2.type=number", "r2.value=[-5, 0]"]
+
+code:
+  <start>: |
+    r1 %= r2 ; this could do modulo 0 so could set r1 = r2
+
+post:
+  - r1.type=number
+  - r1.value=[0, 4]
+  - r2.type=number
+  - r2.value=[-5, 0]
 ---
 test-case: non-zero modulo undefined value register
 

--- a/test-data/divmod.yaml
+++ b/test-data/divmod.yaml
@@ -1,0 +1,211 @@
+# Copyright (c) Prevail Verifier contributors.
+# SPDX-License-Identifier: MIT
+---
+test-case: non-zero divided by zero immediate
+
+pre: ["r1.type=number", "r1.value=6"]
+
+code:
+  <start>: |
+    r1 /= 0
+
+post: []
+
+messages:
+  - "0: Code is unreachable after 0"
+---
+test-case: zero divided by zero immediate
+
+pre: ["r1.type=number", "r1.value=0"]
+
+code:
+  <start>: |
+    r1 /= 0
+
+post: []
+
+messages:
+  - "0: Code is unreachable after 0"
+---
+test-case: non-zero divided by zero register
+
+pre: ["r1.type=number", "r1.value=6", "r2.type=number", "r2.value=0"]
+
+code:
+  <start>: |
+    r1 /= r2
+
+post: []
+
+messages:
+  - "0: Code is unreachable after 0"
+---
+test-case: zero divided by zero register
+
+pre: ["r1.type=number", "r1.value=0", "r2.type=number", "r2.value=0"]
+
+code:
+  <start>: |
+    r1 /= r2
+
+post: []
+
+messages:
+  - "0: Code is unreachable after 0"
+---
+test-case: non-zero divided by possibly zero register
+
+pre: ["r1.type=number", "r1.value=6", "r2.type=number", "r2.value=[-5, 5]"]
+
+code:
+  <start>: |
+    r1 /= r2  ; this could divide by 0
+
+post:
+  - r1.type=number
+  - r1.value=[-6, 6]
+  - r2.type=number
+  - r2.value=[-5, 5]
+---
+test-case: zero divided by possibly zero register
+
+pre: ["r1.type=number", "r1.value=0", "r2.type=number", "r2.value=[-5, 5]"]
+
+code:
+  <start>: |
+    r1 /= r2 ; this could divide by 0 but ok to set to 0
+
+post:
+  - r1.type=number
+  - r1.value=0
+  - r2.type=number
+  - r2.value=[-5, 5]
+---
+test-case: non-zero divided by undefined value register
+
+pre: ["r1.type=number", "r1.value=6", "r2.type=number"]
+
+code:
+  <start>: |
+    r1 /= r2  ; this could divide by 0
+
+post:
+  - r1.type=number
+  - r2.type=number
+---
+test-case: zero divided by undefined value register
+
+pre: ["r1.type=number", "r1.value=0", "r2.type=number"]
+
+code:
+  <start>: |
+    r1 /= r2  ; this could divide by 0
+
+post:
+  - r1.type=number
+  - r1.value=0
+  - r2.type=number
+---
+test-case: non-zero modulo zero immediate
+
+pre: ["r1.type=number", "r1.value=6"]
+
+code:
+  <start>: |
+    r1 %= 0
+
+post: []
+
+messages:
+  - "0: Code is unreachable after 0"
+---
+test-case: zero modulo zero immediate
+
+pre: ["r1.type=number", "r1.value=0"]
+
+code:
+  <start>: |
+    r1 %= 0
+
+post: []
+
+messages:
+  - "0: Code is unreachable after 0"
+---
+test-case: non-zero modulo zero register
+
+pre: ["r1.type=number", "r1.value=6", "r2.type=number", "r2.value=0"]
+
+code:
+  <start>: |
+    r1 %= r2
+
+post: []
+
+messages:
+  - "0: Code is unreachable after 0"
+---
+test-case: zero modulo zero register
+
+pre: ["r1.type=number", "r1.value=0", "r2.type=number", "r2.value=0"]
+
+code:
+  <start>: |
+    r1 %= r2
+
+post: []
+
+messages:
+  - "0: Code is unreachable after 0"
+---
+test-case: non-zero modulo possibly zero register
+
+pre: ["r1.type=number", "r1.value=6", "r2.type=number", "r2.value=[-5, 5]"]
+
+code:
+  <start>: |
+    r1 %= r2 ; this could do modulo 0 so could set r1 = r2
+
+post:
+  - r1.type=number
+  - r1.value=[0, 4]
+  - r2.type=number
+  - r2.value=[-5, 5]
+---
+test-case: zero modulo possibly zero register
+
+pre: ["r1.type=number", "r1.value=0", "r2.type=number", "r2.value=[-5, 5]"]
+
+code:
+  <start>: |
+    r1 %= r2 ; this could do modulo 0 so could set r1 = r2
+
+post:
+  - r1.type=number
+  - r1.value=[0, 4]
+  - r2.type=number
+  - r2.value=[-5, 5]
+---
+test-case: non-zero modulo undefined value register
+
+pre: ["r1.type=number", "r1.value=6", "r2.type=number"]
+
+code:
+  <start>: |
+    r1 %= r2  ; this could be modulo 0
+
+post:
+  - r1.type=number
+  - r2.type=number
+---
+test-case: zero modulo undefined value register
+
+pre: ["r1.type=number", "r1.value=0", "r2.type=number"]
+
+code:
+  <start>: |
+    r1 %= r2  ; this could be modulo 0
+
+post:
+  - r1.type=number
+  - r2.type=number

--- a/test-data/divmod.yaml
+++ b/test-data/divmod.yaml
@@ -58,6 +58,22 @@ post:
 messages:
   - "0: Possible division by zero (r2 != 0)"
 ---
+test-case: non-zero divided by zero register without warning
+
+options: ["allow_division_by_zero"]
+
+pre: ["r1.type=number", "r1.value=6", "r2.type=number", "r2.value=0"]
+
+code:
+  <start>: |
+    r1 /= r2
+
+post:
+  - r1.type=number
+  - r1.value=0
+  - r2.type=number
+  - r2.value=0
+---
 test-case: zero divided by zero register
 
 pre: ["r1.type=number", "r1.value=0", "r2.type=number", "r2.value=0"]
@@ -214,6 +230,22 @@ post:
 
 messages:
   - "0: Possible division by zero (r2 != 0)"
+---
+test-case: non-zero modulo zero register without warning
+
+options: ["allow_division_by_zero"]
+
+pre: ["r1.type=number", "r1.value=-6", "r2.type=number", "r2.value=0"]
+
+code:
+  <start>: |
+    r1 %= r2
+
+post:
+  - r1.type=number
+  - r1.value=-6
+  - r2.type=number
+  - r2.value=0
 ---
 test-case: zero modulo zero register
 

--- a/test-data/divmod.yaml
+++ b/test-data/divmod.yaml
@@ -265,3 +265,39 @@ code:
 post:
   - r1.type=number
   - r2.type=number
+---
+test-case: negative modulo negative
+
+pre: ["r1.type=number", "r1.value=-13"]
+
+code:
+  <start>: |
+    r1 %= 3
+
+post:
+  - r1.type=number
+  - r1.value=-1
+---
+test-case: positive modulo negative
+
+pre: ["r1.type=number", "r1.value=13"]
+
+code:
+  <start>: |
+    r1 %= -3
+
+post:
+  - r1.type=number
+  - r1.value=1
+---
+test-case: negative modulo negative
+
+pre: ["r1.type=number", "r1.value=-13"]
+
+code:
+  <start>: |
+    r1 %= -3
+
+post:
+  - r1.type=number
+  - r1.value=-1

--- a/test-data/divmod.yaml
+++ b/test-data/divmod.yaml
@@ -301,3 +301,17 @@ code:
 post:
   - r1.type=number
   - r1.value=-1
+---
+test-case: smaller modulo larger
+
+pre: ["r1.type=number", "r1.value=6", "r2.type=number", "r2.value=[7, 10]"]
+
+code:
+  <start>: |
+    r1 %= r2
+
+post:
+  - r1.type=number
+  - r1.value=[0, 9]
+  - r2.type=number
+  - r2.value=[7, 10]

--- a/test-data/divmod.yaml
+++ b/test-data/divmod.yaml
@@ -1,6 +1,22 @@
 # Copyright (c) Prevail Verifier contributors.
 # SPDX-License-Identifier: MIT
 ---
+test-case: integer divided by non-integer
+
+pre: ["r1.type=number", "r1.value=6", "r2.value=1"]
+
+code:
+  <start>: |
+    r1 /= r2
+
+post:
+  - r1.type=number
+  - r1.value=6
+  - r2.value=1
+
+messages:
+  - "0: Only numbers can be used as divisors (r2 != 0)"
+---
 test-case: non-zero divided by zero immediate
 
 pre: ["r1.type=number", "r1.value=6"]
@@ -9,10 +25,9 @@ code:
   <start>: |
     r1 /= 0
 
-post: []
-
-messages:
-  - "0: Code is unreachable after 0"
+post:
+  - r1.type=number
+  - r1.value=0
 ---
 test-case: zero divided by zero immediate
 
@@ -22,10 +37,9 @@ code:
   <start>: |
     r1 /= 0
 
-post: []
-
-messages:
-  - "0: Code is unreachable after 0"
+post:
+  - r1.type=number
+  - r1.value=0
 ---
 test-case: non-zero divided by zero register
 
@@ -35,10 +49,14 @@ code:
   <start>: |
     r1 /= r2
 
-post: []
+post:
+  - r1.type=number
+  - r1.value=0
+  - r2.type=number
+  - r2.value=0
 
 messages:
-  - "0: Code is unreachable after 0"
+  - "0: Possible division by zero (r2 != 0)"
 ---
 test-case: zero divided by zero register
 
@@ -48,10 +66,14 @@ code:
   <start>: |
     r1 /= r2
 
-post: []
+post:
+  - r1.type=number
+  - r1.value=0
+  - r2.type=number
+  - r2.value=0
 
 messages:
-  - "0: Code is unreachable after 0"
+  - "0: Possible division by zero (r2 != 0)"
 ---
 test-case: non-zero divided by possibly zero register
 
@@ -66,6 +88,9 @@ post:
   - r1.value=[-6, 6]
   - r2.type=number
   - r2.value=[-5, 5]
+
+messages:
+  - "0: Possible division by zero (r2 != 0)"
 ---
 test-case: zero divided by possibly zero register
 
@@ -80,6 +105,9 @@ post:
   - r1.value=0
   - r2.type=number
   - r2.value=[-5, 5]
+
+messages:
+  - "0: Possible division by zero (r2 != 0)"
 ---
 test-case: non-zero divided by possibly zero register 2
 
@@ -91,9 +119,12 @@ code:
 
 post:
   - r1.type=number
-  - r1.value=[-6, -1]
+  - r1.value=[-6, 0]
   - r2.type=number
   - r2.value=[-5, 0]
+
+messages:
+  - "0: Possible division by zero (r2 != 0)"
 ---
 test-case: zero divided by possibly zero register 2
 
@@ -108,6 +139,9 @@ post:
   - r1.value=0
   - r2.type=number
   - r2.value=[-5, 0]
+
+messages:
+  - "0: Possible division by zero (r2 != 0)"
 ---
 test-case: non-zero divided by undefined value register
 
@@ -120,6 +154,9 @@ code:
 post:
   - r1.type=number
   - r2.type=number
+
+messages:
+  - "0: Possible division by zero (r2 != 0)"
 ---
 test-case: zero divided by undefined value register
 
@@ -133,19 +170,21 @@ post:
   - r1.type=number
   - r1.value=0
   - r2.type=number
+
+messages:
+  - "0: Possible division by zero (r2 != 0)"
 ---
 test-case: non-zero modulo zero immediate
 
-pre: ["r1.type=number", "r1.value=6"]
+pre: ["r1.type=number", "r1.value=-6"]
 
 code:
   <start>: |
     r1 %= 0
 
-post: []
-
-messages:
-  - "0: Code is unreachable after 0"
+post:
+  - r1.type=number
+  - r1.value=-6
 ---
 test-case: zero modulo zero immediate
 
@@ -155,23 +194,26 @@ code:
   <start>: |
     r1 %= 0
 
-post: []
-
-messages:
-  - "0: Code is unreachable after 0"
+post:
+  - r1.type=number
+  - r1.value=0
 ---
 test-case: non-zero modulo zero register
 
-pre: ["r1.type=number", "r1.value=6", "r2.type=number", "r2.value=0"]
+pre: ["r1.type=number", "r1.value=-6", "r2.type=number", "r2.value=0"]
 
 code:
   <start>: |
     r1 %= r2
 
-post: []
+post:
+  - r1.type=number
+  - r1.value=-6
+  - r2.type=number
+  - r2.value=0
 
 messages:
-  - "0: Code is unreachable after 0"
+  - "0: Possible division by zero (r2 != 0)"
 ---
 test-case: zero modulo zero register
 
@@ -181,10 +223,14 @@ code:
   <start>: |
     r1 %= r2
 
-post: []
+post:
+  - r1.type=number
+  - r1.value=0
+  - r2.type=number
+  - r2.value=0
 
 messages:
-  - "0: Code is unreachable after 0"
+  - "0: Possible division by zero (r2 != 0)"
 ---
 test-case: non-zero modulo possibly zero register
 
@@ -196,9 +242,12 @@ code:
 
 post:
   - r1.type=number
-  - r1.value=[0, 4]
+  - r1.value=[0, 6]
   - r2.type=number
   - r2.value=[-5, 5]
+
+messages:
+  - "0: Possible division by zero (r2 != 0)"
 ---
 test-case: zero modulo possibly zero register
 
@@ -210,9 +259,12 @@ code:
 
 post:
   - r1.type=number
-  - r1.value=[0, 4]
+  - r1.value=0
   - r2.type=number
   - r2.value=[-5, 5]
+
+messages:
+  - "0: Possible division by zero (r2 != 0)"
 ---
 test-case: non-zero modulo possibly zero register 2
 
@@ -224,9 +276,12 @@ code:
 
 post:
   - r1.type=number
-  - r1.value=[0, 4]
+  - r1.value=[0, 6]
   - r2.type=number
   - r2.value=[-5, 0]
+
+messages:
+  - "0: Possible division by zero (r2 != 0)"
 ---
 test-case: zero modulo possibly zero register 2
 
@@ -238,9 +293,12 @@ code:
 
 post:
   - r1.type=number
-  - r1.value=[0, 4]
+  - r1.value=0
   - r2.type=number
   - r2.value=[-5, 0]
+
+messages:
+  - "0: Possible division by zero (r2 != 0)"
 ---
 test-case: non-zero modulo undefined value register
 
@@ -252,7 +310,11 @@ code:
 
 post:
   - r1.type=number
+  - r1.value=[0, 6]
   - r2.type=number
+
+messages:
+  - "0: Possible division by zero (r2 != 0)"
 ---
 test-case: zero modulo undefined value register
 
@@ -264,9 +326,13 @@ code:
 
 post:
   - r1.type=number
+  - r1.value=0
   - r2.type=number
+
+messages:
+  - "0: Possible division by zero (r2 != 0)"
 ---
-test-case: negative modulo negative
+test-case: negative modulo positive
 
 pre: ["r1.type=number", "r1.value=-13"]
 
@@ -290,6 +356,20 @@ post:
   - r1.type=number
   - r1.value=1
 ---
+test-case: positive modulo negative range
+
+pre: ["r1.type=number", "r1.value=13", "r2.type=number", "r2.value=[-3, -2]"]
+
+code:
+  <start>: |
+    r1 %= -3
+
+post:
+  - r1.type=number
+  - r1.value=1
+  - r2.type=number
+  - r2.value=[-3, -2]
+---
 test-case: negative modulo negative
 
 pre: ["r1.type=number", "r1.value=-13"]
@@ -302,6 +382,20 @@ post:
   - r1.type=number
   - r1.value=-1
 ---
+test-case: negative modulo negative range
+
+pre: ["r1.type=number", "r1.value=-13", "r2.type=number", "r2.value=[-3, -2]"]
+
+code:
+  <start>: |
+    r1 %= -3
+
+post:
+  - r1.type=number
+  - r1.value=-1
+  - r2.type=number
+  - r2.value=[-3, -2]
+---
 test-case: smaller modulo larger
 
 pre: ["r1.type=number", "r1.value=6", "r2.type=number", "r2.value=[7, 10]"]
@@ -312,6 +406,6 @@ code:
 
 post:
   - r1.type=number
-  - r1.value=[0, 9]
+  - r1.value=6
   - r2.type=number
   - r2.value=[7, 10]

--- a/test-data/divmod.yaml
+++ b/test-data/divmod.yaml
@@ -45,6 +45,8 @@ test-case: non-zero divided by zero register
 
 pre: ["r1.type=number", "r1.value=6", "r2.type=number", "r2.value=0"]
 
+options: ["!allow_division_by_zero"]
+
 code:
   <start>: |
     r1 /= r2
@@ -59,8 +61,6 @@ messages:
   - "0: Possible division by zero (r2 != 0)"
 ---
 test-case: non-zero divided by zero register without warning
-
-options: ["allow_division_by_zero"]
 
 pre: ["r1.type=number", "r1.value=6", "r2.type=number", "r2.value=0"]
 
@@ -77,6 +77,8 @@ post:
 test-case: zero divided by zero register
 
 pre: ["r1.type=number", "r1.value=0", "r2.type=number", "r2.value=0"]
+
+options: ["!allow_division_by_zero"]
 
 code:
   <start>: |
@@ -95,6 +97,8 @@ test-case: non-zero divided by possibly zero register
 
 pre: ["r1.type=number", "r1.value=6", "r2.type=number", "r2.value=[-5, 5]"]
 
+options: ["!allow_division_by_zero"]
+
 code:
   <start>: |
     r1 /= r2  ; this could divide by 0
@@ -111,6 +115,8 @@ messages:
 test-case: zero divided by possibly zero register
 
 pre: ["r1.type=number", "r1.value=0", "r2.type=number", "r2.value=[-5, 5]"]
+
+options: ["!allow_division_by_zero"]
 
 code:
   <start>: |
@@ -129,6 +135,8 @@ test-case: non-zero divided by possibly zero register 2
 
 pre: ["r1.type=number", "r1.value=6", "r2.type=number", "r2.value=[-5, 0]"]
 
+options: ["!allow_division_by_zero"]
+
 code:
   <start>: |
     r1 /= r2  ; this could divide by 0
@@ -143,6 +151,8 @@ messages:
   - "0: Possible division by zero (r2 != 0)"
 ---
 test-case: zero divided by possibly zero register 2
+
+options: ["!allow_division_by_zero"]
 
 pre: ["r1.type=number", "r1.value=0", "r2.type=number", "r2.value=[-5, 0]"]
 
@@ -161,6 +171,8 @@ messages:
 ---
 test-case: non-zero divided by undefined value register
 
+options: ["!allow_division_by_zero"]
+
 pre: ["r1.type=number", "r1.value=6", "r2.type=number"]
 
 code:
@@ -175,6 +187,8 @@ messages:
   - "0: Possible division by zero (r2 != 0)"
 ---
 test-case: zero divided by undefined value register
+
+options: ["!allow_division_by_zero"]
 
 pre: ["r1.type=number", "r1.value=0", "r2.type=number"]
 
@@ -216,6 +230,8 @@ post:
 ---
 test-case: non-zero modulo zero register
 
+options: ["!allow_division_by_zero"]
+
 pre: ["r1.type=number", "r1.value=-6", "r2.type=number", "r2.value=0"]
 
 code:
@@ -233,8 +249,6 @@ messages:
 ---
 test-case: non-zero modulo zero register without warning
 
-options: ["allow_division_by_zero"]
-
 pre: ["r1.type=number", "r1.value=-6", "r2.type=number", "r2.value=0"]
 
 code:
@@ -248,6 +262,8 @@ post:
   - r2.value=0
 ---
 test-case: zero modulo zero register
+
+options: ["!allow_division_by_zero"]
 
 pre: ["r1.type=number", "r1.value=0", "r2.type=number", "r2.value=0"]
 
@@ -266,6 +282,8 @@ messages:
 ---
 test-case: non-zero modulo possibly zero register
 
+options: ["!allow_division_by_zero"]
+
 pre: ["r1.type=number", "r1.value=6", "r2.type=number", "r2.value=[-5, 5]"]
 
 code:
@@ -282,6 +300,8 @@ messages:
   - "0: Possible division by zero (r2 != 0)"
 ---
 test-case: zero modulo possibly zero register
+
+options: ["!allow_division_by_zero"]
 
 pre: ["r1.type=number", "r1.value=0", "r2.type=number", "r2.value=[-5, 5]"]
 
@@ -300,6 +320,8 @@ messages:
 ---
 test-case: non-zero modulo possibly zero register 2
 
+options: ["!allow_division_by_zero"]
+
 pre: ["r1.type=number", "r1.value=6", "r2.type=number", "r2.value=[-5, 0]"]
 
 code:
@@ -316,6 +338,8 @@ messages:
   - "0: Possible division by zero (r2 != 0)"
 ---
 test-case: zero modulo possibly zero register 2
+
+options: ["!allow_division_by_zero"]
 
 pre: ["r1.type=number", "r1.value=0", "r2.type=number", "r2.value=[-5, 0]"]
 
@@ -334,6 +358,8 @@ messages:
 ---
 test-case: non-zero modulo undefined value register
 
+options: ["!allow_division_by_zero"]
+
 pre: ["r1.type=number", "r1.value=6", "r2.type=number"]
 
 code:
@@ -349,6 +375,8 @@ messages:
   - "0: Possible division by zero (r2 != 0)"
 ---
 test-case: zero modulo undefined value register
+
+options: ["!allow_division_by_zero"]
 
 pre: ["r1.type=number", "r1.value=0", "r2.type=number"]
 


### PR DESCRIPTION
PR #381 added tests that show the current (buggy) behavior, which I recommend merging first and then rebasing this one.

This PR changes those tests and add fixes.
Since it is up to the runtime whether to support modulo/division by 0 or not (Linux does, ubpf and rbpf do not currently), I have added verifier support for those that do, when the allow_division_by_zero verifier option is set.
Modulo/division by 0 as immediate is still checked in asm_unmarshal.cpp which is bypassed by the YAML tests, but that path also uses the allow_division_by_zero verifier option.

The default is now to allow division by zero since a bunch of the ebpf-samples actually can do division by zero.  E.g. compare

`check ebpf-samples/linux/xdp_redirect_cpu_kern.o xdp_cpu_map5_lb_hash_ip_pairs`

which passes, with

`check -v --no-division-by-zero ebpf-samples/linux/xdp_redirect_cpu_kern.o xdp_cpu_map5_lb_hash_ip_pairs`

which fails with

```
...
144: Possible division by zero (r2 != 0)

0,0.872,7352
```




Fixes #382 