### PR TITLE
Update CI/CD build script and docs for VS2022 port

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,7 @@ jobs:
     strategy:
       matrix:
         configurations: [Debug, Release]
-    runs-on: windows-2019
+    runs-on: windows-2022
     env:
       # Configuration type to build.  For documentation on how build matrices work, see
       # https://docs.github.com/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,9 +22,8 @@ elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
     exec_program(${NUGET} ARGS install "Boost" -Version 1.78.0 -ExcludeVersion -OutputDirectory ${CMAKE_BINARY_DIR}/packages)
   endif()
   set(Boost_INCLUDE_DIRS ${CMAKE_BINARY_DIR}/packages/boost/lib/native/include)
-  # MSVC's C++17 standard option doesn't actually support all the C++17
-  # features we use, but its "latest" option does.  However, cmake can't
-  # deal with that here, so we set it below.
+  # MSVC's "std:c++20" option is the current standard that supports all the C++17
+  # features we use. However, cmake can't deal with that here, so we set it below.
 
   set(EXTERNAL_INSTALL_LOCATION ${CMAKE_BINARY_DIR}/packages/yaml-cpp)
   include(ExternalProject)
@@ -77,7 +76,7 @@ if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" OR
 
   set(SANITIZE_FLAGS -fsanitize=address -O1 -fno-omit-frame-pointer)
 elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /std:c++latest")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /std:c++20")
 endif ()
 
 add_library(ebpfverifier ${LIB_SRC})

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ pip3 install matplotlib   # for plotting the graphs
 ### Dependencies from vanilla Windows
 
 * Install [git](https://git-scm.com/download/win)
-* Install [Visual Studio Build Tools 2019](https://aka.ms/vs/16/release/vs_buildtools.exe) and choose the "C++ build tools" workload (Visual Studio Build Tools 2019 has support for CMake Version 3.15).
+* Install [Visual Studio Build Tools 2022](https://aka.ms/vs/17/release/vs_buildtools.exe) and choose the "C++ build tools" workload (Visual Studio Build Tools 2022 has support for CMake Version 3.21).
 * Install [nuget.exe](https://www.nuget.org/downloads)
 
 ### Installation


### PR DESCRIPTION
Closes #406

This PR updates the build script and README.md links, for porting the `microsoft\ebpf-for-windows` solution to VS2022.