### PR TITLE
Remove private libbtf

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -12,4 +12,4 @@
 	url = https://github.com/Alan-Jowett/bpf_conformance.git
 [submodule "external/libbtf"]
 	path = external/libbtf
-	url = https://github.com/Alan-Jowett/libbtf.git
+	url = https://github.com/microsoft/libbtf.git


### PR DESCRIPTION
The libbtf library has been migrated from my personal github account to the Microsoft orginazations account.