### PR TITLE
Only set type to pointer if the width is correct

### DIFF
--- a/src/asm_parse.cpp
+++ b/src/asm_parse.cpp
@@ -52,7 +52,7 @@ using crab::linear_expression_t;
 #define ARRAY_RANGE R"_(\s*\[([-+]?\d+)\.\.\.\s*([-+]?\d+)\]?\s*)_"
 
 #define DOT "[.]"
-#define TYPE R"_(\s*(shared|number|packet|stack|ctx|map_fd|map_fd_program)\s*)_"
+#define TYPE R"_(\s*(shared|number|packet|stack|ctx|map_fd|map_fd_programs)\s*)_"
 
 static const std::map<std::string, Bin::Op> str_to_binop = {
     {"", Bin::Op::MOV},   {"+", Bin::Op::ADD},  {"-", Bin::Op::SUB},    {"*", Bin::Op::MUL},

--- a/src/crab/ebpf_domain.cpp
+++ b/src/crab/ebpf_domain.cpp
@@ -1917,15 +1917,15 @@ void ebpf_domain_t::do_load_ctx(NumAbsDomain& inv, const Reg& target_reg, const 
     // but at runtime they will be 64-bit pointers.  We can use the offset values
     // for verification like we use map_fd's as a proxy for maps which
     // at runtime are actually 64-bit memory pointers.
-    int ptrwidth = desc->end - desc->data;
+    int offset_width = desc->end - desc->data;
     if (addr == desc->data) {
-        if (width == ptrwidth)
+        if (width == offset_width)
             inv.assign(target.packet_offset, 0);
     } else if (addr == desc->end) {
-        if (width == ptrwidth)
+        if (width == offset_width)
             inv.assign(target.packet_offset, variable_t::packet_size());
     } else if (addr == desc->meta) {
-        if (width == ptrwidth)
+        if (width == offset_width)
             inv.assign(target.packet_offset, variable_t::meta_offset());
     } else {
         if (may_touch_ptr)
@@ -1934,7 +1934,7 @@ void ebpf_domain_t::do_load_ctx(NumAbsDomain& inv, const Reg& target_reg, const 
             type_inv.assign_type(inv, target_reg, T_NUM);
         return;
     }
-    if (width == ptrwidth) {
+    if (width == offset_width) {
         type_inv.assign_type(inv, target_reg, T_PACKET);
         inv += 4098 <= target.svalue;
         inv += target.svalue <= PTR_MAX;

--- a/src/crab/split_dbm.cpp
+++ b/src/crab/split_dbm.cpp
@@ -1052,7 +1052,7 @@ static std::string to_string(variable_t vd, variable_t vs, const SplitDBM::Param
 }
 
 static const std::vector<std::string> type_string = {
-    "shared", "stack", "packet", "ctx", "number", "map_fd", "map_fd_program", "uninitialized"
+    "shared", "stack", "packet", "ctx", "number", "map_fd", "map_fd_programs", "uninitialized"
 };
 
 string_invariant SplitDBM::to_set() const {

--- a/test-data/assign.yaml
+++ b/test-data/assign.yaml
@@ -172,6 +172,21 @@ post:
   - r1.uvalue=r2.uvalue
   - r1.stack_numeric_size=r2.stack_numeric_size
 ---
+test-case: 32-bit assign register stack value
+
+pre: ["r10.type=stack", "r10.stack_offset=512"]
+
+code:
+  <start>: |
+    w2 = r10
+
+post:
+  - r2.svalue=[0, 4294967295]
+  - r2.svalue=r2.uvalue
+  - r2.uvalue=[0, 4294967295]
+  - r10.type=stack
+  - r10.stack_offset=512
+---
 test-case: assign register shared value
 
 pre: ["r1.type=shared", "r1.shared_offset=0", "r1.shared_region_size=16"]
@@ -189,6 +204,22 @@ post:
   - r2.shared_region_size=16
   - r1.svalue=r2.svalue
   - r1.uvalue=r2.uvalue
+---
+test-case: 32-bit assign register shared value
+
+pre: ["r1.type=shared", "r1.shared_offset=0", "r1.shared_region_size=16"]
+
+code:
+  <start>: |
+    w2 = r1
+
+post:
+  - r1.type=shared
+  - r1.shared_offset=0
+  - r1.shared_region_size=16
+  - r2.svalue=[0, 4294967295]
+  - r2.uvalue=[0, 4294967295]
+  - r2.svalue=r2.uvalue
 ---
 test-case: assign register combination value
 
@@ -229,3 +260,165 @@ post:
   - r1.uvalue=[1, 2147418112]
   - r2.type=packet
   - r2.svalue=[4098, 2147418112]
+---
+test-case: 16-bit indirect assignment from context
+
+pre: ["r1.ctx_offset=0", "r1.type=ctx", "r1.svalue=[1, 2147418112]", "r1.uvalue=[1, 2147418112]"]
+
+code:
+  <start>: |
+    r2 = *(u16 *)(r1 + 4)
+
+post:
+  - r1.ctx_offset=0
+  - r1.type=ctx
+  - r1.svalue=[1, 2147418112]
+  - r1.uvalue=[1, 2147418112]
+---
+test-case: 64-bit indirect assignment from context
+
+pre: ["r1.ctx_offset=0", "r1.type=ctx", "r1.svalue=[1, 2147418112]", "r1.uvalue=[1, 2147418112]"]
+
+code:
+  <start>: |
+    r2 = *(u64 *)(r1 + 4)
+
+post:
+  - r1.ctx_offset=0
+  - r1.type=ctx
+  - r1.svalue=[1, 2147418112]
+  - r1.uvalue=[1, 2147418112]
+---
+test-case: assign register packet value
+
+pre: ["packet_size=r2.packet_offset", "r2.type=packet", "r2.svalue=[4098, 2147418112]"]
+
+code:
+  <start>: |
+    r1 = r2
+
+post:
+  - packet_size=r1.packet_offset
+  - r1.type=packet
+  - r1.svalue=[4098, 2147418112]
+  - packet_size=r2.packet_offset
+  - r2.type=packet
+  - r2.svalue=[4098, 2147418112]
+  - r1.packet_offset=r2.packet_offset
+  - r1.svalue=r2.svalue
+  - r1.uvalue=r2.uvalue
+---
+test-case: 32-bit assign register packet value
+
+pre: ["packet_size=r2.packet_offset", "r2.type=packet", "r2.svalue=[4098, 2147418112]"]
+
+code:
+  <start>: |
+    w1 = r2
+
+post:
+  - r1.svalue=[0, 4294967295]
+  - r1.uvalue=[0, 4294967295]
+  - r1.svalue=r1.uvalue
+  - packet_size=r2.packet_offset
+  - r2.type=packet
+  - r2.svalue=[4098, 2147418112]
+---
+test-case: assign register context value
+
+pre: ["r1.ctx_offset=0", "r1.type=ctx", "r1.svalue=[1, 2147418112]", "r1.uvalue=[1, 2147418112]"]
+
+code:
+  <start>: |
+    r2 = r1
+
+post:
+  - r1.ctx_offset=0
+  - r1.type=ctx
+  - r1.svalue=[1, 2147418112]
+  - r1.uvalue=[1, 2147418112]
+  - r2.ctx_offset=0
+  - r2.type=ctx
+  - r2.svalue=[1, 2147418112]
+  - r2.uvalue=[1, 2147418112]
+  - r1.svalue=r2.svalue
+  - r1.uvalue=r2.uvalue
+---
+test-case: 32-bit assign register context value
+
+pre: ["r1.ctx_offset=0", "r1.type=ctx", "r1.svalue=[1, 2147418112]", "r1.uvalue=[1, 2147418112]"]
+
+code:
+  <start>: |
+    w2 = r1
+
+post:
+  - r1.ctx_offset=0
+  - r1.type=ctx
+  - r1.svalue=[1, 2147418112]
+  - r1.uvalue=[1, 2147418112]
+  - r2.svalue=[1, 2147418112]
+  - r2.uvalue=[1, 2147418112]
+  - r2.svalue=r2.uvalue
+---
+test-case: assign register map value
+
+pre: ["r1.type=map_fd", "r1.map_fd=1"]
+
+code:
+  <start>: |
+    r2 = r1
+
+post:
+  - r1.map_fd=1
+  - r1.type=map_fd
+  - r2.map_fd=1
+  - r2.type=map_fd
+  - r1.svalue=r2.svalue
+  - r1.uvalue=r2.uvalue
+---
+test-case: 32-bit assign register map value
+
+pre: ["r1.type=map_fd", "r1.map_fd=1"]
+
+code:
+  <start>: |
+    w2 = r1
+
+post:
+  - r1.map_fd=1
+  - r1.type=map_fd
+  - r2.svalue=[0, 4294967295]
+  - r2.uvalue=[0, 4294967295]
+  - r2.svalue=r2.uvalue
+---
+test-case: assign register map programs value
+
+pre: ["r1.type=map_fd_programs", "r1.map_fd=1"]
+
+code:
+  <start>: |
+    r2 = r1
+
+post:
+  - r1.map_fd=1
+  - r1.type=map_fd_programs
+  - r2.map_fd=1
+  - r2.type=map_fd_programs
+  - r1.svalue=r2.svalue
+  - r1.uvalue=r2.uvalue
+---
+test-case: 32-bit assign register map programs value
+
+pre: ["r1.type=map_fd_programs", "r1.map_fd=1"]
+
+code:
+  <start>: |
+    w2 = r1
+
+post:
+  - r1.map_fd=1
+  - r1.type=map_fd_programs
+  - r2.svalue=[0, 4294967295]
+  - r2.uvalue=[0, 4294967295]
+  - r2.svalue=r2.uvalue


### PR DESCRIPTION
* If the width is not what is expected, then it can't be a regular pointer.  The Linux kernel verifier checks this but PREVAIL wasn't checking this case, which could cause a machine crash.
* do_load_ctx() is special since it uses 32-bit offsets for packet data, data_end, and meta.  In an actual program these are 64-bit pointers, but at verification time we just use the offset values as a proxy, like we use map_fd's as a proxy for maps which at runtime are actually 64-bit memory pointers.
* Add YAML tests for such cases.
* Added comment explaining why PTR_MAX isn't int64_t max for now.
* Half the places (asm_parse.cpp line 55, split_dbm.cpp line 1055) used "map_fd_program" and half (asm_ostream.cpp lines 24 and 106, asm_parse.cpp line 284), used "map_fd_programs" for the string name of that type.  Use the latter everywhere for consistency.

Addresses issue #560