### PR TITLE
Add support for parsing BTF data from ELF files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,6 +78,7 @@ file(GLOB LIB_SRC
 
 file(GLOB ALL_TEST
         "./src/test/test.cpp"
+        "./src/test/test_btf.cpp"
         "./src/test/test_conformance.cpp"
         "./src/test/test_loop.cpp"
         "./src/test/test_marshal.cpp"

--- a/src/asm_files.cpp
+++ b/src/asm_files.cpp
@@ -190,7 +190,7 @@ vector<raw_program> read_elf(std::istream& input_stream, const std::string& path
         int pseudo_fd = 1;
         // Gather the typeids for each map and assign a pseudo-fd to each map.
         for (auto &map_descriptor : info.map_descriptors) {
-            if (!type_id_to_fd_map.contains(map_descriptor.original_fd)) {
+            if (type_id_to_fd_map.find(map_descriptor.original_fd) == type_id_to_fd_map.end()) {
                 type_id_to_fd_map[map_descriptor.original_fd] = pseudo_fd++;
             }
         }
@@ -202,7 +202,7 @@ vector<raw_program> read_elf(std::istream& input_stream, const std::string& path
             }
         }
         map_section_indices.insert(reader.sections[string(".maps")]->get_index());
-    } else if (btf && btf_ext) {
+    } else {
         map_record_size_or_map_offsets = parse_map_sections(options, platform, reader, info.map_descriptors, map_section_indices, symbols);
     }
 

--- a/src/asm_files.cpp
+++ b/src/asm_files.cpp
@@ -48,16 +48,6 @@ EbpfMapDescriptor* find_map_descriptor(int map_fd) {
     return nullptr;
 }
 
-EbpfMapDescriptor* get_map_descriptor_from_platform_or_program_info(int map_fd)
-{
-    if (global_program_info->map_descriptors.size() > 0) {
-        return &global_program_info->platform->get_map_descriptor(map_fd);
-    }
-    else {
-        return find_map_descriptor(map_fd);
-    }
-}
-
 // Maps sections are identified as any section called "maps", or matching "maps/<map-name>".
 bool is_map_section(const std::string& name) {
     std::string maps_prefix = "maps/";

--- a/src/asm_files.cpp
+++ b/src/asm_files.cpp
@@ -10,6 +10,7 @@
 #include <sys/stat.h>
 
 #include "asm_files.hpp"
+#include "btf.h"
 #include "btf_parser.h"
 #include "platform.hpp"
 
@@ -45,6 +46,16 @@ EbpfMapDescriptor* find_map_descriptor(int map_fd) {
         }
     }
     return nullptr;
+}
+
+EbpfMapDescriptor* get_map_descriptor_from_platform_or_program_info(int map_fd)
+{
+    if (global_program_info->map_descriptors.size() > 0) {
+        return &global_program_info->platform->get_map_descriptor(map_fd);
+    }
+    else {
+        return find_map_descriptor(map_fd);
+    }
 }
 
 // Maps sections are identified as any section called "maps", or matching "maps/<map-name>".
@@ -132,6 +143,10 @@ vector<raw_program> read_elf(std::istream& input_stream, const std::string& path
     program_info info{platform};
     std::set<ELFIO::Elf_Half> map_section_indices;
 
+    auto btf = reader.sections[string(".BTF")];
+    auto btf_ext = reader.sections[string(".BTF.ext")];
+    std::optional<btf_type_data> btf_data;
+
     auto symbol_section = reader.sections[".symtab"];
     if (!symbol_section) {
         throw std::runtime_error(string("No symbol section found in ELF file ") + path);
@@ -146,7 +161,50 @@ vector<raw_program> read_elf(std::istream& input_stream, const std::string& path
     }
 
     ELFIO::const_symbol_section_accessor symbols{reader, symbol_section};
-    size_t map_record_size = parse_map_sections(options, platform, reader, info.map_descriptors, map_section_indices, symbols);
+
+    if (btf) {
+        // Parse the BTF type data.
+        btf_data = vector_of<uint8_t>(*btf);
+        if (options->dump_btf_types_json) {
+            std::stringstream output;
+            std::cout << "Dumping BTF data for" << path << std::endl;
+            // Dump the BTF data to cout for debugging purposes.
+            btf_data->to_json(output);
+            std::cout << pretty_print_json(output.str()) << std::endl;
+            std::cout << std::endl;
+        }
+    }
+
+    std::variant<size_t, std::map<std::string, size_t>>  map_record_size_or_map_offsets = size_t(0);
+    if (reader.sections[string(".maps")]) {
+        if (!btf_data.has_value()){
+            throw std::runtime_error(string("No BTF section found in ELF file ") + path);
+        }
+        map_record_size_or_map_offsets = parse_btf_map_sections(btf_data.value(), info.map_descriptors);
+        // Prevail requires:
+        // Map fds are sequential starting from 1.
+        // Map fds are assigned in the order of the maps in the ELF file.
+
+        // Build a map from the original type id to the pseudo-fd.
+        std::map<int, int> type_id_to_fd_map;
+        int pseudo_fd = 1;
+        // Gather the typeids for each map and assign a pseudo-fd to each map.
+        for (auto &map_descriptor : info.map_descriptors) {
+            if (!type_id_to_fd_map.contains(map_descriptor.original_fd)) {
+                type_id_to_fd_map[map_descriptor.original_fd] = pseudo_fd++;
+            }
+        }
+        // Replace the typeids with the pseudo-fds.
+        for (auto &map_descriptor : info.map_descriptors) {
+            map_descriptor.original_fd = type_id_to_fd_map[map_descriptor.original_fd];
+            if (map_descriptor.inner_map_fd != -1) {
+                map_descriptor.inner_map_fd = type_id_to_fd_map[map_descriptor.inner_map_fd];
+            }
+        }
+        map_section_indices.insert(reader.sections[string(".maps")]->get_index());
+    } else if (btf && btf_ext) {
+        map_record_size_or_map_offsets = parse_map_sections(options, platform, reader, info.map_descriptors, map_section_indices, symbols);
+    }
 
     vector<raw_program> res;
     vector<string> unresolved_symbols;
@@ -208,12 +266,31 @@ vector<raw_program> read_elf(std::istream& input_stream, const std::string& path
                 }
                 inst.src = 1; // magic number for LoadFd
 
-                size_t reloc_value = get_value(symbols, index) / map_record_size;
-                if (reloc_value >= info.map_descriptors.size()) {
-                    throw std::runtime_error("Bad reloc value (" + std::to_string(reloc_value) + "). "
-                                             + "Make sure to compile with -O2.");
+                // Relocation value is an offset into the "maps" or ".maps" section.
+                size_t relocation_offset = get_value(symbols, index);
+                if (map_record_size_or_map_offsets.index() == 0) {
+                    // The older maps section format uses a single map_record_size value, so we can
+                    // calculate the map descriptor index directly.
+                    size_t reloc_value = relocation_offset / std::get<0>(map_record_size_or_map_offsets);
+                    if (reloc_value >= info.map_descriptors.size()) {
+                        throw std::runtime_error("Bad reloc value (" + std::to_string(reloc_value) + "). "
+                                                + "Make sure to compile with -O2.");
+                    }
+
+                    inst.imm = info.map_descriptors.at(reloc_value).original_fd;
                 }
-                inst.imm = info.map_descriptors.at(reloc_value).original_fd;
+                else {
+                    // The newer .maps section format uses a variable-length map descriptor array,
+                    // so we need to look up the map descriptor index in a map.
+                    auto& map_descriptors_offsets = std::get<1>(map_record_size_or_map_offsets);
+                    auto it = map_descriptors_offsets.find(symbol_name);
+
+                    if (it == map_descriptors_offsets.end()) {
+                        throw std::runtime_error("Bad reloc value (" + std::to_string(index) + "). "
+                                                + "Make sure to compile with -O2.");
+                    }
+                    inst.imm = info.map_descriptors.at(it->second).original_fd;
+                }
             }
         }
         prog.line_info.resize(prog.prog.size());
@@ -231,8 +308,6 @@ vector<raw_program> read_elf(std::istream& input_stream, const std::string& path
                                  "\nMake sure to inline all function calls.");
     }
 
-    auto btf = reader.sections[string(".BTF")];
-    auto btf_ext = reader.sections[string(".BTF.ext")];
     if (btf != nullptr && btf_ext != nullptr) {
         std::map<std::string, raw_program&> segment_to_program;
         for (auto& program : res) {

--- a/src/btf.h
+++ b/src/btf.h
@@ -24,10 +24,15 @@
 #define BTF_KIND_FLOAT 16      /* Floating point       */
 #define BTF_KIND_DECL_TAG 17   /* Decl Tag     */
 #define BTF_KIND_TYPE_TAG 18   /* Type Tag     */
+#define BTF_KIND_ENUM64 19     /* Enum w/64bit values  */
 
 #define BTF_INT_ENCODING(VAL) (((VAL)&0x0f000000) >> 24)
 #define BTF_INT_OFFSET(VAL) (((VAL)&0x00ff0000) >> 16)
 #define BTF_INT_BITS(VAL) ((VAL)&0x000000ff)
+
+#define BTF_INT_SIGNED ( 1 << 0 )
+#define BTF_INT_CHAR ( 1 << 1 )
+#define BTF_INT_BOOL ( 1 << 2 )
 
 #define BTF_MEMBER_BITFIELD_SIZE(val) ((val) >> 24)
 #define BTF_MEMBER_BIT_OFFSET(val) ((val)&0xffffff)
@@ -78,6 +83,10 @@ typedef struct _btf_type {
     };
 } btf_type_t;
 
+#define BPF_TYPE_INFO_VLEN(info) ((info)&0xffff)
+#define BPF_TYPE_INFO_KIND(info) (((info) >> 24) & 0x1f)
+#define BPF_TYPE_INFO_KIND_FLAG(info) (((info) >> 31) & 0x1)
+
 typedef struct _btf_array {
     uint32_t type;
     uint32_t index_type;
@@ -102,6 +111,23 @@ typedef struct _btf_var_secinfo {
 typedef struct _btf_decl_tag {
     uint32_t component_idx;
 } btf_decl_tag_t;
+
+typedef struct _btf_member {
+    uint32_t name_off;
+    uint32_t type;
+    uint32_t offset;
+} btf_member_t;
+
+typedef struct _btf_enum {
+    uint32_t name_off;
+    uint32_t val;
+} btf_enum_t;
+
+typedef struct _btf_enum64 {
+    uint32_t name_off;
+    uint32_t val_lo32;
+    uint32_t val_hi32;
+} btf_enum64_t;
 
 typedef struct _btf_ext_header {
     uint16_t magic;

--- a/src/btf_parser.cpp
+++ b/src/btf_parser.cpp
@@ -4,121 +4,1052 @@
 #include <map>
 #include <stdexcept>
 #include <string.h>
+#include <set>
 
 #include "btf.h"
 #include "btf_parser.h"
 
-void btf_parse_line_information(const std::vector<uint8_t>& btf, const std::vector<uint8_t>& btf_ext,
-                                btf_line_info_visitor visitor) {
+/**
+ * @brief Read a type from the .BTF section and advance the offset. Throws if
+ * the reading goes out of bounds.
+ *
+ * @tparam T Type to read
+ * @param[in] btf The .BTF section
+ * @param[in,out] offset Offset to read from. Will be advanced by the size of T.
+ * @param[in] minimum_offset Minimum offset allowed to read from.
+ * @param[in] maximum_offset Maximum offset allowed to read from.
+ * @return Value of type T read from the .BTF section
+ */
+template <typename T>
+static T _read_btf(const std::vector<uint8_t>& btf, size_t& offset, size_t minimum_offset = 0, size_t maximum_offset = 0) {
+    size_t length = 0;
+    if (maximum_offset == 0) {
+        maximum_offset = btf.size();
+    }
+    if (offset < minimum_offset || offset > maximum_offset) {
+        throw std::runtime_error("Invalid .BTF section - invalid offset");
+    }
+
+    if constexpr (std::is_same<T, std::string>::value) {
+        length = strnlen(reinterpret_cast<const char*>(btf.data()) + offset, maximum_offset - offset);
+        offset += length + 1;
+        if (offset > maximum_offset) {
+            throw std::runtime_error("Invalid .BTF section - invalid string length");
+        }
+        return std::string(reinterpret_cast<const char*>(btf.data()) + offset - length - 1, length);
+    } else {
+        length = sizeof(T);
+        offset += length;
+        if (offset > maximum_offset) {
+            throw std::runtime_error("Invalid .BTF section - invalid type length");
+        }
+        return *reinterpret_cast<const T*>(btf.data() + offset - length);
+    }
+}
+
+static void _validate_offset(std::vector<uint8_t> const& btf, size_t offset) {
+    if (offset < 0) {
+        throw std::runtime_error("Invalid .BTF section - invalid offset");
+    }
+
+    if (offset > btf.size()) {
+        throw std::runtime_error("Invalid .BTF section - invalid offset");
+    }
+}
+
+static void _validate_range(std::vector<uint8_t> const& btf, size_t start, size_t end) {
+    _validate_offset(btf, start);
+    _validate_offset(btf, end);
+
+    if (start > end) {
+        throw std::runtime_error("Invalid .BTF section - invalid range");
+    }
+}
+
+static std::map<size_t, std::string> _btf_parse_string_table(const std::vector<uint8_t>& btf) {
     std::map<size_t, std::string> string_table;
 
-    if (btf.size() < sizeof(btf_header_t)) {
-        throw std::runtime_error("Invalid .BTF section - section too small");
-    }
-    auto btf_header = reinterpret_cast<const btf_header_t*>(btf.data());
-    if (btf_header->magic != BTF_HEADER_MAGIC) {
+    size_t offset = 0;
+    auto btf_header = _read_btf<btf_header_t>(btf, offset);
+    if (btf_header.magic != BTF_HEADER_MAGIC) {
         throw std::runtime_error("Invalid .BTF section - wrong magic");
     }
-    if (btf_header->version != BTF_HEADER_VERSION) {
+    if (btf_header.version != BTF_HEADER_VERSION) {
         throw std::runtime_error("Invalid .BTF section - wrong version");
     }
-    if (btf_header->hdr_len < sizeof(btf_header_t)) {
+    if (btf_header.hdr_len < sizeof(btf_header_t)) {
         throw std::runtime_error("Invalid .BTF section - wrong size");
     }
-    if (btf_header->hdr_len > btf.size()) {
+    if (btf_header.hdr_len > btf.size()) {
         throw std::runtime_error("Invalid .BTF section - invalid header length");
     }
 
-    size_t string_table_start = static_cast<size_t>(btf_header->hdr_len) + static_cast<size_t>(btf_header->str_off);
-    size_t string_table_end = string_table_start + static_cast<size_t>(btf_header->str_len);
-    if (string_table_start < 0 || string_table_start > btf.size()) {
-        throw std::runtime_error("Invalid .BTF section - invalid string table start");
-    }
-    if (string_table_end < 0 || string_table_end > btf.size()) {
-        throw std::runtime_error("Invalid .BTF section - invalid string table end");
-    }
+    size_t string_table_start = static_cast<size_t>(btf_header.hdr_len) + static_cast<size_t>(btf_header.str_off);
+    size_t string_table_end = string_table_start + static_cast<size_t>(btf_header.str_len);
+
+    _validate_range(btf, string_table_start, string_table_end);
 
     for (size_t offset = string_table_start; offset < string_table_end;) {
-        const char* string_start = reinterpret_cast<const char*>(btf.data()) + offset;
-        size_t string_length = strnlen(string_start, btf.size() - offset);
-        std::string value(string_start, string_length);
-        size_t string_offset =
-            offset - static_cast<size_t>(btf_header->str_off) - static_cast<size_t>(btf_header->hdr_len);
-        offset += value.size() + 1;
-        string_table.insert(std::make_pair(string_offset, value));
+        size_t string_offset = offset - string_table_start;
+        std::string value = _read_btf<std::string>(btf, offset, string_table_start, string_table_end);
+        if (offset > string_table_end) {
+            throw std::runtime_error("Invalid .BTF section - invalid string length");
+        }
+        string_table.insert({string_offset, value});
     }
+    return string_table;
+}
 
-    if (btf_ext.size() < sizeof(btf_ext_header_t)) {
-        throw std::runtime_error("Invalid .BTF.ext section - section too small");
+static std::string _btf_find_string(const std::map<size_t, std::string>& string_table, size_t string_offset) {
+    auto it = string_table.find(string_offset);
+    if (it == string_table.end()) {
+        throw std::runtime_error(std::string("Invalid .BTF section - invalid string offset"));
     }
-    auto bpf_ext_header = reinterpret_cast<const btf_ext_header_t*>(btf_ext.data());
-    if (bpf_ext_header->magic != BTF_HEADER_MAGIC) {
+    return it->second;
+}
+
+void btf_parse_line_information(const std::vector<uint8_t>& btf, const std::vector<uint8_t>& btf_ext,
+                                btf_line_info_visitor visitor) {
+    std::map<size_t, std::string> string_table = _btf_parse_string_table(btf);
+
+    size_t btf_ext_offset = 0;
+    auto bpf_ext_header = _read_btf<btf_ext_header_t>(btf_ext, btf_ext_offset);
+    if (bpf_ext_header.hdr_len < sizeof(btf_ext_header_t)) {
+        throw std::runtime_error("Invalid .BTF.ext section - wrong size");
+    }
+    if (bpf_ext_header.magic != BTF_HEADER_MAGIC) {
         throw std::runtime_error("Invalid .BTF.ext section - wrong magic");
     }
-    if (bpf_ext_header->version != BTF_HEADER_VERSION) {
+    if (bpf_ext_header.version != BTF_HEADER_VERSION) {
         throw std::runtime_error("Invalid .BTF.ext section - wrong version");
     }
-    if (bpf_ext_header->hdr_len < sizeof(btf_ext_header_t)) {
-        throw std::runtime_error("Invalid .BTF.ext section - wrong size");
+    if (bpf_ext_header.hdr_len > btf_ext.size()) {
+        throw std::runtime_error("Invalid .BTF.ext section - invalid header length");
     }
 
     size_t line_info_start =
-        static_cast<size_t>(bpf_ext_header->hdr_len) + static_cast<size_t>(bpf_ext_header->line_info_off);
-    size_t line_info_end = line_info_start + static_cast<size_t>(bpf_ext_header->line_info_len);
+        static_cast<size_t>(bpf_ext_header.hdr_len) + static_cast<size_t>(bpf_ext_header.line_info_off);
+    size_t line_info_end = line_info_start + static_cast<size_t>(bpf_ext_header.line_info_len);
 
-    if (line_info_start < 0) {
-        throw std::runtime_error("Invalid .BTF.ext section - invalid btf_line_info table start");
-    }
-    if (line_info_end < 0 || line_info_end > btf_ext.size()) {
-        throw std::runtime_error("Invalid .BTF.ext section - invalid btf_line_info string table end");
-    }
-    if (static_cast<size_t>(bpf_ext_header->line_info_off) < 4) {
-        throw std::runtime_error("Invalid .BTF.ext section - invalid line info off size");
-    }
-    if (line_info_start + sizeof(uint32_t) > line_info_end) {
-        throw std::runtime_error("Invalid .BTF.ext section - invalid btf_line_info table size");
-    }
+    _validate_range(btf_ext, line_info_start, line_info_end);
 
-    uint32_t line_info_record_size =
-        *reinterpret_cast<const uint32_t*>(btf_ext.data() + line_info_start);
-
+    btf_ext_offset = line_info_start;
+    uint32_t line_info_record_size = _read_btf<uint32_t>(btf_ext, btf_ext_offset, line_info_start, line_info_end);
     if (line_info_record_size < sizeof(bpf_line_info_t)) {
         throw std::runtime_error(std::string("Invalid .BTF.ext section - invalid line info record size"));
     }
 
-    for (size_t offset = line_info_start + sizeof(line_info_record_size); offset < line_info_end;) {
-        if ((offset + offsetof(btf_ext_info_sec_t, data)) > line_info_end) {
-            throw std::runtime_error(std::string("Invalid info section offset"));
+    for (; btf_ext_offset < line_info_end;) {
+        auto section_info = _read_btf<btf_ext_info_sec_t>(btf_ext, btf_ext_offset, line_info_start, line_info_end);
+        auto section_name = _btf_find_string(string_table, section_info.sec_name_off);
+        for (size_t index = 0; index < section_info.num_info; index++) {
+            auto btf_line_info = _read_btf<bpf_line_info_t>(btf_ext, btf_ext_offset, line_info_start, line_info_end);
+            auto file_name = _btf_find_string(string_table, btf_line_info.file_name_off);
+            auto source = _btf_find_string(string_table, btf_line_info.line_off);
+            visitor(section_name, btf_line_info.insn_off, file_name, source,
+                    BPF_LINE_INFO_LINE_NUM(btf_line_info.line_col), BPF_LINE_INFO_LINE_COL(btf_line_info.line_col));
         }
-
-        auto section_info = reinterpret_cast<const btf_ext_info_sec_t*>(btf_ext.data() + offset);
-        size_t section_info_size = offsetof(btf_ext_info_sec_t, data) + static_cast<size_t>(line_info_record_size) *
-                                                                            static_cast<size_t>(section_info->num_info);
-        if ((offset + section_info_size) > line_info_end) {
-            throw std::runtime_error(std::string("Invalid .BTF.ext section - invalid size"));
-        }
-
-        auto section_name = string_table.find(section_info->sec_name_off);
-        if (section_name == string_table.end()) {
-            throw std::runtime_error(std::string("Invalid .BTF.ext section - invalid string offset ") +
-                                     std::to_string(section_info->sec_name_off));
-        }
-        for (size_t index = 0; index < section_info->num_info; index++) {
-            auto btf_line_info =
-                reinterpret_cast<const bpf_line_info_t*>(section_info->data + index * line_info_record_size);
-            auto file_name = string_table.find(btf_line_info->file_name_off);
-            auto source = string_table.find(btf_line_info->line_off);
-            std::string file_name_string;
-            std::string source_line_string;
-            if (file_name != string_table.end()) {
-                file_name_string = file_name->second;
-            }
-            if (source != string_table.end()) {
-                source_line_string = source->second;
-            }
-            visitor(section_name->second, btf_line_info->insn_off, file_name_string, source_line_string,
-                    BPF_LINE_INFO_LINE_NUM(btf_line_info->line_col), BPF_LINE_INFO_LINE_COL(btf_line_info->line_col));
-        }
-        offset += section_info_size;
     }
+}
+
+void btf_parse_types(const std::vector<uint8_t>& btf, btf_type_visitor visitor) {
+    std::map<size_t, std::string> string_table = _btf_parse_string_table(btf);
+    btf_type_id id = 0;
+    size_t offset = 0;
+
+    auto btf_header = _read_btf<btf_header_t>(btf, offset);
+
+    if (btf_header.magic != BTF_HEADER_MAGIC) {
+        throw std::runtime_error("Invalid .BTF section - wrong magic");
+    }
+
+    if (btf_header.version != BTF_HEADER_VERSION) {
+        throw std::runtime_error("Invalid .BTF section - wrong version");
+    }
+
+    if (btf_header.hdr_len < sizeof(btf_header_t)) {
+        throw std::runtime_error("Invalid .BTF section - wrong size");
+    }
+
+    size_t type_start = static_cast<size_t>(btf_header.hdr_len) + static_cast<size_t>(btf_header.type_off);
+    size_t type_end = type_start + static_cast<size_t>(btf_header.type_len);
+
+    _validate_range(btf, type_start, type_end);
+
+    btf_kind_null kind_null;
+    visitor(0, "void", {kind_null});
+
+    size_t type_offset = type_start;
+    for (offset = type_start; offset < type_end;) {
+        std::optional<std::string> name;
+        auto btf_type = _read_btf<btf_type_t>(btf, offset, type_start, type_end);
+        if (btf_type.name_off) {
+            name = _btf_find_string(string_table, btf_type.name_off);
+        }
+        else {
+            // Throw for types that should have a name.
+            switch (BPF_TYPE_INFO_KIND(btf_type.info)) {
+                case BTF_KIND_INT:
+                case BTF_KIND_FWD:
+                case BTF_KIND_TYPEDEF:
+                case BTF_KIND_FUNC:
+                case BTF_KIND_VAR:
+                case BTF_KIND_DATASEC:
+                case BTF_KIND_FLOAT:
+                case BTF_KIND_DECL_TAG:
+                case BTF_KIND_TYPE_TAG:
+                    throw std::runtime_error("Invalid .BTF section - missing name");
+                default:
+                    name = std::nullopt;
+                    break;
+            }
+        }
+        btf_kind kind;
+        switch (BPF_TYPE_INFO_KIND(btf_type.info)) {
+        case BTF_KIND_INT: {
+            btf_kind_int kind_int;
+            uint32_t int_data = _read_btf<uint32_t>(btf, offset, type_start, type_end);
+            uint32_t encoding = BTF_INT_ENCODING(int_data);
+            kind_int.offset_from_start_in_bits = BTF_INT_OFFSET(int_data);
+            kind_int.field_width_in_bits = BTF_INT_BITS(int_data);
+            kind_int.is_signed = BTF_INT_SIGNED & encoding;
+            kind_int.is_bool = BTF_INT_BOOL & encoding;
+            kind_int.is_char = BTF_INT_CHAR & encoding;
+            kind_int.size_in_bytes = btf_type.size;
+            kind_int.name = name.value();
+            kind = kind_int;
+            break;
+        }
+        case BTF_KIND_PTR: {
+            btf_kind_ptr kind_ptr;
+            kind_ptr.type = btf_type.type;
+            kind = kind_ptr;
+            break;
+        }
+        case BTF_KIND_ARRAY: {
+            auto btf_array = _read_btf<btf_array_t>(btf, offset, type_start, type_end);
+            btf_kind_array kind_array;
+            kind_array.element_type = btf_array.type;
+            kind_array.index_type = btf_array.index_type;
+            kind_array.count_of_elements = btf_array.nelems;
+            kind = kind_array;
+            break;
+        }
+        case BTF_KIND_STRUCT: {
+            uint32_t member_count = BPF_TYPE_INFO_VLEN(btf_type.info);
+            btf_kind_struct kind_struct;
+            for (uint32_t index = 0; index < member_count; index++) {
+                btf_kind_struct_member member;
+                auto btf_member = _read_btf<btf_member_t>(btf, offset, type_start, type_end);
+                if (btf_member.name_off) {
+                    member.name = _btf_find_string(string_table, btf_member.name_off);
+                }
+                member.type = btf_member.type;
+                member.offset_from_start_in_bits = btf_member.offset;
+                kind_struct.members.push_back(member);
+            }
+            kind_struct.size_in_bytes = btf_type.size;
+            kind_struct.name = name;
+            kind = kind_struct;
+            break;
+        }
+        case BTF_KIND_UNION: {
+            uint32_t member_count = BPF_TYPE_INFO_VLEN(btf_type.info);
+            btf_kind_union kind_union;
+            for (uint32_t index = 0; index < member_count; index++) {
+                btf_kind_struct_member member;
+                auto btf_member = _read_btf<btf_member_t>(btf, offset, type_start, type_end);
+                if (btf_member.name_off) {
+                    member.name = _btf_find_string(string_table, btf_member.name_off);
+                }
+                member.type = btf_member.type;
+                member.offset_from_start_in_bits = btf_member.offset;
+                kind_union.members.push_back(member);
+            }
+            kind_union.name = name;
+            kind_union.size_in_bytes = btf_type.size;
+            kind = kind_union;
+            break;
+        }
+        case BTF_KIND_ENUM: {
+            uint32_t enum_count = BPF_TYPE_INFO_VLEN(btf_type.info);
+            btf_kind_enum kind_enum;
+            for (uint32_t index = 0; index < enum_count; index++) {
+                auto btf_enum = _read_btf<btf_enum_t>(btf, offset, type_start, type_end);
+                btf_kind_enum_member member;
+                if (!btf_enum.name_off) {
+                    throw std::runtime_error("Invalid .BTF section - invalid BTF_KIND_ENUM member name");
+                }
+                member.name = _btf_find_string(string_table, btf_enum.name_off);
+                member.value = btf_enum.val;
+                kind_enum.members.push_back(member);
+            }
+            kind_enum.is_signed = BPF_TYPE_INFO_KIND_FLAG(btf_type.info);
+            kind_enum.name = name;
+            kind_enum.size_in_bytes = btf_type.size;
+            kind = kind_enum;
+            break;
+        }
+        case BTF_KIND_FWD: {
+            btf_kind_fwd kind_fwd;
+            kind_fwd.name = name.value();
+            kind_fwd.is_struct = BPF_TYPE_INFO_KIND_FLAG(btf_type.info);
+            kind = kind_fwd;
+            break;
+        }
+        case BTF_KIND_TYPEDEF: {
+            btf_kind_typedef kind_typedef;
+            kind_typedef.name = name.value();
+            kind_typedef.type = btf_type.type;
+            kind = kind_typedef;
+            break;
+        }
+        case BTF_KIND_VOLATILE: {
+            btf_kind_volatile kind_volatile;
+            kind_volatile.type = btf_type.type;
+            kind = kind_volatile;
+            break;
+        }
+        case BTF_KIND_CONST: {
+            btf_kind_const kind_const;
+            kind_const.type = btf_type.type;
+            kind = kind_const;
+            break;
+        }
+        case BTF_KIND_RESTRICT: {
+            btf_kind_restrict kind_restrict;
+            kind_restrict.type = btf_type.type;
+            kind = kind_restrict;
+            break;
+        }
+        case BTF_KIND_FUNC: {
+            btf_kind_func kind_func;
+            kind_func.name = name.value();
+            kind_func.type = btf_type.type;
+            kind_func.linkage = static_cast<decltype(btf_kind_func::linkage)>(BPF_TYPE_INFO_VLEN(btf_type.info));
+            kind = kind_func;
+            break;
+        }
+        case BTF_KIND_FUNC_PROTO: {
+            btf_kind_function kind_function;
+            uint32_t param_count = BPF_TYPE_INFO_VLEN(btf_type.info);
+            for (uint32_t index = 0; index < param_count; index++) {
+                auto btf_param = _read_btf<btf_param_t>(btf, offset, type_start, type_end);
+                btf_kind_function_parameter param;
+                // Name is optional.
+                if (btf_param.name_off) {
+                    param.name = _btf_find_string(string_table, btf_param.name_off);
+                }
+                param.type = btf_param.type;
+                kind_function.parameters.push_back(param);
+            }
+            kind_function.return_type = btf_type.type;
+            kind = kind_function;
+            break;
+        }
+        case BTF_KIND_VAR: {
+            btf_kind_var kind_var;
+            auto btf_var = _read_btf<btf_var_t>(btf, offset, type_start, type_end);
+            kind_var.name = name.value();
+            kind_var.type = btf_type.type;
+            kind_var.linkage = static_cast<decltype(btf_kind_var::linkage)>(btf_var.linkage);
+            kind = kind_var;
+            break;
+        }
+        case BTF_KIND_DATASEC: {
+            btf_kind_data_section kind_data_section;
+            uint32_t section_count = BPF_TYPE_INFO_VLEN(btf_type.info);
+            for (uint32_t index = 0; index < section_count; index++) {
+                auto btf_section_info = _read_btf<btf_var_secinfo_t>(btf, offset, type_start, type_end);
+                btf_kind_data_member member;
+                member.type = btf_section_info.type;
+                member.offset = btf_section_info.offset;
+                member.size = btf_section_info.size;
+                kind_data_section.members.push_back(member);
+            }
+            kind_data_section.name = name.value();
+            kind_data_section.size = btf_type.size;
+            kind = kind_data_section;
+            break;
+        }
+        case BTF_KIND_FLOAT: {
+            btf_kind_float kind_float;
+            kind_float.name = name.value();
+            kind_float.size_in_bytes = btf_type.size;
+            kind = kind_float;
+            break;
+        }
+        case BTF_KIND_DECL_TAG: {
+            btf_kind_decl_tag kind_decl_tag;
+            auto btf_decl_tag = _read_btf<btf_decl_tag_t>(btf, offset, type_start, type_end);
+            kind_decl_tag.name = name.value();
+            kind_decl_tag.type = btf_type.type;
+            kind_decl_tag.component_index = btf_decl_tag.component_idx;
+            kind = kind_decl_tag;
+            break;
+        }
+        case BTF_KIND_TYPE_TAG: {
+            btf_kind_type_tag kind_type_tag;
+            kind_type_tag.name = name.value();
+            kind_type_tag.type = btf_type.type;
+            kind = kind_type_tag;
+            break;
+        }
+        case BTF_KIND_ENUM64: {
+            uint32_t enum_count = BPF_TYPE_INFO_VLEN(btf_type.info);
+            btf_kind_enum64 kind_enum;
+            for (uint32_t index = 0; index < enum_count; index++) {
+                auto btf_enum64 = _read_btf<btf_enum64_t>(btf, offset, type_start, type_end);
+                btf_kind_enum64_member member;
+                member.name = _btf_find_string(string_table, btf_enum64.name_off);
+                member.value = (static_cast<uint64_t>(btf_enum64.val_hi32) << 32) | btf_enum64.val_lo32;
+                kind_enum.members.push_back(member);
+            }
+            kind_enum.is_signed = BPF_TYPE_INFO_KIND_FLAG(btf_type.info);
+            kind_enum.name = name;
+            kind_enum.size_in_bytes = btf_type.size;
+            kind = kind_enum;
+            break;
+        }
+        default: throw std::runtime_error("Invalid .BTF section - invalid BTF_KIND");
+        }
+        visitor(++id, name, kind);
+    }
+}
+
+std::string pretty_print_json(const std::string& input)
+{
+    // Walk over the input string, inserting newlines and indentation.
+    std::string output;
+    int indent = 0;
+    bool in_string = false;
+    for (size_t i = 0; i < input.size(); i++)
+    {
+        char c = input[i];
+        if (c == '"')
+        {
+            in_string = !in_string;
+        }
+        if (in_string)
+        {
+            output += c;
+            continue;
+        }
+        switch (c)
+        {
+        case '{':
+        case '[':
+            output += c;
+            if (i + 1 < input.size() && input[i + 1] != '}' && input[i + 1] != ']')
+            {
+                output += '\n';
+                indent += 2;
+                output += std::string(indent, ' ');
+            }
+            else {
+                output += input[++i];
+            }
+            break;
+        case '}':
+        case ']':
+            output += '\n';
+            indent -= 2;
+            output += std::string(indent, ' ');
+            output += c;
+            break;
+        case ',':
+            output += c;
+            output += '\n';
+            output += std::string(indent, ' ');
+            break;
+        case ':':
+            output += c;
+            output += ' ';
+            break;
+        default:
+            output += c;
+            break;
+        }
+    }
+    return output;
+}
+
+template <typename T>
+void print_json_value(bool& first, const std::string& name, T value, std::ostream& out)
+{
+    // If T is a string type, print it as a string, then quote the value.
+    if constexpr (std::is_same_v<T, std::string> || std::is_same_v<T, const char*> || std::is_same_v<T, char*>)
+    {
+        out << (first ? "" : ",") << "\"" << name << "\":\"" << value << "\"";
+        first = false;
+    }
+    // If T is a bool, print it as a string, then quote the value.
+    else if constexpr (std::is_same_v<T, bool>)
+    {
+        out << (first ? "" : ",") << "\"" << name << "\":" << (value ? "true" : "false");
+        first = false;
+    }
+    // If T is a std::optional<std::string>, then only print if it's present
+    else if constexpr (std::is_same_v<T, std::optional<std::string>>)
+    {
+        if (value.has_value())
+        {
+            out << (first ? "" : ",") << "\"" << name << "\":\"" << value.value() << "\"";
+            first = false;
+        }
+    }
+    else
+    {
+        out << (first ? "" : ",") << "\"" << name << "\":" << std::to_string(value);
+        first = false;
+    }
+}
+
+void print_array_start(const std::string& name, std::ostream& out)
+{
+    out << "\"" << name << "\":[";
+}
+
+void print_array_end(std::ostream& out)
+{
+    out << "]";
+}
+
+#define PRINT_JSON_FIXED(name, value) \
+    print_json_value(first, name, value, out);
+
+#define PRINT_JSON_VALUE(object, value) \
+    print_json_value(first, #value, object.value, out)
+
+#define PRINT_JSON_TYPE(object, value) \
+    if (!first) { out << ",";} else { first = false; }; \
+    out << "\"" << #value << "\":"; \
+    print_btf_kind(object.value, id_to_kind.at(object.value));
+
+#define PRINT_JSON_ARRAY_START(object, value) \
+    if (!first) {                             \
+        out << ",";                           \
+    } else {                                  \
+        first = false;                        \
+    }                                         \
+    print_array_start(#value, out);           \
+    {                                         \
+        bool first = true;
+
+#define PRINT_JSON_ARRAY_END() \
+    print_array_end(out); \
+    }
+
+#define PRINT_JSON_OBJECT_START() \
+    if (!first) { out << ",";} else { first = false; }; \
+    {\
+    bool first = true; \
+    out << "{";
+
+#define PRINT_JSON_OBJECT_END() \
+    out << "}";\
+    }
+
+void btf_type_to_json(const std::map<btf_type_id, btf_kind>& id_to_kind, std::ostream& out)
+{
+    std::function<void (btf_type_id, const btf_kind&)> print_btf_kind = [&](btf_type_id id, const btf_kind& kind) {
+        bool first = true;
+        PRINT_JSON_OBJECT_START();
+        PRINT_JSON_FIXED("id", id);
+        switch (kind.index()) {
+        case 0: PRINT_JSON_FIXED("kind_type", "BTF_KIND_VOID"); break;
+        case BTF_KIND_INT: {
+            auto& kind_int = std::get<BTF_KIND_INT>(kind);
+            PRINT_JSON_FIXED("kind_type", "BTF_KIND_INT");
+            PRINT_JSON_VALUE(kind_int, name);
+            PRINT_JSON_VALUE(kind_int, size_in_bytes);
+            PRINT_JSON_VALUE(kind_int, offset_from_start_in_bits);
+            PRINT_JSON_VALUE(kind_int, field_width_in_bits);
+            PRINT_JSON_VALUE(kind_int, is_signed);
+            PRINT_JSON_VALUE(kind_int, is_char);
+            PRINT_JSON_VALUE(kind_int, is_bool);
+            break;
+        }
+        case BTF_KIND_PTR: {
+            auto& kind_ptr = std::get<BTF_KIND_PTR>(kind);
+            PRINT_JSON_FIXED("kind_type", "BTF_KIND_PTR");
+            PRINT_JSON_TYPE(kind_ptr, type);
+            break;
+        }
+        case BTF_KIND_ARRAY: {
+            auto& kind_array = std::get<BTF_KIND_ARRAY>(kind);
+            PRINT_JSON_FIXED("kind_type", "BTF_KIND_ARRAY");
+            PRINT_JSON_VALUE(kind_array, count_of_elements);
+            PRINT_JSON_TYPE(kind_array, element_type);
+            PRINT_JSON_TYPE(kind_array, index_type);
+            break;
+        }
+        case BTF_KIND_STRUCT: {
+            auto& kind_struct = std::get<BTF_KIND_STRUCT>(kind);
+            PRINT_JSON_FIXED("kind_type", "BTF_KIND_STRUCT");
+            PRINT_JSON_VALUE(kind_struct, name);
+            PRINT_JSON_VALUE(kind_struct, size_in_bytes);
+            PRINT_JSON_ARRAY_START(kind_struct, members);
+            for (auto& member : kind_struct.members) {
+                PRINT_JSON_OBJECT_START();
+                PRINT_JSON_VALUE(member, name);
+                PRINT_JSON_VALUE(member, offset_from_start_in_bits);
+                PRINT_JSON_TYPE(member, type);
+                PRINT_JSON_OBJECT_END();
+            }
+            PRINT_JSON_ARRAY_END();
+            break;
+        }
+        case BTF_KIND_UNION: {
+            auto kind_union = std::get<BTF_KIND_UNION>(kind);
+            PRINT_JSON_FIXED("kind_type", "BTF_KIND_UNION");
+            PRINT_JSON_VALUE(kind_union, name);
+            PRINT_JSON_VALUE(kind_union, size_in_bytes);
+            PRINT_JSON_ARRAY_START(kind_union, members);
+            for (auto& member : kind_union.members) {
+                PRINT_JSON_OBJECT_START();
+                PRINT_JSON_VALUE(member, name);
+                PRINT_JSON_VALUE(member, offset_from_start_in_bits);
+                PRINT_JSON_TYPE(member, type);
+                PRINT_JSON_OBJECT_END();
+            }
+            PRINT_JSON_ARRAY_END();
+            break;
+        }
+        case BTF_KIND_ENUM: {
+            auto& kind_enum = std::get<BTF_KIND_ENUM>(kind);
+            PRINT_JSON_FIXED("kind_type", "BTF_KIND_ENUM");
+            PRINT_JSON_VALUE(kind_enum, name);
+            PRINT_JSON_VALUE(kind_enum, size_in_bytes);
+            PRINT_JSON_ARRAY_START(kind_union, members);
+            for (auto& member : kind_enum.members) {
+                PRINT_JSON_OBJECT_START();
+                PRINT_JSON_VALUE(member, name);
+                PRINT_JSON_VALUE(member, value);
+                PRINT_JSON_OBJECT_END();
+            }
+            PRINT_JSON_ARRAY_END();
+            break;
+        }
+        case BTF_KIND_FWD: {
+            auto kind_fwd = std::get<BTF_KIND_FWD>(kind);
+            PRINT_JSON_FIXED("kind_type", "BTF_KIND_FWD");
+            PRINT_JSON_VALUE(kind_fwd, name);
+            PRINT_JSON_VALUE(kind_fwd, is_struct);
+            break;
+        }
+        case BTF_KIND_TYPEDEF: {
+            auto& kind_typedef = std::get<BTF_KIND_TYPEDEF>(kind);
+            PRINT_JSON_FIXED("kind_type", "BTF_KIND_TYPEDEF");
+            PRINT_JSON_VALUE(kind_typedef, name);
+            PRINT_JSON_TYPE(kind_typedef, type);
+            break;
+        }
+        case BTF_KIND_VOLATILE: {
+            auto& kind_volatile = std::get<BTF_KIND_VOLATILE>(kind);
+            PRINT_JSON_FIXED("kind_type", "BTF_KIND_VOLATILE");
+            PRINT_JSON_TYPE(kind_volatile, type);
+            break;
+        }
+        case BTF_KIND_CONST: {
+            auto& kind_const = std::get<BTF_KIND_CONST>(kind);
+            PRINT_JSON_FIXED("kind_type", "BTF_KIND_CONST");
+            PRINT_JSON_TYPE(kind_const, type);
+            break;
+        }
+        case BTF_KIND_RESTRICT: {
+            auto& kind_restrict = std::get<BTF_KIND_RESTRICT>(kind);
+            PRINT_JSON_FIXED("kind_type", "BTF_KIND_RESTRICT");
+            PRINT_JSON_TYPE(kind_restrict, type);
+            break;
+        }
+        case BTF_KIND_FUNC: {
+            auto kind_func = std::get<BTF_KIND_FUNC>(kind);
+            PRINT_JSON_FIXED("kind_type", "BTF_KIND_FUNC");
+            PRINT_JSON_VALUE(kind_func, name);
+            switch (kind_func.linkage) {
+            case 0: PRINT_JSON_FIXED("linkage", "BTF_FUNC_STATIC"); break;
+            case 1: PRINT_JSON_FIXED("linkage", "BTF_FUNC_GLOBAL"); break;
+            case 2: PRINT_JSON_FIXED("linkage", "BTF_FUNC_EXTERN"); break;
+            default: PRINT_JSON_FIXED("linkage", "UNKNOWN"); break;
+            }
+            PRINT_JSON_TYPE(kind_func, type);
+            break;
+        }
+        case BTF_KIND_FUNC_PROTO: {
+            auto& kind_func_proto = std::get<BTF_KIND_FUNC_PROTO>(kind);
+            PRINT_JSON_FIXED("kind_type", "BTF_KIND_FUNC_PROTO");
+            PRINT_JSON_ARRAY_START(kind_func_proto, parameters);
+            for (auto& parameter : kind_func_proto.parameters) {
+                PRINT_JSON_OBJECT_START();
+                PRINT_JSON_VALUE(parameter, name);
+                PRINT_JSON_TYPE(parameter, type);
+                PRINT_JSON_OBJECT_END();
+            }
+            PRINT_JSON_ARRAY_END();
+            PRINT_JSON_TYPE(kind_func_proto, return_type);
+            break;
+        }
+        case BTF_KIND_VAR: {
+            auto& kind_var = std::get<BTF_KIND_VAR>(kind);
+            PRINT_JSON_FIXED("kind_type", "BTF_KIND_VAR");
+            PRINT_JSON_VALUE(kind_var, name);
+            switch (kind_var.linkage) {
+            case 0: PRINT_JSON_FIXED("linkage", "BTF_LINKAGE_GLOBAL"); break;
+            case 1: PRINT_JSON_FIXED("linkage", "BTF_LINKAGE_STATIC"); break;
+            default: PRINT_JSON_FIXED("linkage", "UNKNOWN"); break;
+            }
+            PRINT_JSON_TYPE(kind_var, type);
+            break;
+        }
+        case BTF_KIND_DATASEC: {
+            auto& kind_datasec = std::get<BTF_KIND_DATASEC>(kind);
+            PRINT_JSON_FIXED("kind_type", "BTF_KIND_DATASEC");
+            PRINT_JSON_VALUE(kind_datasec, name);
+            PRINT_JSON_VALUE(kind_datasec, size);
+            PRINT_JSON_ARRAY_START(kind_datasec, members);
+            for (auto& data : kind_datasec.members) {
+                PRINT_JSON_OBJECT_START();
+                PRINT_JSON_VALUE(data, offset);
+                PRINT_JSON_VALUE(data, size);
+                PRINT_JSON_TYPE(data, type);
+                PRINT_JSON_OBJECT_END();
+            }
+            PRINT_JSON_ARRAY_END();
+            break;
+        }
+        case BTF_KIND_FLOAT: {
+            auto kind_float = std::get<BTF_KIND_FLOAT>(kind);
+            PRINT_JSON_FIXED("kind_type", "BTF_KIND_FLOAT");
+            PRINT_JSON_VALUE(kind_float, name);
+            PRINT_JSON_VALUE(kind_float, size_in_bytes);
+            break;
+        }
+        case BTF_KIND_DECL_TAG: {
+            auto& kind_decl_tag = std::get<BTF_KIND_DECL_TAG>(kind);
+            PRINT_JSON_FIXED("kind_type", "BTF_KIND_DECL_TAG");
+            PRINT_JSON_VALUE(kind_decl_tag, name);
+            PRINT_JSON_TYPE(kind_decl_tag, type);
+            break;
+        }
+        case BTF_KIND_TYPE_TAG: {
+            auto& kind_type_tag = std::get<BTF_KIND_TYPE_TAG>(kind);
+            PRINT_JSON_FIXED("kind_type", "BTF_KIND_TYPE_TAG");
+            PRINT_JSON_VALUE(kind_type_tag, name);
+            PRINT_JSON_TYPE(kind_type_tag, type);
+            break;
+        }
+        case BTF_KIND_ENUM64: {
+            auto& kind_enum = std::get<BTF_KIND_ENUM64>(kind);
+            PRINT_JSON_FIXED("kind_type", "BTF_KIND_ENUM64");
+            PRINT_JSON_VALUE(kind_enum, name);
+            PRINT_JSON_VALUE(kind_enum, size_in_bytes);
+            PRINT_JSON_ARRAY_START(kind_enum, members);
+            for (auto& member : kind_enum.members) {
+                PRINT_JSON_OBJECT_START();
+                PRINT_JSON_VALUE(member, name);
+                PRINT_JSON_VALUE(member, value);
+                PRINT_JSON_OBJECT_END();
+
+            }
+            PRINT_JSON_ARRAY_END();
+            break;
+        }
+        default:
+            PRINT_JSON_FIXED("kind_type", "UNKNOWN");
+        }
+        PRINT_JSON_OBJECT_END();
+    };
+
+    // Determine the list of types that are not referenced by other types. These are the root types.
+    std::set<btf_type_id> root_types;
+
+    // Add all types as root types.
+    for (auto& [id, kind] : id_to_kind) {
+        root_types.insert(id);
+    }
+
+    // Erase the VOID type.
+    root_types.erase(0);
+
+    // Remove all types that are referenced by other types.
+    for (auto& [id, kind] : id_to_kind) {
+        switch (kind.index()) {
+        case BTF_KIND_PTR: root_types.erase(std::get<BTF_KIND_PTR>(kind).type); break;
+        case BTF_KIND_ARRAY:
+            root_types.erase(std::get<BTF_KIND_ARRAY>(kind).element_type);
+            root_types.erase(std::get<BTF_KIND_ARRAY>(kind).index_type);
+            break;
+        case BTF_KIND_STRUCT:
+            for (auto& member : std::get<BTF_KIND_STRUCT>(kind).members) {
+                root_types.erase(member.type);
+            }
+            break;
+        case BTF_KIND_UNION:
+            for (auto& member : std::get<BTF_KIND_UNION>(kind).members) {
+                root_types.erase(member.type);
+            }
+            break;
+        case BTF_KIND_TYPEDEF: root_types.erase(std::get<BTF_KIND_TYPEDEF>(kind).type); break;
+        case BTF_KIND_VOLATILE: root_types.erase(std::get<BTF_KIND_VOLATILE>(kind).type); break;
+        case BTF_KIND_CONST: root_types.erase(std::get<BTF_KIND_CONST>(kind).type); break;
+        case BTF_KIND_RESTRICT: root_types.erase(std::get<BTF_KIND_RESTRICT>(kind).type); break;
+        case BTF_KIND_FUNC_PROTO:
+            for (auto& param : std::get<BTF_KIND_FUNC_PROTO>(kind).parameters) {
+                root_types.erase(param.type);
+            }
+            root_types.erase(std::get<BTF_KIND_FUNC_PROTO>(kind).return_type);
+            break;
+        case BTF_KIND_FUNC: root_types.erase(std::get<BTF_KIND_FUNC>(kind).type); break;
+        case BTF_KIND_VAR: root_types.erase(std::get<BTF_KIND_VAR>(kind).type); break;
+        case BTF_KIND_DATASEC:
+            for (auto& variable : std::get<BTF_KIND_DATASEC>(kind).members) {
+                root_types.erase(variable.type);
+            }
+            break;
+        case BTF_KIND_DECL_TAG: root_types.erase(std::get<BTF_KIND_DECL_TAG>(kind).type); break;
+        case BTF_KIND_TYPE_TAG: root_types.erase(std::get<BTF_KIND_TYPE_TAG>(kind).type); break;
+        }
+    }
+    bool first = true;
+    PRINT_JSON_OBJECT_START();
+    PRINT_JSON_ARRAY_START("", btf_kinds);
+    for (const auto & [id, kind] : id_to_kind) {
+        // Skip non-root types.
+        if (root_types.find(id) == root_types.end()) {
+            continue;
+        }
+
+        out << (first ? "" : ",");
+        first = false;
+        print_btf_kind(id, kind);
+    }
+    PRINT_JSON_ARRAY_END();
+    PRINT_JSON_OBJECT_END();
+}
+
+btf_type_data::btf_type_data(const std::vector<uint8_t>& btf_data) {
+    auto visitor = [&, this](btf_type_id id, const std::optional<std::string>& name, const btf_kind& kind) {
+        this->id_to_kind.insert({id, kind});
+        if (name.has_value()) {
+            this->name_to_id.insert({name.value(), id});
+        }
+    };
+    btf_parse_types(btf_data, visitor);
+}
+
+btf_type_id btf_type_data::get_id(const std::string& name) const {
+    auto it = name_to_id.find(name);
+    if (it == name_to_id.end()) {
+        return 0;
+    }
+    return it->second;
+}
+
+btf_kind btf_type_data::get_kind(btf_type_id id) const {
+    auto it = id_to_kind.find(id);
+    if (it == id_to_kind.end()) {
+        throw std::runtime_error("BTF type id not found: " + std::to_string(id));
+    }
+    return it->second;
+}
+
+btf_type_id btf_type_data::dereference_pointer(btf_type_id id) const {
+    auto kind = get_kind(id);
+    if (kind.index() != BTF_KIND_PTR) {
+        throw std::runtime_error("BTF type is not a pointer: " + std::to_string(id));
+    }
+    return std::get<BTF_KIND_PTR>(kind).type;
+}
+
+size_t btf_type_data::get_size(btf_type_id id) const {
+    // Compute the effective size of a BTF type.
+
+    auto kind = id_to_kind.at(id);
+
+    switch (kind.index()) {
+    case BTF_KIND_INT:
+        return std::get<BTF_KIND_INT>(kind).size_in_bytes;
+    case BTF_KIND_PTR:
+        return sizeof(void*);
+    case BTF_KIND_ARRAY:
+        return std::get<BTF_KIND_ARRAY>(kind).count_of_elements * get_size(std::get<BTF_KIND_ARRAY>(kind).element_type);
+    case BTF_KIND_STRUCT:
+        return std::get<BTF_KIND_STRUCT>(kind).size_in_bytes;
+    case BTF_KIND_UNION:
+        return std::get<BTF_KIND_UNION>(kind).size_in_bytes;
+    case BTF_KIND_ENUM:
+        return std::get<BTF_KIND_ENUM>(kind).size_in_bytes;
+    case BTF_KIND_FWD:
+        return 0;
+    case BTF_KIND_TYPEDEF:
+        return get_size(std::get<BTF_KIND_TYPEDEF>(kind).type);
+    case BTF_KIND_VOLATILE:
+        return get_size(std::get<BTF_KIND_VOLATILE>(kind).type);
+    case BTF_KIND_CONST:
+        return get_size(std::get<BTF_KIND_CONST>(kind).type);
+    case BTF_KIND_RESTRICT:
+        return get_size(std::get<BTF_KIND_RESTRICT>(kind).type);
+    case BTF_KIND_FUNC_PROTO:
+        return 0;
+    case BTF_KIND_FUNC:
+        return 0;
+    case BTF_KIND_VAR:
+        return get_size(std::get<BTF_KIND_VAR>(kind).type);
+    case BTF_KIND_DATASEC:
+        return 0;
+    case BTF_KIND_FLOAT:
+        return std::get<BTF_KIND_FLOAT>(kind).size_in_bytes;
+    case BTF_KIND_DECL_TAG:
+        return get_size(std::get<BTF_KIND_DECL_TAG>(kind).type);
+    case BTF_KIND_TYPE_TAG:
+        return get_size(std::get<BTF_KIND_TYPE_TAG>(kind).type);
+    case BTF_KIND_ENUM64:
+        return std::get<BTF_KIND_ENUM64>(kind).size_in_bytes;
+    default:
+        throw std::runtime_error("unknown BTF type kind");
+    }
+}
+
+void btf_type_data::to_json(std::ostream& out) const {
+    btf_type_to_json(id_to_kind, out);
+}
+
+/**
+ * @brief Given the BTF type ID of a value declared via the __uint macro, return the value.
+ *
+ * @param[in] type_id The BTF type ID of the value.
+ * @param[in] id_to_kind The map from BTF type ID to BTF type kind.
+ * @return The value.
+ */
+static uint32_t value_from_BTF__uint(const btf_type_data& btf_types, btf_type_id type_id)
+{
+    // The __uint macro is defined as follows:
+    // #define __uint(name, val) int (*name)[val]
+    // So, we need to get the value of val from the BTF type.
+
+    // Top level should be a pointer. Dereference it.
+    type_id = btf_types.dereference_pointer(type_id);
+
+    // Next level should be an array.
+    auto array = btf_types.get_kind(type_id);
+    if (array.index() != BTF_KIND_ARRAY) {
+        throw std::runtime_error("expected array type");
+    }
+    auto array_type = std::get<BTF_KIND_ARRAY>(array);
+
+    // Value is encoded in the count of elements.
+    return array_type.count_of_elements;
+}
+
+/**
+ * @brief Get the map descriptor from a BTF map type.
+ *
+ * @param[in] map_type_id The BTF type ID of the map type.
+ * @param[in] id_to_kind The map from BTF type ID to BTF type kind.
+ * @return The map descriptor.
+ */
+static EbpfMapDescriptor get_map_descriptor_from_btf(const btf_type_data& btf_types, btf_type_id map_type_id)
+{
+    btf_type_id type = 0;
+    btf_type_id max_entries = 0;
+    btf_type_id key = 0;
+    btf_type_id key_size = 0;
+    btf_type_id value = 0;
+    btf_type_id value_size = 0;
+    btf_type_id values = 0;
+
+    auto map_var = btf_types.get_kind(map_type_id);
+    if (map_var.index() != BTF_KIND_VAR) {
+        throw std::runtime_error("expected BTF_KIND_VAR type");
+    }
+
+    auto map_struct = btf_types.get_kind(std::get<BTF_KIND_VAR>(map_var).type);
+    if (map_struct.index() != BTF_KIND_STRUCT) {
+        throw std::runtime_error("expected BTF_KIND_STRUCT type");
+    }
+
+    for (const auto& member : std::get<BTF_KIND_STRUCT>(map_struct).members) {
+        if (member.name == "type") {
+            type = member.type;
+        } else if (member.name == "max_entries") {
+            max_entries = member.type;
+        } else if (member.name == "key") {
+            key = btf_types.dereference_pointer(member.type);
+        } else if (member.name == "value") {
+            value = btf_types.dereference_pointer(member.type);
+        } else if (member.name == "key_size") {
+            key_size = member.type;
+        } else if (member.name == "value_size") {
+            value_size = member.type;
+        } else if (member.name == "values") {
+            values = member.type;
+        }
+    }
+
+    if (type == 0) {
+        throw std::runtime_error("invalid map type");
+    }
+
+    EbpfMapDescriptor map_descriptor = {0};
+
+    // Required fields.
+    map_descriptor.original_fd = static_cast<int>(std::get<BTF_KIND_VAR>(map_var).type);
+    map_descriptor.type = value_from_BTF__uint(btf_types, type);
+    map_descriptor.max_entries = value_from_BTF__uint(btf_types, max_entries);
+
+    // Optional fields.
+    if (key) {
+        map_descriptor.key_size = btf_types.get_size(key);
+    } else if (key_size) {
+        map_descriptor.key_size = value_from_BTF__uint(btf_types, key_size);
+    }
+
+    if (value) {
+        map_descriptor.value_size = btf_types.get_size(value);
+    } else if (value_size) {
+        map_descriptor.value_size = value_from_BTF__uint(btf_types, value_size);
+    }
+
+    if (values) {
+        // Values is an array of pointers to BTF map definitions.
+        auto values_array = btf_types.get_kind(values);
+        if (values_array.index() != BTF_KIND_ARRAY) {
+            throw std::runtime_error("expected array type");
+        }
+        auto ptr = btf_types.get_kind(std::get<BTF_KIND_ARRAY>(values_array).element_type);
+        if (ptr.index() != BTF_KIND_PTR) {
+            throw std::runtime_error("expected pointer type");
+        }
+        // Verify this is a pointer to a BTF map definition.
+        auto map_def = btf_types.get_kind(std::get<BTF_KIND_PTR>(ptr).type);
+        map_descriptor.inner_map_fd = static_cast<int>(std::get<BTF_KIND_PTR>(ptr).type);
+    }
+    else {
+        map_descriptor.inner_map_fd = -1;
+    }
+
+    return map_descriptor;
+}
+
+std::map<std::string, size_t> parse_btf_map_sections(const btf_type_data& btf_data, std::vector<EbpfMapDescriptor>& map_descriptors)
+{
+    std::map<std::string, size_t> map_offset_to_descriptor_index;
+    auto maps_section_kind = btf_data.get_kind(btf_data.get_id(".maps"));
+
+    // Check that the .maps section is a BTF_KIND_DATASEC.
+    if (maps_section_kind.index() != BTF_KIND_DATASEC) {
+        throw std::runtime_error("expected .maps section to be a BTF_KIND_DATASEC");
+    }
+
+    // For each BTF_KIND_VAR in the maps section, compose the map descriptor from the BTF type.
+    auto maps_section = std::get<BTF_KIND_DATASEC>(maps_section_kind);
+    size_t index = 0;
+    for (const auto& var : maps_section.members) {
+        auto map_descriptor = get_map_descriptor_from_btf(btf_data, var.type);
+        auto var_kind = btf_data.get_kind(var.type);
+        map_descriptors.push_back(map_descriptor);
+        map_offset_to_descriptor_index.insert({std::get<BTF_KIND_VAR>(var_kind).name, map_descriptors.size() - 1});
+    }
+    return map_offset_to_descriptor_index;
 }

--- a/src/btf_parser.h
+++ b/src/btf_parser.h
@@ -2,14 +2,175 @@
 // SPDX-License-Identifier: MIT
 
 #pragma once
+#include "spec_type_descriptors.hpp"
+
 #include <functional>
+#include <iostream>
+#include <optional>
 #include <stdint.h>
 #include <string>
+#include <variant>
 #include <vector>
 
 typedef std::function<void(const std::string& section, uint32_t instruction_offset, const std::string& file_name,
                            const std::string& source, uint32_t line_number, uint32_t column_number)>
     btf_line_info_visitor;
+
+typedef uint32_t btf_type_id;
+
+typedef struct btf_kind_int {
+    std::string name;
+    uint32_t size_in_bytes;                 // The size of the integer in bytes. This value multiplied by 8 must be >= field_width_in_bits
+    uint16_t offset_from_start_in_bits;     // The start of the integer relative to the start of the member.
+    uint8_t field_width_in_bits;            // The size of the integer in bits.
+    bool is_signed;
+    bool is_char;
+    bool is_bool;
+} btf_kind_int;
+
+typedef struct btf_kind_ptr {
+    btf_type_id type;
+} btf_kind_ptr;
+
+typedef struct btf_kind_array {
+    btf_type_id element_type;
+    btf_type_id index_type;
+    uint32_t count_of_elements;
+} btf_kind_array;
+
+typedef struct btf_kind_struct_member {
+    std::optional<std::string> name;
+    btf_type_id type;
+    uint32_t offset_from_start_in_bits;
+} btf_kind_struct_member, btf_kind_union_member;
+
+typedef struct btf_kind_struct {
+    std::optional<std::string> name;
+    std::vector<btf_kind_struct_member> members;
+    uint32_t size_in_bytes;
+} btf_kind_struct;
+
+typedef struct btf_kind_union {
+    std::optional<std::string> name;
+    std::vector<btf_kind_union_member> members;
+    uint32_t size_in_bytes;
+} btf_kind_union;
+
+typedef struct btf_kind_enum_member {
+    std::string name;
+    uint32_t value;
+} btf_kind_enum_member;
+
+typedef struct btf_kind_enum {
+    std::optional<std::string> name;
+    bool is_signed;
+    std::vector<btf_kind_enum_member> members;
+    uint32_t size_in_bytes;
+} btf_kind_enum;
+
+typedef struct btf_kind_fwd {
+    std::string name;
+    bool is_struct;
+} btf_kind_fwd;
+
+typedef struct btf_kind_typedef {
+    std::string name;
+    btf_type_id type;
+} btf_kind_typedef;
+
+typedef struct btf_kind_volatile {
+    btf_type_id type;
+} btf_kind_volatile;
+
+typedef struct btf_kind_const {
+    btf_type_id type;
+} btf_kind_const;
+
+typedef struct btf_kind_restrict {
+    btf_type_id type;
+} btf_kind_restrict;
+
+typedef struct btf_kind_func {
+    std::string name;
+    enum linkage {
+        BTF_LINKAGE_GLOBAL,
+        BTF_LINKAGE_STATIC,
+        BTF_LINKAGE_EXTERN,
+    } linkage;
+    btf_type_id type;
+} btf_kind_func;
+
+typedef struct btf_kind_function_parameter {
+    std::string name;
+    btf_type_id type;
+} btf_kind_function_parameter;
+
+typedef struct btf_kind_function_prototype {
+    std::vector<btf_kind_function_parameter> parameters;
+    btf_type_id return_type;
+} btf_kind_function;
+
+typedef struct btf_kind_var {
+    std::string name;
+    btf_type_id type;
+    enum linkage {
+        BTF_LINKAGE_GLOBAL,
+        BTF_LINKAGE_STATIC,
+    } linkage;
+} btf_kind_var;
+
+typedef struct btf_kind_data_member {
+    btf_type_id type;
+    uint32_t offset;
+    uint32_t size;
+} btf_kind_data_member;
+
+typedef struct btf_kind_data_section {
+    std::string name;
+    std::vector<btf_kind_data_member> members;
+    uint32_t size;
+} btf_kind_data_section;
+
+typedef struct btf_kind_float {
+    std::string name;
+    uint32_t size_in_bytes;
+} btf_kind_float;
+
+typedef struct btf_kind_decl_tag {
+    std::string name;
+    btf_type_id type;
+    uint32_t component_index;
+} btf_kind_decl_tag;
+
+typedef struct btf_kind_type_tag {
+    std::string name;
+    btf_type_id type;
+} btf_kind_type_tag;
+
+typedef struct btf_kind_enum64_member {
+    std::string name;
+    uint64_t value;
+} btf_kind_enum64_member;
+
+typedef struct btf_kind_enum64 {
+    std::optional<std::string> name;
+    bool is_signed;
+    std::vector<btf_kind_enum64_member> members;
+    uint32_t size_in_bytes;
+} btf_kind_enum64;
+
+typedef struct btf_kind_null {
+
+} btf_kind_null;
+
+typedef std::variant<btf_kind_null, btf_kind_int, btf_kind_ptr, btf_kind_array, btf_kind_struct, btf_kind_union,
+                     btf_kind_enum, btf_kind_fwd, btf_kind_typedef, btf_kind_volatile, btf_kind_const,
+                     btf_kind_restrict, btf_kind_func, btf_kind_function, btf_kind_var, btf_kind_data_section,
+                     btf_kind_float, btf_kind_decl_tag, btf_kind_type_tag, btf_kind_enum64>
+    btf_kind;
+
+typedef std::function<void(btf_type_id, const std::optional<std::string>&, const btf_kind&)> btf_type_visitor;
+
 /**
  * @brief Parse a .BTF and .BTF.ext section from an ELF file invoke vistor for
  * each btf_line_info record.
@@ -21,3 +182,56 @@ typedef std::function<void(const std::string& section, uint32_t instruction_offs
  */
 void btf_parse_line_information(const std::vector<uint8_t>& btf, const std::vector<uint8_t>& btf_ext,
                                 btf_line_info_visitor visitor);
+
+/**
+ * @brief Parse a .BTF section from an ELF file and invoke visitor for each
+ * btf_type record.
+ *
+ * @param[in] btf The .BTF section (containing type info and strings).
+ * @param[in] visitor Function to invoke on each btf_type record.
+ */
+void btf_parse_types(const std::vector<uint8_t>& btf, btf_type_visitor visitor);
+
+/**
+ * @brief Given a map of btf_type_id to btf_kind, print the types as JSON to
+ * the given output stream. The JSON is not pretty printed. This is useful for
+ * debugging and testing.
+ *
+ * @param[in] id_to_kind A map of btf_type_id to btf_kind.
+ * @param[in,out] out The output stream to write the JSON to.
+ */
+void btf_type_to_json(const std::map<btf_type_id, btf_kind>& id_to_kind, std::ostream& out);
+
+/**
+ * @brief Helper function to insert line breaks and indentation into a JSON
+ * string to make it more human readable.
+ *
+ * @param[in] input JSON string to pretty print.
+ * @return The pretty printed JSON string.
+ */
+std::string pretty_print_json(const std::string& input);
+
+class btf_type_data {
+public:
+    btf_type_data(const std::vector<uint8_t>& btf_data);
+    ~btf_type_data() = default;
+    btf_type_id get_id(const std::string& name) const;
+    btf_kind get_kind(btf_type_id id) const;
+    btf_type_id dereference_pointer(btf_type_id id) const;
+    size_t get_size(btf_type_id id) const;
+    void to_json(std::ostream& out) const;
+
+private:
+    std::map<btf_type_id, btf_kind> id_to_kind;
+    std::map<std::string, btf_type_id> name_to_id;
+};
+
+/**
+ * @brief Parse the .BTF section of the ELF file and return a map from map offset to map descriptor.
+ *
+ * @param[in] options The verifier options.
+ * @param[in] platform The platform abstraction layer.
+ * @param[in] reader ELFIO reader.
+ * @return Map from map name to map descriptor index.
+ */
+std::map<std::string, size_t> parse_btf_map_sections(const btf_type_data& btf_data, std::vector<EbpfMapDescriptor>& map_descriptors);

--- a/src/btf_parser.h
+++ b/src/btf_parser.h
@@ -12,164 +12,166 @@
 #include <variant>
 #include <vector>
 
-typedef std::function<void(const std::string& section, uint32_t instruction_offset, const std::string& file_name,
-                           const std::string& source, uint32_t line_number, uint32_t column_number)>
-    btf_line_info_visitor;
+using btf_line_info_visitor =
+    std::function<void(const std::string& section, uint32_t instruction_offset, const std::string& file_name,
+                       const std::string& source, uint32_t line_number, uint32_t column_number)>;
 
 typedef uint32_t btf_type_id;
 
-typedef struct btf_kind_int {
+struct btf_kind_int {
     std::string name;
-    uint32_t size_in_bytes;                 // The size of the integer in bytes. This value multiplied by 8 must be >= field_width_in_bits
-    uint16_t offset_from_start_in_bits;     // The start of the integer relative to the start of the member.
-    uint8_t field_width_in_bits;            // The size of the integer in bits.
+    uint32_t
+        size_in_bytes; // The size of the integer in bytes. This value multiplied by 8 must be >= field_width_in_bits
+    uint16_t offset_from_start_in_bits; // The start of the integer relative to the start of the member.
+    uint8_t field_width_in_bits;        // The size of the integer in bits.
     bool is_signed;
     bool is_char;
     bool is_bool;
-} btf_kind_int;
+};
 
-typedef struct btf_kind_ptr {
+struct btf_kind_ptr {
     btf_type_id type;
-} btf_kind_ptr;
+};
 
-typedef struct btf_kind_array {
+struct btf_kind_array {
     btf_type_id element_type;
     btf_type_id index_type;
     uint32_t count_of_elements;
-} btf_kind_array;
+};
 
-typedef struct btf_kind_struct_member {
+struct btf_kind_struct_member {
     std::optional<std::string> name;
     btf_type_id type;
     uint32_t offset_from_start_in_bits;
-} btf_kind_struct_member, btf_kind_union_member;
+};
 
-typedef struct btf_kind_struct {
+using btf_kind_union_member = btf_kind_struct_member;
+
+struct btf_kind_struct {
     std::optional<std::string> name;
     std::vector<btf_kind_struct_member> members;
     uint32_t size_in_bytes;
-} btf_kind_struct;
+};
 
-typedef struct btf_kind_union {
+struct btf_kind_union {
     std::optional<std::string> name;
     std::vector<btf_kind_union_member> members;
     uint32_t size_in_bytes;
-} btf_kind_union;
+};
 
-typedef struct btf_kind_enum_member {
+struct btf_kind_enum_member {
     std::string name;
     uint32_t value;
-} btf_kind_enum_member;
+};
 
-typedef struct btf_kind_enum {
+struct btf_kind_enum {
     std::optional<std::string> name;
     bool is_signed;
     std::vector<btf_kind_enum_member> members;
     uint32_t size_in_bytes;
-} btf_kind_enum;
+};
 
-typedef struct btf_kind_fwd {
+struct btf_kind_fwd {
     std::string name;
     bool is_struct;
-} btf_kind_fwd;
+};
 
-typedef struct btf_kind_typedef {
+struct btf_kind_typedef {
     std::string name;
     btf_type_id type;
-} btf_kind_typedef;
+};
 
-typedef struct btf_kind_volatile {
+struct btf_kind_volatile {
     btf_type_id type;
-} btf_kind_volatile;
+};
 
-typedef struct btf_kind_const {
+struct btf_kind_const {
     btf_type_id type;
-} btf_kind_const;
+};
 
-typedef struct btf_kind_restrict {
+struct btf_kind_restrict {
     btf_type_id type;
-} btf_kind_restrict;
+};
 
-typedef struct btf_kind_func {
+struct btf_kind_function {
     std::string name;
-    enum linkage {
+    enum {
         BTF_LINKAGE_GLOBAL,
         BTF_LINKAGE_STATIC,
         BTF_LINKAGE_EXTERN,
     } linkage;
     btf_type_id type;
-} btf_kind_func;
+};
 
-typedef struct btf_kind_function_parameter {
+struct btf_kind_function_parameter {
     std::string name;
     btf_type_id type;
-} btf_kind_function_parameter;
+};
 
-typedef struct btf_kind_function_prototype {
+struct btf_kind_function_prototype {
     std::vector<btf_kind_function_parameter> parameters;
     btf_type_id return_type;
-} btf_kind_function;
+};
 
-typedef struct btf_kind_var {
+struct btf_kind_var {
     std::string name;
     btf_type_id type;
-    enum linkage {
+    enum {
         BTF_LINKAGE_GLOBAL,
         BTF_LINKAGE_STATIC,
     } linkage;
-} btf_kind_var;
+};
 
-typedef struct btf_kind_data_member {
+struct btf_kind_data_member {
     btf_type_id type;
     uint32_t offset;
     uint32_t size;
-} btf_kind_data_member;
+};
 
-typedef struct btf_kind_data_section {
+struct btf_kind_data_section {
     std::string name;
     std::vector<btf_kind_data_member> members;
     uint32_t size;
-} btf_kind_data_section;
+};
 
-typedef struct btf_kind_float {
+struct btf_kind_float {
     std::string name;
     uint32_t size_in_bytes;
-} btf_kind_float;
+};
 
-typedef struct btf_kind_decl_tag {
+struct btf_kind_decl_tag {
     std::string name;
     btf_type_id type;
     uint32_t component_index;
-} btf_kind_decl_tag;
+};
 
-typedef struct btf_kind_type_tag {
+struct btf_kind_type_tag {
     std::string name;
     btf_type_id type;
-} btf_kind_type_tag;
+};
 
-typedef struct btf_kind_enum64_member {
+struct btf_kind_enum64_member {
     std::string name;
     uint64_t value;
-} btf_kind_enum64_member;
+};
 
-typedef struct btf_kind_enum64 {
+struct btf_kind_enum64 {
     std::optional<std::string> name;
     bool is_signed;
     std::vector<btf_kind_enum64_member> members;
     uint32_t size_in_bytes;
-} btf_kind_enum64;
+};
 
-typedef struct btf_kind_null {
+struct btf_kind_null {};
 
-} btf_kind_null;
+// Note: The order of the variant types must match the #define in btf.h.
+using btf_kind =
+    std::variant<btf_kind_null, btf_kind_int, btf_kind_ptr, btf_kind_array, btf_kind_struct, btf_kind_union,
+                 btf_kind_enum, btf_kind_fwd, btf_kind_typedef, btf_kind_volatile, btf_kind_const, btf_kind_restrict,
+                 btf_kind_function, btf_kind_function_prototype, btf_kind_var, btf_kind_data_section, btf_kind_float,
+                 btf_kind_decl_tag, btf_kind_type_tag, btf_kind_enum64>;
 
-typedef std::variant<btf_kind_null, btf_kind_int, btf_kind_ptr, btf_kind_array, btf_kind_struct, btf_kind_union,
-                     btf_kind_enum, btf_kind_fwd, btf_kind_typedef, btf_kind_volatile, btf_kind_const,
-                     btf_kind_restrict, btf_kind_func, btf_kind_function, btf_kind_var, btf_kind_data_section,
-                     btf_kind_float, btf_kind_decl_tag, btf_kind_type_tag, btf_kind_enum64>
-    btf_kind;
-
-typedef std::function<void(btf_type_id, const std::optional<std::string>&, const btf_kind&)> btf_type_visitor;
+using btf_type_visitor = std::function<void(btf_type_id, const std::optional<std::string>&, const btf_kind&)>;
 
 /**
  * @brief Parse a .BTF and .BTF.ext section from an ELF file invoke vistor for
@@ -212,7 +214,7 @@ void btf_type_to_json(const std::map<btf_type_id, btf_kind>& id_to_kind, std::os
 std::string pretty_print_json(const std::string& input);
 
 class btf_type_data {
-public:
+  public:
     btf_type_data(const std::vector<uint8_t>& btf_data);
     ~btf_type_data() = default;
     btf_type_id get_id(const std::string& name) const;
@@ -221,7 +223,7 @@ public:
     size_t get_size(btf_type_id id) const;
     void to_json(std::ostream& out) const;
 
-private:
+  private:
     std::map<btf_type_id, btf_kind> id_to_kind;
     std::map<std::string, btf_type_id> name_to_id;
 };
@@ -234,4 +236,5 @@ private:
  * @param[in] reader ELFIO reader.
  * @return Map from map name to map descriptor index.
  */
-std::map<std::string, size_t> parse_btf_map_sections(const btf_type_data& btf_data, std::vector<EbpfMapDescriptor>& map_descriptors);
+std::map<std::string, size_t> parse_btf_map_sections(const btf_type_data& btf_data,
+                                                     std::vector<EbpfMapDescriptor>& map_descriptors);

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -18,6 +18,8 @@ struct ebpf_verifier_options_t {
     bool print_line_info;
     bool allow_division_by_zero;
     bool setup_constraints;
+
+    bool dump_btf_types_json;
 };
 
 struct ebpf_verifier_stats_t {

--- a/src/crab/ebpf_domain.cpp
+++ b/src/crab/ebpf_domain.cpp
@@ -1578,7 +1578,7 @@ std::optional<uint32_t> ebpf_domain_t::get_map_type(const Reg& map_fd_reg) const
 
     std::optional<uint32_t> type;
     for (int32_t map_fd = start_fd; map_fd <= end_fd; map_fd++) {
-        EbpfMapDescriptor* map = &global_program_info->platform->get_map_descriptor(map_fd);
+        EbpfMapDescriptor* map = get_map_descriptor_from_platform_or_program_info(map_fd);
         if (map == nullptr)
             return std::optional<uint32_t>();
         if (!type.has_value())
@@ -1597,7 +1597,7 @@ std::optional<uint32_t> ebpf_domain_t::get_map_inner_map_fd(const Reg& map_fd_re
 
     std::optional<uint32_t> inner_map_fd;
     for (int map_fd = start_fd; map_fd <= end_fd; map_fd++) {
-        EbpfMapDescriptor* map = &global_program_info->platform->get_map_descriptor(map_fd);
+        EbpfMapDescriptor* map = get_map_descriptor_from_platform_or_program_info(map_fd);
         if (map == nullptr)
             return {};
         if (!inner_map_fd.has_value())
@@ -1616,7 +1616,7 @@ crab::interval_t ebpf_domain_t::get_map_key_size(const Reg& map_fd_reg) const {
 
     crab::interval_t result = crab::interval_t::bottom();
     for (int map_fd = start_fd; map_fd <= end_fd; map_fd++) {
-        if (EbpfMapDescriptor* map = &global_program_info->platform->get_map_descriptor(map_fd))
+        if (EbpfMapDescriptor* map = get_map_descriptor_from_platform_or_program_info(map_fd))
             result = result | crab::interval_t(number_t(map->key_size));
         else
             return crab::interval_t::top();
@@ -1632,7 +1632,7 @@ crab::interval_t ebpf_domain_t::get_map_value_size(const Reg& map_fd_reg) const 
 
     crab::interval_t result = crab::interval_t::bottom();
     for (int map_fd = start_fd; map_fd <= end_fd; map_fd++) {
-        if (EbpfMapDescriptor* map = &global_program_info->platform->get_map_descriptor(map_fd))
+        if (EbpfMapDescriptor* map = get_map_descriptor_from_platform_or_program_info(map_fd))
             result = result | crab::interval_t(number_t(map->value_size));
         else
             return crab::interval_t::top();
@@ -1648,7 +1648,7 @@ crab::interval_t ebpf_domain_t::get_map_max_entries(const Reg& map_fd_reg) const
 
     crab::interval_t result = crab::interval_t::bottom();
     for (int map_fd = start_fd; map_fd <= end_fd; map_fd++) {
-        if (EbpfMapDescriptor* map = &global_program_info->platform->get_map_descriptor(map_fd))
+        if (EbpfMapDescriptor* map = get_map_descriptor_from_platform_or_program_info(map_fd))
             result = result | crab::interval_t(number_t(map->max_entries));
         else
             return crab::interval_t::top();
@@ -2193,7 +2193,7 @@ out:
 }
 
 void ebpf_domain_t::do_load_mapfd(const Reg& dst_reg, int mapfd, bool maybe_null) {
-    const EbpfMapDescriptor& desc = global_program_info->platform->get_map_descriptor(mapfd);
+    const EbpfMapDescriptor& desc = *get_map_descriptor_from_platform_or_program_info(mapfd);
     const EbpfMapType& type = global_program_info->platform->get_map_type(desc.type);
     if (type.value_type == EbpfMapValueType::PROGRAM) {
         type_inv.assign_type(m_inv, dst_reg, T_MAP_PROGRAMS);

--- a/src/crab/ebpf_domain.cpp
+++ b/src/crab/ebpf_domain.cpp
@@ -1578,7 +1578,7 @@ std::optional<uint32_t> ebpf_domain_t::get_map_type(const Reg& map_fd_reg) const
 
     std::optional<uint32_t> type;
     for (int32_t map_fd = start_fd; map_fd <= end_fd; map_fd++) {
-        EbpfMapDescriptor* map = get_map_descriptor_from_platform_or_program_info(map_fd);
+        EbpfMapDescriptor* map = &global_program_info->platform->get_map_descriptor(map_fd);
         if (map == nullptr)
             return std::optional<uint32_t>();
         if (!type.has_value())
@@ -1597,7 +1597,7 @@ std::optional<uint32_t> ebpf_domain_t::get_map_inner_map_fd(const Reg& map_fd_re
 
     std::optional<uint32_t> inner_map_fd;
     for (int map_fd = start_fd; map_fd <= end_fd; map_fd++) {
-        EbpfMapDescriptor* map = get_map_descriptor_from_platform_or_program_info(map_fd);
+        EbpfMapDescriptor* map = &global_program_info->platform->get_map_descriptor(map_fd);
         if (map == nullptr)
             return {};
         if (!inner_map_fd.has_value())
@@ -1616,7 +1616,7 @@ crab::interval_t ebpf_domain_t::get_map_key_size(const Reg& map_fd_reg) const {
 
     crab::interval_t result = crab::interval_t::bottom();
     for (int map_fd = start_fd; map_fd <= end_fd; map_fd++) {
-        if (EbpfMapDescriptor* map = get_map_descriptor_from_platform_or_program_info(map_fd))
+        if (EbpfMapDescriptor* map = &global_program_info->platform->get_map_descriptor(map_fd))
             result = result | crab::interval_t(number_t(map->key_size));
         else
             return crab::interval_t::top();
@@ -1632,7 +1632,7 @@ crab::interval_t ebpf_domain_t::get_map_value_size(const Reg& map_fd_reg) const 
 
     crab::interval_t result = crab::interval_t::bottom();
     for (int map_fd = start_fd; map_fd <= end_fd; map_fd++) {
-        if (EbpfMapDescriptor* map = get_map_descriptor_from_platform_or_program_info(map_fd))
+        if (EbpfMapDescriptor* map = &global_program_info->platform->get_map_descriptor(map_fd))
             result = result | crab::interval_t(number_t(map->value_size));
         else
             return crab::interval_t::top();
@@ -1648,7 +1648,7 @@ crab::interval_t ebpf_domain_t::get_map_max_entries(const Reg& map_fd_reg) const
 
     crab::interval_t result = crab::interval_t::bottom();
     for (int map_fd = start_fd; map_fd <= end_fd; map_fd++) {
-        if (EbpfMapDescriptor* map = get_map_descriptor_from_platform_or_program_info(map_fd))
+        if (EbpfMapDescriptor* map = &global_program_info->platform->get_map_descriptor(map_fd))
             result = result | crab::interval_t(number_t(map->max_entries));
         else
             return crab::interval_t::top();
@@ -2193,7 +2193,7 @@ out:
 }
 
 void ebpf_domain_t::do_load_mapfd(const Reg& dst_reg, int mapfd, bool maybe_null) {
-    const EbpfMapDescriptor& desc = *get_map_descriptor_from_platform_or_program_info(mapfd);
+    const EbpfMapDescriptor& desc = global_program_info->platform->get_map_descriptor(mapfd);
     const EbpfMapType& type = global_program_info->platform->get_map_type(desc.type);
     if (type.value_type == EbpfMapValueType::PROGRAM) {
         type_inv.assign_type(m_inv, dst_reg, T_MAP_PROGRAMS);

--- a/src/main/check.cpp
+++ b/src/main/check.cpp
@@ -70,6 +70,7 @@ int main(int argc, char** argv) {
     app.add_flag("--no-division-by-zero", no_division_by_zero, "Do not allow division by zero");
     app.add_flag("--no-simplify", ebpf_verifier_options.no_simplify, "Do not simplify");
     app.add_flag("--line-info", ebpf_verifier_options.print_line_info, "Print line information");
+    app.add_flag("--print-btf-types", ebpf_verifier_options.dump_btf_types_json, "Print BTF types");
 
     std::string asmfile;
     app.add_option("--asm", asmfile, "Print disassembly to FILE")->type_name("FILE");

--- a/src/spec_type_descriptors.hpp
+++ b/src/spec_type_descriptors.hpp
@@ -40,7 +40,6 @@ struct EbpfProgramType {
     bool is_privileged {};
 };
 void print_map_descriptors(const std::vector<EbpfMapDescriptor>& descriptors, std::ostream& o);
-EbpfMapDescriptor* get_map_descriptor_from_platform_or_program_info(int map_fd);
 
 using EquivalenceKey = std::tuple<
     EbpfMapValueType /* value_type */,

--- a/src/spec_type_descriptors.hpp
+++ b/src/spec_type_descriptors.hpp
@@ -40,6 +40,7 @@ struct EbpfProgramType {
     bool is_privileged {};
 };
 void print_map_descriptors(const std::vector<EbpfMapDescriptor>& descriptors, std::ostream& o);
+EbpfMapDescriptor* get_map_descriptor_from_platform_or_program_info(int map_fd);
 
 using EquivalenceKey = std::tuple<
     EbpfMapValueType /* value_type */,

--- a/src/test/test_btf.cpp
+++ b/src/test/test_btf.cpp
@@ -1,0 +1,87 @@
+// Copyright (c) Prevail Verifier contributors.
+// SPDX-License-Identifier: MIT
+#include <catch2/catch_all.hpp>
+
+#include <map>
+#include <string>
+#include <vector>
+
+#include <boost/algorithm/string/trim.hpp>
+
+#if !defined(MAX_PATH)
+#define MAX_PATH (256)
+#endif
+
+#include "btf_parser.h"
+#include "elfio/elfio.hpp"
+
+#define TEST_OBJECT_FILE_DIRECTORY "ebpf-samples/build/"
+#define TEST_JSON_FILE_DIRECTORY "ebpf-samples/json/"
+#define BTF_CASE(file) \
+    TEST_CASE("BTF suite: " #file, "[BTF]") { \
+        verify_BTF_json(#file);\
+    }
+
+template <typename T>
+static std::vector<T> vector_of(const ELFIO::section& sec) {
+    auto data = sec.get_data();
+    auto size = sec.get_size();
+    if ((size % sizeof(T) != 0) || size > UINT32_MAX || !data) {
+        throw std::runtime_error("Invalid argument to vector_of");
+    }
+    return {(T*)data, (T*)(data + size)};
+}
+
+void verify_BTF_json(const std::string& file)
+{
+    std::stringstream generated_output;
+    auto reader = ELFIO::elfio();
+    REQUIRE(reader.load(std::string(TEST_OBJECT_FILE_DIRECTORY) + file + ".o"));
+
+    auto btf = reader.sections[".BTF"];
+
+    btf_type_data btf_data = vector_of<uint8_t>(*btf);
+
+    btf_data.to_json(generated_output);
+
+    // Pretty print the JSON output.
+    std::string pretty_printed_json = pretty_print_json(generated_output.str());
+
+    // Read the expected output from the .json file.
+    std::ifstream expected_stream(std::string(TEST_JSON_FILE_DIRECTORY) + file + std::string(".json"));
+    std::stringstream genereated_stream(pretty_printed_json);
+
+    // Compare each line of the expected output with the actual output.
+    std::string expected_line;
+    std::string actual_line;
+    while (std::getline(expected_stream, expected_line)) {
+        bool has_more = (bool)std::getline(genereated_stream, actual_line);
+        REQUIRE(has_more);
+        boost::algorithm::trim_right(expected_line);
+        boost::algorithm::trim_right(actual_line);
+        REQUIRE(expected_line == actual_line);
+    }
+    bool has_more = (bool)std::getline(expected_stream, actual_line);
+    REQUIRE_FALSE(has_more);
+}
+
+
+BTF_CASE(byteswap)
+BTF_CASE(ctxoffset)
+BTF_CASE(exposeptr)
+BTF_CASE(exposeptr2)
+BTF_CASE(map_in_map)
+BTF_CASE(mapoverflow)
+BTF_CASE(mapunderflow)
+BTF_CASE(mapvalue-overrun)
+BTF_CASE(nullmapref)
+BTF_CASE(packet_access)
+BTF_CASE(packet_overflow)
+BTF_CASE(packet_reallocate)
+BTF_CASE(packet_start_ok)
+BTF_CASE(stackok)
+BTF_CASE(tail_call)
+BTF_CASE(tail_call_bad)
+BTF_CASE(twomaps)
+BTF_CASE(twostackvars)
+BTF_CASE(twotypes)

--- a/src/test/test_btf.cpp
+++ b/src/test/test_btf.cpp
@@ -22,16 +22,6 @@
         verify_BTF_json(#file);\
     }
 
-template <typename T>
-static std::vector<T> vector_of(const ELFIO::section& sec) {
-    auto data = sec.get_data();
-    auto size = sec.get_size();
-    if ((size % sizeof(T) != 0) || size > UINT32_MAX || !data) {
-        throw std::runtime_error("Invalid argument to vector_of");
-    }
-    return {(T*)data, (T*)(data + size)};
-}
-
 void verify_BTF_json(const std::string& file)
 {
     std::stringstream generated_output;
@@ -40,7 +30,7 @@ void verify_BTF_json(const std::string& file)
 
     auto btf = reader.sections[".BTF"];
 
-    btf_type_data btf_data = vector_of<uint8_t>(*btf);
+    btf_type_data btf_data = std::vector<uint8_t>({btf->get_data(), btf->get_data() + btf->get_size()});
 
     btf_data.to_json(generated_output);
 

--- a/src/test/test_btf.cpp
+++ b/src/test/test_btf.cpp
@@ -18,12 +18,9 @@
 #define TEST_OBJECT_FILE_DIRECTORY "ebpf-samples/build/"
 #define TEST_JSON_FILE_DIRECTORY "ebpf-samples/json/"
 #define BTF_CASE(file) \
-    TEST_CASE("BTF suite: " #file, "[BTF]") { \
-        verify_BTF_json(#file);\
-    }
+    TEST_CASE("BTF suite: " #file, "[BTF]") { verify_BTF_json(#file); }
 
-void verify_BTF_json(const std::string& file)
-{
+void verify_BTF_json(const std::string& file) {
     std::stringstream generated_output;
     auto reader = ELFIO::elfio();
     REQUIRE(reader.load(std::string(TEST_OBJECT_FILE_DIRECTORY) + file + ".o"));
@@ -54,7 +51,6 @@ void verify_BTF_json(const std::string& file)
     bool has_more = (bool)std::getline(expected_stream, actual_line);
     REQUIRE_FALSE(has_more);
 }
-
 
 BTF_CASE(byteswap)
 BTF_CASE(ctxoffset)

--- a/src/test/test_print.cpp
+++ b/src/test/test_print.cpp
@@ -30,7 +30,8 @@ void verify_printed_string(const std::string& file)
     std::variant<InstructionSeq, std::string> prog_or_error = unmarshal(raw_prog);
     REQUIRE(std::holds_alternative<InstructionSeq>(prog_or_error));
     auto& program = std::get<InstructionSeq>(prog_or_error);
-    print(program, generated_output, {}, true);
+    print(program, generated_output, {});
+    print_map_descriptors(raw_prog.info.map_descriptors, generated_output);
     std::ifstream expected_stream(std::string(TEST_ASM_FILE_DIRECTORY) + file + std::string(".asm"));
     REQUIRE(expected_stream);
     std::string expected_line;


### PR DESCRIPTION
Blocked on https://github.com/vbpf/ebpf-samples/pull/34

Initial support for parsing BTF data from ELF files. This is needed to implement #394 as that uses BTF data to encode the map data in the new .maps section.