### PR TITLE
Make ALU operations check for invalid register values

### DIFF
--- a/src/asm_unmarshal.cpp
+++ b/src/asm_unmarshal.cpp
@@ -249,6 +249,8 @@ struct Unmarshaller {
     auto makeAluOp(size_t pc, ebpf_inst inst) -> Instruction {
         if (inst.dst == R10_STACK_POINTER)
             throw InvalidInstruction(pc, "Invalid target r10");
+        if (inst.dst > R10_STACK_POINTER || inst.src > R10_STACK_POINTER)
+            throw InvalidInstruction(pc, "Bad register");
         return std::visit(overloaded{[&](Un::Op op) -> Instruction { return Un{.op = op, .dst = Reg{inst.dst}, .is64 = (inst.opcode & INST_CLS_MASK) == INST_CLS_ALU64}; },
                                      [&](Bin::Op op) -> Instruction {
                                          Bin res{

--- a/src/test/test_marshal.cpp
+++ b/src/test/test_marshal.cpp
@@ -208,6 +208,12 @@ TEST_CASE("disasm_marshal_Mem", "[disasm][marshal]") {
 TEST_CASE("fail unmarshal", "[disasm][marshal]") {
     check_unmarshal_fail(ebpf_inst{.opcode = ((INST_MEM << 5) | INST_SIZE_B | INST_CLS_LDX), .dst = 11, .imm = 8},
                          "0: Bad register\n");
+    check_unmarshal_fail(ebpf_inst{.opcode = ((INST_MEM << 5) | INST_SIZE_B | INST_CLS_LDX), .dst = 1, .src = 11},
+                         "0: Bad register\n");
+    check_unmarshal_fail(ebpf_inst{.opcode = (INST_ALU_OP_MOV | INST_SRC_IMM | INST_CLS_ALU), .dst = 11, .imm = 8},
+                         "0: Bad register\n");
+    check_unmarshal_fail(ebpf_inst{.opcode = (INST_ALU_OP_MOV | INST_SRC_REG | INST_CLS_ALU), .dst = 1, .src = 11},
+                         "0: Bad register\n");
     check_unmarshal_fail(ebpf_inst{.opcode = ((INST_MEM << 5) | INST_SIZE_W | INST_CLS_LD)},
                          "0: plain LD\n");
     check_unmarshal_fail(ebpf_inst{.opcode = INST_ALU_OP_END | INST_END_LE | INST_CLS_ALU, .dst = 1, .imm = 8}, "0: invalid endian immediate\n");


### PR DESCRIPTION
makeMemOp() already had a check but makeAluOp() didn't.

Fixes #505