### PR TITLE
Add failing test for dependent read

### DIFF
--- a/src/test/test_verify.cpp
+++ b/src/test/test_verify.cpp
@@ -476,6 +476,7 @@ TEST_SECTION("build", "prog_array.o", ".text");
 TEST_SECTION_REJECT("build", "badhelpercall.o", ".text")
 TEST_SECTION_REJECT("build", "ctxoffset.o", "sockops")
 TEST_SECTION_REJECT("build", "badmapptr.o", "test")
+TEST_SECTION_FAIL("build", "dependent_read.o", "xdp")
 TEST_SECTION_REJECT("build", "exposeptr.o", ".text")
 TEST_SECTION_REJECT("build", "exposeptr2.o", ".text")
 TEST_SECTION_REJECT("build", "mapvalue-overrun.o", ".text")


### PR DESCRIPTION
This failure is the simplified version of a failure that was hit while verifying a Cilium program.

Short version:
Packet length is checked and if >= 4, register R5 is set to 1.
If register r5  == 1 then the first 4 bytes are accessed.

This passes on Linux, but fails on Prevail.