### PR TITLE
Allow 64-bit numbers in YAML invariants

### DIFF
--- a/src/crab/dsl_syntax.hpp
+++ b/src/crab/dsl_syntax.hpp
@@ -39,11 +39,15 @@ inline linear_expression_t operator+(variable_t x, const linear_expression_t& e)
 
 inline linear_expression_t operator-(variable_t x, const number_t& n) { return linear_expression_t(x).operator-(n); }
 
+inline linear_expression_t operator-(variable_t x, int64_t n) { return linear_expression_t(x).operator-(n); }
+
 inline linear_expression_t operator-(variable_t x, int n) { return linear_expression_t(x).operator-(n); }
 
 inline linear_expression_t operator-(number_t n, variable_t x) {
     return linear_expression_t(number_t(-1), x).operator+(n);
 }
+
+inline linear_expression_t operator-(int64_t n, variable_t x) { return linear_expression_t(number_t(-1), x).operator+(n); }
 
 inline linear_expression_t operator-(int n, variable_t x) { return linear_expression_t(number_t(-1), x).operator+(n); }
 
@@ -93,11 +97,19 @@ inline linear_constraint_t operator<=(variable_t x, int n) {
     return linear_constraint_t(x - n, constraint_kind_t::LESS_THAN_OR_EQUALS_ZERO);
 }
 
+inline linear_constraint_t operator<=(variable_t x, int64_t n) {
+    return linear_constraint_t(x - n, constraint_kind_t::LESS_THAN_OR_EQUALS_ZERO);
+}
+
 inline linear_constraint_t operator<=(number_t n, variable_t x) {
     return linear_constraint_t(n - x, constraint_kind_t::LESS_THAN_OR_EQUALS_ZERO);
 }
 
 inline linear_constraint_t operator<=(int n, variable_t x) {
+    return linear_constraint_t(n - x, constraint_kind_t::LESS_THAN_OR_EQUALS_ZERO);
+}
+
+inline linear_constraint_t operator<=(int64_t n, variable_t x) {
     return linear_constraint_t(n - x, constraint_kind_t::LESS_THAN_OR_EQUALS_ZERO);
 }
 
@@ -280,6 +292,10 @@ inline linear_constraint_t operator==(variable_t x, const linear_expression_t& e
 }
 
 inline linear_constraint_t operator==(variable_t x, const number_t& n) {
+    return linear_constraint_t(x - n, constraint_kind_t::EQUALS_ZERO);
+}
+
+inline linear_constraint_t operator==(variable_t x, int64_t n) {
     return linear_constraint_t(x - n, constraint_kind_t::EQUALS_ZERO);
 }
 

--- a/src/string_constraints.cpp
+++ b/src/string_constraints.cpp
@@ -45,9 +45,9 @@ static crab::data_kind_t regkind(const string& s) {
     throw std::runtime_error(string() + "Bad kind: " + s);
 }
 
-static long number(const string& s) {
+static int64_t number(const string& s) {
     try {
-        return (long)boost::lexical_cast<int64_t>(s);
+        return boost::lexical_cast<int64_t>(s);
     } catch (const boost::bad_lexical_cast&) {
         throw std::invalid_argument("number too large");
     }
@@ -113,8 +113,8 @@ std::vector<linear_constraint_t> parse_linear_constraints(const std::set<string>
             if (type == type_encoding_t::T_NUM) {
                 numeric_ranges.push_back(crab::interval_t(number(m[1]), number(m[2])));
             } else {
-                long lb = number(m[1]);
-                long ub = number(m[2]);
+                int64_t lb = number(m[1]);
+                int64_t ub = number(m[2]);
                 variable_t d = variable_t::cell_var(data_kind_t::types, lb, ub - lb + 1);
                 res.push_back(d == type);
             }

--- a/test-data/add.yaml
+++ b/test-data/add.yaml
@@ -1,6 +1,30 @@
 # Copyright (c) Prevail Verifier contributors.
 # SPDX-License-Identifier: MIT
 ---
+test-case: add immediate to large singleton number
+
+pre: ["r0.type=number", "r0.value=2147483647"]
+
+code:
+  <start>: |
+    r0 += 2 ; make sure value does not become a negative 64 bit number
+
+post:
+  - r0.type=number
+  - r0.value=2147483649
+---
+test-case: add immediate to large number range
+
+pre: ["r0.type=number", "r0.value=[2147483645, 2147483647]"]
+
+code:
+  <start>: |
+    r0 += 4 ; make sure value does not become a negative 64 bit number
+
+post:
+  - r0.type=number
+  - r0.value=[2147483649, 2147483651]
+---
 test-case: add immediate to unknown number
 
 pre: ["r1.type=number"]

--- a/test-data/subtract.yaml
+++ b/test-data/subtract.yaml
@@ -1,6 +1,30 @@
 # Copyright (c) Prevail Verifier contributors.
 # SPDX-License-Identifier: MIT
 ---
+test-case: subtract immediate from large singleton number
+
+pre: ["r0.type=number", "r0.value=2147483649"]
+
+code:
+  <start>: |
+    r0 -= 2 ; make sure value does not become a negative 64 bit number
+
+post:
+  - r0.type=number
+  - r0.value=2147483647
+---
+test-case: subtract immediate from large number range
+
+pre: ["r0.type=number", "r0.value=[2147483649, 2147483651]"]
+
+code:
+  <start>: |
+    r0 -= 4 ; make sure value does not become a negative 64 bit number
+
+post:
+  - r0.type=number
+  - r0.value=[2147483645, 2147483647]
+---
 test-case: subtract a register from itself
 
 pre: ["r1.type=number"]


### PR DESCRIPTION
This is a prerequisite for testing JMP32 support

Signed-off-by: Dave Thaler <dthaler@microsoft.com>