### PR TITLE
adjust_head statistic is not cross-platform safe

### DIFF
--- a/src/asm_cfg.cpp
+++ b/src/asm_cfg.cpp
@@ -203,7 +203,7 @@ std::vector<std::string> stats_headers() {
     return {
         "basic_blocks", "joins",       "other",      "jumps",         "assign",  "arith",
         "load",         "store",       "load_store", "packet_access", "call_1",  "call_mem",
-        "call_nomem",   "adjust_head", "map_in_map", "arith64",       "arith32",
+        "call_nomem",   "reallocate",  "map_in_map", "arith64",       "arith32",
     };
 }
 
@@ -224,8 +224,8 @@ std::map<std::string, int> collect_stats(const cfg_t& cfg) {
             }
             if (std::holds_alternative<Call>(ins)) {
                 auto call = std::get<Call>(ins);
-                if (call.func == 43 || call.func == 44)
-                    res["adjust_head"] = 1;
+                if (call.reallocate_packet)
+                    res["reallocate"] = 1;
             }
             if (std::holds_alternative<Bin>(ins)) {
                 auto const& bin = std::get<Bin>(ins);


### PR DESCRIPTION
Replace with a stat counting calls that reallocate packet, in a cross-platform way similar to the map_in_map stat.

Fixes #583