### PR TITLE
Address compiler warnings

### DIFF
--- a/src/asm_parse.cpp
+++ b/src/asm_parse.cpp
@@ -169,6 +169,7 @@ Instruction parse_instruction(const std::string& line, const std::map<std::strin
     return Undefined{0};
 }
 
+[[maybe_unused]]
 static InstructionSeq parse_program(std::istream& is) {
     std::string line;
     int lineno = 0;

--- a/src/crab/ebpf_domain.cpp
+++ b/src/crab/ebpf_domain.cpp
@@ -289,18 +289,6 @@ static std::vector<linear_constraint_t> jmp_to_cst_reg(const NumAbsDomain& inv, 
     }
 }
 
-static bool is_unsigned_cmp(Condition::Op op) {
-    using Op = Condition::Op;
-    switch (op) {
-    case Op::GE:
-    case Op::LE:
-    case Op::GT:
-    case Op::LT: return true;
-    default: return false;
-    }
-    return {};
-}
-
 std::optional<variable_t> ebpf_domain_t::get_type_offset_variable(const Reg& reg, int type) {
     reg_pack_t r = reg_pack(reg);
     switch (type) {

--- a/src/crab_utils/adapt_sgraph.hpp
+++ b/src/crab_utils/adapt_sgraph.hpp
@@ -96,7 +96,7 @@ class TreeSMap final {
         if (v != map.end()) {
             return {v->second};
         }
-        return {};
+        return std::nullopt;
     }
 
     // precondition: k \in S

--- a/src/ebpf_yaml.cpp
+++ b/src/ebpf_yaml.cpp
@@ -333,7 +333,7 @@ ConformanceTestResult run_conformance_test_case(const std::vector<uint8_t>& memo
             }
         }
         return {result, crab::interval_t::top()};
-    } catch (std::exception) {
+    } catch (const std::exception&) {
         // Catch exceptions thrown in ebpf_domain.cpp.
         return {};
     }


### PR DESCRIPTION
* Remove unused function `is_unsigned_cmp`
* Mark `parse_program` as `[[maybe_unused]]`
* Use `std::nullopt` instead of `{}` due to a compiler bug (maybe [80635](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=80635))
* Catch exception by reference