### PR TITLE
Add tests around modifying r10

### DIFF
--- a/src/test/test_marshal.cpp
+++ b/src/test/test_marshal.cpp
@@ -46,6 +46,10 @@ TEST_CASE("disasm_marshal", "[disasm][marshal]") {
                 compare_marshal_unmarshal(
                     Bin{.op = Bin::Op::MOV, .dst = Reg{1}, .v = Imm{2}, .is64 = true, .lddw = true}, true);
             }
+            SECTION("r10") {
+                // BUG: This ought to fail but doesn't.
+                compare_marshal_unmarshal(Bin{.op = Bin::Op::ADD, .dst = Reg{10}, .v = Imm{4}, .is64 = true});
+            }
         }
     }
 
@@ -163,6 +167,14 @@ TEST_CASE("disasm_marshal_Mem", "[disasm][marshal]") {
             access.width = w;
             compare_marshal_unmarshal(Mem{.access = access, .value = Reg{3}, .is_load = true});
         }
+    }
+    SECTION("Load R10") {
+        Deref access;
+        access.basereg = Reg{0};
+        access.offset = 0;
+        access.width = 8;
+        // BUG: This ought to fail but doesn't.
+        compare_marshal_unmarshal(Mem{.access = access, .value = Reg{10}, .is_load = true});
     }
     SECTION("Store Register") {
         for (int w : ws) {


### PR DESCRIPTION
In Linux, r10 is [documented ](https://www.kernel.org/doc/Documentation/bpf/instruction-set.rst) to be read-only. This PR adds tests to see what the impact is. of modifying it.

Increasing it and then writing into the space will correctly result in an error message because stack_numeric_size will be unset, as shown in the first test case added.

Decreasing it however will result in the wrong stack data being tracked in the verifier, as shown in the 2nd test case added.  This is a bug.  This should be fixed either by disallowing modifications to r10, or else correctly tracking the offset.

Signed-off-by: Dave Thaler <dthaler@microsoft.com>