### PR TITLE
Disallow JMP32 until support is added

### DIFF
--- a/src/asm_unmarshal.cpp
+++ b/src/asm_unmarshal.cpp
@@ -359,6 +359,8 @@ struct Unmarshaller {
             if ((inst.opcode & INST_CLS_MASK) != INST_CLS_JMP)
                 throw InvalidInstruction(pc, "Bad instruction");
         default: {
+            if ((inst.opcode & INST_CLS_MASK) != INST_CLS_JMP)
+                throw InvalidInstruction(pc, "JMP32 is not yet supported");
             pc_t new_pc = pc + 1 + inst.offset;
             if (new_pc >= insts.size())
                 throw InvalidInstruction(pc, "jump out of bounds");

--- a/src/test/test_marshal.cpp
+++ b/src/test/test_marshal.cpp
@@ -237,4 +237,5 @@ TEST_CASE("fail unmarshal", "[disasm][marshal]") {
                          "0: Bad instruction\n");
     check_unmarshal_fail(ebpf_inst{.opcode = INST_CLS_JMP32}, "0: Bad instruction\n");
     check_unmarshal_fail(ebpf_inst{.opcode = 0x90 | INST_CLS_JMP32}, "0: Bad instruction\n");
+    check_unmarshal_fail(ebpf_inst{.opcode = 0x10 | INST_CLS_JMP32}, "0: JMP32 is not yet supported\n");
 }

--- a/src/test/test_verify.cpp
+++ b/src/test/test_verify.cpp
@@ -167,10 +167,9 @@ TEST_SECTION("cilium", "bpf_overlay.o", "from-overlay")
 
 TEST_SECTION("cilium", "bpf_xdp.o", "from-netdev")
 
-TEST_SECTION("cilium", "bpf_xdp_dsr_linux.o", "from-netdev")
+TEST_SECTION("cilium", "bpf_xdp_dsr_linux_v1_1.o", "from-netdev")
 TEST_SECTION("cilium", "bpf_xdp_dsr_linux.o", "2/1")
 
-TEST_SECTION("cilium", "bpf_xdp_snat_linux.o", "from-netdev")
 TEST_SECTION("cilium", "bpf_xdp_snat_linux.o", "2/1")
 
 TEST_SECTION("linux", "cpustat_kern.o", "tracepoint/power/cpu_frequency")
@@ -507,6 +506,10 @@ TEST_SECTION_FAIL("cilium", "bpf_xdp_snat_linux.o", "2/17")
 TEST_SECTION_FAIL("cilium", "bpf_xdp_snat_linux.o", "2/18")
 TEST_SECTION_FAIL("cilium", "bpf_xdp_snat_linux.o", "2/19")
 TEST_SECTION_FAIL("cilium", "bpf_xdp_snat_linux.o", "2/24")
+
+// Unsupported: JMP32
+TEST_SECTION_FAIL("cilium", "bpf_xdp_dsr_linux.o", "from-netdev")
+TEST_SECTION_FAIL("cilium", "bpf_xdp_snat_linux.o", "from-netdev")
 
 // False positive, unknown cause
 TEST_SECTION_FAIL("linux", "test_map_in_map_kern.o", "kprobe/sys_connect")


### PR DESCRIPTION
Previously JMP32 would pass verification and be incorrectly treated like JMP.  This change causes verification to fail until correct support is added.

See issue #243 for more discussion.

Signed-off-by: Dave Thaler <dthaler@microsoft.com>