### PR TITLE
Fix BTF line info for sections with multiple programs

### DIFF
--- a/src/spec_type_descriptors.hpp
+++ b/src/spec_type_descriptors.hpp
@@ -67,6 +67,7 @@ struct btf_line_info_t {
 struct raw_program {
     std::string filename{};
     std::string section_name{};
+    uint32_t insn_off{}; // Byte offset in section of first instruction in this program.
     std::string function_name{};
     std::vector<ebpf_inst> prog{};
     program_info info{};

--- a/src/test/test_marshal.cpp
+++ b/src/test/test_marshal.cpp
@@ -207,7 +207,7 @@ static const ebpf_instruction_template_t instruction_template[] = {
 static void check_unmarshal_succeed(const ebpf_inst& ins, const ebpf_platform_t& platform = g_ebpf_platform_linux) {
     program_info info{.platform = &platform, .type = platform.get_program_type("unspec", "unspec")};
     const ebpf_inst exit{.opcode = INST_OP_EXIT};
-    InstructionSeq parsed = std::get<InstructionSeq>(unmarshal(raw_program{"", "", "", {ins, exit, exit}, info}));
+    InstructionSeq parsed = std::get<InstructionSeq>(unmarshal(raw_program{"", "", 0, "", {ins, exit, exit}, info}));
     REQUIRE(parsed.size() == 3);
 }
 
@@ -215,7 +215,7 @@ static void check_unmarshal_succeed(const ebpf_inst& ins, const ebpf_platform_t&
 static void check_unmarshal_succeed(ebpf_inst inst1, ebpf_inst inst2, const ebpf_platform_t& platform = g_ebpf_platform_linux) {
     program_info info{.platform = &platform, .type = platform.get_program_type("unspec", "unspec")};
     const ebpf_inst exit{.opcode = INST_OP_EXIT};
-    InstructionSeq parsed = std::get<InstructionSeq>(unmarshal(raw_program{"", "", "", {inst1, inst2, exit, exit}, info}));
+    InstructionSeq parsed = std::get<InstructionSeq>(unmarshal(raw_program{"", "", 0, "", {inst1, inst2, exit, exit}, info}));
     REQUIRE(parsed.size() == 3);
 }
 
@@ -225,7 +225,7 @@ static void compare_unmarshal_marshal(const ebpf_inst& ins, const ebpf_inst& exp
     program_info info{.platform = &platform,
                       .type = platform.get_program_type("unspec", "unspec")};
     const ebpf_inst exit{.opcode = INST_OP_EXIT};
-    InstructionSeq parsed = std::get<InstructionSeq>(unmarshal(raw_program{"", "", "", {ins, exit, exit}, info}));
+    InstructionSeq parsed = std::get<InstructionSeq>(unmarshal(raw_program{"", "", 0, "", {ins, exit, exit}, info}));
     REQUIRE(parsed.size() == 3);
     auto [_, single, _2] = parsed.front();
     (void)_;  // unused
@@ -242,7 +242,7 @@ static void compare_unmarshal_marshal(const ebpf_inst& ins1, const ebpf_inst& in
     program_info info{.platform = &g_ebpf_platform_linux,
                       .type = g_ebpf_platform_linux.get_program_type("unspec", "unspec")};
     const ebpf_inst exit{.opcode = INST_OP_EXIT};
-    InstructionSeq parsed = std::get<InstructionSeq>(unmarshal(raw_program{"", "", "", {ins1, ins2, exit, exit}, info}));
+    InstructionSeq parsed = std::get<InstructionSeq>(unmarshal(raw_program{"", "", 0, "", {ins1, ins2, exit, exit}, info}));
     REQUIRE(parsed.size() == 3);
     auto [_, single, _2] = parsed.front();
     (void)_;  // unused
@@ -260,7 +260,7 @@ static void compare_unmarshal_marshal(const ebpf_inst& ins1, const ebpf_inst& in
     program_info info{.platform = &g_ebpf_platform_linux,
                       .type = g_ebpf_platform_linux.get_program_type("unspec", "unspec")};
     const ebpf_inst exit{.opcode = INST_OP_EXIT};
-    InstructionSeq parsed = std::get<InstructionSeq>(unmarshal(raw_program{"", "", "", {ins1, ins2, exit, exit}, info}));
+    InstructionSeq parsed = std::get<InstructionSeq>(unmarshal(raw_program{"", "", 0, "", {ins1, ins2, exit, exit}, info}));
     REQUIRE(parsed.size() == 3);
     auto [_, single, _2] = parsed.front();
     (void)_;  // unused
@@ -277,7 +277,7 @@ static void compare_unmarshal_marshal(const ebpf_inst& ins1, const ebpf_inst& in
 // we get the original.
 static void compare_marshal_unmarshal(const Instruction& ins, bool double_cmd = false, const ebpf_platform_t& platform = g_ebpf_platform_linux) {
     program_info info{.platform = &platform, .type = platform.get_program_type("unspec", "unspec")};
-    InstructionSeq parsed = std::get<InstructionSeq>(unmarshal(raw_program{"", "", "", marshal(ins, 0), info}));
+    InstructionSeq parsed = std::get<InstructionSeq>(unmarshal(raw_program{"", "", 0, "", marshal(ins, 0), info}));
     REQUIRE(parsed.size() == 1);
     auto [_, single, _2] = parsed.back();
     (void)_;  // unused
@@ -287,14 +287,14 @@ static void compare_marshal_unmarshal(const Instruction& ins, bool double_cmd = 
 
 static void check_marshal_unmarshal_fail(const Instruction& ins, std::string expected_error_message, const ebpf_platform_t& platform = g_ebpf_platform_linux) {
     program_info info{.platform = &platform, .type = platform.get_program_type("unspec", "unspec")};
-    std::string error_message = std::get<std::string>(unmarshal(raw_program{"", "", "", marshal(ins, 0), info}));
+    std::string error_message = std::get<std::string>(unmarshal(raw_program{"", "", 0, "", marshal(ins, 0), info}));
     REQUIRE(error_message == expected_error_message);
 }
 
 static void check_unmarshal_fail(ebpf_inst inst, std::string expected_error_message, const ebpf_platform_t& platform = g_ebpf_platform_linux) {
     program_info info{.platform = &platform, .type = platform.get_program_type("unspec", "unspec")};
     std::vector<ebpf_inst> insns = {inst};
-    auto result = unmarshal(raw_program{"", "", "", insns, info});
+    auto result = unmarshal(raw_program{"", "", 0, "", insns, info});
     REQUIRE(std::holds_alternative<std::string>(result));
     std::string error_message = std::get<std::string>(result);
     REQUIRE(error_message == expected_error_message);
@@ -304,7 +304,7 @@ static void check_unmarshal_fail_goto(ebpf_inst inst, const std::string& expecte
     program_info info{.platform = &platform, .type = platform.get_program_type("unspec", "unspec")};
     const ebpf_inst exit{.opcode = INST_OP_EXIT};
     std::vector<ebpf_inst> insns{inst, exit, exit};
-    auto result = unmarshal(raw_program{"", "", "", insns, info});
+    auto result = unmarshal(raw_program{"", "", 0, "", insns, info});
     REQUIRE(std::holds_alternative<std::string>(result));
     std::string error_message = std::get<std::string>(result);
     REQUIRE(error_message == expected_error_message);
@@ -314,7 +314,7 @@ static void check_unmarshal_fail_goto(ebpf_inst inst, const std::string& expecte
 static void check_unmarshal_fail(ebpf_inst inst1, ebpf_inst inst2, std::string expected_error_message, const ebpf_platform_t& platform = g_ebpf_platform_linux) {
     program_info info{.platform = &platform, .type = platform.get_program_type("unspec", "unspec")};
     std::vector<ebpf_inst> insns = {inst1, inst2};
-    auto result = unmarshal(raw_program{"", "", "", insns, info});
+    auto result = unmarshal(raw_program{"", "", 0, "", insns, info});
     REQUIRE(std::holds_alternative<std::string>(result));
     std::string error_message = std::get<std::string>(result);
     REQUIRE(error_message == expected_error_message);


### PR DESCRIPTION
PR #638 didn't correctly fix the code that fills in BTF info (e.g., source line) per instruction, when multiple programs appear in a section.  This PR corrects that oversight.