### PR TITLE
Pickup update libbtf that supports anonymous inner maps

### DIFF
--- a/src/test/test_verify.cpp
+++ b/src/test/test_verify.cpp
@@ -465,6 +465,7 @@ TEST_SECTION("build", "packet_start_ok.o", "xdp")
 TEST_SECTION("build", "packet_access.o", "xdp")
 TEST_SECTION("build", "tail_call.o", "xdp_prog")
 TEST_SECTION("build", "map_in_map.o", ".text")
+TEST_SECTION("build", "map_in_map_anonymous.o", ".text")
 TEST_SECTION("build", "map_in_map_legacy.o", ".text")
 TEST_SECTION("build", "twomaps.o", ".text");
 TEST_SECTION("build", "twostackvars.o", ".text");


### PR DESCRIPTION
This map definition fails verification because libbtf doesn't return the descriptor for maps that aren't associated with variables in the .maps section (like an anonymous inner map). 

```
__attribute__((section(".maps"), used))
struct {
    __uint(type, BPF_MAP_TYPE_ARRAY_OF_MAPS);
    __uint(max_entries, 1);
    __type(key, uint32_t);
    __array(values, struct
    {
        __uint(type, BPF_MAP_TYPE_ARRAY);
        __type(key, uint32_t);
        __type(value, uint32_t);
        __uint(max_entries, 1);
    });
} outer_map;
```

Pickup updated libbtf and ebpf-samples.
Add test to check verification of anonymous map-in-map.