### PR TITLE
heap-buffer-overflow in btf_parse_line_information 

### DIFF
--- a/src/btf_parser.cpp
+++ b/src/btf_parser.cpp
@@ -72,7 +72,7 @@ void btf_parse_line_information(const std::vector<uint8_t>& btf, const std::vect
     if (line_info_end < 0 || line_info_end > btf_ext.size()) {
         throw std::runtime_error("Invalid .BTF.ext section - invalid btf_line_info string table end");
     }
-    if (static_cast<size_t>(bpf_ext_header->line_info_off)<4){
+    if (static_cast<size_t>(bpf_ext_header->line_info_off) < 4) {
         throw std::runtime_error("Invalid .BTF.ext section - invalid line info off size");
     }
 

--- a/src/btf_parser.cpp
+++ b/src/btf_parser.cpp
@@ -72,6 +72,9 @@ void btf_parse_line_information(const std::vector<uint8_t>& btf, const std::vect
     if (line_info_end < 0 || line_info_end > btf_ext.size()) {
         throw std::runtime_error("Invalid .BTF.ext section - invalid btf_line_info string table end");
     }
+    if (static_cast<size_t>(bpf_ext_header->line_info_off)<4){
+        throw std::runtime_error("Invalid .BTF.ext section - invalid line info off size");
+    }
 
     uint32_t line_info_record_size =
         *reinterpret_cast<const uint32_t*>(btf_ext.data() + line_info_start);


### PR DESCRIPTION
"btf_parser.cpp" fails when the "    uint32_t line_info_record_size" is trying to calculate from the start to the end. However, the line_info_record_size is not checked for at least a size of 4 bytes. 
In fact bpf_line_info_t has the following information:
```
bpf_line_info_t
   +0x000 insn_off         : Uint4B
   +0x004 file_name_off    : Uint4B
   +0x008 line_off         : Uint4B
   +0x00c line_col         : Uint4B
```
This means that line_off needs to be at least 4B and this check hasn't been done before. When a smaller size of line_off is passed, the program will crash. 
verifier fuzzer is crashing [in this line](https://github.com/microsoft/ebpf-for-windows/actions/runs/3666222777/jobs/6197891129#step:16:1006)
[The is  issue opened for the bug](https://github.com/microsoft/ebpf-for-windows/issues/1735)