### PR TITLE
Update bpf_conformance dependency

### DIFF
--- a/src/test/test_conformance.cpp
+++ b/src/test/test_conformance.cpp
@@ -13,7 +13,8 @@ void test_conformance(std::string filename, bpf_conformance_test_result_t expect
     std::filesystem::path plugin_path =
         test_path.remove_filename().append("conformance_check" + extension.string()).string();
     std::map<std::filesystem::path, std::tuple<bpf_conformance_test_result_t, std::string>> result =
-        bpf_conformance(test_files, plugin_path, {}, {}, {}, bpf_conformance_test_CPU_version_t::v3, false, true);
+        bpf_conformance(test_files, plugin_path, {}, {}, {}, bpf_conformance_test_CPU_version_t::v3,
+                        bpf_conformance_list_instructions_t::LIST_INSTRUCTIONS_NONE, true);
     for (auto file : test_files) {
         auto& [file_result, reason] = result[file];
         REQUIRE(file_result == expected_result);


### PR DESCRIPTION
Replaces PR #430

There was a breaking change to an API exposed by bpf_conformance so needed to update the caller to match the new API.

Signed-off-by: Dave Thaler <dthaler@microsoft.com>