### PR TITLE
Allow multiple maps sections

### DIFF
--- a/src/asm_files.cpp
+++ b/src/asm_files.cpp
@@ -108,6 +108,7 @@ static size_t parse_map_sections(const ebpf_verifier_options_t* options, const e
         }
         section_indices.insert(s->get_index());
     }
+    platform->resolve_inner_map_references(map_descriptors);
     return map_record_size;
 }
 

--- a/src/platform.hpp
+++ b/src/platform.hpp
@@ -26,6 +26,7 @@ typedef int (*ebpf_create_map_fn)(uint32_t map_type, uint32_t key_size, uint32_t
 // Parse map records and allocate map fd's.
 // In the future we may want to move map fd allocation after the verifier step.
 typedef void (*ebpf_parse_maps_section_fn)(std::vector<EbpfMapDescriptor>& map_descriptors, const char* data, size_t map_record_size, int map_count, const struct ebpf_platform_t* platform, ebpf_verifier_options_t options);
+typedef void (*ebpf_resolve_inner_map_references_fn)(std::vector<EbpfMapDescriptor>& map_descriptors);
 
 typedef EbpfMapDescriptor& (*ebpf_get_map_descriptor_fn)(int map_fd);
 
@@ -40,6 +41,7 @@ struct ebpf_platform_t {
     ebpf_parse_maps_section_fn parse_maps_section;
     ebpf_get_map_descriptor_fn get_map_descriptor;
     ebpf_get_map_type_fn get_map_type;
+    ebpf_resolve_inner_map_references_fn resolve_inner_map_references;
 };
 
 extern const ebpf_platform_t g_ebpf_platform_linux;

--- a/src/test/test_verify.cpp
+++ b/src/test/test_verify.cpp
@@ -465,6 +465,7 @@ TEST_SECTION("build", "packet_start_ok.o", "xdp")
 TEST_SECTION("build", "packet_access.o", "xdp")
 TEST_SECTION("build", "tail_call.o", "xdp_prog")
 TEST_SECTION("build", "map_in_map.o", ".text")
+TEST_SECTION("build", "map_in_map_legacy.o", ".text")
 TEST_SECTION("build", "twomaps.o", ".text");
 TEST_SECTION("build", "twostackvars.o", ".text");
 TEST_SECTION("build", "twotypes.o", ".text");


### PR DESCRIPTION
Added a test that uses named maps sections as discussed in issue #231.
Fixed bug found by the test, which is that if there are multiple maps sections, one cannot fill in the actual inner_map_fd until they're all parsed.

Fixes #231