### PR TITLE
Update c++ standard for .vcxproj to std:c++20

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,9 +22,8 @@ elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
     exec_program(${NUGET} ARGS install "Boost" -Version 1.78.0 -ExcludeVersion -OutputDirectory ${CMAKE_BINARY_DIR}/packages)
   endif()
   set(Boost_INCLUDE_DIRS ${CMAKE_BINARY_DIR}/packages/boost/lib/native/include)
-  # MSVC's C++17 standard option doesn't actually support all the C++17
-  # features we use, but its "latest" option does.  However, cmake can't
-  # deal with that here, so we set it below.
+  # MSVC's "std:c++20" option is the current standard that supports all the C++17
+  # features we use. However, cmake can't deal with that here, so we set it below.
 
   set(EXTERNAL_INSTALL_LOCATION ${CMAKE_BINARY_DIR}/packages/yaml-cpp)
   include(ExternalProject)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,7 +77,7 @@ if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" OR
 
   set(SANITIZE_FLAGS -fsanitize=address -O1 -fno-omit-frame-pointer)
 elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /std:c++latest")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /std:c++20")
 endif ()
 
 add_library(ebpfverifier ${LIB_SRC})


### PR DESCRIPTION
Closes #404

This PR is propaedeutic to porting the `/microsoft/ebpf-for-windows` solution to build on Visual Studio 2022, and proposes to change the `CMakeLists.txt` script to instantiate the related Visual Studio .`vcxproj` project using the `std:c++20` standard. This would also be a necessary update in moving away from draft standards, as we get close to releasing eBPF for Windows.
