### PR TITLE
Print precise location within blocks

### DIFF
--- a/src/asm_syntax.hpp
+++ b/src/asm_syntax.hpp
@@ -26,7 +26,7 @@ struct label_t {
         return label_t{src_label.from, target_label.from, target_label.stack_frame_prefix};
     }
 
-    constexpr bool operator==(const label_t& other) const noexcept = default;
+    bool operator==(const label_t& other) const noexcept = default;
 
     constexpr bool operator<(const label_t& other) const {
         if (this == &other) {
@@ -76,7 +76,7 @@ struct location_t {
 
     location_t(label_t  label, const size_t offset) : label(std::move(label)), offset(offset){ }
 
-    constexpr bool operator==(const location_t&) const = default;
+    bool operator==(const location_t&) const = default;
     constexpr bool operator<(const location_t& other) const {
         if (this == &other) return false;
         return label < other.label || (label == other.label && offset < other.offset);

--- a/src/asm_syntax.hpp
+++ b/src/asm_syntax.hpp
@@ -49,6 +49,20 @@ struct label_t {
     static const label_t exit;
 };
 
+struct location_t {
+    label_t label;
+    int offset{};
+
+    constexpr bool operator==(const location_t&) const = default;
+    constexpr bool operator<(const location_t& other) const {
+        if (this == &other) return false;
+        return label < other.label || (label == other.label && offset < other.offset);
+    }
+    friend std::ostream& operator<<(std::ostream& os, const location_t& location) {
+        return os << location.label << "." << location.offset;
+    }
+};
+
 inline const label_t label_t::entry{-1};
 inline const label_t label_t::exit{-2};
 

--- a/src/asm_syntax.hpp
+++ b/src/asm_syntax.hpp
@@ -13,8 +13,8 @@
 
 namespace crab {
 struct label_t {
-    int from; ///< Jump source, or simply index of instruction
-    int to; ///< Jump target or -1
+    int from{}; ///< Jump source, or simply index of instruction
+    int to{}; ///< Jump target or -1
 
     constexpr explicit label_t(int index, int to = -1) noexcept : from(index), to(to) {}
 
@@ -51,7 +51,9 @@ struct label_t {
 
 struct location_t {
     label_t label;
-    int offset{};
+    size_t offset{};
+
+    location_t(const label_t& label, size_t offset) : label(label), offset(offset){ }
 
     constexpr bool operator==(const location_t&) const = default;
     constexpr bool operator<(const location_t& other) const {

--- a/src/asm_syntax.hpp
+++ b/src/asm_syntax.hpp
@@ -26,7 +26,7 @@ struct label_t {
         return label_t{src_label.from, target_label.from, target_label.stack_frame_prefix};
     }
 
-    bool operator==(const label_t& other) const noexcept = default;
+    constexpr bool operator==(const label_t& other) const noexcept = default;
 
     constexpr bool operator<(const label_t& other) const {
         if (this == &other) {
@@ -74,7 +74,7 @@ struct location_t {
     label_t label;
     size_t offset{};
 
-    location_t(const label_t& label, size_t offset) : label(label), offset(offset){ }
+    location_t(label_t  label, const size_t offset) : label(std::move(label)), offset(offset){ }
 
     constexpr bool operator==(const location_t&) const = default;
     constexpr bool operator<(const location_t& other) const {

--- a/src/crab/cfg.hpp
+++ b/src/crab/cfg.hpp
@@ -37,8 +37,6 @@ class cfg_t;
 class basic_block_t final {
     friend class cfg_t;
 
-  private:
-
   public:
     basic_block_t(const basic_block_t&) = delete;
 
@@ -73,6 +71,10 @@ class basic_block_t final {
     ~basic_block_t() = default;
 
     [[nodiscard]] label_t label() const { return m_label; }
+
+    [[nodiscard]] const Instruction& at(size_t idx) const {
+        return m_ts.at(idx);
+    }
 
     iterator begin() { return (m_ts.begin()); }
     iterator end() { return (m_ts.end()); }

--- a/test-data/atomic.yaml
+++ b/test-data/atomic.yaml
@@ -258,7 +258,7 @@ post: ["r1.type=number", "r1.svalue=2", "r1.uvalue=2",
        "r2.type=shared", "r2.shared_region_size=10", "r2.shared_offset=4", "r2.svalue=[1, 2147418112]", "r2.uvalue=[1, 2147418112]", "r2.svalue=r2.uvalue"]
 
 messages:
-  - "0: Upper bound must be at most r2.shared_region_size (valid_access(r2.offset+4, width=4) for write)"
+  - "0.1: Upper bound must be at most r2.shared_region_size (valid_access(r2.offset+4, width=4) for write)"
 ---
 test-case: atomic 32-bit ADD stack
 
@@ -557,8 +557,8 @@ post: ["r1.type=number", "r1.svalue=2", "r1.uvalue=2",
        "r2.type=number", "r2.svalue=[1, 2147418112]", "r2.uvalue=[1, 2147418112]", "r2.svalue=r2.uvalue"]
 
 messages:
-  - "0: Invalid type (r2.type in {ctx, stack, packet, shared})"
-  - "0: Only pointers can be dereferenced (valid_access(r2.offset+4, width=4) for write)"
+  - "0.0: Invalid type (r2.type in {ctx, stack, packet, shared})"
+  - "0.1: Only pointers can be dereferenced (valid_access(r2.offset+4, width=4) for write)"
 ---
 test-case: atomic 64-bit CMPXCHG comparing against non-number
 
@@ -575,4 +575,4 @@ post: ["r0.type=number", "r0.svalue=2", "r0.uvalue=2",
        "r2.type=shared", "r2.shared_region_size=16", "r2.shared_offset=4", "r2.svalue=[1, 2147418112]", "r2.uvalue=[1, 2147418112]", "r2.svalue=r2.uvalue"]
 
 messages:
-  - "0: Invalid type (r1.type == number)"
+  - "0.2: Invalid type (r1.type == number)"

--- a/test-data/call.yaml
+++ b/test-data/call.yaml
@@ -75,7 +75,7 @@ post:
   - r0.svalue=r0.uvalue
 
 messages:
-  - "0: Possible null access (within stack(r2:key_size(r1)))"
+  - "0.2: Possible null access (within stack(r2:key_size(r1)))"
 
 ---
 test-case: bpf_map_lookup_elem shared key - too small
@@ -96,7 +96,7 @@ post:
   - r0.svalue=r0.uvalue
 
 messages:
-  - "0: Upper bound must be at most r2.shared_region_size (within stack(r2:key_size(r1)))"
+  - "0.2: Upper bound must be at most r2.shared_region_size (within stack(r2:key_size(r1)))"
 ---
 test-case: bpf_map_lookup_elem shared key - too small
 
@@ -116,7 +116,7 @@ post:
   - r0.svalue=r0.uvalue
 
 messages:
-  - "0: Lower bound must be at least 0 (within stack(r2:key_size(r1)))"
+  - "0.2: Lower bound must be at least 0 (within stack(r2:key_size(r1)))"
 ---
 test-case: bpf_map_lookup_elem with non-numeric stack key
 
@@ -136,7 +136,7 @@ post:
   - r0.svalue=r0.uvalue
 
 messages:
-  - "0: Illegal map update with a non-numerical value [-oo-oo) (within stack(r2:key_size(r1)))"
+  - "0.2: Illegal map update with a non-numerical value [-oo-oo) (within stack(r2:key_size(r1)))"
 ---
 test-case: bpf_map_update_elem with numeric stack value
 
@@ -189,7 +189,7 @@ post:
   - s[496...511].type=number
 
 messages:
-  - "0: Upper bound must be at most r3.shared_region_size (within stack(r3:value_size(r1)))"
+  - "0.4: Upper bound must be at most r3.shared_region_size (within stack(r3:value_size(r1)))"
 
 ---
 test-case: bpf_map_update_elem with shared value larger than target region
@@ -226,7 +226,7 @@ post:
   - s[496...511].type=number
 
 messages:
-  - "0: Possible null access (within stack(r3:value_size(r1)))"
+  - "0.4: Possible null access (within stack(r3:value_size(r1)))"
 
 ---
 test-case: bpf_map_update_elem with packet value
@@ -266,7 +266,7 @@ post:
   - s[504...511].type=number
 
 messages:
-  - "0: Illegal map update with a non-numerical value [496-500) (within stack(r3:value_size(r1)))"
+  - "0.4: Illegal map update with a non-numerical value [496-500) (within stack(r3:value_size(r1)))"
 ---
 test-case: bpf_map_update_elem with context value
 
@@ -285,8 +285,8 @@ post:
   - s[504...511].type=number
 
 messages:
-  - "0: Invalid type (r3.type in {stack, packet, shared})"
-  - "0: Only stack or packet can be used as a parameter (within stack(r3:value_size(r1)))"
+  - "0.3: Invalid type (r3.type in {stack, packet, shared})"
+  - "0.4: Only stack or packet can be used as a parameter (within stack(r3:value_size(r1)))"
 ---
 test-case: bpf_ringbuf_output with numeric stack value
 
@@ -319,7 +319,7 @@ post:
   - r0.type=number
 
 messages:
-  - "0: Stack content is not numeric (valid_access(r2.offset, width=r3) for read)"
+  - "0.5: Stack content is not numeric (valid_access(r2.offset, width=r3) for read)"
 ---
 test-case: bpf_ringbuf_output with context value
 
@@ -338,7 +338,7 @@ post:
   - s[504...511].type=number
 
 messages:
-  - "0: Invalid type (r2.type in {stack, packet, shared})"
+  - "0.4: Invalid type (r2.type in {stack, packet, shared})"
 ---
 test-case: bpf_get_stack
 
@@ -370,7 +370,7 @@ post:
   - r0.type=number
 
 messages:
-  - "0: Invalid type (r2.type in {stack, packet, shared})"
+  - "0.5: Invalid type (r2.type in {stack, packet, shared})"
 ---
 test-case: bpf_get_stack writing into shared memory
 
@@ -399,4 +399,4 @@ post:
   - r0.type=number
 
 messages:
-  - "0: Invalid size (r2.value > 0)"
+  - "0.1: Invalid size (r2.value > 0)"

--- a/test-data/call.yaml
+++ b/test-data/call.yaml
@@ -75,7 +75,7 @@ post:
   - r0.svalue=r0.uvalue
 
 messages:
-  - "0.2: Possible null access (within stack(r2:key_size(r1)))"
+  - "0.3: Possible null access (within stack(r2:key_size(r1)))"
 
 ---
 test-case: bpf_map_lookup_elem shared key - too small

--- a/test-data/call.yaml
+++ b/test-data/call.yaml
@@ -96,7 +96,7 @@ post:
   - r0.svalue=r0.uvalue
 
 messages:
-  - "0.2: Upper bound must be at most r2.shared_region_size (within stack(r2:key_size(r1)))"
+  - "0.3: Upper bound must be at most r2.shared_region_size (within stack(r2:key_size(r1)))"
 ---
 test-case: bpf_map_lookup_elem shared key - too small
 
@@ -116,7 +116,7 @@ post:
   - r0.svalue=r0.uvalue
 
 messages:
-  - "0.2: Lower bound must be at least 0 (within stack(r2:key_size(r1)))"
+  - "0.3: Lower bound must be at least 0 (within stack(r2:key_size(r1)))"
 ---
 test-case: bpf_map_lookup_elem with non-numeric stack key
 
@@ -136,7 +136,7 @@ post:
   - r0.svalue=r0.uvalue
 
 messages:
-  - "0.2: Illegal map update with a non-numerical value [-oo-oo) (within stack(r2:key_size(r1)))"
+  - "0.3: Illegal map update with a non-numerical value [-oo-oo) (within stack(r2:key_size(r1)))"
 ---
 test-case: bpf_map_update_elem with numeric stack value
 
@@ -189,7 +189,7 @@ post:
   - s[496...511].type=number
 
 messages:
-  - "0.4: Upper bound must be at most r3.shared_region_size (within stack(r3:value_size(r1)))"
+  - "0.5: Upper bound must be at most r3.shared_region_size (within stack(r3:value_size(r1)))"
 
 ---
 test-case: bpf_map_update_elem with shared value larger than target region
@@ -226,7 +226,7 @@ post:
   - s[496...511].type=number
 
 messages:
-  - "0.4: Possible null access (within stack(r3:value_size(r1)))"
+  - "0.5: Possible null access (within stack(r3:value_size(r1)))"
 
 ---
 test-case: bpf_map_update_elem with packet value
@@ -266,7 +266,7 @@ post:
   - s[504...511].type=number
 
 messages:
-  - "0.4: Illegal map update with a non-numerical value [496-500) (within stack(r3:value_size(r1)))"
+  - "0.5: Illegal map update with a non-numerical value [496-500) (within stack(r3:value_size(r1)))"
 ---
 test-case: bpf_map_update_elem with context value
 
@@ -285,8 +285,8 @@ post:
   - s[504...511].type=number
 
 messages:
-  - "0.3: Invalid type (r3.type in {stack, packet, shared})"
-  - "0.4: Only stack or packet can be used as a parameter (within stack(r3:value_size(r1)))"
+  - "0.4: Invalid type (r3.type in {stack, packet, shared})"
+  - "0.5: Only stack or packet can be used as a parameter (within stack(r3:value_size(r1)))"
 ---
 test-case: bpf_ringbuf_output with numeric stack value
 
@@ -319,7 +319,7 @@ post:
   - r0.type=number
 
 messages:
-  - "0.5: Stack content is not numeric (valid_access(r2.offset, width=r3) for read)"
+  - "0.6: Stack content is not numeric (valid_access(r2.offset, width=r3) for read)"
 ---
 test-case: bpf_ringbuf_output with context value
 
@@ -338,7 +338,7 @@ post:
   - s[504...511].type=number
 
 messages:
-  - "0.4: Invalid type (r2.type in {stack, packet, shared})"
+  - "0.5: Invalid type (r2.type in {stack, packet, shared})"
 ---
 test-case: bpf_get_stack
 
@@ -370,7 +370,7 @@ post:
   - r0.type=number
 
 messages:
-  - "0.5: Invalid type (r2.type in {stack, packet, shared})"
+  - "0.6: Invalid type (r2.type in {stack, packet, shared})"
 ---
 test-case: bpf_get_stack writing into shared memory
 
@@ -399,4 +399,4 @@ post:
   - r0.type=number
 
 messages:
-  - "0.1: Invalid size (r2.value > 0)"
+  - "0.2: Invalid size (r2.value > 0)"

--- a/test-data/calllocal.yaml
+++ b/test-data/calllocal.yaml
@@ -259,7 +259,7 @@ code:
 post: ["r0.type=number"]
 
 messages:
-  - "0/2: tail call not supported in subprogram (valid call(tail_call))"
+  - "0/2.0: tail call not supported in subprogram (valid call(tail_call))"
 ---
 test-case: call local must preserve R6-R9 types
 

--- a/test-data/callx.yaml
+++ b/test-data/callx.yaml
@@ -91,7 +91,7 @@ post:
   - r8.uvalue=1
 
 messages:
-  - "0: Possible null access (within stack(r2:key_size(r1)))"
+  - "0.1: Possible null access (within stack(r2:key_size(r1)))"
 ---
 test-case: callx bpf_map_lookup_elem shared key - too small
 
@@ -115,7 +115,7 @@ post:
   - r8.uvalue=1
 
 messages:
-  - "0: Upper bound must be at most r2.shared_region_size (within stack(r2:key_size(r1)))"
+  - "0.1: Upper bound must be at most r2.shared_region_size (within stack(r2:key_size(r1)))"
 ---
 test-case: callx bpf_map_lookup_elem shared key - too small
 
@@ -139,7 +139,7 @@ post:
   - r8.uvalue=1
 
 messages:
-  - "0: Lower bound must be at least 0 (within stack(r2:key_size(r1)))"
+  - "0.1: Lower bound must be at least 0 (within stack(r2:key_size(r1)))"
 ---
 test-case: callx 0
 
@@ -155,7 +155,7 @@ post:
   - r8.uvalue=1000
 
 messages:
-  - "0: invalid helper function id 1000 (r8.type is helper)"
+  - "0.1: invalid helper function id 1000 (r8.type is helper)"
 ---
 test-case: callx with invalid id
 
@@ -171,7 +171,7 @@ post:
   - r8.uvalue=1000
 
 messages:
-  - "0: invalid helper function id 1000 (r8.type is helper)"
+  - "0.1: invalid helper function id 1000 (r8.type is helper)"
 ---
 test-case: callx with interval
 
@@ -187,7 +187,7 @@ post:
   - r8.uvalue=[1, 2]
 
 messages:
-  - "0: callx helper function id is not a valid singleton (r8.type is helper)"
+  - "0.1: callx helper function id is not a valid singleton (r8.type is helper)"
 ---
 test-case: callx bpf_map_lookup_elem with non-numeric stack key
 
@@ -211,7 +211,7 @@ post:
   - r8.uvalue=1
 
 messages:
-  - "0: Illegal map update with a non-numerical value [-oo-oo) (within stack(r2:key_size(r1)))"
+  - "0.1: Illegal map update with a non-numerical value [-oo-oo) (within stack(r2:key_size(r1)))"
 ---
 test-case: callx bpf_map_update_elem with numeric stack value
 
@@ -276,7 +276,7 @@ post:
   - r8.uvalue=2
 
 messages:
-  - "0: Upper bound must be at most r3.shared_region_size (within stack(r3:value_size(r1)))"
+  - "0.1: Upper bound must be at most r3.shared_region_size (within stack(r3:value_size(r1)))"
 
 ---
 test-case: callx bpf_map_update_elem with shared value larger than target region
@@ -321,7 +321,7 @@ post:
   - r8.uvalue=2
 
 messages:
-  - "0: Possible null access (within stack(r3:value_size(r1)))"
+  - "0.1: Possible null access (within stack(r3:value_size(r1)))"
 
 ---
 test-case: callx bpf_map_update_elem with packet value
@@ -368,7 +368,7 @@ post:
   - r8.uvalue=2
 
 messages:
-  - "0: Illegal map update with a non-numerical value [496-500) (within stack(r3:value_size(r1)))"
+  - "0.1: Illegal map update with a non-numerical value [496-500) (within stack(r3:value_size(r1)))"
 ---
 test-case: callx bpf_map_update_elem with context value
 
@@ -391,8 +391,8 @@ post:
   - r8.uvalue=2
 
 messages:
-  - "0: Invalid type (r3.type in {stack, packet, shared})"
-  - "0: Only stack or packet can be used as a parameter (within stack(r3:value_size(r1)))"
+  - "0.1: Invalid type (r3.type in {stack, packet, shared})"
+  - "0.1: Only stack or packet can be used as a parameter (within stack(r3:value_size(r1)))"
 ---
 test-case: callx bpf_ringbuf_output with numeric stack value
 
@@ -433,7 +433,7 @@ post:
   - r8.uvalue=130
 
 messages:
-  - "0: Stack content is not numeric (valid_access(r2.offset, width=r3) for read)"
+  - "0.1: Stack content is not numeric (valid_access(r2.offset, width=r3) for read)"
 ---
 test-case: callx bpf_ringbuf_output with context value
 
@@ -456,7 +456,7 @@ post:
   - s[504...511].type=number
 
 messages:
-  - "0: Invalid type (r2.type in {stack, packet, shared})"
+  - "0.1: Invalid type (r2.type in {stack, packet, shared})"
 ---
 test-case: callx bpf_get_stack
 
@@ -496,7 +496,7 @@ post:
   - r8.uvalue=67
 
 messages:
-  - "0: Invalid type (r2.type in {stack, packet, shared})"
+  - "0.1: Invalid type (r2.type in {stack, packet, shared})"
 ---
 test-case: callx bpf_get_stack writing into shared memory
 

--- a/test-data/jump.yaml
+++ b/test-data/jump.yaml
@@ -103,7 +103,7 @@ code:
 
 post: []
 messages:
-  - "0: Code is unreachable after 0"
+  - "0.1: Code is unreachable after 0"
 ---
 test-case: assume number w!= reg
 
@@ -186,9 +186,9 @@ post:
   - r0.svalue=1
   - r0.uvalue=1
 messages:
-  - "2:5: Code is unreachable after 2:5"
-  - "3:5: Code is unreachable after 3:5"
-  - "4:5: Code is unreachable after 4:5"
+  - "2:5.0: Code is unreachable after 2:5"
+  - "3:5.0: Code is unreachable after 3:5"
+  - "4:5.0: Code is unreachable after 4:5"
 ---
 test-case: jump-32
 
@@ -220,9 +220,9 @@ post:
   - r0.svalue=1
   - r0.uvalue=1
 messages:
-  - "3:9: Code is unreachable after 3:9"
-  - "4:9: Code is unreachable after 4:9"
-  - "5:6: Code is unreachable after 5:6"
+  - "3:9.0: Code is unreachable after 3:9"
+  - "4:9.0: Code is unreachable after 4:9"
+  - "5:6.0: Code is unreachable after 5:6"
 ---
 test-case: join stack
 
@@ -330,7 +330,7 @@ post:
   - r9.type=ctx
 
 messages:
-  - "8: Cannot subtract pointers to different regions (r1.type == number or r3.type == r1.type in {ctx, stack, packet})"
+  - "8.1: Cannot subtract pointers to different regions (r1.type == number or r3.type == r1.type in {ctx, stack, packet})"
 ---
 test-case: multiple types add ok
 
@@ -483,8 +483,8 @@ post:
   - r8.uvalue=1024
 
 messages:
-  - "8: Only numbers can be added to pointers (r2.type in {ctx, stack, packet, shared} -> r3.type == number)"
-  - "8: Only numbers can be added to pointers (r3.type in {ctx, stack, packet, shared} -> r2.type == number)"
+  - "8.2: Only numbers can be added to pointers (r2.type in {ctx, stack, packet, shared} -> r3.type == number)"
+  - "8.3: Only numbers can be added to pointers (r3.type in {ctx, stack, packet, shared} -> r2.type == number)"
 ---
 test-case: multiple types compare
 
@@ -534,7 +534,7 @@ post:
   - r9.packet_offset=0
 
 messages:
-  - "7:9: Code is unreachable after 7:9"
+  - "7:9.0: Code is unreachable after 7:9"
 ---
 test-case: lost implications in correlated branches
 
@@ -576,7 +576,7 @@ post:
   - r4.svalue=r4.uvalue
 
 messages:
-  - "7: Upper bound must be at most packet_size (valid_access(r1.offset-8, width=8) for read)"
+  - "7.1: Upper bound must be at most packet_size (valid_access(r1.offset-8, width=8) for read)"
 ---
 test-case: 32-bit compare
 
@@ -601,7 +601,7 @@ post:
   - r4.uvalue=18446744073709551594
 
 messages:
-  - "0:1: Code is unreachable after 0:1"
+  - "0:1.0: Code is unreachable after 0:1"
 ---
 test-case: unsigned comparison of negative number
 
@@ -624,7 +624,7 @@ post:
   - r1.uvalue=18446744073709551615
 
 messages:
-  - "0:1: Code is unreachable after 0:1"
+  - "0:1.0: Code is unreachable after 0:1"
 ---
 test-case: JMP32
 
@@ -647,7 +647,7 @@ post:
   - r1.uvalue=4294967294
 
 messages:
-  - "0:2: Code is unreachable after 0:2"
+  - "0:2.0: Code is unreachable after 0:2"
 ---
 test-case: assume map_fd == map_fd
 
@@ -670,7 +670,7 @@ code:
 
 post: []
 messages:
-  - "0: Code is unreachable after 0"
+  - "0.3: Code is unreachable after 0"
 ---
 test-case: assume map_fd1 != map_fd2
 
@@ -696,7 +696,7 @@ code:
 
 post: []
 messages:
-  - "0: Code is unreachable after 0"
+  - "0.3: Code is unreachable after 0"
 ---
 test-case: assume map_fd1 < map_fd2
 
@@ -714,4 +714,4 @@ post:
   - r1.map_fd-r2.map_fd<=-1
 
 messages:
-  - "0: Invalid type (r1.type == non_map_fd)"
+  - "0.2: Invalid type (r1.type == non_map_fd)"

--- a/test-data/movsx.yaml
+++ b/test-data/movsx.yaml
@@ -97,7 +97,7 @@ code:
 post: []
 
 messages:
-  - "0: Invalid type (r1.type == number)"
+  - "0.0: Invalid type (r1.type == number)"
 ---
 test-case: movsx8 register range to 32 bits without wrap
 

--- a/test-data/packet.yaml
+++ b/test-data/packet.yaml
@@ -17,7 +17,7 @@ post: ["meta_offset=0",
        "r2.type=packet", "r2.packet_offset=[0, 65534]", "packet_size=r2.packet_offset",
        "packet_size=[0, 65534]", "r4.type=number", "r4.svalue=0", "r4.uvalue=0"]
 messages:
-  - "1: Upper bound must be at most packet_size (valid_access(r1.offset, width=8) for write)"
+  - "1.1: Upper bound must be at most packet_size (valid_access(r1.offset, width=8) for write)"
 
 ---
 test-case: simple invalid read
@@ -35,7 +35,7 @@ post: ["meta_offset=0",
        "r2.type=packet", "r2.packet_offset=[0, 65534]", "packet_size=r2.packet_offset",
        "packet_size=[0, 65534]", "r4.type=number"]
 messages:
-  - "0: Upper bound must be at most packet_size (valid_access(r1.offset, width=8) for read)"
+  - "0.1: Upper bound must be at most packet_size (valid_access(r1.offset, width=8) for read)"
 
 ---
 test-case: writing 8 bytes when packet size is 4
@@ -63,7 +63,7 @@ post: ["meta_offset=0",
        "r3.packet_offset-packet_size<=4", "r3.svalue=r1.svalue+4", "r3.uvalue=r1.svalue+4",
        "r2.packet_offset-r3.packet_offset<=65530", "r3.packet_offset-r2.packet_offset<=4"]
 messages:
-  - "4: Upper bound must be at most packet_size (valid_access(r1.offset, width=8) for write)"
+  - "4.1: Upper bound must be at most packet_size (valid_access(r1.offset, width=8) for write)"
 
 ---
 test-case: simple valid access

--- a/test-data/sdivmod.yaml
+++ b/test-data/sdivmod.yaml
@@ -18,7 +18,7 @@ post:
   - r2.uvalue=1
 
 messages:
-  - "0: Only numbers can be used as divisors (r2 != 0)"
+  - "0.1: Only numbers can be used as divisors (r2 != 0)"
 ---
 test-case: non-zero divided by zero immediate
 
@@ -66,7 +66,7 @@ post:
   - r2.uvalue=0
 
 messages:
-  - "0: Possible division by zero (r2 != 0)"
+  - "0.1: Possible division by zero (r2 != 0)"
 ---
 test-case: non-zero divided by zero register without warning
 
@@ -105,7 +105,7 @@ post:
   - r2.uvalue=0
 
 messages:
-  - "0: Possible division by zero (r2 != 0)"
+  - "0.1: Possible division by zero (r2 != 0)"
 ---
 test-case: non-zero divided by possibly zero register
 
@@ -125,7 +125,7 @@ post:
   - r2.svalue=[-5, 5]
 
 messages:
-  - "0: Possible division by zero (r2 != 0)"
+  - "0.1: Possible division by zero (r2 != 0)"
 ---
 test-case: zero divided by possibly zero register
 
@@ -146,7 +146,7 @@ post:
   - r2.svalue=[-5, 5]
 
 messages:
-  - "0: Possible division by zero (r2 != 0)"
+  - "0.1: Possible division by zero (r2 != 0)"
 ---
 test-case: non-zero divided by possibly zero register 2
 
@@ -170,7 +170,7 @@ post:
   - r2.svalue=r2.uvalue
 
 messages:
-  - "0: Possible division by zero (r2 != 0)"
+  - "0.1: Possible division by zero (r2 != 0)"
 ---
 test-case: zero divided by possibly zero register 2
 
@@ -191,7 +191,7 @@ post:
   - r2.svalue=[-5, 0]
 
 messages:
-  - "0: Possible division by zero (r2 != 0)"
+  - "0.1: Possible division by zero (r2 != 0)"
 ---
 test-case: non-zero divided by undefined value register
 
@@ -210,7 +210,7 @@ post:
   - r2.type=number
 
 messages:
-  - "0: Possible division by zero (r2 != 0)"
+  - "0.1: Possible division by zero (r2 != 0)"
 ---
 test-case: zero divided by undefined value register
 
@@ -230,7 +230,7 @@ post:
   - r2.type=number
 
 messages:
-  - "0: Possible division by zero (r2 != 0)"
+  - "0.1: Possible division by zero (r2 != 0)"
 ---
 test-case: undefined value register divided by signed non-zero range
 
@@ -292,7 +292,7 @@ post:
   - r2.uvalue=0
 
 messages:
-  - "0: Possible division by zero (r2 != 0)"
+  - "0.1: Possible division by zero (r2 != 0)"
 ---
 test-case: non-zero modulo zero register without warning
 
@@ -331,7 +331,7 @@ post:
   - r2.uvalue=0
 
 messages:
-  - "0: Possible division by zero (r2 != 0)"
+  - "0.1: Possible division by zero (r2 != 0)"
 ---
 test-case: non-zero modulo possibly zero register
 
@@ -353,7 +353,7 @@ post:
   - r2.svalue=[-5, 5]
 
 messages:
-  - "0: Possible division by zero (r2 != 0)"
+  - "0.1: Possible division by zero (r2 != 0)"
 ---
 test-case: zero modulo possibly zero register
 
@@ -374,7 +374,7 @@ post:
   - r2.svalue=[-5, 5]
 
 messages:
-  - "0: Possible division by zero (r2 != 0)"
+  - "0.1: Possible division by zero (r2 != 0)"
 ---
 test-case: non-zero modulo possibly zero register 2
 
@@ -398,7 +398,7 @@ post:
   - r2.svalue=r2.uvalue
 
 messages:
-  - "0: Possible division by zero (r2 != 0)"
+  - "0.1: Possible division by zero (r2 != 0)"
 ---
 test-case: zero modulo possibly zero register 2
 
@@ -419,7 +419,7 @@ post:
   - r2.svalue=[-5, 0]
 
 messages:
-  - "0: Possible division by zero (r2 != 0)"
+  - "0.1: Possible division by zero (r2 != 0)"
 ---
 test-case: non-zero modulo undefined value register
 
@@ -440,7 +440,7 @@ post:
   - r2.type=number
 
 messages:
-  - "0: Possible division by zero (r2 != 0)"
+  - "0.1: Possible division by zero (r2 != 0)"
 ---
 test-case: zero modulo undefined value register
 
@@ -460,7 +460,7 @@ post:
   - r2.type=number
 
 messages:
-  - "0: Possible division by zero (r2 != 0)"
+  - "0.1: Possible division by zero (r2 != 0)"
 ---
 test-case: positive modulo positive range
 

--- a/test-data/subtract.yaml
+++ b/test-data/subtract.yaml
@@ -77,7 +77,7 @@ post:
   - r3.uvalue=4
 
 messages:
-  - "0: Cannot subtract pointers to non-singleton regions (r2.type == number or r3.type == r2.type in {ctx, stack, packet})"
+  - "0.1: Cannot subtract pointers to non-singleton regions (r2.type == number or r3.type == r2.type in {ctx, stack, packet})"
 ---
 test-case: disallow subtraction of unequal dual-typed pointers
 
@@ -94,7 +94,7 @@ post:
   - r2.stack_offset=4
 
 messages:
-  - "0: Cannot subtract pointers to different regions (r2.type == number or r3.type == r2.type in {ctx, stack, packet})"
+  - "0.1: Cannot subtract pointers to different regions (r2.type == number or r3.type == r2.type in {ctx, stack, packet})"
 
 ---
 test-case: allow subtraction of equal dual-typed pointers
@@ -152,4 +152,4 @@ post:
   - r2.type=stack
   - r2.stack_offset=[140, 230]
 messages:
-  - "0: Upper bound must be at most EBPF_STACK_SIZE (r2.type == number or r1.type == r2.type in {ctx, stack, packet})"
+  - "0.1: Upper bound must be at most EBPF_STACK_SIZE (r2.type == number or r1.type == r2.type in {ctx, stack, packet})"

--- a/test-data/udivmod.yaml
+++ b/test-data/udivmod.yaml
@@ -18,7 +18,7 @@ post:
   - r2.uvalue=1
 
 messages:
-  - "0: Only numbers can be used as divisors (r2 != 0)"
+  - "0.1: Only numbers can be used as divisors (r2 != 0)"
 ---
 test-case: non-zero divided by zero immediate
 
@@ -66,7 +66,7 @@ post:
   - r2.uvalue=0
 
 messages:
-  - "0: Possible division by zero (r2 != 0)"
+  - "0.1: Possible division by zero (r2 != 0)"
 ---
 test-case: non-zero divided by zero register without warning
 
@@ -105,7 +105,7 @@ post:
   - r2.uvalue=0
 
 messages:
-  - "0: Possible division by zero (r2 != 0)"
+  - "0.1: Possible division by zero (r2 != 0)"
 ---
 test-case: non-zero divided by possibly zero register
 
@@ -127,7 +127,7 @@ post:
   - r2.svalue=[-5, 5]
 
 messages:
-  - "0: Possible division by zero (r2 != 0)"
+  - "0.1: Possible division by zero (r2 != 0)"
 ---
 test-case: zero divided by possibly zero register
 
@@ -148,7 +148,7 @@ post:
   - r2.svalue=[-5, 5]
 
 messages:
-  - "0: Possible division by zero (r2 != 0)"
+  - "0.1: Possible division by zero (r2 != 0)"
 ---
 test-case: non-zero divided by possibly zero register 2
 
@@ -172,7 +172,7 @@ post:
   - r2.svalue=r2.uvalue
 
 messages:
-  - "0: Possible division by zero (r2 != 0)"
+  - "0.1: Possible division by zero (r2 != 0)"
 ---
 test-case: zero divided by possibly zero register 2
 
@@ -193,7 +193,7 @@ post:
   - r2.svalue=[-5, 0]
 
 messages:
-  - "0: Possible division by zero (r2 != 0)"
+  - "0.1: Possible division by zero (r2 != 0)"
 ---
 test-case: non-zero divided by undefined value register
 
@@ -214,7 +214,7 @@ post:
   - r2.type=number
 
 messages:
-  - "0: Possible division by zero (r2 != 0)"
+  - "0.1: Possible division by zero (r2 != 0)"
 ---
 test-case: zero divided by undefined value register
 
@@ -234,7 +234,7 @@ post:
   - r2.type=number
 
 messages:
-  - "0: Possible division by zero (r2 != 0)"
+  - "0.1: Possible division by zero (r2 != 0)"
 ---
 test-case: undefined value register divided by unsigned non-zero range
 
@@ -296,7 +296,7 @@ post:
   - r2.uvalue=0
 
 messages:
-  - "0: Possible division by zero (r2 != 0)"
+  - "0.1: Possible division by zero (r2 != 0)"
 ---
 test-case: non-zero modulo zero register without warning
 
@@ -335,7 +335,7 @@ post:
   - r2.uvalue=0
 
 messages:
-  - "0: Possible division by zero (r2 != 0)"
+  - "0.1: Possible division by zero (r2 != 0)"
 ---
 test-case: non-zero modulo possibly zero register
 
@@ -357,7 +357,7 @@ post:
   - r2.svalue=[-5, 5]
 
 messages:
-  - "0: Possible division by zero (r2 != 0)"
+  - "0.1: Possible division by zero (r2 != 0)"
 ---
 test-case: zero modulo possibly zero register
 
@@ -378,7 +378,7 @@ post:
   - r2.svalue=[-5, 5]
 
 messages:
-  - "0: Possible division by zero (r2 != 0)"
+  - "0.1: Possible division by zero (r2 != 0)"
 ---
 test-case: non-zero modulo possibly zero register 2
 
@@ -402,7 +402,7 @@ post:
   - r2.svalue=r2.uvalue
 
 messages:
-  - "0: Possible division by zero (r2 != 0)"
+  - "0.1: Possible division by zero (r2 != 0)"
 ---
 test-case: zero modulo possibly zero register 2
 
@@ -423,7 +423,7 @@ post:
   - r2.svalue=[-5, 0]
 
 messages:
-  - "0: Possible division by zero (r2 != 0)"
+  - "0.1: Possible division by zero (r2 != 0)"
 ---
 test-case: non-zero modulo undefined value register
 
@@ -444,7 +444,7 @@ post:
   - r2.type=number
 
 messages:
-  - "0: Possible division by zero (r2 != 0)"
+  - "0.1: Possible division by zero (r2 != 0)"
 ---
 test-case: zero modulo undefined value register
 
@@ -464,7 +464,7 @@ post:
   - r2.type=number
 
 messages:
-  - "0: Possible division by zero (r2 != 0)"
+  - "0.1: Possible division by zero (r2 != 0)"
 ---
 test-case: positive modulo positive range
 

--- a/test-data/unsigned.yaml
+++ b/test-data/unsigned.yaml
@@ -7,7 +7,7 @@ code:
   <start>: assume r1 < 0
 post: []
 messages:
-  - "0: Code is unreachable after 0"
+  - "0.1: Code is unreachable after 0"
 ---
 test-case: "assume 0 w< 0 implies bottom"
 pre: ["r1.type=number", "r1.svalue=0", "r1.uvalue=0"]
@@ -15,7 +15,7 @@ code:
   <start>: assume w1 < 0
 post: []
 messages:
-  - "0: Code is unreachable after 0"
+  - "0.1: Code is unreachable after 0"
 ---
 test-case: "assume -1 < 0 implies bottom"
 pre: ["r1.type=number", "r1.svalue=-1", "r1.uvalue=18446744073709551615"]
@@ -23,7 +23,7 @@ code:
   <start>: assume r1 < 0
 post: []
 messages:
-  - "0: Code is unreachable after 0"
+  - "0.1: Code is unreachable after 0"
 ---
 test-case: "assume -1 w< 0 implies bottom"
 pre: ["r1.type=number", "r1.svalue=-1", "r1.uvalue=18446744073709551615"]
@@ -31,7 +31,7 @@ code:
   <start>: assume w1 < 0
 post: []
 messages:
-  - "0: Code is unreachable after 0"
+  - "0.1: Code is unreachable after 0"
 ---
 test-case: "assume -1 < 1 implies bottom"
 pre: ["r1.type=number", "r1.svalue=-1", "r1.uvalue=18446744073709551615"]
@@ -39,7 +39,7 @@ code:
   <start>: assume r1 < 1
 post: []
 messages:
-  - "0: Code is unreachable after 0"
+  - "0.1: Code is unreachable after 0"
 ---
 test-case: "assume -1 w< 1 implies bottom"
 pre: ["r1.type=number", "r1.svalue=-1", "r1.uvalue=18446744073709551615"]
@@ -47,7 +47,7 @@ code:
   <start>: assume w1 < 1
 post: []
 messages:
-  - "0: Code is unreachable after 0"
+  - "0.1: Code is unreachable after 0"
 ---
 test-case: "assume 1 < 0 implies bottom"
 pre: ["r1.type=number", "r1.svalue=1", "r1.uvalue=1"]
@@ -55,7 +55,7 @@ code:
   <start>: assume r1 < 0
 post: []
 messages:
-  - "0: Code is unreachable after 0"
+  - "0.1: Code is unreachable after 0"
 ---
 test-case: "assume 1 w< 0 implies bottom"
 pre: ["r1.type=number", "r1.svalue=1", "r1.uvalue=1"]
@@ -63,7 +63,7 @@ code:
   <start>: assume w1 < 0
 post: []
 messages:
-  - "0: Code is unreachable after 0"
+  - "0.1: Code is unreachable after 0"
 ---
 test-case: "assume 1 < 1 implies bottom"
 pre: ["r1.type=number", "r1.svalue=1", "r1.uvalue=1"]
@@ -71,7 +71,7 @@ code:
   <start>: assume r1 < 1
 post: []
 messages:
-  - "0: Code is unreachable after 0"
+  - "0.1: Code is unreachable after 0"
 ---
 test-case: "assume 1 w< 1 implies bottom"
 pre: ["r1.type=number", "r1.svalue=1", "r1.uvalue=1"]
@@ -79,7 +79,7 @@ code:
   <start>: assume w1 < 1
 post: []
 messages:
-  - "0: Code is unreachable after 0"
+  - "0.1: Code is unreachable after 0"
 ---
 test-case: "assume 2 < 1 implies bottom"
 pre: ["r1.type=number", "r1.svalue=2", "r1.uvalue=2"]
@@ -87,7 +87,7 @@ code:
   <start>: assume r1 < 1
 post: []
 messages:
-  - "0: Code is unreachable after 0"
+  - "0.1: Code is unreachable after 0"
 ---
 test-case: "assume 2 w< 1 implies bottom"
 pre: ["r1.type=number", "r1.svalue=2", "r1.uvalue=2"]
@@ -95,7 +95,7 @@ code:
   <start>: assume w1 < 1
 post: []
 messages:
-  - "0: Code is unreachable after 0"
+  - "0.1: Code is unreachable after 0"
 ---
 test-case: "assume [0, 1] < 0 implies bottom"
 pre: ["r1.type=number", "r1.svalue=[0, 1]", "r1.uvalue=[0, 1]", "r1.svalue=r1.uvalue"]
@@ -103,7 +103,7 @@ code:
   <start>: assume r1 < 0
 post: []
 messages:
-  - "0: Code is unreachable after 0"
+  - "0.1: Code is unreachable after 0"
 ---
 test-case: "assume [0, 1] w< 0 implies bottom"
 pre: ["r1.type=number", "r1.svalue=[0, 1]", "r1.uvalue=[0, 1]", "r1.svalue=r1.uvalue"]
@@ -111,7 +111,7 @@ code:
   <start>: assume w1 < 0
 post: []
 messages:
-  - "0: Code is unreachable after 0"
+  - "0.1: Code is unreachable after 0"
 ---
 test-case: "assume [2, 3] < 1 implies bottom"
 pre: ["r1.type=number", "r1.svalue=[2, 3]", "r1.uvalue=[2, 3]", "r1.svalue=r1.uvalue"]
@@ -119,7 +119,7 @@ code:
   <start>: assume r1 < 1
 post: []
 messages:
-  - "0: Code is unreachable after 0"
+  - "0.1: Code is unreachable after 0"
 ---
 test-case: "assume [2, 3] w< 1 implies bottom"
 pre: ["r1.type=number", "r1.svalue=[2, 3]", "r1.uvalue=[2, 3]", "r1.svalue=r1.uvalue"]
@@ -127,7 +127,7 @@ code:
   <start>: assume w1 < 1
 post: []
 messages:
-  - "0: Code is unreachable after 0"
+  - "0.1: Code is unreachable after 0"
 ---
 test-case: "assume [-2, -1] < 0 implies bottom"
 pre: ["r1.type=number", "r1.svalue=[-2, -1]", "r1.uvalue=[18446744073709551614, 18446744073709551615]"]
@@ -135,7 +135,7 @@ code:
   <start>: assume r1 < 1
 post: []
 messages:
-  - "0: Code is unreachable after 0"
+  - "0.1: Code is unreachable after 0"
 ---
 test-case: "assume [-2, -1] w< 0 implies bottom"
 pre: ["r1.type=number", "r1.svalue=[-2, -1]", "r1.uvalue=[18446744073709551614, 18446744073709551615]"]
@@ -143,7 +143,7 @@ code:
   <start>: assume w1 < 1
 post: []
 messages:
-  - "0: Code is unreachable after 0"
+  - "0.1: Code is unreachable after 0"
 ---
 test-case: "assume [-3, -2] < -3 implies bottom"
 pre: ["r1.type=number", "r1.svalue=[-3, -2]", "r1.uvalue=[18446744073709551613, 18446744073709551614]"]
@@ -151,7 +151,7 @@ code:
   <start>: assume r1 < -3
 post: []
 messages:
-  - "0: Code is unreachable after 0"
+  - "0.1: Code is unreachable after 0"
 ---
 test-case: "assume [-3, -2] w< -3 implies bottom"
 pre: ["r1.type=number", "r1.svalue=[-3, -2]", "r1.uvalue=[18446744073709551613, 18446744073709551614]"]
@@ -159,7 +159,7 @@ code:
   <start>: assume w1 < -3
 post: []
 messages:
-  - "0: Code is unreachable after 0"
+  - "0.1: Code is unreachable after 0"
 ---
 test-case: "assume [-3, -2] < -4 implies bottom"
 pre: ["r1.type=number", "r1.svalue=[-3, -2]", "r1.uvalue=[18446744073709551613, 18446744073709551614]"]
@@ -167,7 +167,7 @@ code:
   <start>: assume r1 < -4
 post: []
 messages:
-  - "0: Code is unreachable after 0"
+  - "0.1: Code is unreachable after 0"
 ---
 test-case: "assume [-3, -2] w< -4 implies bottom"
 pre: ["r1.type=number", "r1.svalue=[-3, -2]", "r1.uvalue=[18446744073709551613, 18446744073709551614]"]
@@ -175,7 +175,7 @@ code:
   <start>: assume w1 < -4
 post: []
 messages:
-  - "0: Code is unreachable after 0"
+  - "0.1: Code is unreachable after 0"
 ---
 test-case: "assume 1 < [0, 1] implies bottom"
 pre: ["r1.type=number", "r1.svalue=1", "r1.uvalue=1",
@@ -184,7 +184,7 @@ code:
   <start>: assume r1 < r2
 post: []
 messages:
-  - "0: Code is unreachable after 0"
+  - "0.4: Code is unreachable after 0"
 ---
 test-case: "assume 1 w< [0, 1] implies bottom"
 pre: ["r1.type=number", "r1.svalue=1", "r1.uvalue=1",
@@ -193,7 +193,7 @@ code:
   <start>: assume w1 < r2
 post: []
 messages:
-  - "0: Code is unreachable after 0"
+  - "0.4: Code is unreachable after 0"
 ---
 test-case: "assume -1 < [0, 1] implies bottom"
 pre: ["r1.type=number", "r1.svalue=-1", "r1.uvalue=18446744073709551615",
@@ -202,7 +202,7 @@ code:
   <start>: assume r1 < r2
 post: []
 messages:
-  - "0: Code is unreachable after 0"
+  - "0.4: Code is unreachable after 0"
 ---
 test-case: "assume -1 w< [0, 1] implies bottom"
 pre: ["r1.type=number", "r1.svalue=-1", "r1.uvalue=18446744073709551615",
@@ -211,7 +211,7 @@ code:
   <start>: assume w1 < r2
 post: []
 messages:
-  - "0: Code is unreachable after 0"
+  - "0.4: Code is unreachable after 0"
 ---
 test-case: "assume -1 < [1, 2] implies bottom"
 pre: ["r1.type=number", "r1.svalue=-1", "r1.uvalue=18446744073709551615",
@@ -220,7 +220,7 @@ code:
   <start>: assume r1 < r2
 post: []
 messages:
-  - "0: Code is unreachable after 0"
+  - "0.4: Code is unreachable after 0"
 ---
 test-case: "assume -1 w< [1, 2] implies bottom"
 pre: ["r1.type=number", "r1.svalue=-1", "r1.uvalue=18446744073709551615",
@@ -229,7 +229,7 @@ code:
   <start>: assume w1 < r2
 post: []
 messages:
-  - "0: Code is unreachable after 0"
+  - "0.4: Code is unreachable after 0"
 ---
 test-case: "assume 2 < [0, 1] implies bottom"
 pre: ["r1.type=number", "r1.svalue=2", "r1.uvalue=2",
@@ -238,7 +238,7 @@ code:
   <start>: assume r1 < r2
 post: []
 messages:
-  - "0: Code is unreachable after 0"
+  - "0.4: Code is unreachable after 0"
 ---
 test-case: "assume 2 w< [0, 1] implies bottom"
 pre: ["r1.type=number", "r1.svalue=2", "r1.uvalue=2",
@@ -247,7 +247,7 @@ code:
   <start>: assume w1 < r2
 post: []
 messages:
-  - "0: Code is unreachable after 0"
+  - "0.4: Code is unreachable after 0"
 ---
 test-case: "assume 1 < [0, 1] implies bottom"
 pre: ["r1.type=number", "r1.svalue=1", "r1.uvalue=1",
@@ -256,7 +256,7 @@ code:
   <start>: assume r1 < r2
 post: []
 messages:
-  - "0: Code is unreachable after 0"
+  - "0.4: Code is unreachable after 0"
 ---
 test-case: "assume 1 w< [0, 1] implies bottom"
 pre: ["r1.type=number", "r1.svalue=1", "r1.uvalue=1",
@@ -265,7 +265,7 @@ code:
   <start>: assume w1 < r2
 post: []
 messages:
-  - "0: Code is unreachable after 0"
+  - "0.4: Code is unreachable after 0"
 ---
 test-case: "assume 2 < [0, 1] implies bottom"
 pre: ["r1.type=number", "r1.svalue=1", "r1.uvalue=1",
@@ -274,7 +274,7 @@ code:
   <start>: assume r1 < r2
 post: []
 messages:
-  - "0: Code is unreachable after 0"
+  - "0.4: Code is unreachable after 0"
 ---
 test-case: "assume 2 w< [0, 1] implies bottom"
 pre: ["r1.type=number", "r1.svalue=1", "r1.uvalue=1",
@@ -283,7 +283,7 @@ code:
   <start>: assume w1 < r2
 post: []
 messages:
-  - "0: Code is unreachable after 0"
+  - "0.4: Code is unreachable after 0"
 ---
 test-case: "assume [2, 3] < [1, 2] implies bottom"
 pre: ["r1.type=number", "r1.svalue=[2, 3]", "r1.uvalue=[2, 3]", "r1.svalue=r1.uvalue",
@@ -292,7 +292,7 @@ code:
   <start>: assume r1 < r2
 post: []
 messages:
-  - "0: Code is unreachable after 0"
+  - "0.4: Code is unreachable after 0"
 ---
 test-case: "assume [2, 3] w< [1, 2] implies bottom"
 pre: ["r1.type=number", "r1.svalue=[2, 3]", "r1.uvalue=[2, 3]", "r1.svalue=r1.uvalue",
@@ -301,7 +301,7 @@ code:
   <start>: assume w1 < r2
 post: []
 messages:
-  - "0: Code is unreachable after 0"
+  - "0.4: Code is unreachable after 0"
 ---
 test-case: "assume [-2, -1] < [0, 1] implies bottom"
 pre: ["r1.type=number", "r1.svalue=[-2, -1]", "r1.uvalue=[18446744073709551614, 18446744073709551615]",
@@ -310,7 +310,7 @@ code:
   <start>: assume r1 < r2
 post: []
 messages:
-  - "0: Code is unreachable after 0"
+  - "0.4: Code is unreachable after 0"
 ---
 test-case: "assume [-2, -1] w< [0, 1] implies bottom"
 pre: ["r1.type=number", "r1.svalue=[-2, -1]", "r1.uvalue=[18446744073709551614, 18446744073709551615]",
@@ -319,7 +319,7 @@ code:
   <start>: assume w1 < r2
 post: []
 messages:
-  - "0: Code is unreachable after 0"
+  - "0.4: Code is unreachable after 0"
 ---
 test-case: "assume [-3, -2] < [-4, -3] implies bottom"
 pre: ["r1.type=number", "r1.svalue=[-3, -2]", "r1.uvalue=[18446744073709551613, 18446744073709551614]",
@@ -328,7 +328,7 @@ code:
   <start>: assume r1 < r2
 post: []
 messages:
-  - "0: Code is unreachable after 0"
+  - "0.4: Code is unreachable after 0"
 ---
 test-case: "assume [-3, -2] w< [-4, -3] implies bottom"
 pre: ["r1.type=number", "r1.svalue=[-3, -2]", "r1.uvalue=[18446744073709551613, 18446744073709551614]",
@@ -337,7 +337,7 @@ code:
   <start>: assume w1 < r2
 post: []
 messages:
-  - "0: Code is unreachable after 0"
+  - "0.4: Code is unreachable after 0"
 ---
 test-case: "assume [-3, -2] < [-5, -4] implies bottom"
 pre: ["r1.type=number", "r1.svalue=[-3, -2]", "r1.uvalue=[18446744073709551613, 18446744073709551614]",
@@ -346,7 +346,7 @@ code:
   <start>: assume r1 < r2
 post: []
 messages:
-  - "0: Code is unreachable after 0"
+  - "0.4: Code is unreachable after 0"
 ---
 test-case: "assume [-3, -2] w< [-5, -4] implies bottom"
 pre: ["r1.type=number", "r1.svalue=[-3, -2]", "r1.uvalue=[18446744073709551613, 18446744073709551614]",
@@ -355,7 +355,7 @@ code:
   <start>: assume w1 < r2
 post: []
 messages:
-  - "0: Code is unreachable after 0"
+  - "0.4: Code is unreachable after 0"
 ---
 test-case: "assume INT_MIN+1 < 0 implies bottom"
 pre: []
@@ -365,7 +365,7 @@ code:
     assume r1 < 0
 post: []
 messages:
-  - "1: Code is unreachable after 1"
+  - "1.1: Code is unreachable after 1"
 ---
 test-case: "assume INT_MIN+1 w< 0 implies bottom"
 pre: []
@@ -375,7 +375,7 @@ code:
     assume w1 < 0
 post: []
 messages:
-  - "1: Code is unreachable after 1"
+  - "1.1: Code is unreachable after 1"
 ---
 test-case: "assume INT_MIN+1 w< 2 nop"
 pre: []
@@ -391,7 +391,7 @@ code:
   <start>: assume r1 < 0
 post: []
 messages:
-  - "0: Code is unreachable after 0"
+  - "0.1: Code is unreachable after 0"
 ---
 test-case: "assume [INT32_MIN, -1] w< 0 implies bottom"
 pre: ["r1.type=number", "r1.svalue=[-2147483648, -1]", "r1.uvalue=[18446744071562067968, 18446744073709551615]"]
@@ -400,7 +400,7 @@ code:
     assume w1 < 0
 post: []
 messages:
-  - "0: Code is unreachable after 0"
+  - "0.1: Code is unreachable after 0"
 ---
 test-case: "assume something w< 0 implies bottom"
 pre: ["r1.type=number", "r1.svalue=-4294967298", "r1.uvalue=18446744069414584318"]
@@ -409,7 +409,7 @@ code:
     assume w1 < 0
 post: []
 messages:
-  - "0: Code is unreachable after 0"
+  - "0.1: Code is unreachable after 0"
 ---
 test-case: "assume INT_MIN+1 < 1 implies bottom"
 pre: []
@@ -419,7 +419,7 @@ code:
     assume r1 < 1
 post: []
 messages:
-  - "1: Code is unreachable after 1"
+  - "1.1: Code is unreachable after 1"
 ---
 test-case: "assume INT32_MIN w< 1 implies bottom"
 pre: []
@@ -429,7 +429,7 @@ code:
     assume w1 < 1
 post: []
 messages:
-  - "1: Code is unreachable after 1"
+  - "1.1: Code is unreachable after 1"
 ---
 test-case: "assume INT_MIN+1 < INT_MIN+1 implies bottom"
 pre: []
@@ -440,7 +440,7 @@ code:
     assume r1 < r2
 post: []
 messages:
-  - "2: Code is unreachable after 2"
+  - "2.4: Code is unreachable after 2"
 ---
 test-case: "assume INT32_MIN w< INT32_MIN implies bottom"
 pre: []
@@ -451,7 +451,7 @@ code:
     assume w1 < r2
 post: []
 messages:
-  - "2: Code is unreachable after 2"
+  - "2.4: Code is unreachable after 2"
 ---
 test-case: "assume INT_MIN+2 < INT_MIN+1 implies bottom"
 pre: []
@@ -462,7 +462,7 @@ code:
     assume r1 < r2
 post: []
 messages:
-  - "2: Code is unreachable after 2"
+  - "2.4: Code is unreachable after 2"
 ---
 test-case: "assume -1 < INT_MIN+1 implies bottom"
 pre: []
@@ -473,7 +473,7 @@ code:
     assume r1 < r2
 post: []
 messages:
-  - "2: Code is unreachable after 2"
+  - "2.4: Code is unreachable after 2"
 ---
 test-case: "assume -1 w< INT32_MIN implies bottom"
 pre: []
@@ -484,7 +484,7 @@ code:
     assume w1 < r2
 post: []
 messages:
-  - "2: Code is unreachable after 2"
+  - "2.4: Code is unreachable after 2"
 ---
 test-case: "assume INT32_MIN w< INT32_MAX implies bottom"
 pre: []
@@ -495,7 +495,7 @@ code:
     assume w1 < r2
 post: []
 messages:
-  - "2: Code is unreachable after 2"
+  - "2.4: Code is unreachable after 2"
 ---
 test-case: "assume [1, INT_MAX] < 1 implies bottom"
 pre: ["r1.type=number", "r1.svalue=[0, 9223372036854775806]", "r1.uvalue=[0, 9223372036854775806]", "r1.svalue=r1.uvalue"]
@@ -505,7 +505,7 @@ code:
     assume r1 < 1
 post: []
 messages:
-  - "1: Code is unreachable after 1"
+  - "1.1: Code is unreachable after 1"
 ---
 test-case: "assume [1, INT32_MAX] w< 1 implies bottom"
 pre: ["r1.type=number", "r1.svalue=[1, 2147483647]", "r1.uvalue=[1, 2147483647]", "r1.svalue=r1.uvalue"]
@@ -514,7 +514,7 @@ code:
     assume w1 < 1
 post: []
 messages:
-  - "0: Code is unreachable after 0"
+  - "0.1: Code is unreachable after 0"
 ---
 test-case: "assume [INT_MAX-1, INT_MAX] < 1 implies bottom"
 pre: ["r1.type=number", "r1.svalue=[9223372036854775803, 9223372036854775804]", "r1.uvalue=[9223372036854775803, 9223372036854775804]", "r1.svalue=r1.uvalue"]
@@ -524,7 +524,7 @@ code:
     assume r1 < 1
 post: []
 messages:
-  - "1: Code is unreachable after 1"
+  - "1.1: Code is unreachable after 1"
 ---
 test-case: "assume [INT32_MAX-1, INT32_MAX] < 1 implies bottom"
 pre: ["r1.type=number", "r1.svalue=[2147483646, 2147483647]", "r1.uvalue=[2147483646, 2147483647]", "r1.svalue=r1.uvalue"]
@@ -533,7 +533,7 @@ code:
     assume w1 < 1
 post: []
 messages:
-  - "0: Code is unreachable after 0"
+  - "0.1: Code is unreachable after 0"
 ---
 test-case: "assume [INT_MAX, INT_MAX+1] < 1 implies bottom"
 pre: ["r1.type=number", "r1.svalue=[9223372036854775803, 9223372036854775804]", "r1.uvalue=[9223372036854775803, 9223372036854775804]", "r1.svalue=r1.uvalue"]
@@ -543,7 +543,7 @@ code:
     assume r1 < 1
 post: []
 messages:
-  - "1: Code is unreachable after 1"
+  - "1.1: Code is unreachable after 1"
 ---
 test-case: "assume 0 < 1 nop"
 pre: []
@@ -596,7 +596,7 @@ code:
     assume r1 > 1
 post: []
 messages:
-  - "0: Code is unreachable after 0"
+  - "0.1: Code is unreachable after 0"
 ---
 test-case: "assume [0, 1] w> 1 implies bottom"
 pre: ["r1.type=number", "r1.svalue=[0, 1]", "r1.uvalue=[0, 1]", "r1.svalue=r1.uvalue"]
@@ -605,7 +605,7 @@ code:
     assume w1 > 1
 post: []
 messages:
-  - "0: Code is unreachable after 0"
+  - "0.1: Code is unreachable after 0"
 ---
 test-case: "assume [1, 2] > 1 narrows to 2"
 pre: ["r1.type=number", "r1.svalue=[1, 2]", "r1.uvalue=[1, 2]", "r1.svalue=r1.uvalue"]
@@ -685,7 +685,7 @@ code:
     assume r1 > r2
 post: []
 messages:
-  - "1: Code is unreachable after 1"
+  - "1.4: Code is unreachable after 1"
 ---
 test-case: "assume [0, INT32_MAX] w> INT32_MAX implies bottom"
 pre: ["r1.type=number", "r1.svalue=[0, 2147483647]", "r1.uvalue=[0, 2147483647]", "r1.svalue=r1.uvalue"]
@@ -694,7 +694,7 @@ code:
     assume w1 > 2147483647
 post: []
 messages:
-  - "0: Code is unreachable after 0"
+  - "0.1: Code is unreachable after 0"
 ---
 test-case: "assume [0, INT_MAX-4] >= INT_MAX-4 narrows to INT_MAX-4"
 pre: ["r1.type=number", "r1.svalue=[0, 9223372036854775803]", "r1.uvalue=[0, 9223372036854775803]", "r1.svalue=r1.uvalue"]
@@ -1085,7 +1085,7 @@ code:
   <start>: assume r1 != 11
 post: []
 messages:
-  - "0: Code is unreachable after 0"
+  - "0.1: Code is unreachable after 0"
 ---
 test-case: "assume [0, 1] != 1 narrows to 0"
 pre: ["r1.type=number", "r1.svalue=[0, 1]", "r1.uvalue=[0, 1]"]
@@ -1111,7 +1111,7 @@ code:
   <start>: assume w1 != 11
 post: []
 messages:
-  - "0: Code is unreachable after 0"
+  - "0.1: Code is unreachable after 0"
 ---
 test-case: "assume [3, 4] w< 2 implies bottom"
 pre: ["r1.type=number", "r1.svalue=[3, 4]", "r1.uvalue=[3, 4]"]
@@ -1119,7 +1119,7 @@ code:
   <start>: assume w1 < 2
 post: []
 messages:
-  - "0: Code is unreachable after 0"
+  - "0.1: Code is unreachable after 0"
 ---
 test-case: "assume [UINT32_MAX+1, UINT32_MAX+5] w< 2"
 pre: ["r1.type=number", "r1.uvalue=[4294967296, 4294967300]"]
@@ -1248,7 +1248,7 @@ code:
   <start>: assume w1 s> 0
 post: []
 messages:
-  - "0: Code is unreachable after 0"
+  - "0.1: Code is unreachable after 0"
 ---
 test-case: signed 32-bit GT reg
 pre: ["r1.type=number", "r1.svalue=[-2, 2]", "r2.type=number", "r2.svalue=[-2, 2]"]


### PR DESCRIPTION
Add the location within a basic block of the offending assertion. For example "3.4" instead of "3".

There's an issue with the yaml tests, since the assertions are not visible so it's not obvious to the reader what is the correct line. I think we should add the assertions as parts of the yaml code, as comments preceding each instruction. 