### PR TITLE
Fix shortening of bidirectional inequality

### DIFF
--- a/src/crab/split_dbm.cpp
+++ b/src/crab/split_dbm.cpp
@@ -1139,12 +1139,14 @@ string_invariant SplitDBM::to_set() const {
             diff_csts.emplace(vd, vs, g_excl.edge_val(s, d));
         }
     }
-    // simplify: x - y <= k && y - x <= -k -> y = x + k
+    // simplify: x - y <= k && y - x <= -k
+    //        -> x <= y + k <= x
+    //        -> x = y + k
     for (const auto& [vd, vs, w] : diff_csts) {
         auto dual = to_string(vs, vd, -w, false);
         if (result.count(dual)) {
             result.erase(dual);
-            result.insert(to_string(vs, vd, w, true));
+            result.insert(to_string(vd, vs, w, true));
         } else {
             result.insert(to_string(vd, vs, w, false));
         }

--- a/test-data/packet.yaml
+++ b/test-data/packet.yaml
@@ -70,7 +70,7 @@ post: [
     "r2.type=packet", "r2.packet_offset=[0, 65534]", "packet_size=r2.packet_offset",
     "r3.type=packet", "r3.packet_offset=4", "r3.value=[4102, 2147418116]",
     "packet_size-r3.packet_offset<=65530", "packet_size=[0, 65534]",
-    "r3.packet_offset-packet_size<=4", "r1.value=r3.value+4",
+    "r3.packet_offset-packet_size<=4", "r3.value=r1.value+4",
     "r2.packet_offset-r3.packet_offset<=65530", "r3.packet_offset-r2.packet_offset<=4"
 ]
 messages:
@@ -101,6 +101,6 @@ post: [
     "r2.type=packet", "r2.packet_offset=[0, 65534]", "packet_size=r2.packet_offset",
     "r3.type=packet", "r3.packet_offset=8", "r3.value=[4106, 2147418120]",
     "packet_size-r3.packet_offset<=65526", "packet_size=[0, 65534]",
-    "r3.packet_offset-packet_size<=8", "r1.value=r3.value+8",
+    "r3.packet_offset-packet_size<=8", "r3.value=r1.value+8",
     "r2.packet_offset-r3.packet_offset<=65526", "r3.packet_offset-r2.packet_offset<=8"
 ]


### PR DESCRIPTION
`x - y <= k && y - x <= -k` is equivalent to `x = y + k` and not to `y = x + k`.

This only affects invariant output and yaml tests, and somehow only two tests reach that point.