### PR TITLE
Disallow JMP32 with BPF_JA and BPF_EXIT

### DIFF
--- a/src/ebpf_vm_isa.hpp
+++ b/src/ebpf_vm_isa.hpp
@@ -32,6 +32,9 @@ enum {
     INST_SRC_IMM = 0x00,
     INST_SRC_REG = 0x08,
 
+    INST_END_LE = 0x00,
+    INST_END_BE = 0x08,
+
     INST_SIZE_W = 0x00,
     INST_SIZE_H = 0x08,
     INST_SIZE_B = 0x10,

--- a/src/test/test_marshal.cpp
+++ b/src/test/test_marshal.cpp
@@ -210,8 +210,8 @@ TEST_CASE("fail unmarshal", "[disasm][marshal]") {
                          "0: Bad register\n");
     check_unmarshal_fail(ebpf_inst{.opcode = ((INST_MEM << 5) | INST_SIZE_W | INST_CLS_LD)},
                          "0: plain LD\n");
-    check_unmarshal_fail(ebpf_inst{.opcode = 0xd4, .dst = 1, .imm = 8}, "0: invalid endian immediate\n");
-    check_unmarshal_fail(ebpf_inst{.opcode = 0xdc, .dst = 1, .imm = 8}, "0: invalid endian immediate\n");
+    check_unmarshal_fail(ebpf_inst{.opcode = INST_ALU_OP_END | INST_END_LE | INST_CLS_ALU, .dst = 1, .imm = 8}, "0: invalid endian immediate\n");
+    check_unmarshal_fail(ebpf_inst{.opcode = INST_ALU_OP_END | INST_END_BE | INST_CLS_ALU, .dst = 1, .imm = 8}, "0: invalid endian immediate\n");
     check_unmarshal_fail(ebpf_inst{}, "0: Bad instruction\n");
     check_unmarshal_fail(ebpf_inst{.opcode = INST_CLS_LDX}, "0: Bad instruction\n");
     check_unmarshal_fail(ebpf_inst{.opcode = ((INST_XADD << 5) | INST_CLS_ST)}, "0: Bad instruction\n");
@@ -235,4 +235,6 @@ TEST_CASE("fail unmarshal", "[disasm][marshal]") {
                          "0: Bad instruction\n");
     check_unmarshal_fail(ebpf_inst{.opcode = (INST_MEM_UNUSED << 5) | INST_SIZE_W | INST_CLS_LDX, .imm = 8},
                          "0: Bad instruction\n");
+    check_unmarshal_fail(ebpf_inst{.opcode = INST_CLS_JMP32}, "0: Bad instruction\n");
+    check_unmarshal_fail(ebpf_inst{.opcode = 0x90 | INST_CLS_JMP32}, "0: Bad instruction\n");
 }


### PR DESCRIPTION
Per specification

Also add defines for byte endian operations instead of just using numeric values for big/little endian

Signed-off-by: Dave Thaler <dthaler@microsoft.com>