### PR TITLE
Print failures in wto for easier debugging

### DIFF
--- a/src/config.hpp
+++ b/src/config.hpp
@@ -7,6 +7,7 @@ struct ebpf_verifier_options_t {
     bool assume_assertions;
     bool print_invariants;
     bool print_failures;
+    bool print_failures_in_weak_topological_order;
     bool no_simplify;
 
     // False to use actual map fd's, true to use mock fd's.

--- a/src/ebpf_yaml.cpp
+++ b/src/ebpf_yaml.cpp
@@ -239,6 +239,8 @@ std::optional<Failure> run_yaml_test_case(TestCase test_case, bool debug) {
         test_case.options.no_simplify = true;
     }
 
+    test_case.options.print_failures = true;
+
     ebpf_context_descriptor_t context_descriptor{64, 0, 4, -1};
     EbpfProgramType program_type = make_program_type(test_case.name, &context_descriptor);
 


### PR DESCRIPTION
Resolves: #632 

*Why*
In a recent investigation, there was a single failed assertion, which expanded into over 500 failed assertions further down the graph. Unfortunately, the failure occurred approximately 60% of the way through the section and the code was aggressively in-lined and folded by LLVM. 

The result was that of the 500 assertions, the one that represented the root cause is located approximately 60% of the way through the report that is generated, with the remaining assertions being downstream failures. 

When the failures are instead printed in WTO, the failure ended up as the 3rd failed assertion in the list (with the first two warning about unreachable code), which was immediately actionable.

* What*
Add option to print verification failures in weak topographical order (WTO) instead of linear order (as they appear in the ELF file).

*Result*
This tends to bring actionable failures closer to the start of the list of errors.