### PR TITLE
Refactor: overload integers for number_t only

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -4,3 +4,6 @@ AlwaysBreakTemplateDeclarations: Yes
 AllowShortCaseLabelsOnASingleLine: true
 PointerAlignment: Left
 AlignEscapedNewlines: Left
+#BreakAfterAttributes: Always
+PenaltyReturnTypeOnItsOwnLine: 60
+AlwaysBreakAfterReturnType: None

--- a/src/asm_ostream.cpp
+++ b/src/asm_ostream.cpp
@@ -328,6 +328,7 @@ struct InstructionPrinterVisitor {
     void operator()(Assert const& a) {
         os_ << "assert " << a.cst;
     }
+
 };
 
 string to_string(label_t const& label) {
@@ -509,8 +510,11 @@ std::ostream& operator<<(std::ostream& os, const btf_line_info_t& line_info) {
     return os;
 }
 
-std::string to_string(const crab::interval_t& interval) {
+
+std::string crab::z_number::to_string() const { return _n.str(); }
+
+std::string crab::interval_t::to_string() const {
     std::ostringstream s;
-    s << interval;
+    s << *this;
     return s.str();
 }

--- a/src/asm_syntax.hpp
+++ b/src/asm_syntax.hpp
@@ -309,6 +309,12 @@ struct Assert {
     Assert(AssertionConstraint cst): cst(cst) { }
 };
 
+using Instruction = std::variant<Undefined, Bin, Un, LoadMapFd, Call, Exit, Jmp, Mem, Packet, LockAdd, Assume, Assert>;
+
+using LabeledInstruction = std::tuple<label_t, Instruction, std::optional<btf_line_info_t>>;
+using InstructionSeq = std::vector<LabeledInstruction>;
+
+
 #define DECLARE_EQ5(T, f1, f2, f3, f4, f5)                                                   \
     inline bool operator==(T const& a, T const& b) {                                         \
         return a.f1 == b.f1 && a.f2 == b.f2 && a.f3 == b.f3 && a.f4 == b.f4 && a.f5 == b.f5; \
@@ -319,11 +325,6 @@ struct Assert {
     inline bool operator==(T const& a, T const& b) { return a.f1 == b.f1 && a.f2 == b.f2; }
 #define DECLARE_EQ1(T, f1) \
     inline bool operator==(T const& a, T const& b) { return a.f1 == b.f1; }
-
-using Instruction = std::variant<Undefined, Bin, Un, LoadMapFd, Call, Exit, Jmp, Mem, Packet, LockAdd, Assume, Assert>;
-
-using LabeledInstruction = std::tuple<label_t, Instruction, std::optional<btf_line_info_t>>;
-using InstructionSeq = std::vector<LabeledInstruction>;
 
 using pc_t = uint16_t;
 

--- a/src/assertions.cpp
+++ b/src/assertions.cpp
@@ -35,9 +35,9 @@ class AssertExtractor {
   public:
     explicit AssertExtractor(program_info info) : info{std::move(info)} {}
 
-    vector<Assert> operator()(Undefined const& ins) const { assert(0); return {}; }
+    vector<Assert> operator()(Undefined const& ins) const { assert(false); return {}; }
 
-    vector<Assert> operator()(Assert const& ins) const { assert(0); return {}; }
+    vector<Assert> operator()(Assert const& ins) const { assert(false); return {}; }
 
     vector<Assert> operator()(LoadMapFd const& ins) const { return {}; }
 
@@ -217,6 +217,8 @@ class AssertExtractor {
         default:
             return { Assert{TypeConstraint{ins.dst, TypeGroup::number}} };
         }
+        assert(false);
+        return {};
     }
 };
 

--- a/src/crab/dsl_syntax.hpp
+++ b/src/crab/dsl_syntax.hpp
@@ -9,291 +9,83 @@
 
 namespace crab::dsl_syntax {
 
-inline linear_expression_t operator*(const number_t& n, variable_t x) { return {n, x}; }
-
-inline linear_expression_t operator*(int n, variable_t x) { return linear_expression_t(number_t(n), x); }
+inline linear_expression_t operator-(const linear_expression_t& e) { return e.negate(); }
 
 inline linear_expression_t operator*(variable_t x, const number_t& n) { return linear_expression_t(n, x); }
 
-inline linear_expression_t operator*(variable_t x, int n) { return linear_expression_t(number_t(n), x); }
+inline linear_expression_t operator*(const number_t& n, const linear_expression_t& e) { return e.multiply(n); }
 
-inline linear_expression_t operator*(const number_t& n, const linear_expression_t& e) { return e.operator*(n); }
+inline linear_expression_t operator+(const linear_expression_t& e1, const linear_expression_t& e2) { return e1.plus(e2); }
 
-inline linear_expression_t operator*(int n, const linear_expression_t& e) { return e.operator*(n); }
+inline linear_expression_t operator+(const linear_expression_t& e, const number_t& n) { return e.plus(n); }
 
-inline linear_expression_t operator+(variable_t x, number_t n) { return linear_expression_t(x).operator+(n); }
+inline linear_expression_t operator+(const number_t& n, const linear_expression_t& e) { return e.plus(n); }
 
-inline linear_expression_t operator+(variable_t x, int n) { return linear_expression_t(x).operator+(n); }
-
-inline linear_expression_t operator+(number_t n, variable_t x) { return linear_expression_t(x).operator+(n); }
-
-inline linear_expression_t operator+(int n, variable_t x) { return linear_expression_t(x).operator+(n); }
-
-inline linear_expression_t operator+(variable_t x, variable_t y) { return linear_expression_t(x).operator+(y); }
-
-inline linear_expression_t operator+(number_t n, const linear_expression_t& e) { return e.operator+(n); }
-
-inline linear_expression_t operator+(int n, const linear_expression_t& e) { return e.operator+(n); }
-
-inline linear_expression_t operator+(variable_t x, const linear_expression_t& e) { return e.operator+(x); }
-
-inline linear_expression_t operator-(variable_t x, const number_t& n) { return linear_expression_t(x).operator-(n); }
-
-inline linear_expression_t operator-(variable_t x, int64_t n) { return linear_expression_t(x).operator-((signed long long)n); }
-
-inline linear_expression_t operator-(variable_t x, uint64_t n) { return linear_expression_t(x).operator-((unsigned long long)n); }
-
-inline linear_expression_t operator-(variable_t x, int n) { return linear_expression_t(x).operator-(n); }
-
-inline linear_expression_t operator-(number_t n, variable_t x) {
-    return linear_expression_t(number_t(-1), x).operator+(n);
+inline linear_expression_t operator-(const linear_expression_t& e1, const linear_expression_t& e2) {
+    return e1.subtract(e2);
 }
 
-inline linear_expression_t operator-(int64_t n, variable_t x) { return linear_expression_t(number_t(-1), x).operator+(n); }
-
-inline linear_expression_t operator-(int n, variable_t x) { return linear_expression_t(number_t(-1), x).operator+(n); }
-
-inline linear_expression_t operator-(variable_t x, variable_t y) { return linear_expression_t(x).operator-(y); }
-
-inline linear_expression_t operator-(number_t n, const linear_expression_t& e) {
-    return linear_expression_t(n).operator-(e);
+inline linear_expression_t operator-(const number_t& n, const linear_expression_t& e) {
+    return linear_expression_t(n).subtract(e);
 }
 
-inline linear_expression_t operator-(int n, const linear_expression_t& e) {
-    return linear_expression_t(number_t(n)).operator-(e);
-}
-
-inline linear_expression_t operator-(variable_t x, const linear_expression_t& e) {
-    return linear_expression_t(number_t(1), x).operator-(e);
-}
-
-inline linear_constraint_t operator<=(const linear_expression_t& e, const number_t& n) {
-    return linear_constraint_t(e - n, constraint_kind_t::LESS_THAN_OR_EQUALS_ZERO);
-}
-
-inline linear_constraint_t operator<=(const linear_expression_t& e, int n) {
-    return linear_constraint_t(e - n, constraint_kind_t::LESS_THAN_OR_EQUALS_ZERO);
-}
-
-inline linear_constraint_t operator<=(number_t n, const linear_expression_t& e) {
-    return linear_constraint_t(n - e, constraint_kind_t::LESS_THAN_OR_EQUALS_ZERO);
-}
-
-inline linear_constraint_t operator<=(int n, const linear_expression_t& e) {
-    return linear_constraint_t(n - e, constraint_kind_t::LESS_THAN_OR_EQUALS_ZERO);
-}
-
-inline linear_constraint_t operator<=(const linear_expression_t& e, variable_t x) {
-    return linear_constraint_t(e - x, constraint_kind_t::LESS_THAN_OR_EQUALS_ZERO);
-}
-
-inline linear_constraint_t operator<=(variable_t x, const linear_expression_t& e) {
-    return linear_constraint_t(x - e, constraint_kind_t::LESS_THAN_OR_EQUALS_ZERO);
-}
-
-inline linear_constraint_t operator<=(variable_t x, const number_t& n) {
-    return linear_constraint_t(x - n, constraint_kind_t::LESS_THAN_OR_EQUALS_ZERO);
-}
-
-inline linear_constraint_t operator<=(variable_t x, int n) {
-    return linear_constraint_t(x - n, constraint_kind_t::LESS_THAN_OR_EQUALS_ZERO);
-}
-
-inline linear_constraint_t operator<=(variable_t x, int64_t n) {
-    return linear_constraint_t(x - n, constraint_kind_t::LESS_THAN_OR_EQUALS_ZERO);
-}
-
-inline linear_constraint_t operator<=(variable_t x, uint64_t n) {
-    return linear_constraint_t(x - n, constraint_kind_t::LESS_THAN_OR_EQUALS_ZERO);
-}
-
-inline linear_constraint_t operator<=(number_t n, variable_t x) {
-    return linear_constraint_t(n - x, constraint_kind_t::LESS_THAN_OR_EQUALS_ZERO);
-}
-
-inline linear_constraint_t operator<=(int n, variable_t x) {
-    return linear_constraint_t(n - x, constraint_kind_t::LESS_THAN_OR_EQUALS_ZERO);
-}
-
-inline linear_constraint_t operator<=(int64_t n, variable_t x) {
-    return linear_constraint_t(n - x, constraint_kind_t::LESS_THAN_OR_EQUALS_ZERO);
-}
-
-inline linear_constraint_t operator<=(variable_t x, variable_t y) {
-    return linear_constraint_t(x - y, constraint_kind_t::LESS_THAN_OR_EQUALS_ZERO);
+inline linear_expression_t operator-(const linear_expression_t& e, const number_t& n) {
+    return e.subtract(n);
 }
 
 inline linear_constraint_t operator<=(const linear_expression_t& e1, const linear_expression_t& e2) {
     return linear_constraint_t(e1 - e2, constraint_kind_t::LESS_THAN_OR_EQUALS_ZERO);
 }
 
-inline linear_constraint_t operator>=(const linear_expression_t& e, number_t n) {
-    return linear_constraint_t(n - e, constraint_kind_t::LESS_THAN_OR_EQUALS_ZERO);
-}
-
-inline linear_constraint_t operator>=(const linear_expression_t& e, int n) {
-    return linear_constraint_t(n - e, constraint_kind_t::LESS_THAN_OR_EQUALS_ZERO);
-}
-
-inline linear_constraint_t operator>=(const number_t& n, const linear_expression_t& e) {
+inline linear_constraint_t operator<=(const linear_expression_t& e, const number_t& n) {
     return linear_constraint_t(e - n, constraint_kind_t::LESS_THAN_OR_EQUALS_ZERO);
 }
 
-inline linear_constraint_t operator>=(int n, const linear_expression_t& e) {
-    return linear_constraint_t(e - n, constraint_kind_t::LESS_THAN_OR_EQUALS_ZERO);
-}
-
-inline linear_constraint_t operator>=(const linear_expression_t& e, variable_t x) {
-    return linear_constraint_t(x - e, constraint_kind_t::LESS_THAN_OR_EQUALS_ZERO);
-}
-
-inline linear_constraint_t operator>=(variable_t x, const linear_expression_t& e) {
-    return linear_constraint_t(e - x, constraint_kind_t::LESS_THAN_OR_EQUALS_ZERO);
-}
-
-inline linear_constraint_t operator>=(variable_t x, number_t n) {
-    return linear_constraint_t(n - x, constraint_kind_t::LESS_THAN_OR_EQUALS_ZERO);
-}
-
-inline linear_constraint_t operator>=(variable_t x, int64_t n) {
-    return linear_constraint_t(n - x, constraint_kind_t::LESS_THAN_OR_EQUALS_ZERO);
-}
-
-inline linear_constraint_t operator>=(variable_t x, int n) {
-    return linear_constraint_t(n - x, constraint_kind_t::LESS_THAN_OR_EQUALS_ZERO);
-}
-
-inline linear_constraint_t operator>=(const number_t& n, variable_t x) {
-    return linear_constraint_t(x - n, constraint_kind_t::LESS_THAN_OR_EQUALS_ZERO);
-}
-
-inline linear_constraint_t operator>=(int n, variable_t x) {
-    return linear_constraint_t(x - n, constraint_kind_t::LESS_THAN_OR_EQUALS_ZERO);
-}
-
-inline linear_constraint_t operator>=(variable_t x, variable_t y) {
-    return linear_constraint_t(y - x, constraint_kind_t::LESS_THAN_OR_EQUALS_ZERO);
-}
-
-inline linear_constraint_t operator>=(const linear_expression_t& e1, const linear_expression_t& e2) {
-    return linear_constraint_t(e2 - e1, constraint_kind_t::LESS_THAN_OR_EQUALS_ZERO);
-}
-
-inline linear_constraint_t operator<(const linear_expression_t& e, const number_t& n) {
-    return linear_constraint_t(e - n, constraint_kind_t::LESS_THAN_ZERO);
-}
-
-inline linear_constraint_t operator<(const linear_expression_t& e, int n) {
-    return linear_constraint_t(e - n, constraint_kind_t::LESS_THAN_ZERO);
-}
-
-inline linear_constraint_t operator<(number_t n, const linear_expression_t& e) {
-    return linear_constraint_t(n - e, constraint_kind_t::LESS_THAN_ZERO);
-}
-
-inline linear_constraint_t operator<(int n, const linear_expression_t& e) {
-    return linear_constraint_t(n - e, constraint_kind_t::LESS_THAN_ZERO);
-}
-
-inline linear_constraint_t operator<(const linear_expression_t& e, variable_t x) {
-    return linear_constraint_t(e - x, constraint_kind_t::LESS_THAN_ZERO);
-}
-
-inline linear_constraint_t operator<(variable_t x, const linear_expression_t& e) {
-    return linear_constraint_t(x - e, constraint_kind_t::LESS_THAN_ZERO);
-}
-
-inline linear_constraint_t operator<(variable_t x, const number_t& n) {
-    return linear_constraint_t(x - n, constraint_kind_t::LESS_THAN_ZERO);
-}
-
-inline linear_constraint_t operator<(variable_t x, int64_t n) {
-    return linear_constraint_t(x - number_t{n}, constraint_kind_t::LESS_THAN_ZERO);
-}
-
-inline linear_constraint_t operator<(variable_t x, uint64_t n) {
-    return linear_constraint_t(x - number_t{n}, constraint_kind_t::LESS_THAN_ZERO);
-}
-
-inline linear_constraint_t operator<(variable_t x, int n) {
-    return linear_constraint_t(x - number_t{n}, constraint_kind_t::LESS_THAN_ZERO);
-}
-
-inline linear_constraint_t operator<(number_t n, variable_t x) {
-    return linear_constraint_t(n - x, constraint_kind_t::LESS_THAN_ZERO);
-}
-
-inline linear_constraint_t operator<(int n, variable_t x) {
-    return linear_constraint_t(n - x, constraint_kind_t::LESS_THAN_ZERO);
-}
-
-inline linear_constraint_t operator<(variable_t x, variable_t y) {
-    return linear_constraint_t(x - y, constraint_kind_t::LESS_THAN_ZERO);
+inline linear_constraint_t operator<=(const number_t& n, const linear_expression_t& e) {
+    return linear_constraint_t(n - e, constraint_kind_t::LESS_THAN_OR_EQUALS_ZERO);
 }
 
 inline linear_constraint_t operator<(const linear_expression_t& e1, const linear_expression_t& e2) {
     return linear_constraint_t(e1 - e2, constraint_kind_t::LESS_THAN_ZERO);
 }
 
-// inline bool operator>(number_t n, int x) { return n.operator>(x); }
-
-inline linear_constraint_t operator>(const linear_expression_t& e, number_t n) {
-    return linear_constraint_t(n - e, constraint_kind_t::LESS_THAN_ZERO);
-}
-
-inline linear_constraint_t operator>(const linear_expression_t& e, int n) {
-    return linear_constraint_t(n - e, constraint_kind_t::LESS_THAN_ZERO);
-}
-
-inline linear_constraint_t operator>(const number_t& n, const linear_expression_t& e) {
+inline linear_constraint_t operator<(const linear_expression_t& e, const number_t& n) {
     return linear_constraint_t(e - n, constraint_kind_t::LESS_THAN_ZERO);
 }
 
-inline linear_constraint_t operator>(int n, const linear_expression_t& e) {
-    return linear_constraint_t(e - n, constraint_kind_t::LESS_THAN_ZERO);
+inline linear_constraint_t operator<(const number_t& n, const linear_expression_t& e) {
+    return linear_constraint_t(n - e, constraint_kind_t::LESS_THAN_ZERO);
 }
 
-inline linear_constraint_t operator>(const linear_expression_t& e, variable_t x) {
-    return linear_constraint_t(x - e, constraint_kind_t::LESS_THAN_ZERO);
+inline linear_constraint_t operator>=(const linear_expression_t& e1, const linear_expression_t& e2) {
+    return e2 <= e1;
 }
 
-inline linear_constraint_t operator>(variable_t x, const linear_expression_t& e) {
-    return linear_constraint_t(e - x, constraint_kind_t::LESS_THAN_ZERO);
+inline linear_constraint_t operator>=(const linear_expression_t& e, const number_t& n) {
+    return n <= e;
 }
 
-inline linear_constraint_t operator>(variable_t x, number_t n) {
-    return linear_constraint_t(n - x, constraint_kind_t::LESS_THAN_ZERO);
-}
-
-inline linear_constraint_t operator>(variable_t x, int64_t n) {
-    return linear_constraint_t(n - x, constraint_kind_t::LESS_THAN_ZERO);
-}
-
-inline linear_constraint_t operator>(variable_t x, int n) {
-    return linear_constraint_t(n - x, constraint_kind_t::LESS_THAN_ZERO);
-}
-
-inline linear_constraint_t operator>(const number_t& n, variable_t x) {
-    return linear_constraint_t(x - n, constraint_kind_t::LESS_THAN_ZERO);
-}
-
-inline linear_constraint_t operator>(int n, variable_t x) {
-    return linear_constraint_t(x - n, constraint_kind_t::LESS_THAN_ZERO);
-}
-
-inline linear_constraint_t operator>(variable_t x, variable_t y) {
-    return linear_constraint_t(y - x, constraint_kind_t::LESS_THAN_ZERO);
+inline linear_constraint_t operator>=(const number_t& n, const linear_expression_t& e) {
+    return e <= n;
 }
 
 inline linear_constraint_t operator>(const linear_expression_t& e1, const linear_expression_t& e2) {
-    return linear_constraint_t(e2 - e1, constraint_kind_t::LESS_THAN_ZERO);
+    return e2 < e1;
+}
+
+inline linear_constraint_t operator>(const linear_expression_t& e, const number_t& n) {
+    return n < e;
+}
+
+inline linear_constraint_t operator>(const number_t& n, const linear_expression_t& e) {
+    return e < n;
+}
+
+inline linear_constraint_t operator==(const linear_expression_t& e1, const linear_expression_t& e2) {
+    return linear_constraint_t(e1 - e2, constraint_kind_t::EQUALS_ZERO);
 }
 
 inline linear_constraint_t operator==(const linear_expression_t& e, const number_t& n) {
-    return linear_constraint_t(e - n, constraint_kind_t::EQUALS_ZERO);
-}
-
-inline linear_constraint_t operator==(const linear_expression_t& e, int n) {
     return linear_constraint_t(e - n, constraint_kind_t::EQUALS_ZERO);
 }
 
@@ -301,99 +93,15 @@ inline linear_constraint_t operator==(const number_t& n, const linear_expression
     return linear_constraint_t(e - n, constraint_kind_t::EQUALS_ZERO);
 }
 
-inline linear_constraint_t operator==(int n, const linear_expression_t& e) {
-    return linear_constraint_t(e - n, constraint_kind_t::EQUALS_ZERO);
-}
-
-inline linear_constraint_t operator==(const linear_expression_t& e, variable_t x) {
-    return linear_constraint_t(e - x, constraint_kind_t::EQUALS_ZERO);
-}
-
-inline linear_constraint_t operator==(variable_t x, const linear_expression_t& e) {
-    return linear_constraint_t(e - x, constraint_kind_t::EQUALS_ZERO);
-}
-
-inline linear_constraint_t operator==(variable_t x, const number_t& n) {
-    return linear_constraint_t(x - n, constraint_kind_t::EQUALS_ZERO);
-}
-
-inline linear_constraint_t operator==(variable_t x, int64_t n) {
-    return linear_constraint_t(x - n, constraint_kind_t::EQUALS_ZERO);
-}
-
-inline linear_constraint_t operator==(variable_t x, int n) {
-    return linear_constraint_t(x - n, constraint_kind_t::EQUALS_ZERO);
-}
-
-inline linear_constraint_t operator==(const number_t& n, variable_t x) {
-    return linear_constraint_t(x - n, constraint_kind_t::EQUALS_ZERO);
-}
-
-inline linear_constraint_t operator==(int n, variable_t x) {
-    return linear_constraint_t(x - n, constraint_kind_t::EQUALS_ZERO);
-}
-
-inline linear_constraint_t operator==(variable_t x, variable_t y) {
-    return linear_constraint_t(x - y, constraint_kind_t::EQUALS_ZERO);
-}
-
-inline linear_constraint_t equals(variable_t x, variable_t y) {
-    return linear_constraint_t(x - y, constraint_kind_t::EQUALS_ZERO);
-}
-
-inline linear_constraint_t operator==(const linear_expression_t& e1, const linear_expression_t& e2) {
-    return linear_constraint_t(e1 - e2, constraint_kind_t::EQUALS_ZERO);
+inline linear_constraint_t operator!=(const linear_expression_t& e1, const linear_expression_t& e2) {
+    return linear_constraint_t(e1 - e2, constraint_kind_t::NOT_ZERO);
 }
 
 inline linear_constraint_t operator!=(const linear_expression_t& e, const number_t& n) {
     return linear_constraint_t(e - n, constraint_kind_t::NOT_ZERO);
 }
 
-inline linear_constraint_t operator!=(const linear_expression_t& e, int n) {
-    return linear_constraint_t(e - n, constraint_kind_t::NOT_ZERO);
-}
-
 inline linear_constraint_t operator!=(const number_t& n, const linear_expression_t& e) {
     return linear_constraint_t(e - n, constraint_kind_t::NOT_ZERO);
 }
-
-inline linear_constraint_t operator!=(int n, const linear_expression_t& e) {
-    return linear_constraint_t(e - n, constraint_kind_t::NOT_ZERO);
-}
-
-inline linear_constraint_t operator!=(const linear_expression_t& e, variable_t x) {
-    return linear_constraint_t(e - x, constraint_kind_t::NOT_ZERO);
-}
-
-inline linear_constraint_t operator!=(variable_t x, const linear_expression_t& e) {
-    return linear_constraint_t(e - x, constraint_kind_t::NOT_ZERO);
-}
-
-inline linear_constraint_t operator!=(variable_t x, const number_t& n) {
-    return linear_constraint_t(x - n, constraint_kind_t::NOT_ZERO);
-}
-
-inline linear_constraint_t operator!=(variable_t x, int64_t n) {
-    return linear_constraint_t(x - n, constraint_kind_t::NOT_ZERO);
-}
-
-inline linear_constraint_t operator!=(variable_t x, int n) {
-    return linear_constraint_t(x - n, constraint_kind_t::NOT_ZERO);
-}
-
-inline linear_constraint_t operator!=(const number_t& n, variable_t x) {
-    return linear_constraint_t(x - n, constraint_kind_t::NOT_ZERO);
-}
-
-inline linear_constraint_t operator!=(int n, variable_t x) {
-    return linear_constraint_t(x - n, constraint_kind_t::NOT_ZERO);
-}
-
-inline linear_constraint_t operator!=(variable_t x, variable_t y) {
-    return linear_constraint_t(x - y, constraint_kind_t::NOT_ZERO);
-}
-
-inline linear_constraint_t operator!=(const linear_expression_t& e1, const linear_expression_t& e2) {
-    return linear_constraint_t(e1 - e2, constraint_kind_t::NOT_ZERO);
-}
-} // end namespace crab
+} // end namespace crab::dsl_syntax

--- a/src/crab/ebpf_domain.hpp
+++ b/src/crab/ebpf_domain.hpp
@@ -13,7 +13,9 @@
 #include "crab/variable.hpp"
 #include "string_constraints.hpp"
 
-using NumAbsDomain = crab::domains::NumAbsDomain;
+namespace crab {
+
+using NumAbsDomain = domains::NumAbsDomain;
 
 struct reg_pack_t;
 
@@ -45,7 +47,7 @@ class ebpf_domain_t final {
 
     typedef bool check_require_func_t(NumAbsDomain&, const linear_constraint_t&, std::string);
     void set_require_check(std::function<check_require_func_t> f);
-    int get_instruction_count_upper_bound();
+    bound_t get_instruction_count_upper_bound();
     static ebpf_domain_t setup_entry(bool check_termination, bool init_r1);
 
     static ebpf_domain_t from_constraints(const std::set<std::string>& constraints, bool setup_constraints);
@@ -133,11 +135,7 @@ class ebpf_domain_t final {
     void shl_overflow(variable_t lhss, variable_t lhsu, variable_t op2);
     void shl_overflow(variable_t lhss, variable_t lhsu, const number_t& op2);
     void lshr(const Reg& reg, int imm, int finite_width);
-    void lshr(variable_t lhss, variable_t lhsu, variable_t op2, int finite_width);
-    void lshr(variable_t lhss, variable_t lhsu, const number_t& op2);
     void ashr(const Reg& reg, const linear_expression_t& right_svalue, int finite_width);
-    void ashr(variable_t lhss, variable_t lhsu, variable_t op2, int finite_width);
-    void ashr(variable_t lhss, variable_t lhsu, const number_t& op2);
 
     void assume(const linear_constraint_t& cst);
 
@@ -185,8 +183,8 @@ class ebpf_domain_t final {
     void do_load_packet_or_shared(NumAbsDomain& inv, const Reg& target_reg, const linear_expression_t& addr, int width);
     void do_load(const Mem& b, const Reg& target_reg);
 
-    template <typename A, typename X, typename Y, typename Z>
-    void do_store_stack(crab::domains::NumAbsDomain& inv, int width, const A& addr, X val_type, Y val_svalue, Z val_uvalue,
+    template <typename X, typename Y, typename Z>
+    void do_store_stack(crab::domains::NumAbsDomain& inv, const number_t& width, const linear_expression_t& addr, X val_type, Y val_svalue, Z val_uvalue,
                         const std::optional<reg_pack_t>& opt_val_reg);
 
     template <typename Type, typename SValue, typename UValue>
@@ -217,17 +215,17 @@ class ebpf_domain_t final {
         void assign_type(NumAbsDomain& inv, const Reg& lhs, const Reg& rhs);
         void assign_type(NumAbsDomain& inv, const Reg& lhs, const std::optional<linear_expression_t>& rhs);
         void assign_type(NumAbsDomain& inv, std::optional<variable_t> lhs, const Reg& rhs);
-        void assign_type(NumAbsDomain& inv, std::optional<variable_t> lhs, int rhs);
+        void assign_type(NumAbsDomain& inv, std::optional<variable_t> lhs, const number_t& rhs);
 
         void havoc_type(NumAbsDomain& inv, const Reg& r);
 
         [[nodiscard]] int get_type(const NumAbsDomain& inv, variable_t v) const;
         [[nodiscard]] int get_type(const NumAbsDomain& inv, const Reg& r) const;
-        [[nodiscard]] int get_type(const NumAbsDomain& inv, int t) const;
+        [[nodiscard]] int get_type(const NumAbsDomain& inv, const number_t& t) const;
 
         [[nodiscard]] bool has_type(const NumAbsDomain& inv, variable_t v, type_encoding_t type) const;
         [[nodiscard]] bool has_type(const NumAbsDomain& inv, const Reg& r, type_encoding_t type) const;
-        [[nodiscard]] bool has_type(const NumAbsDomain& inv, int t, type_encoding_t type) const;
+        [[nodiscard]] bool has_type(const NumAbsDomain& inv, const number_t& t, type_encoding_t type) const;
 
         [[nodiscard]] bool same_type(const NumAbsDomain& inv, const Reg& a, const Reg& b) const;
         [[nodiscard]] bool implies_type(const NumAbsDomain& inv, const linear_constraint_t& a, const linear_constraint_t& b) const;
@@ -249,3 +247,5 @@ class ebpf_domain_t final {
     TypeDomain type_inv;
     std::string current_assertion;
 }; // end ebpf_domain_t
+
+}

--- a/src/crab/interval.cpp
+++ b/src/crab/interval.cpp
@@ -14,11 +14,11 @@ interval_t interval_t::operator/(const interval_t& x) const {
         //   the divisor is a singleton interval. We optimize for this case.
         if (std::optional<number_t> n = x.singleton()) {
             number_t c = *n;
-            if (c == 1) {
+            if (c == number_t{1}) {
                 return *this;
-            } else if (c > 0) {
+            } else if (c > number_t{0}) {
                 return interval_t(_lb / bound_t{c}, _ub / bound_t{c});
-            } else if (c < 0) {
+            } else if (c < number_t{0}) {
                 return interval_t(_ub / bound_t{c}, _lb / bound_t{c});
             } else {
                 // The eBPF ISA defines division by 0 as resulting in 0.
@@ -39,8 +39,8 @@ interval_t interval_t::operator/(const interval_t& x) const {
             return ((l / x) | (u / x) | z_interval(number_t(0)));
         } else {
             // Neither the dividend nor the divisor contains 0
-            z_interval a = (_ub < 0)
-                               ? (*this + ((x._ub < 0) ? (x + z_interval(number_t(1))) : (z_interval(number_t(1)) - x)))
+            z_interval a = (_ub < number_t{0})
+                               ? (*this + ((x._ub < number_t{0}) ? (x + z_interval(number_t(1))) : (z_interval(number_t(1)) - x)))
                                : *this;
             bound_t ll = a._lb / x._lb;
             bound_t lu = a._lb / x._ub;
@@ -64,7 +64,7 @@ interval_t interval_t::UDiv(const interval_t& x) const {
             number_t c{n->cast_to_uint64()};
             if (c == 1) {
                 return *this;
-            } else if (c > 0) {
+            } else if (c > number_t{0}) {
                 return interval_t(_lb.UDiv(bound_t{c}), _ub.UDiv(bound_t{c}));
             } else {
                 // The eBPF ISA defines division by 0 as resulting in 0.
@@ -85,8 +85,8 @@ interval_t interval_t::UDiv(const interval_t& x) const {
             return (l.UDiv(x) | u.UDiv(x) | z_interval(number_t(0)));
         } else {
             // Neither the dividend nor the divisor contains 0
-            z_interval a = (_ub < 0)
-                               ? (*this + ((x._ub < 0) ? (x + z_interval(number_t(1))) : (z_interval(number_t(1)) - x)))
+            z_interval a = (_ub < number_t{0})
+                               ? (*this + ((x._ub < number_t{0}) ? (x + z_interval(number_t(1))) : (z_interval(number_t(1)) - x)))
                                : *this;
             bound_t ll = a._lb.UDiv(x._lb);
             bound_t lu = a._lb.UDiv(x._ub);
@@ -126,14 +126,14 @@ interval_t interval_t::SRem(const interval_t& x) const {
             return *this;
         }
 
-        if (lb() < 0) {
-            if (ub() > 0) {
+        if (lb() < number_t{0}) {
+            if (ub() > number_t{0}) {
                 return interval_t(-(max_divisor - 1), max_divisor - 1);
             } else {
-                return interval_t(-(max_divisor - 1), 0);
+                return interval_t(-(max_divisor - 1), number_t{0});
             }
         } else {
-            return interval_t(0, max_divisor - 1);
+            return interval_t(number_t{0}, max_divisor - 1);
         }
     } else {
         // Divisor has infinite range, so result can be anything between the dividend and zero.
@@ -152,7 +152,7 @@ interval_t interval_t::URem(const interval_t& x) const {
         //   the divisor is a singleton interval. We optimize for this case.
         if (std::optional<number_t> n = x.singleton()) {
             number_t c = *n;
-            if (c > 0) {
+            if (c > number_t{0}) {
                 return interval_t(_lb.UMod(bound_t{c}), _ub.UMod(bound_t{c}));
             } else {
                 // The eBPF ISA defines modulo 0 as being unchanged.
@@ -177,13 +177,13 @@ interval_t interval_t::URem(const interval_t& x) const {
                 // Divisor is infinite. A "negative" dividend could result in anything except
                 // a value between the upper bound and 0, so set to top.  A "positive" dividend
                 // could result in anything between 0 and the dividend - 1.
-                return (_ub < 0) ? top() : ((*this - 1) | interval_t(number_t(0)));
+                return (_ub < number_t{0}) ? top() : ((*this - interval_t(number_t {1})) | interval_t(number_t(0)));
             } else if (_ub.number()->cast_to_uint64() < x._lb.number()->cast_to_uint64()) {
                 // Dividend lower than divisor, so the dividend is the remainder.
                 return *this;
             } else {
-                number_t max_divisor = number_t{x._ub.number()->cast_to_uint64()};
-                return interval_t(0, max_divisor - 1);
+                number_t max_divisor{x._ub.number()->cast_to_uint64()};
+                return interval_t(number_t{0}, max_divisor - 1);
             }
         }
     }
@@ -197,34 +197,31 @@ interval_t interval_t::And(const interval_t& x) const {
         std::optional<number_t> left_op = singleton();
         std::optional<number_t> right_op = x.singleton();
 
-        assert(is_top() || (lb() >= 0));
-        assert(x.is_top() || (x.lb() >= 0));
+        assert(is_top() || (lb() >= number_t{0}));
+        assert(x.is_top() || (x.lb() >= number_t{0}));
 
         if (left_op && right_op) {
             return interval_t((*left_op) & (*right_op));
         } else if (right_op && right_op.value().fits_uint32() && right_op.value().cast_to_uint32() == UINT32_MAX) {
             // Handle bitwise-AND with UINT32_MAX, which we do for 32-bit operations.
             if (auto width = finite_size()) {
-                uint64_t lb_n = lb().number().value().cast_to_uint64();
-                uint32_t lb32_n = (uint32_t)lb_n;
-                uint64_t ub_n = ub().number().value().cast_to_uint64();
-                uint32_t ub32_n = (uint32_t)ub_n;
-                uint64_t width_n = width.value().cast_to_uint64();
-                uint32_t width32_n = (uint32_t)width_n;
-                if ((width_n <= UINT32_MAX) && (lb32_n < ub32_n) && (lb32_n + width32_n == ub32_n)) {
+                number_t lb32_n = (uint32_t)lb().number()->cast_to_uint64();
+                number_t ub32_n = (uint32_t)ub().number()->cast_to_uint64();
+                number_t width32_n = (uint32_t)width->cast_to_uint64();
+                if ((width->cast_to_uint64() <= UINT32_MAX) && (lb32_n < ub32_n) && (lb32_n + width32_n == ub32_n)) {
                     return interval_t{lb32_n, ub32_n};
                 }
             }
 
             // Return the full range of all 32-bit numbers.  Use unsigned bounds to
             // avoid setting other bits via sign extension.
-            return interval_t{0, UINT32_MAX};
+            return interval_t{number_t{0}, number_t{UINT32_MAX}};
         } else if (!is_top() && !x.is_top()) {
-            return interval_t(0, bound_t::min(ub(), x.ub()));
+            return interval_t(number_t{0}, bound_t::min(ub(), x.ub()));
         } else if (!x.is_top()) {
-            return interval_t(0, x.ub());
+            return interval_t(number_t{0}, x.ub());
         } else if (!is_top()) {
-            return interval_t(0, ub());
+            return interval_t(number_t{0}, ub());
         } else {
             return top();
         }
@@ -240,15 +237,15 @@ interval_t interval_t::Or(const interval_t& x) const {
 
         if (left_op && right_op) {
             return interval_t((*left_op) | (*right_op));
-        } else if (lb() >= 0 && x.lb() >= 0) {
+        } else if (lb() >= number_t{0} && x.lb() >= number_t{0}) {
             std::optional<number_t> left_ub = ub().number();
             std::optional<number_t> right_ub = x.ub().number();
 
             if (left_ub && right_ub) {
                 number_t m = (*left_ub > *right_ub ? *left_ub : *right_ub);
-                return interval_t(0, m.fill_ones());
+                return interval_t(number_t{0}, m.fill_ones());
             } else {
-                return interval_t(0, bound_t::plus_infinity());
+                return interval_t(number_t{0}, bound_t::plus_infinity());
             }
         } else {
             return top();
@@ -277,7 +274,7 @@ interval_t interval_t::Shl(const interval_t& x) const {
     } else {
         if (std::optional<number_t> shift = x.singleton()) {
             number_t k = *shift;
-            if (k < 0) {
+            if (k < number_t{0}) {
                 // CRAB_ERROR("lshr shift operand cannot be negative");
                 return top();
             }
@@ -289,7 +286,7 @@ interval_t interval_t::Shl(const interval_t& x) const {
                 for (int i = 0; k > i; i++) {
                     factor *= 2;
                 }
-                return (*this) * factor;
+                return this->operator*(interval_t{factor});
             }
         }
         return top();
@@ -302,7 +299,7 @@ interval_t interval_t::AShr(const interval_t& x) const {
     } else {
         if (std::optional<number_t> shift = x.singleton()) {
             number_t k = *shift;
-            if (k < 0) {
+            if (k < number_t{0}) {
                 // CRAB_ERROR("ashr shift operand cannot be negative");
                 return top();
             }
@@ -314,7 +311,7 @@ interval_t interval_t::AShr(const interval_t& x) const {
                 for (int i = 0; k > i; i++) {
                     factor *= 2;
                 }
-                return (*this) / factor;
+                return this->operator/(interval_t{factor});
             }
         }
         return top();
@@ -327,7 +324,7 @@ interval_t interval_t::LShr(const interval_t& x) const {
     } else {
         if (std::optional<number_t> shift = x.singleton()) {
             number_t k = *shift;
-            if (k < 0) {
+            if (k < number_t{0}) {
                 // CRAB_ERROR("lshr shift operand cannot be negative");
                 return top();
             }
@@ -335,7 +332,7 @@ interval_t interval_t::LShr(const interval_t& x) const {
             // huge shifts.  We limit the number of times the loop is run
             // to avoid wasting too much time on it.
             if (k <= 128) {
-                if (lb() >= 0 && ub().is_finite() && shift) {
+                if (lb() >= number_t{0} && ub().is_finite() && shift) {
                     number_t lb = *this->lb().number();
                     number_t ub = *this->ub().number();
                     return interval_t(lb >> k, ub >> k);

--- a/src/crab/linear_constraint.hpp
+++ b/src/crab/linear_constraint.hpp
@@ -6,6 +6,7 @@
 
 // A linear constraint is of the form:
 //    <linear expression> <operator> 0
+namespace crab {
 
 enum class constraint_kind_t {
     EQUALS_ZERO,
@@ -56,9 +57,9 @@ class linear_constraint_t final {
         case constraint_kind_t::EQUALS_ZERO:
             return linear_constraint_t(_expression, constraint_kind_t::NOT_ZERO);
         case constraint_kind_t::LESS_THAN_ZERO:
-            return linear_constraint_t(-_expression, constraint_kind_t::LESS_THAN_OR_EQUALS_ZERO);
+            return linear_constraint_t(_expression.negate(), constraint_kind_t::LESS_THAN_OR_EQUALS_ZERO);
         case constraint_kind_t::LESS_THAN_OR_EQUALS_ZERO:
-            return linear_constraint_t(-_expression, constraint_kind_t::LESS_THAN_ZERO);
+            return linear_constraint_t(_expression.negate(), constraint_kind_t::LESS_THAN_ZERO);
         default: throw std::exception();
         }
     }
@@ -95,4 +96,6 @@ inline std::ostream& operator<<(std::ostream& o, const linear_constraint_t& cons
         o << constraint_kind_label[kind] << -expression.constant_term();
     }
     return o;
+}
+
 }

--- a/src/crab/thresholds.cpp
+++ b/src/crab/thresholds.cpp
@@ -14,17 +14,17 @@ void thresholds_t::add(bound_t v1) {
             auto ub = std::upper_bound(m_thresholds.begin(), m_thresholds.end(), v);
 
             // don't add consecutive thresholds
-            if (v > 0) {
+            if (v > number_t{0}) {
                 auto prev = ub;
                 --prev;
                 if (prev != m_thresholds.begin()) {
-                    if (*prev + 1 == v) {
+                    if (*prev + number_t{1} == v) {
                         *prev = v;
                         return;
                     }
                 }
-            } else if (v < 0) {
-                if (*ub - 1 == v) {
+            } else if (v < number_t{0}) {
+                if (*ub - number_t{1} == v) {
                     *ub = v;
                     return;
                 }

--- a/src/crab/var_factory.cpp
+++ b/src/crab/var_factory.cpp
@@ -4,6 +4,7 @@
  * Factories for variable names.
  */
 
+#include "asm_syntax.hpp"
 #include "crab/variable.hpp"
 #include "crab_utils/lazy_allocator.hpp"
 
@@ -38,8 +39,7 @@ std::vector<std::string> variable_t::_default_names() {
 
 thread_local crab::lazy_allocator<std::vector<std::string>, variable_t::variable_name_factory> variable_t::names;
 
-void
-variable_t::clear_thread_local_state() {
+void variable_t::clear_thread_local_state() {
     names.clear();
 }
 
@@ -66,7 +66,7 @@ std::ostream& operator<<(std::ostream& o, const data_kind_t& s) {
     return o << name_of(s);
 }
 
-static std::string mk_scalar_name(data_kind_t kind, int o, int size) {
+static std::string mk_scalar_name(data_kind_t kind, const number_t& o, const number_t& size) {
     std::stringstream os;
     os << "s" << "[" << o;
     if (size != 1) {
@@ -76,8 +76,8 @@ static std::string mk_scalar_name(data_kind_t kind, int o, int size) {
     return os.str();
 }
 
-variable_t variable_t::cell_var(data_kind_t array, index_t offset, unsigned size) {
-    return make(mk_scalar_name(array, (int)offset, (int)size));
+variable_t variable_t::cell_var(data_kind_t array, const number_t& offset, const number_t& size) {
+    return make(mk_scalar_name(array, offset.cast_to_uint64(), size));
 }
 
 // Given a type variable, get the associated variable of a given kind.
@@ -103,7 +103,9 @@ std::vector<variable_t> variable_t::get_type_variables() {
     }
     return res;
 }
+
 bool variable_t::is_in_stack() const {
     return this->name()[0] == 's';
 }
+
 } // end namespace crab

--- a/src/crab/variable.hpp
+++ b/src/crab/variable.hpp
@@ -9,6 +9,7 @@
 #include <optional>
 #include <vector>
 
+#include "asm_syntax.hpp"
 #include "crab_utils/bignums.hpp"
 #include "crab_utils/debug.hpp"
 #include "crab_utils/lazy_allocator.hpp"
@@ -70,11 +71,12 @@ class variable_t final {
 
     static std::vector<variable_t> get_type_variables();
     static variable_t reg(data_kind_t, int);
-    static variable_t cell_var(data_kind_t array, index_t offset, unsigned size);
+    static variable_t cell_var(data_kind_t array, const number_t& offset, const number_t& size);
     static variable_t kind_var(data_kind_t kind, variable_t type_variable);
     static variable_t meta_offset();
     static variable_t packet_size();
     static variable_t instruction_count();
+
     [[nodiscard]] bool is_in_stack() const;
 
     struct Hasher {

--- a/src/crab_utils/bignums.hpp
+++ b/src/crab_utils/bignums.hpp
@@ -203,15 +203,9 @@ class z_number final {
         return z_number(_n + x._n);
     }
 
-    z_number operator+(int x) const { return operator+(z_number(x)); }
-
     z_number operator*(const z_number& x) const { return z_number(_n * x._n); }
 
-    z_number operator*(int x) const { return operator*(z_number(x)); }
-
     z_number operator-(const z_number& x) const { return z_number(_n - x._n); }
-
-    z_number operator-(int x) const { return operator-(z_number(x)); }
 
     z_number operator-() const { return z_number(-_n); }
 
@@ -223,8 +217,6 @@ class z_number final {
         }
     }
 
-    z_number operator/(int x) const { return operator/(z_number(x)); }
-
     z_number operator%(const z_number& x) const {
         if (x._n.is_zero()) {
             CRAB_ERROR("z_number: division by zero [2]");
@@ -233,28 +225,20 @@ class z_number final {
         }
     }
 
-    z_number operator%(int x) const { return operator%(z_number(x)); }
-
     z_number& operator+=(const z_number& x) {
         _n += x._n;
         return *this;
     }
-
-    z_number& operator+=(int x) { return operator+=(z_number(x)); }
 
     z_number& operator*=(const z_number& x) {
         _n *= x._n;
         return *this;
     }
 
-    z_number& operator*=(int x) { return operator*=(z_number(x)); }
-
     z_number& operator-=(const z_number& x) {
         _n -= x._n;
         return *this;
     }
-
-    z_number& operator-=(int x) { return operator-=(z_number(x)); }
 
     z_number& operator/=(const z_number& x) {
         if (x._n.is_zero()) {
@@ -265,8 +249,6 @@ class z_number final {
         }
     }
 
-    z_number& operator/=(int x) { return operator/=(z_number(x)); }
-
     z_number& operator%=(const z_number& x) {
         if (x._n.is_zero()) {
             CRAB_ERROR("z_number: division by zero [4]");
@@ -275,8 +257,6 @@ class z_number final {
             return *this;
         }
     }
-
-    z_number& operator%=(int x) { return operator%=(z_number(x)); }
 
     z_number& operator--() & {
         _n--;
@@ -304,39 +284,21 @@ class z_number final {
         return (_n == x._n);
     }
 
-    bool operator==(int x) const { return operator==(z_number(x)); }
-
     bool operator!=(const z_number& x) const { return (_n != x._n); }
-
-    bool operator!=(int x) const { return operator!=(z_number(x)); }
 
     bool operator<(const z_number& x) const { return (_n < x._n); }
 
-    bool operator<(int x) const { return operator<(z_number(x)); }
-
     bool operator<=(const z_number& x) const { return (_n <= x._n); }
-
-    bool operator<=(int x) const { return operator<=(z_number(x)); }
 
     bool operator>(const z_number& x) const { return (_n > x._n); }
 
-    bool operator>(int x) const { return operator>(z_number(x)); }
-
     bool operator>=(const z_number& x) const { return (_n >= x._n); }
-
-    bool operator>=(int x) const { return operator>=(z_number(x)); }
 
     z_number operator&(const z_number& x) const { return z_number(_n & x._n); }
 
-    z_number operator&(int x) const { return z_number(_n & x); }
-
     z_number operator|(const z_number& x) const { return z_number(_n | x._n); }
 
-    z_number operator|(int x) const { return z_number(_n | x); }
-
     z_number operator^(const z_number& x) const { return z_number(_n ^ x._n); }
-
-    z_number operator^(int x) const { return z_number(_n ^ x); }
 
     z_number operator<<(z_number x) const {
         if (!x.fits_sint32()) {
@@ -345,16 +307,12 @@ class z_number final {
         return z_number(_n << (int32_t)x);
     }
 
-    z_number operator<<(int x) const { return z_number(_n << x); }
-
     z_number operator>>(z_number x) const {
         if (!x.fits_sint32()) {
             CRAB_ERROR("z_number ", x._n.str(), " does not fit into an int32");
         }
         return z_number(_n >> (int32_t)x);
     }
-
-    z_number operator>>(int x) const { return z_number(_n >> x); }
 
     [[nodiscard]] z_number fill_ones() const {
         if (_n.is_zero()) {
@@ -371,10 +329,11 @@ class z_number final {
         return o << z._n.str();
     }
 
-}; // class z_number
+    [[nodiscard]] std::string to_string() const;
+};
+// class z_number
 
 using number_t = z_number;
 
 inline std::size_t hash_value(const z_number& z) { return z.hash(); }
-
 } // namespace crab

--- a/src/crab_utils/debug.cpp
+++ b/src/crab_utils/debug.cpp
@@ -10,4 +10,5 @@ unsigned CrabVerbosity = 0;
 
 bool CrabWarningFlag = false;
 void CrabEnableWarningMsg(bool v) { CrabWarningFlag = v; }
+
 } // namespace crab

--- a/src/crab_verifier.cpp
+++ b/src/crab_verifier.cpp
@@ -24,16 +24,17 @@
 #include "string_constraints.hpp"
 
 using std::string;
+using crab::ebpf_domain_t;
 
 thread_local crab::lazy_allocator<program_info> global_program_info;
 thread_local ebpf_verifier_options_t thread_local_options;
 
 // Toy database to store invariants.
 struct checks_db final {
-    std::map<label_t, std::vector<std::string>> m_db;
+    std::map<label_t, std::vector<std::string>> m_db{};
     int total_warnings{};
     int total_unreachable{};
-    int max_instruction_count{};
+    crab::bound_t max_instruction_count{crab::number_t{0}};;
     std::set<label_t> maybe_nonterminating;
 
     void add(const label_t& label, const std::string& msg) {
@@ -55,6 +56,13 @@ struct checks_db final {
         total_warnings++;
     }
 
+    [[nodiscard]] int get_max_instruction_count() const {
+        auto m = this->max_instruction_count.number();
+        if (m && m->fits_sint32())
+            return m->cast_to_sint32();
+        else
+            return std::numeric_limits<int>::max();
+    }
     checks_db() = default;
 };
 
@@ -65,7 +73,8 @@ static checks_db generate_report(cfg_t& cfg,
     for (const label_t& label : cfg.sorted_labels()) {
         basic_block_t& bb = cfg.get_node(label);
         ebpf_domain_t from_inv(pre_invariants.at(label));
-        from_inv.set_require_check([&m_db, label](auto& inv, const linear_constraint_t& cst, const std::string& s) {
+        from_inv.set_require_check([&m_db, label](auto& inv, const crab::linear_constraint_t& cst,
+                                                     const std::string& s) {
             if (inv.is_bottom())
                 return true;
             if (cst.is_contradiction()) {
@@ -88,14 +97,14 @@ static checks_db generate_report(cfg_t& cfg,
 
         if (thread_local_options.check_termination) {
             // Pinpoint the places where divergence might occur.
-            int min_instruction_count_upper_bound = INT_MAX;
+            crab::bound_t min_instruction_count_upper_bound{crab::bound_t::plus_infinity()};
             for (const label_t& prev_label : bb.prev_blocks_set()) {
-                int instruction_count = pre_invariants.at(prev_label).get_instruction_count_upper_bound();
+                crab::bound_t instruction_count = pre_invariants.at(prev_label).get_instruction_count_upper_bound();
                 min_instruction_count_upper_bound = std::min(min_instruction_count_upper_bound, instruction_count);
             }
 
-            constexpr int max_instructions = 100000;
-            int instruction_count_upper_bound = from_inv.get_instruction_count_upper_bound();
+            crab::bound_t max_instructions{100000};
+            crab::bound_t instruction_count_upper_bound = from_inv.get_instruction_count_upper_bound();
             if ((min_instruction_count_upper_bound < max_instructions) &&
                 (instruction_count_upper_bound >= max_instructions))
                 m_db.add_nontermination(label);
@@ -114,11 +123,11 @@ static checks_db generate_report(cfg_t& cfg,
     return m_db;
 }
 
-auto get_line_info(const InstructionSeq& insts) {
-    std::map<int, std::optional<btf_line_info_t>> label_to_line_info;
+static auto get_line_info(const InstructionSeq& insts) {
+    std::map<int, btf_line_info_t> label_to_line_info;
     for (auto& [label, inst, line_info] : insts) {
         if (line_info.has_value())
-            label_to_line_info.insert({label.from, line_info});
+            label_to_line_info.emplace(label.from, line_info.value());
     }
     return label_to_line_info;
 }
@@ -130,8 +139,8 @@ static void print_report(std::ostream& os, const checks_db& db, const Instructio
         for (const auto& msg : messages) {
             if (print_line_info) {
                 auto line_info = label_to_line_info.find(label.from);
-                if (line_info != label_to_line_info.end() && line_info->second.has_value())
-                    os << line_info->second.value();
+                if (line_info != label_to_line_info.end())
+                    os << line_info->second;
             }
             os << label << ": " << msg << "\n";
         }
@@ -146,8 +155,8 @@ static void print_report(std::ostream& os, const checks_db& db, const Instructio
     }
 }
 
-checks_db get_analysis_report(std::ostream& s, cfg_t& cfg, crab::invariant_table_t& pre_invariants,
-                              crab::invariant_table_t& post_invariants) {
+static checks_db get_analysis_report(std::ostream& s, cfg_t& cfg, crab::invariant_table_t& pre_invariants,
+                                     crab::invariant_table_t& post_invariants) {
     // Analyze the control-flow graph.
     checks_db db = generate_report(cfg, pre_invariants, post_invariants);
     if (thread_local_options.print_invariants) {
@@ -160,10 +169,11 @@ checks_db get_analysis_report(std::ostream& s, cfg_t& cfg, crab::invariant_table
     return db;
 }
 
-checks_db get_ebpf_report(std::ostream& s, cfg_t& cfg, program_info info, const ebpf_verifier_options_t* options) {
+static checks_db get_ebpf_report(std::ostream& s, cfg_t& cfg, program_info info,
+                                 const ebpf_verifier_options_t* options) {
     global_program_info = std::move(info);
     crab::domains::clear_global_state();
-    variable_t::clear_thread_local_state();
+    crab::variable_t::clear_thread_local_state();
     thread_local_options = *options;
 
     try {
@@ -189,7 +199,7 @@ bool run_ebpf_analysis(std::ostream& s, cfg_t& cfg, const program_info& info, co
     if (stats) {
         stats->total_unreachable = report.total_unreachable;
         stats->total_warnings = report.total_warnings;
-        stats->max_instruction_count = report.max_instruction_count;
+        stats->max_instruction_count = report.get_max_instruction_count();
     }
     return (report.total_warnings == 0);
 }
@@ -207,10 +217,10 @@ ebpf_analyze_program_for_test(std::ostream& os, const InstructionSeq& prog, cons
                               const program_info& info, const ebpf_verifier_options_t& options) {
     thread_local_options = options;
     global_program_info = info;
-    ebpf_domain_t entry_inv = entry_invariant.is_bottom()
-        ? ebpf_domain_t::bottom()
-        : ebpf_domain_t::from_constraints(entry_invariant.value(), options.setup_constraints);
-    assert(!entry_inv.is_bottom());
+    assert(!entry_invariant.is_bottom());
+    ebpf_domain_t entry_inv = ebpf_domain_t::from_constraints(entry_invariant.value(), options.setup_constraints);
+    if (entry_inv.is_bottom())
+        throw std::runtime_error("Entry invariant is inconsistent");
     cfg_t cfg = prepare_cfg(prog, info, !options.no_simplify, false);
     auto [pre_invariants, post_invariants] = crab::run_forward_analyzer(cfg, entry_inv, options.check_termination);
     checks_db report = get_analysis_report(std::cerr, cfg, pre_invariants, post_invariants);
@@ -241,14 +251,13 @@ bool ebpf_verify_program(std::ostream& os, const InstructionSeq& prog, const pro
     if (stats) {
         stats->total_unreachable = report.total_unreachable;
         stats->total_warnings = report.total_warnings;
-        stats->max_instruction_count = report.max_instruction_count;
+        stats->max_instruction_count = report.get_max_instruction_count();
     }
     return (report.total_warnings == 0);
 }
 
-void ebpf_verifier_clear_thread_local_state()
-{
-    variable_t::clear_thread_local_state();
+void ebpf_verifier_clear_thread_local_state() {
+    crab::variable_t::clear_thread_local_state();
     crab::CrabStats::clear_thread_local_state();
     global_program_info.clear();
     crab::domains::clear_thread_local_state();

--- a/src/ebpf_yaml.cpp
+++ b/src/ebpf_yaml.cpp
@@ -170,9 +170,15 @@ static ebpf_verifier_options_t raw_options_to_options(const std::set<string>& ra
     options.no_simplify = true;
     options.setup_constraints = false;
 
-    for (string name : raw_options) {
+    for (const string& name : raw_options) {
         if (name == "!allow_division_by_zero") {
             options.allow_division_by_zero = false;
+        } else if (name == "termination") {
+            options.check_termination = true;
+        } else if (name == "strict") {
+            options.strict = true;
+        } else {
+            throw std::runtime_error("Unknown option: " + name);
         }
     }
     return options;
@@ -341,7 +347,7 @@ ConformanceTestResult run_conformance_test_case(const std::vector<uint8_t>& memo
 
         for (const std::string& invariant : actual_last_invariant.value()) {
             if (invariant.rfind("r0.svalue=", 0) == 0) {
-                int64_t lb, ub;
+                crab::number_t lb, ub;
                 if (invariant[10] == '[') {
                     lb = std::stoll(invariant.substr(11));
                     ub = std::stoll(invariant.substr(invariant.find(",", 11) + 1));

--- a/src/string_constraints.hpp
+++ b/src/string_constraints.hpp
@@ -58,4 +58,4 @@ struct string_invariant {
     friend std::ostream& operator<<(std::ostream&, const string_invariant& inv);
 };
 
-std::vector<linear_constraint_t> parse_linear_constraints(const std::set<std::string>& constraints, std::vector<crab::interval_t>& numeric_ranges);
+std::vector<crab::linear_constraint_t> parse_linear_constraints(const std::set<std::string>& constraints, std::vector<crab::interval_t>& numeric_ranges);

--- a/test-schema.yaml
+++ b/test-schema.yaml
@@ -12,6 +12,10 @@ required:
 properties:
   test-case:
     type: string
+  options:
+    type: array
+    items:
+      type: string
   pre:
     type: array
     items:


### PR DESCRIPTION
Trying to minimize the number of locations where accidental integer conversion may occur, and also simplify dsl_syntax. It is somewhat clunky; many explicit conversions may be avoided using templated constructor for e.g. interval_t.

This PR takes unimportant changes from #479. 