### PR TITLE
Add git and ca-certificates to the docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,8 @@ FROM ubuntu:20.04
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt update
 RUN apt -yq --no-install-suggests --no-install-recommends install build-essential cmake \
-    libboost-dev libboost-filesystem-dev libboost-program-options-dev libyaml-cpp-dev
+    libboost-dev libboost-filesystem-dev libboost-program-options-dev libyaml-cpp-dev git \
+    ca-certificates
 WORKDIR /verifier
 COPY . /verifier/
 RUN mkdir build


### PR DESCRIPTION
Dockerfile is missing these dependencies for compiling the verifier.

`git` is required for fetching the `catch2-populate` dependency. Building the image with `docker build -t verifier .` gets:
```
0.766 -- Detecting CXX compile features - done
0.795 CMake Error at /usr/share/cmake-3.16/Modules/ExternalProject.cmake:2421 (message):
0.795   error: could not find git for clone of catch2-populate
0.795 Call Stack (most recent call first):
0.795   /usr/share/cmake-3.16/Modules/ExternalProject.cmake:3236 (_ep_add_download_command)
0.795   CMakeLists.txt:13 (ExternalProject_Add)
0.795
0.795
0.795 -- Configuring incomplete, errors occurred!
0.795 See also "/verifier/build/_deps/catch2-subbuild/CMakeFiles/CMakeOutput.log".
0.795
0.795 CMake Error at /usr/share/cmake-3.16/Modules/FetchContent.cmake:903 (message):
0.795   CMake step for catch2 failed: 1
0.795 Call Stack (most recent call first):
0.795   /usr/share/cmake-3.16/Modules/FetchContent.cmake:1006 (__FetchContent_directPopulate)
0.795   /usr/share/cmake-3.16/Modules/FetchContent.cmake:1047 (FetchContent_Populate)
0.795   CMakeLists.txt:12 (FetchContent_MakeAvailable)
```

Adding git isn't enough, though, as the repo download is, by default, using HTTPS:
```
0.630 -- Detecting CXX compile features - done
1.138 Scanning dependencies of target catch2-populate
1.138 [ 11%] Creating directories for 'catch2-populate'
1.138 [ 22%] Performing download step (git clone) for 'catch2-populate'
1.138 Cloning into 'catch2-src'...
1.138 fatal: unable to access 'https://github.com/catchorg/Catch2.git/': server certificate verification failed. CAfile: none CRLfile: none
1.138 Cloning into 'catch2-src'...
1.138 fatal: unable to access 'https://github.com/catchorg/Catch2.git/': server certificate verification failed. CAfile: none CRLfile: none
1.138 Cloning into 'catch2-src'...
1.138 fatal: unable to access 'https://github.com/catchorg/Catch2.git/': server certificate verification failed. CAfile: none CRLfile: none
1.138 -- Had to git clone more than once:
1.138           3 times.
1.138 CMake Error at catch2-subbuild/catch2-populate-prefix/tmp/catch2-populate-gitclone.cmake:31 (message):
1.138   Failed to clone repository: 'https://github.com/catchorg/Catch2.git'
1.138
1.138
1.138 make[2]: *** [CMakeFiles/catch2-populate.dir/build.make:92: catch2-populate-prefix/src/catch2-populate-stamp/catch2-populate-download] Error 1
1.138 make[1]: *** [CMakeFiles/Makefile2:76: CMakeFiles/catch2-populate.dir/all] Error 2
1.138 make: *** [Makefile:84: all] Error 2
1.138
1.138 CMake Error at /usr/share/cmake-3.16/Modules/FetchContent.cmake:915 (message):
1.138   Build step for catch2 failed: 2
1.138 Call Stack (most recent call first):
1.138   /usr/share/cmake-3.16/Modules/FetchContent.cmake:1006 (__FetchContent_directPopulate)
1.138   /usr/share/cmake-3.16/Modules/FetchContent.cmake:1047 (FetchContent_Populate)
1.138   CMakeLists.txt:12 (FetchContent_MakeAvailable)
```

Hence, including both `git` and `ca-certificates`