### PR TITLE
Fix segfault in URem

### DIFF
--- a/src/crab/interval.cpp
+++ b/src/crab/interval.cpp
@@ -178,7 +178,7 @@ interval_t interval_t::URem(const interval_t& x) const {
                 // a value between the upper bound and 0, so set to top.  A "positive" dividend
                 // could result in anything between 0 and the dividend - 1.
                 return (_ub < number_t{0}) ? top() : ((*this - interval_t(number_t {1})) | interval_t(number_t(0)));
-            } else if (_ub.number()->cast_to_uint64() < x._lb.number()->cast_to_uint64()) {
+            } else if (_ub.is_finite() && (_ub.number()->cast_to_uint64() < x._lb.number()->cast_to_uint64())) {
                 // Dividend lower than divisor, so the dividend is the remainder.
                 return *this;
             } else {


### PR DESCRIPTION
_ub().number() was null in this case.

Fixes #493