### PR TITLE
Gracefully handle a negative size

### DIFF
--- a/src/crab/array_domain.cpp
+++ b/src/crab/array_domain.cpp
@@ -493,6 +493,13 @@ bool array_domain_t::all_num(NumAbsDomain& inv, const linear_expression_t& lb, c
     auto max_ub = inv.eval_interval(ub).ub().number();
     if (!min_lb || !max_ub || !min_lb->fits_sint32() || !max_ub->fits_sint32())
         return false;
+
+    // The all_num() call requires a legal range. If we have an illegal range,
+    // we should have already generated an error about the invalid range so just
+    // return true now to avoid an extra error about a non-numeric range.
+    if (*min_lb >= *max_ub)
+        return true;
+
     return this->num_bytes.all_num((int32_t)*min_lb, (int32_t)*max_ub);
 }
 

--- a/test-data/call.yaml
+++ b/test-data/call.yaml
@@ -176,3 +176,18 @@ code:
 
 post:
   - r0.type=number
+---
+test-case: bpf_trace_printk with negative size buffer
+
+pre: ["r1.type=stack", "r1.stack_offset=504",
+      "r2.type=number", "r2.svalue=-13", "r2.uvalue=18446744073709551603"]
+
+code:
+  <start>: |
+    call 6; bpf_trace_printk
+
+post:
+  - r0.type=number
+
+messages:
+  - "0: Invalid size (r2.value > 0)"


### PR DESCRIPTION
Prior to this, the verifier would crash due to an assert() inside the all_num() function.
This bug was found by fuzz testing.

Fixes #611