### PR TITLE
Add FiniteDomain

### DIFF
--- a/src/assertions.cpp
+++ b/src/assertions.cpp
@@ -227,6 +227,10 @@ class AssertExtractor {
             }
         case Bin::Op::SUB:
             if (std::holds_alternative<Reg>(ins.v)) {
+                if (std::get<Reg>(ins.v) == ins.dst) {
+                    // We always allow rx -= rx
+                    return {};
+                }
                 vector<Assert> res;
                 // disallow map-map since same type does not mean same offset
                 // TODO: map identities

--- a/src/crab/add_bottom.hpp
+++ b/src/crab/add_bottom.hpp
@@ -4,6 +4,7 @@
 
 #include <optional>
 
+#include "crab/finite_domain.hpp"
 #include "crab/split_dbm.hpp"
 #include "string_constraints.hpp"
 
@@ -12,7 +13,7 @@ namespace crab {
 namespace domains {
 
 class AddBottom final {
-    using T = SplitDBM;
+    using T = FiniteDomain;
     std::optional<T> dom{};
     AddBottom() {}
 
@@ -25,6 +26,12 @@ class AddBottom final {
 
     AddBottom& operator=(const AddBottom& o) = default;
     AddBottom& operator=(AddBottom&& o) = default;
+
+    explicit operator bool() const { return static_cast<bool>(dom); }
+
+    T* operator->() { return &dom.value(); }
+
+    const T* operator->() const { return &dom.value(); }
 
     void set_to_top() {
         if (dom) {
@@ -110,7 +117,7 @@ class AddBottom final {
         if (!dom || !o.dom) {
             return bottom();
         }
-        if (auto res = (*dom).meet(*o.dom)) {
+        if (auto res = dom->meet(*o.dom)) {
             return AddBottom(*res);
         }
         return bottom();

--- a/src/crab/dsl_syntax.hpp
+++ b/src/crab/dsl_syntax.hpp
@@ -67,6 +67,10 @@ inline linear_constraint_t operator>(const linear_expression_t& e, const number_
 
 inline linear_constraint_t operator>(const number_t& n, const linear_expression_t& e) { return e < n; }
 
+inline linear_constraint_t eq(const variable_t a, const variable_t b) {
+    return {a - b, constraint_kind_t::EQUALS_ZERO};
+}
+
 inline linear_constraint_t operator==(const linear_expression_t& e1, const linear_expression_t& e2) {
     return linear_constraint_t(e1 - e2, constraint_kind_t::EQUALS_ZERO);
 }

--- a/src/crab/ebpf_domain.cpp
+++ b/src/crab/ebpf_domain.cpp
@@ -9,10 +9,10 @@
 #include <vector>
 
 #include "boost/endian/conversion.hpp"
-#include "boost/range/algorithm/set_algorithm.hpp"
 
 #include "crab/array_domain.hpp"
 #include "crab/ebpf_domain.hpp"
+#include "crab/finite_domain.hpp"
 
 #include "asm_ostream.hpp"
 #include "asm_unmarshal.hpp"
@@ -36,7 +36,7 @@ struct reg_pack_t {
     variable_t stack_numeric_size;
 };
 
-reg_pack_t reg_pack(int i) {
+reg_pack_t reg_pack(const int i) {
     return {
         variable_t::reg(data_kind_t::svalues, i),
         variable_t::reg(data_kind_t::uvalues, i),
@@ -50,16 +50,14 @@ reg_pack_t reg_pack(int i) {
         variable_t::reg(data_kind_t::stack_numeric_sizes, i),
     };
 }
-reg_pack_t reg_pack(Reg r) { return reg_pack(r.v); }
+reg_pack_t reg_pack(const Reg r) { return reg_pack(r.v); }
 
-static linear_constraint_t eq(variable_t a, variable_t b) {
-    using namespace crab::dsl_syntax;
-    return {a - b, constraint_kind_t::EQUALS_ZERO};
+static linear_constraint_t eq_types(const Reg& a, const Reg& b) {
+    using dsl_syntax::eq;
+    return eq(reg_pack(a).type, reg_pack(b).type);
 }
 
-static linear_constraint_t eq_types(const Reg& a, const Reg& b) { return eq(reg_pack(a).type, reg_pack(b).type); }
-
-static linear_constraint_t neq(variable_t a, variable_t b) {
+static linear_constraint_t neq(const variable_t a, const variable_t b) {
     using namespace crab::dsl_syntax;
     return {a - b, constraint_kind_t::NOT_ZERO};
 }
@@ -76,8 +74,8 @@ constexpr int64_t PTR_MAX = std::numeric_limits<int32_t>::max() - MAX_PACKET_SIZ
 
 /** Linear constraint for a pointer comparison.
  */
-static linear_constraint_t assume_cst_offsets_reg(Condition::Op op, bool is64, variable_t dst_offset,
-                                                  variable_t src_offset) {
+static linear_constraint_t assume_cst_offsets_reg(const Condition::Op op, bool is64, const variable_t dst_offset,
+                                                  const variable_t src_offset) {
     using namespace crab::dsl_syntax;
     using Op = Condition::Op;
     switch (op) {
@@ -96,612 +94,11 @@ static linear_constraint_t assume_cst_offsets_reg(Condition::Op op, bool is64, v
     }
 }
 
-static std::vector<linear_constraint_t> assume_bit_cst_interval(const NumAbsDomain& inv, Condition::Op op, bool is64,
-                                                                variable_t dst_uvalue, crab::interval_t src_interval) {
-    using namespace crab::dsl_syntax;
-    using Op = Condition::Op;
-
-    auto dst_interval = inv.eval_interval(dst_uvalue);
-    std::optional<number_t> dst_n = dst_interval.singleton();
-    if (!dst_n || !dst_n.value().fits_cast_to_int64()) {
-        return {};
-    }
-
-    std::optional<number_t> src_n = src_interval.singleton();
-    if (!src_n || !src_n->fits_cast_to_int64()) {
-        return {};
-    }
-    uint64_t src_int_value = src_n.value().cast_to_uint64();
-    if (!is64) {
-        src_int_value = (uint32_t)src_int_value;
-    }
-
-    bool result;
-    switch (op) {
-    case Op::SET: result = ((dst_n.value().cast_to_uint64() & src_int_value) != 0); break;
-    case Op::NSET: result = ((dst_n.value().cast_to_uint64() & src_int_value) == 0); break;
-    default: throw std::exception();
-    }
-
-    return {result ? linear_constraint_t::true_const() : linear_constraint_t::false_const()};
-}
-
-static std::vector<linear_constraint_t> assume_signed_64bit_eq(const NumAbsDomain& inv, variable_t left_svalue,
-                                                               variable_t left_uvalue, crab::interval_t& right_interval,
-                                                               const linear_expression_t& right_svalue,
-                                                               const linear_expression_t& right_uvalue) {
-    using namespace crab::dsl_syntax;
-    if (right_interval <= crab::interval_t::nonnegative_int(true) && !right_interval.is_singleton()) {
-        return {(left_svalue == right_svalue), (left_uvalue == right_uvalue), eq(left_svalue, left_uvalue)};
-    } else {
-        return {(left_svalue == right_svalue), (left_uvalue == right_uvalue)};
-    }
-}
-
-static std::vector<linear_constraint_t> assume_signed_32bit_eq(const NumAbsDomain& inv, variable_t left_svalue,
-                                                               variable_t left_uvalue,
-                                                               crab::interval_t& right_interval) {
-    using namespace crab::dsl_syntax;
-
-    if (auto rn = right_interval.singleton()) {
-        if (auto size = inv.eval_interval(left_svalue).finite_size()) {
-            // Find the lowest 64-bit svalue whose low 32 bits match the singleton.
-
-            // Get lower bound as a 64-bit value.
-            int64_t lb = inv.eval_interval(left_svalue).lb().number()->cast_to_sint64();
-
-            // Use the high 32-bits from the left lower bound and the low 32-bits from the right singleton.
-            // The result might be lower than the lower bound.
-            int64_t lb_match = ((lb & 0xFFFFFFFF00000000) | (rn->cast_to_sint64() & 0xFFFFFFFF));
-            if (lb_match < lb) {
-                // The result is lower than the left interval, so try the next higher matching 64-bit value.
-                // It's ok if this goes higher than the left upper bound.
-                lb += 0x100000000;
-            }
-
-            // Find the highest 64-bit svalue whose low 32 bits match the singleton.
-
-            // Get upper bound as a 64-bit value.
-            int64_t ub = inv.eval_interval(left_svalue).ub().number()->cast_to_sint64();
-
-            // Use the high 32-bits from the left upper bound and the low 32-bits from the right singleton.
-            // The result might be higher than the upper bound.
-            int64_t ub_match = ((ub & 0xFFFFFFFF00000000) | (rn->cast_to_sint64() & 0xFFFFFFFF));
-            if (ub_match > ub) {
-                // The result is higher than the left interval, so try the next lower matching 64-bit value.
-                // It's ok if this goes lower than the left lower bound.
-                lb -= 0x100000000;
-            }
-
-            if ((uint64_t)lb_match <= (uint64_t)ub_match) {
-                // The interval is also valid when cast to a uvalue, meaning
-                // both bounds are positive or both are negative.
-                return {left_svalue >= lb_match, left_svalue <= ub_match, left_uvalue >= number_t((uint64_t)lb_match),
-                        left_uvalue <= number_t((uint64_t)ub_match)};
-            } else {
-                // The interval can only be represented as an svalue.
-                return {left_svalue >= lb_match, left_svalue <= ub_match};
-            }
-        }
-    }
-    return {};
-}
-
-// Given left and right values, get the left and right intervals, and also split
-// the left interval into separate negative and positive intervals.
-static void get_signed_intervals(const NumAbsDomain& inv, bool is64, variable_t left_svalue, variable_t left_uvalue,
-                                 const linear_expression_t& right_svalue, crab::interval_t& left_interval,
-                                 crab::interval_t& right_interval, crab::interval_t& left_interval_positive,
-                                 crab::interval_t& left_interval_negative) {
-    using crab::interval_t;
-    using namespace crab::dsl_syntax;
-
-    // Get intervals as 32-bit or 64-bit as appropriate.
-    left_interval = inv.eval_interval(left_svalue);
-    right_interval = inv.eval_interval(right_svalue);
-    if (!is64) {
-        if ((left_interval <= interval_t::nonnegative_int(false) &&
-             right_interval <= interval_t::nonnegative_int(false)) ||
-            (left_interval <= interval_t::negative_int(false) && right_interval <= interval_t::negative_int(false))) {
-            is64 = true;
-            // fallthrough as 64bit, including deduction of relational information
-        } else {
-            for (interval_t* interval : {&left_interval, &right_interval}) {
-                if (!(*interval <= interval_t::signed_int(false))) {
-                    *interval = interval->truncate_to_sint(false);
-                }
-            }
-            // continue as 32bit
-        }
-    }
-
-    if (!left_interval.is_top()) {
-        left_interval_positive = left_interval & interval_t::nonnegative_int(true);
-        left_interval_negative = left_interval & interval_t::negative_int(true);
-    } else {
-        left_interval = inv.eval_interval(left_uvalue);
-        if (!left_interval.is_top()) {
-            // The interval is TOP as a signed interval but is represented precisely as an unsigned interval,
-            // so split into two signed intervals that can be treated separately.
-            left_interval_positive = left_interval & interval_t::nonnegative_int(true);
-            number_t lih_ub = left_interval.ub().number() ? left_interval.ub().number()->truncate_to_sint64() : -1;
-            left_interval_negative = interval_t(number_t{std::numeric_limits<int64_t>::min()}, lih_ub);
-        } else {
-            left_interval_positive = interval_t::nonnegative_int(true);
-            left_interval_negative = interval_t::negative_int(true);
-        }
-    }
-
-    for (interval_t* interval : {&left_interval, &right_interval}) {
-        if (!(*interval <= interval_t::signed_int(true))) {
-            *interval = interval->truncate_to_sint(true);
-        }
-    }
-}
-
-// Given left and right values, get the left and right intervals, and also split
-// the left interval into separate low and high intervals.
-static void get_unsigned_intervals(const NumAbsDomain& inv, bool is64, variable_t left_svalue, variable_t left_uvalue,
-                                   const linear_expression_t& right_uvalue, crab::interval_t& left_interval,
-                                   crab::interval_t& right_interval, crab::interval_t& left_interval_low,
-                                   crab::interval_t& left_interval_high) {
-    using crab::interval_t;
-    using namespace crab::dsl_syntax;
-
-    // Get intervals as 32-bit or 64-bit as appropriate.
-    left_interval = inv.eval_interval(left_uvalue);
-    right_interval = inv.eval_interval(right_uvalue);
-    if (!is64) {
-        if ((left_interval <= interval_t::nonnegative_int(false) &&
-             right_interval <= interval_t::nonnegative_int(false)) ||
-            (left_interval <= interval_t::unsigned_high(false) && right_interval <= interval_t::unsigned_high(false))) {
-            is64 = true;
-            // fallthrough as 64bit, including deduction of relational information
-        } else {
-            for (interval_t* interval : {&left_interval, &right_interval}) {
-                if (!(*interval <= interval_t::unsigned_int(false))) {
-                    *interval = interval->truncate_to_uint(false);
-                }
-            }
-            // continue as 32bit
-        }
-    }
-
-    if (!left_interval.is_top()) {
-        left_interval_low = left_interval & interval_t::nonnegative_int(true);
-        left_interval_high = left_interval & interval_t::unsigned_high(true);
-    } else {
-        left_interval = inv.eval_interval(left_svalue);
-        if (!left_interval.is_top()) {
-            // The interval is TOP as an unsigned interval but is represented precisely as a signed interval,
-            // so split into two unsigned intervals that can be treated separately.
-            left_interval_low = interval_t(number_t{0}, left_interval.ub()).truncate_to_uint(true);
-            left_interval_high = interval_t(left_interval.lb(), number_t{-1}).truncate_to_uint(true);
-        } else {
-            left_interval_low = interval_t::nonnegative_int(true);
-            left_interval_high = interval_t::unsigned_high(true);
-        }
-    }
-
-    for (interval_t* interval : {&left_interval, &right_interval}) {
-        if (!(*interval <= interval_t::unsigned_int(true))) {
-            *interval = interval->truncate_to_uint(true);
-        }
-    }
-}
-
-static std::vector<linear_constraint_t>
-assume_signed_64bit_lt(const NumAbsDomain& inv, bool strict, variable_t left_svalue, variable_t left_uvalue,
-                       const crab::interval_t& left_interval_positive, const crab::interval_t& left_interval_negative,
-                       const linear_expression_t& right_svalue, const linear_expression_t& right_uvalue,
-                       const crab::interval_t& right_interval) {
-    using crab::interval_t;
-    using namespace crab::dsl_syntax;
-
-    if (right_interval <= interval_t::negative_int(true)) {
-        // Interval can be represented as both an svalue and a uvalue since it fits in [INT_MIN, -1].
-        return {strict ? (left_svalue < right_svalue) : (left_svalue <= right_svalue), number_t{0} <= left_uvalue,
-                strict ? (left_uvalue < right_uvalue) : (left_uvalue <= right_uvalue)};
-    } else if ((left_interval_negative | left_interval_positive) <= interval_t::nonnegative_int(true) &&
-               right_interval <= interval_t::nonnegative_int(true)) {
-        // Interval can be represented as both an svalue and a uvalue since it fits in [0, INT_MAX].
-        return {strict ? (left_svalue < right_svalue) : (left_svalue <= right_svalue), number_t{0} <= left_uvalue,
-                strict ? (left_uvalue < right_uvalue) : (left_uvalue <= right_uvalue)};
-    } else {
-        // Interval can only be represented as an svalue.
-        return {strict ? (left_svalue < right_svalue) : (left_svalue <= right_svalue)};
-    }
-}
-
-static std::vector<linear_constraint_t>
-assume_signed_32bit_lt(const NumAbsDomain& inv, bool strict, variable_t left_svalue, variable_t left_uvalue,
-                       const crab::interval_t& left_interval_positive, const crab::interval_t& left_interval_negative,
-                       const linear_expression_t& right_svalue, const linear_expression_t& right_uvalue,
-                       const crab::interval_t& right_interval) {
-    using crab::interval_t;
-    using namespace crab::dsl_syntax;
-
-    if (right_interval <= interval_t::negative_int(false)) {
-        // Interval can be represented as both an svalue and a uvalue since it fits in [INT_MIN, -1],
-        // aka [INT_MAX+1, UINT_MAX].
-        return {left_uvalue >= (number_t{INT32_MAX} + 1),
-                strict ? (left_uvalue < right_uvalue) : (left_uvalue <= right_uvalue),
-                strict ? (left_svalue < right_svalue) : (left_svalue <= right_svalue)};
-    } else if ((left_interval_negative | left_interval_positive) <= interval_t::nonnegative_int(false) &&
-               right_interval <= interval_t::nonnegative_int(false)) {
-        // Interval can be represented as both an svalue and a uvalue since it fits in [0, INT_MAX]
-        auto lpub = left_interval_positive.truncate_to_sint(false).ub();
-        return {left_svalue >= 0,
-                strict ? left_svalue < right_svalue : left_svalue <= right_svalue,
-                left_svalue <= left_uvalue,
-                left_svalue >= left_uvalue,
-                left_uvalue >= 0,
-                strict ? left_uvalue < right_uvalue : left_uvalue <= right_uvalue,
-                left_uvalue <= *lpub.number()};
-    } else if (inv.eval_interval(left_svalue) <= interval_t::signed_int(false) &&
-               inv.eval_interval(right_svalue) <= interval_t::signed_int(false)) {
-        // Interval can only be represented as an svalue.
-        return {strict ? (left_svalue < right_svalue) : (left_svalue <= right_svalue)};
-    } else {
-        // We can't directly compare the svalues since they may differ in high order bits.
-        return {};
-    }
-}
-
-static std::vector<linear_constraint_t>
-assume_signed_64bit_gt(const NumAbsDomain& inv, bool strict, variable_t left_svalue, variable_t left_uvalue,
-                       const crab::interval_t& left_interval_positive, const crab::interval_t& left_interval_negative,
-                       const linear_expression_t& right_svalue, const linear_expression_t& right_uvalue,
-                       const crab::interval_t& right_interval) {
-    using crab::interval_t;
-    using namespace crab::dsl_syntax;
-
-    if (right_interval <= interval_t::nonnegative_int(true)) {
-        // Interval can be represented as both an svalue and a uvalue since it fits in [0, INT_MAX].
-        auto lpub = left_interval_positive.truncate_to_sint(true).ub();
-        return {left_svalue >= 0,
-                strict ? left_svalue > right_svalue : left_svalue >= right_svalue,
-                left_svalue <= left_uvalue,
-                left_svalue >= left_uvalue,
-                left_uvalue >= 0,
-                strict ? left_uvalue > right_uvalue : left_uvalue >= right_uvalue,
-                left_uvalue <= *lpub.number()};
-    } else if ((left_interval_negative | left_interval_positive) <= interval_t::negative_int(true) &&
-               right_interval <= interval_t::negative_int(true)) {
-        // Interval can be represented as both an svalue and a uvalue since it fits in [INT_MIN, -1],
-        // aka [INT_MAX+1, UINT_MAX].
-        return {left_uvalue >= (number_t{INT64_MAX} + 1),
-                strict ? (left_uvalue > right_uvalue) : (left_uvalue >= right_uvalue),
-                strict ? (left_svalue > right_svalue) : (left_svalue >= right_svalue)};
-    } else {
-        // Interval can only be represented as an svalue.
-        return {strict ? (left_svalue > right_svalue) : (left_svalue >= right_svalue)};
-    }
-}
-
-static std::vector<linear_constraint_t>
-assume_signed_32bit_gt(const NumAbsDomain& inv, bool strict, variable_t left_svalue, variable_t left_uvalue,
-                       const crab::interval_t& left_interval_positive, const crab::interval_t& left_interval_negative,
-                       const linear_expression_t& right_svalue, const linear_expression_t& right_uvalue,
-                       const crab::interval_t& right_interval) {
-    using crab::interval_t;
-    using namespace crab::dsl_syntax;
-
-    if (right_interval <= interval_t::nonnegative_int(false)) {
-        // Interval can be represented as both an svalue and a uvalue since it fits in [0, INT_MAX].
-        auto lpub = left_interval_positive.truncate_to_sint(false).ub();
-        return {left_svalue >= 0,
-                strict ? left_svalue > right_svalue : left_svalue >= right_svalue,
-                left_svalue <= left_uvalue,
-                left_svalue >= left_uvalue,
-                left_uvalue >= 0,
-                strict ? left_uvalue > right_uvalue : left_uvalue >= right_uvalue,
-                left_uvalue <= *lpub.number()};
-    } else if ((left_interval_negative | left_interval_positive) <= interval_t::negative_int(false) &&
-               right_interval <= interval_t::negative_int(false)) {
-        // Interval can be represented as both an svalue and a uvalue since it fits in [INT_MIN, -1],
-        // aka [INT_MAX+1, UINT_MAX].
-        return {left_uvalue >= (number_t{INT32_MAX} + 1),
-                strict ? (left_uvalue > right_uvalue) : (left_uvalue >= right_uvalue),
-                strict ? (left_svalue > right_svalue) : (left_svalue >= right_svalue)};
-    } else if (inv.eval_interval(left_svalue) <= interval_t::signed_int(false) &&
-               inv.eval_interval(right_svalue) <= interval_t::signed_int(false)) {
-        // Interval can only be represented as an svalue.
-        return {strict ? (left_svalue > right_svalue) : (left_svalue >= right_svalue)};
-    } else {
-        // We can't directly compare the svalues since they may differ in high order bits.
-        return {};
-    }
-}
-
-static std::vector<linear_constraint_t> assume_signed_cst_interval(const NumAbsDomain& inv, Condition::Op op, bool is64,
-                                                                   variable_t left_svalue, variable_t left_uvalue,
-                                                                   const linear_expression_t& right_svalue,
-                                                                   const linear_expression_t& right_uvalue) {
-    using crab::interval_t;
-    using namespace crab::dsl_syntax;
-
-    interval_t left_interval = interval_t::bottom();
-    interval_t right_interval = interval_t::bottom();
-    interval_t left_interval_positive = interval_t::bottom();
-    interval_t left_interval_negative = interval_t::bottom();
-    get_signed_intervals(inv, is64, left_svalue, left_uvalue, right_svalue, left_interval, right_interval,
-                         left_interval_positive, left_interval_negative);
-
-    if (op == Condition::Op::EQ) {
-        // Handle svalue == right.
-        if (is64) {
-            return assume_signed_64bit_eq(inv, left_svalue, left_uvalue, right_interval, right_svalue, right_uvalue);
-        } else {
-            return assume_signed_32bit_eq(inv, left_svalue, left_uvalue, right_interval);
-        }
-    }
-
-    const bool is_lt = op == Condition::Op::SLT || op == Condition::Op::SLE;
-    bool strict = op == Condition::Op::SLT || op == Condition::Op::SGT;
-
-    auto llb = left_interval.lb();
-    auto lub = left_interval.ub();
-    auto rlb = right_interval.lb();
-    auto rub = right_interval.ub();
-    if (!is_lt && (strict ? (lub <= rlb) : (lub < rlb))) {
-        // Left signed interval is lower than right signed interval.
-        return {linear_constraint_t::false_const()};
-    } else if (is_lt && (strict ? (llb >= rub) : (llb > rub))) {
-        // Left signed interval is higher than right signed interval.
-        return {linear_constraint_t::false_const()};
-    }
-    if (is_lt && (strict ? (lub < rlb) : (lub <= rlb))) {
-        // Left signed interval is lower than right signed interval.
-        return {linear_constraint_t::true_const()};
-    } else if (!is_lt && (strict ? (llb > rub) : (llb >= rub))) {
-        // Left signed interval is higher than right signed interval.
-        return {linear_constraint_t::true_const()};
-    }
-
-    if (is64) {
-        if (is_lt) {
-            return assume_signed_64bit_lt(inv, strict, left_svalue, left_uvalue, left_interval_positive,
-                                          left_interval_negative, right_svalue, right_uvalue, right_interval);
-        } else {
-            return assume_signed_64bit_gt(inv, strict, left_svalue, left_uvalue, left_interval_positive,
-                                          left_interval_negative, right_svalue, right_uvalue, right_interval);
-        }
-    } else {
-        // 32-bit compare.
-        if (is_lt) {
-            return assume_signed_32bit_lt(inv, strict, left_svalue, left_uvalue, left_interval_positive,
-                                          left_interval_negative, right_svalue, right_uvalue, right_interval);
-        } else {
-            return assume_signed_32bit_gt(inv, strict, left_svalue, left_uvalue, left_interval_positive,
-                                          left_interval_negative, right_svalue, right_uvalue, right_interval);
-        }
-    }
-    return {};
-}
-
-static std::vector<linear_constraint_t>
-assume_unsigned_64bit_lt(const NumAbsDomain& inv, bool strict, variable_t left_svalue, variable_t left_uvalue,
-                         const crab::interval_t& left_interval_low, const crab::interval_t& left_interval_high,
-                         const linear_expression_t& right_svalue, const linear_expression_t& right_uvalue,
-                         const crab::interval_t& right_interval) {
-    using crab::interval_t;
-    using namespace crab::dsl_syntax;
-
-    auto rub = right_interval.ub();
-    auto lllb = left_interval_low.truncate_to_uint(true).lb();
-    if ((right_interval <= interval_t::nonnegative_int(true)) && (strict ? (lllb >= rub) : (lllb > rub))) {
-        // The high interval is out of range.
-        if (auto lsubn = inv.eval_interval(left_svalue).ub().number()) {
-            return {left_uvalue >= 0, ((strict) ? left_uvalue < right_uvalue : left_uvalue <= right_uvalue),
-                    left_uvalue <= *lsubn, left_svalue >= 0};
-        } else {
-            return {left_uvalue >= 0, ((strict) ? left_uvalue < right_uvalue : left_uvalue <= right_uvalue),
-                    left_svalue >= 0};
-        }
-    }
-    auto lhlb = left_interval_high.truncate_to_uint(true).lb();
-    if ((right_interval <= interval_t::unsigned_high(true)) && (strict ? (lhlb >= rub) : (lhlb > rub))) {
-        // The high interval is out of range.
-        if (auto lsubn = inv.eval_interval(left_svalue).ub().number()) {
-            return {left_uvalue >= 0, ((strict) ? left_uvalue < *rub.number() : left_uvalue <= *rub.number()),
-                    left_uvalue <= *lsubn, left_svalue >= 0};
-        } else {
-            return {left_uvalue >= 0, ((strict) ? left_uvalue < *rub.number() : left_uvalue <= *rub.number()),
-                    left_svalue >= 0};
-        }
-    }
-    if (right_interval <= interval_t::signed_int(true)) {
-        // Interval can be represented as both an svalue and a uvalue since it fits in [0, INT_MAX].
-        auto llub = left_interval_low.truncate_to_uint(true).ub();
-        return {number_t{0} <= left_uvalue, strict ? (left_uvalue < right_uvalue) : (left_uvalue <= right_uvalue),
-                left_uvalue <= *llub.number(), number_t{0} <= left_svalue,
-                strict ? (left_svalue < right_svalue) : (left_svalue <= right_svalue)};
-    } else if (left_interval_low.is_bottom() && right_interval <= interval_t::unsigned_high(true)) {
-        // Interval can be represented as both an svalue and a uvalue since it fits in [INT_MAX+1, UINT_MAX].
-        return {number_t{0} <= left_uvalue, strict ? (left_uvalue < right_uvalue) : (left_uvalue <= right_uvalue),
-                strict ? (left_svalue < right_svalue) : (left_svalue <= right_svalue)};
-    } else if ((left_interval_low | left_interval_high) == interval_t::unsigned_int(true)) {
-        // Interval can only be represented as a uvalue, and was TOP before.
-        return {strict ? (left_uvalue < right_uvalue) : (left_uvalue <= right_uvalue)};
-    } else {
-        // Interval can only be represented as a uvalue.
-        return {number_t{0} <= left_uvalue, strict ? (left_uvalue < right_uvalue) : (left_uvalue <= right_uvalue)};
-    }
-}
-
-static std::vector<linear_constraint_t>
-assume_unsigned_32bit_lt(const NumAbsDomain& inv, bool strict, variable_t left_svalue, variable_t left_uvalue,
-                         const crab::interval_t& left_interval_low, const crab::interval_t& left_interval_high,
-                         const linear_expression_t& right_svalue, const linear_expression_t& right_uvalue,
-                         const crab::interval_t& right_interval) {
-    using crab::interval_t;
-    using namespace crab::dsl_syntax;
-
-    if (inv.eval_interval(left_uvalue) <= interval_t::nonnegative_int(false) &&
-        inv.eval_interval(right_uvalue) <= interval_t::nonnegative_int(false)) {
-        // Interval can be represented as both an svalue and a uvalue since it fits in [0, INT32_MAX].
-        return {number_t{0} <= left_uvalue, strict ? (left_uvalue < right_uvalue) : (left_uvalue <= right_uvalue),
-                strict ? (left_svalue < right_svalue) : (left_svalue <= right_svalue)};
-    } else if (inv.eval_interval(left_svalue) <= interval_t::negative_int(false) &&
-               inv.eval_interval(right_svalue) <= interval_t::negative_int(false)) {
-        // Interval can be represented as both an svalue and a uvalue since it fits in [INT32_MIN, -1].
-        return {number_t{0} <= left_uvalue, strict ? (left_uvalue < right_uvalue) : (left_uvalue <= right_uvalue),
-                strict ? (left_svalue < right_svalue) : (left_svalue <= right_svalue)};
-    } else if (inv.eval_interval(left_uvalue) <= interval_t::unsigned_int(false) &&
-               inv.eval_interval(right_uvalue) <= interval_t::unsigned_int(false)) {
-        // Interval can only be represented as a uvalue.
-        return {number_t{0} <= left_uvalue, strict ? (left_uvalue < right_uvalue) : (left_uvalue <= right_uvalue)};
-    } else {
-        // We can't directly compare the uvalues since they may differ in high order bits.
-        return {};
-    }
-}
-
-static std::vector<linear_constraint_t>
-assume_unsigned_64bit_gt(const NumAbsDomain& inv, bool strict, variable_t left_svalue, variable_t left_uvalue,
-                         const crab::interval_t& left_interval_low, const crab::interval_t& left_interval_high,
-                         const linear_expression_t& right_svalue, const linear_expression_t& right_uvalue,
-                         const crab::interval_t& right_interval) {
-    using crab::interval_t;
-    using namespace crab::dsl_syntax;
-
-    auto rlb = right_interval.lb();
-    auto llub = left_interval_low.truncate_to_uint(true).ub();
-    auto lhlb = left_interval_high.truncate_to_uint(true).lb();
-
-    if ((right_interval <= interval_t::nonnegative_int(true)) && (strict ? (llub <= rlb) : (llub < rlb))) {
-        // The low interval is out of range.
-        return {(strict) ? (left_uvalue > right_uvalue) : (left_uvalue >= right_uvalue),
-                (*lhlb.number() == number_t(std::numeric_limits<uint64_t>::max())) ? (left_uvalue == *lhlb.number())
-                                                                                   : (left_uvalue >= *lhlb.number()),
-                left_svalue < 0};
-    } else if (right_interval <= interval_t::unsigned_high(true)) {
-        // Interval can be represented as both an svalue and a uvalue since it fits in [INT_MAX+1, UINT_MAX].
-        return {number_t{0} <= left_uvalue, strict ? (left_uvalue > right_uvalue) : (left_uvalue >= right_uvalue),
-                strict ? (left_svalue > right_svalue) : (left_svalue >= right_svalue)};
-    } else if ((left_interval_low | left_interval_high) <= interval_t::nonnegative_int(true) &&
-               right_interval <= interval_t::nonnegative_int(true)) {
-        // Interval can be represented as both an svalue and a uvalue since it fits in [0, INT_MAX].
-        return {number_t{0} <= left_uvalue, strict ? (left_uvalue > right_uvalue) : (left_uvalue >= right_uvalue),
-                strict ? (left_svalue > right_svalue) : (left_svalue >= right_svalue)};
-    } else {
-        // Interval can only be represented as a uvalue.
-        return {number_t{0} <= left_uvalue, strict ? (left_uvalue > right_uvalue) : (left_uvalue >= right_uvalue)};
-    }
-}
-
-static std::vector<linear_constraint_t>
-assume_unsigned_32bit_gt(const NumAbsDomain& inv, bool strict, variable_t left_svalue, variable_t left_uvalue,
-                         const crab::interval_t& left_interval_low, const crab::interval_t& left_interval_high,
-                         const linear_expression_t& right_svalue, const linear_expression_t& right_uvalue,
-                         const crab::interval_t& right_interval) {
-    using crab::interval_t;
-    using namespace crab::dsl_syntax;
-
-    if (right_interval <= interval_t::unsigned_high(false)) {
-        // Interval can be represented as both an svalue and a uvalue since it fits in [INT32_MAX+1, UINT32_MAX].
-        return {number_t{0} <= left_uvalue, strict ? (left_uvalue > right_uvalue) : (left_uvalue >= right_uvalue),
-                strict ? (left_svalue > right_svalue) : (left_svalue >= right_svalue)};
-    } else if (inv.eval_interval(left_uvalue) <= interval_t::unsigned_int(false) &&
-               inv.eval_interval(right_uvalue) <= interval_t::unsigned_int(false)) {
-        // Interval can only be represented as a uvalue.
-        return {number_t{0} <= left_uvalue, strict ? (left_uvalue > right_uvalue) : (left_uvalue >= right_uvalue)};
-    } else {
-        // We can't directly compare the uvalues since they may differ in high order bits.
-        return {};
-    };
-}
-
-static std::vector<linear_constraint_t> assume_unsigned_cst_interval(const NumAbsDomain& inv, Condition::Op op,
-                                                                     bool is64, variable_t left_svalue,
-                                                                     variable_t left_uvalue,
-                                                                     const linear_expression_t& right_svalue,
-                                                                     const linear_expression_t& right_uvalue) {
-    using crab::interval_t;
-    using namespace crab::dsl_syntax;
-
-    interval_t left_interval = interval_t::bottom();
-    interval_t right_interval = interval_t::bottom();
-    interval_t left_interval_low = interval_t::bottom();
-    interval_t left_interval_high = interval_t::bottom();
-    get_unsigned_intervals(inv, is64, left_svalue, left_uvalue, right_uvalue, left_interval, right_interval,
-                           left_interval_low, left_interval_high);
-
-    // Handle uvalue != right.
-    if (op == Condition::Op::NE) {
-        if (auto rn = right_interval.singleton()) {
-            if (rn == left_interval.truncate_to_uint(is64).lb().number()) {
-                // "NE lower bound" is equivalent to "GT lower bound".
-                op = Condition::Op::GT;
-                right_interval = interval_t{left_interval.lb()};
-            } else if (rn == left_interval.ub().number()) {
-                // "NE upper bound" is equivalent to "LT upper bound".
-                op = Condition::Op::LT;
-                right_interval = interval_t{left_interval.ub()};
-            } else {
-                return {};
-            }
-        } else {
-            return {};
-        }
-    }
-
-    const bool is_lt = op == Condition::Op::LT || op == Condition::Op::LE;
-    bool strict = op == Condition::Op::LT || op == Condition::Op::GT;
-
-    auto llb = left_interval.lb();
-    auto lub = left_interval.ub();
-    auto rlb = right_interval.lb();
-    auto rub = right_interval.ub();
-    if (!is_lt && (strict ? (lub <= rlb) : (lub < rlb))) {
-        // Left unsigned interval is lower than right unsigned interval.
-        return {linear_constraint_t::false_const()};
-    } else if (is_lt && (strict ? (llb >= rub) : (llb > rub))) {
-        // Left unsigned interval is higher than right unsigned interval.
-        return {linear_constraint_t::false_const()};
-    }
-    if (is_lt && (strict ? (lub < rlb) : (lub <= rlb))) {
-        // Left unsigned interval is lower than right unsigned interval. We still add a
-        // relationship for use when widening, such as is used in the prime conformance test.
-        if (is64) {
-            return {strict ? left_uvalue < right_uvalue : left_uvalue <= right_uvalue};
-        } else {
-            return {linear_constraint_t::true_const()};
-        }
-    } else if (!is_lt && (strict ? (llb > rub) : (llb >= rub))) {
-        // Left unsigned interval is higher than right unsigned interval. We still add a
-        // relationship for use when widening, such as is used in the prime conformance test.
-        if (is64) {
-            return {strict ? left_uvalue > right_uvalue : left_uvalue >= right_uvalue};
-        } else {
-            return {linear_constraint_t::true_const()};
-        }
-    }
-
-    if (is64) {
-        if (is_lt) {
-            return assume_unsigned_64bit_lt(inv, strict, left_svalue, left_uvalue, left_interval_low,
-                                            left_interval_high, right_svalue, right_uvalue, right_interval);
-        } else {
-            return assume_unsigned_64bit_gt(inv, strict, left_svalue, left_uvalue, left_interval_low,
-                                            left_interval_high, right_svalue, right_uvalue, right_interval);
-        }
-    } else {
-        if (is_lt) {
-            return assume_unsigned_32bit_lt(inv, strict, left_svalue, left_uvalue, left_interval_low,
-                                            left_interval_high, right_svalue, right_uvalue, right_interval);
-        } else {
-            return assume_unsigned_32bit_gt(inv, strict, left_svalue, left_uvalue, left_interval_low,
-                                            left_interval_high, right_svalue, right_uvalue, right_interval);
-        }
-    }
-}
-
 /** Linear constraints for a comparison with a constant.
  */
-static std::vector<linear_constraint_t> assume_cst_imm(const NumAbsDomain& inv, Condition::Op op, bool is64,
-                                                       variable_t dst_svalue, variable_t dst_uvalue, int64_t imm) {
+static std::vector<linear_constraint_t> assume_cst_imm(const NumAbsDomain& inv, const Condition::Op op, const bool is64,
+                                                       const variable_t dst_svalue, const variable_t dst_uvalue,
+                                                       const int64_t imm) {
     using namespace crab::dsl_syntax;
     using Op = Condition::Op;
     switch (op) {
@@ -710,33 +107,33 @@ static std::vector<linear_constraint_t> assume_cst_imm(const NumAbsDomain& inv, 
     case Op::SLE:
     case Op::SGT:
     case Op::SLT:
-        return assume_signed_cst_interval(inv, op, is64, dst_svalue, dst_uvalue, number_t{imm},
-                                          number_t{(uint64_t)imm});
+        return inv->assume_signed_cst_interval(op, is64, dst_svalue, dst_uvalue, number_t{imm},
+                                               number_t{static_cast<uint64_t>(imm)});
     case Op::SET:
-    case Op::NSET: return assume_bit_cst_interval(inv, op, is64, dst_uvalue, crab::interval_t(imm));
+    case Op::NSET: return inv->assume_bit_cst_interval(op, is64, dst_uvalue, interval_t(imm));
     case Op::NE:
     case Op::GE:
     case Op::LE:
     case Op::GT:
     case Op::LT:
-        return assume_unsigned_cst_interval(inv, op, is64, dst_svalue, dst_uvalue, number_t{imm},
-                                            number_t{(uint64_t)imm});
+        return inv->assume_unsigned_cst_interval(op, is64, dst_svalue, dst_uvalue, number_t{imm},
+                                                 number_t{static_cast<uint64_t>(imm)});
     }
     return {};
 }
 
 /** Linear constraint for a numerical comparison between registers.
  */
-static std::vector<linear_constraint_t> assume_cst_reg(const NumAbsDomain& inv, Condition::Op op, bool is64,
-                                                       variable_t dst_svalue, variable_t dst_uvalue,
-                                                       variable_t src_svalue, variable_t src_uvalue) {
+static std::vector<linear_constraint_t> assume_cst_reg(const NumAbsDomain& inv, const Condition::Op op, const bool is64,
+                                                       const variable_t dst_svalue, const variable_t dst_uvalue,
+                                                       const variable_t src_svalue, const variable_t src_uvalue) {
     using namespace crab::dsl_syntax;
     using Op = Condition::Op;
     if (is64) {
         switch (op) {
         case Op::EQ: {
-            crab::interval_t src_interval = inv.eval_interval(src_svalue);
-            if (!src_interval.is_singleton() && (src_interval <= crab::interval_t::nonnegative_int(true))) {
+            const interval_t src_interval = inv.eval_interval(src_svalue);
+            if (!src_interval.is_singleton() && (src_interval <= interval_t::nonnegative_int(true))) {
                 return {eq(dst_svalue, src_svalue), eq(dst_uvalue, src_uvalue), eq(dst_svalue, dst_uvalue)};
             } else {
                 return {eq(dst_svalue, src_svalue), eq(dst_uvalue, src_uvalue)};
@@ -749,11 +146,11 @@ static std::vector<linear_constraint_t> assume_cst_reg(const NumAbsDomain& inv, 
         // Note: reverse the test as a workaround strange lookup:
         case Op::SLT: return {src_svalue > dst_svalue};
         case Op::SET:
-        case Op::NSET: return assume_bit_cst_interval(inv, op, is64, dst_uvalue, inv.eval_interval(src_uvalue));
+        case Op::NSET: return inv->assume_bit_cst_interval(op, is64, dst_uvalue, inv.eval_interval(src_uvalue));
         case Op::GE:
         case Op::LE:
         case Op::GT:
-        case Op::LT: return assume_unsigned_cst_interval(inv, op, is64, dst_svalue, dst_uvalue, src_svalue, src_uvalue);
+        case Op::LT: return inv->assume_unsigned_cst_interval(op, is64, dst_svalue, dst_uvalue, src_svalue, src_uvalue);
         }
     } else {
         switch (op) {
@@ -761,21 +158,21 @@ static std::vector<linear_constraint_t> assume_cst_reg(const NumAbsDomain& inv, 
         case Op::SGE:
         case Op::SLE:
         case Op::SGT:
-        case Op::SLT: return assume_signed_cst_interval(inv, op, is64, dst_svalue, dst_uvalue, src_svalue, src_uvalue);
+        case Op::SLT: return inv->assume_signed_cst_interval(op, is64, dst_svalue, dst_uvalue, src_svalue, src_uvalue);
         case Op::SET:
-        case Op::NSET: return assume_bit_cst_interval(inv, op, is64, dst_uvalue, inv.eval_interval(src_uvalue));
+        case Op::NSET: return inv->assume_bit_cst_interval(op, is64, dst_uvalue, inv.eval_interval(src_uvalue));
         case Op::NE:
         case Op::GE:
         case Op::LE:
         case Op::GT:
-        case Op::LT: return assume_unsigned_cst_interval(inv, op, is64, dst_svalue, dst_uvalue, src_svalue, src_uvalue);
+        case Op::LT: return inv->assume_unsigned_cst_interval(op, is64, dst_svalue, dst_uvalue, src_svalue, src_uvalue);
         }
     }
     assert(false);
     throw std::exception();
 }
 
-std::optional<variable_t> ebpf_domain_t::get_type_offset_variable(const Reg& reg, int type) {
+std::optional<variable_t> ebpf_domain_t::get_type_offset_variable(const Reg& reg, const int type) {
     reg_pack_t r = reg_pack(reg);
     switch (type) {
     case T_CTX: return r.ctx_offset;
@@ -812,7 +209,7 @@ ebpf_domain_t ebpf_domain_t::bottom() {
 
 ebpf_domain_t::ebpf_domain_t() : m_inv(NumAbsDomain::top()) {}
 
-ebpf_domain_t::ebpf_domain_t(NumAbsDomain inv, crab::domains::array_domain_t stack)
+ebpf_domain_t::ebpf_domain_t(NumAbsDomain inv, const crab::domains::array_domain_t& stack)
     : m_inv(std::move(inv)), stack(stack) {}
 
 void ebpf_domain_t::set_to_top() {
@@ -826,18 +223,20 @@ bool ebpf_domain_t::is_bottom() const { return m_inv.is_bottom(); }
 
 bool ebpf_domain_t::is_top() const { return m_inv.is_top() && stack.is_top(); }
 
-bool ebpf_domain_t::operator<=(const ebpf_domain_t& other) { return m_inv <= other.m_inv && stack <= other.stack; }
+bool ebpf_domain_t::operator<=(const ebpf_domain_t& other) const {
+    return m_inv <= other.m_inv && stack <= other.stack;
+}
 
 bool ebpf_domain_t::operator==(const ebpf_domain_t& other) const {
     return stack == other.stack && m_inv <= other.m_inv && other.m_inv <= m_inv;
 }
 
-void ebpf_domain_t::TypeDomain::add_extra_invariant(NumAbsDomain& dst,
-                                                    std::map<crab::variable_t, crab::interval_t>& extra_invariants,
-                                                    variable_t type_variable, type_encoding_t type, data_kind_t kind,
-                                                    const NumAbsDomain& src) const {
-    bool dst_has_type = has_type(dst, type_variable, type);
-    bool src_has_type = has_type(src, type_variable, type);
+void ebpf_domain_t::TypeDomain::add_extra_invariant(const NumAbsDomain& dst,
+                                                    std::map<variable_t, interval_t>& extra_invariants,
+                                                    const variable_t type_variable, const type_encoding_t type,
+                                                    const data_kind_t kind, const NumAbsDomain& src) const {
+    const bool dst_has_type = has_type(dst, type_variable, type);
+    const bool src_has_type = has_type(src, type_variable, type);
     variable_t v = variable_t::kind_var(kind, type_variable);
 
     // If type is contained in exactly one of dst or src,
@@ -874,9 +273,9 @@ void ebpf_domain_t::TypeDomain::selectively_join_based_on_type(NumAbsDomain& dst
     // Output:
     //   r1.type={stack,packet}, r1.stack_offset=100, r1.packet_offset=4
 
-    std::map<crab::variable_t, crab::interval_t> extra_invariants;
+    std::map<crab::variable_t, interval_t> extra_invariants;
     if (!dst.is_bottom()) {
-        for (variable_t v : variable_t::get_type_variables()) {
+        for (const variable_t v : variable_t::get_type_variables()) {
             add_extra_invariant(dst, extra_invariants, v, T_CTX, data_kind_t::ctx_offsets, src);
             add_extra_invariant(dst, extra_invariants, v, T_MAP, data_kind_t::map_fds, src);
             add_extra_invariant(dst, extra_invariants, v, T_MAP_PROGRAMS, data_kind_t::map_fds, src);
@@ -935,23 +334,23 @@ ebpf_domain_t ebpf_domain_t::operator&(const ebpf_domain_t& other) const {
 ebpf_domain_t ebpf_domain_t::calculate_constant_limits() {
     ebpf_domain_t inv;
     using namespace crab::dsl_syntax;
-    for (int i : {0, 1, 2, 3, 4, 5, 6, 7, 8, 9}) {
-        auto r = reg_pack(i);
-        inv += r.svalue <= std::numeric_limits<int32_t>::max();
-        inv += r.svalue >= std::numeric_limits<int32_t>::min();
-        inv += r.uvalue <= std::numeric_limits<uint32_t>::max();
-        inv += r.uvalue >= 0;
-        inv += r.stack_offset <= EBPF_STACK_SIZE;
-        inv += r.stack_offset >= 0;
-        inv += r.shared_offset <= r.shared_region_size;
-        inv += r.shared_offset >= 0;
-        inv += r.packet_offset <= variable_t::packet_size();
-        inv += r.packet_offset >= 0;
+    for (const int i : {0, 1, 2, 3, 4, 5, 6, 7, 8, 9}) {
+        const auto r = reg_pack(i);
+        inv.m_inv += r.svalue <= std::numeric_limits<int32_t>::max();
+        inv.m_inv += r.svalue >= std::numeric_limits<int32_t>::min();
+        inv.m_inv += r.uvalue <= std::numeric_limits<uint32_t>::max();
+        inv.m_inv += r.uvalue >= 0;
+        inv.m_inv += r.stack_offset <= EBPF_STACK_SIZE;
+        inv.m_inv += r.stack_offset >= 0;
+        inv.m_inv += r.shared_offset <= r.shared_region_size;
+        inv.m_inv += r.shared_offset >= 0;
+        inv.m_inv += r.packet_offset <= variable_t::packet_size();
+        inv.m_inv += r.packet_offset >= 0;
         if (thread_local_options.check_termination) {
-            for (variable_t counter : variable_t::get_loop_counters()) {
-                inv += counter <= std::numeric_limits<int32_t>::max();
-                inv += counter >= 0;
-                inv += counter <= r.svalue;
+            for (const variable_t counter : variable_t::get_loop_counters()) {
+                inv.m_inv += counter <= std::numeric_limits<int32_t>::max();
+                inv.m_inv += counter >= 0;
+                inv.m_inv += counter <= r.svalue;
             }
         }
     }
@@ -960,7 +359,7 @@ ebpf_domain_t ebpf_domain_t::calculate_constant_limits() {
 
 static const ebpf_domain_t constant_limits = ebpf_domain_t::calculate_constant_limits();
 
-ebpf_domain_t ebpf_domain_t::widen(const ebpf_domain_t& other, bool to_constants) {
+ebpf_domain_t ebpf_domain_t::widen(const ebpf_domain_t& other, const bool to_constants) const {
     ebpf_domain_t res{m_inv.widen(other.m_inv), stack | other.stack};
     if (to_constants) {
         return res & constant_limits;
@@ -968,45 +367,34 @@ ebpf_domain_t ebpf_domain_t::widen(const ebpf_domain_t& other, bool to_constants
     return res;
 }
 
-ebpf_domain_t ebpf_domain_t::narrow(const ebpf_domain_t& other) {
+ebpf_domain_t ebpf_domain_t::narrow(const ebpf_domain_t& other) const {
     return ebpf_domain_t(m_inv.narrow(other.m_inv), stack & other.stack);
 }
 
-void ebpf_domain_t::operator+=(const linear_constraint_t& cst) { m_inv += cst; }
-
-void ebpf_domain_t::operator-=(variable_t var) { m_inv -= var; }
-
-void ebpf_domain_t::assign(variable_t x, const linear_expression_t& e) { m_inv.assign(x, e); }
-void ebpf_domain_t::assign(variable_t x, int64_t e) { m_inv.set(x, crab::interval_t(number_t(e))); }
-
-void ebpf_domain_t::apply(crab::arith_binop_t op, variable_t x, variable_t y, const number_t& z, int finite_width) {
-    m_inv.apply(op, x, y, z, finite_width);
+/// Forget everything we know about the value of a variable.
+void ebpf_domain_t::havoc(const variable_t v) { m_inv -= v; }
+void havoc_offsets(NumAbsDomain& inv, const Reg& reg) {
+    const reg_pack_t r = reg_pack(reg);
+    inv -= r.ctx_offset;
+    inv -= r.map_fd;
+    inv -= r.packet_offset;
+    inv -= r.shared_offset;
+    inv -= r.shared_region_size;
+    inv -= r.stack_offset;
+    inv -= r.stack_numeric_size;
 }
-
-void ebpf_domain_t::apply(crab::arith_binop_t op, variable_t x, variable_t y, variable_t z, int finite_width) {
-    m_inv.apply(op, x, y, z, finite_width);
-}
-
-void ebpf_domain_t::apply(crab::bitwise_binop_t op, variable_t x, variable_t y, variable_t z, int finite_width) {
-    m_inv.apply(op, x, y, z, finite_width);
-}
-
-void ebpf_domain_t::apply(crab::bitwise_binop_t op, variable_t x, variable_t y, const number_t& k, int finite_width) {
-    m_inv.apply(op, x, y, k, finite_width);
-}
-
-void ebpf_domain_t::apply(crab::binop_t op, variable_t x, variable_t y, const number_t& z, int finite_width) {
-    std::visit([&](auto top) { apply(top, x, y, z, finite_width); }, op);
-}
-
-void ebpf_domain_t::apply(crab::binop_t op, variable_t x, variable_t y, variable_t z, int finite_width) {
-    std::visit([&](auto top) { apply(top, x, y, z, finite_width); }, op);
+void ebpf_domain_t::havoc_offsets(const Reg& reg) { crab::havoc_offsets(m_inv, reg); }
+void havoc_register(NumAbsDomain& inv, const Reg& reg) {
+    const reg_pack_t r = reg_pack(reg);
+    havoc_offsets(inv, reg);
+    inv -= r.svalue;
+    inv -= r.uvalue;
 }
 
 void ebpf_domain_t::scratch_caller_saved_registers() {
     for (int i = R1_ARG; i <= R5_ARG; i++) {
-        Reg r{(uint8_t)i};
-        havoc_register(m_inv, r);
+        Reg r{static_cast<uint8_t>(i)};
+        crab::havoc_register(m_inv, r);
         type_inv.havoc_type(m_inv, r);
     }
 }
@@ -1016,10 +404,10 @@ void ebpf_domain_t::save_callee_saved_registers(const std::string& prefix) {
     // copies of the states of r6 through r9.
     for (int r = R6; r <= R9; r++) {
         for (data_kind_t kind = data_kind_t::types; kind <= data_kind_t::stack_numeric_sizes;
-             kind = (data_kind_t)((int)kind + 1)) {
-            variable_t src_var = variable_t::reg(kind, r);
+             kind = static_cast<data_kind_t>(static_cast<int>(kind) + 1)) {
+            const variable_t src_var = variable_t::reg(kind, r);
             if (!m_inv[src_var].is_top()) {
-                assign(variable_t::stack_frame_var(kind, r, prefix), src_var);
+                m_inv->assign(variable_t::stack_frame_var(kind, r, prefix), src_var);
             }
         }
     }
@@ -1028,10 +416,10 @@ void ebpf_domain_t::save_callee_saved_registers(const std::string& prefix) {
 void ebpf_domain_t::restore_callee_saved_registers(const std::string& prefix) {
     for (int r = R6; r <= R9; r++) {
         for (data_kind_t kind = data_kind_t::types; kind <= data_kind_t::stack_numeric_sizes;
-             kind = (data_kind_t)((int)kind + 1)) {
-            variable_t src_var = variable_t::stack_frame_var(kind, r, prefix);
+             kind = static_cast<data_kind_t>(static_cast<int>(kind) + 1)) {
+            const variable_t src_var = variable_t::stack_frame_var(kind, r, prefix);
             if (!m_inv[src_var].is_top()) {
-                assign(variable_t::reg(kind, r), src_var);
+                m_inv->assign(variable_t::reg(kind, r), src_var);
             } else {
                 havoc(variable_t::reg(kind, r));
             }
@@ -1043,7 +431,7 @@ void ebpf_domain_t::restore_callee_saved_registers(const std::string& prefix) {
 void ebpf_domain_t::forget_packet_pointers() {
     using namespace crab::dsl_syntax;
 
-    for (variable_t type_variable : variable_t::get_type_variables()) {
+    for (const variable_t type_variable : variable_t::get_type_variables()) {
         if (type_inv.has_type(m_inv, type_variable, T_PACKET)) {
             havoc(variable_t::kind_var(data_kind_t::types, type_variable));
             havoc(variable_t::kind_var(data_kind_t::packet_offsets, type_variable));
@@ -1053,142 +441,6 @@ void ebpf_domain_t::forget_packet_pointers() {
     }
 
     initialize_packet(*this);
-}
-
-void ebpf_domain_t::apply_signed(NumAbsDomain& inv, crab::binop_t op, variable_t xs, variable_t xu, variable_t y,
-                                 const number_t& z, int finite_width) {
-    inv.apply(op, xs, y, z, finite_width);
-    if (finite_width) {
-        inv.assign(xu, xs);
-        overflow_signed(inv, xs, finite_width);
-        overflow_unsigned(inv, xu, finite_width);
-    }
-}
-
-void ebpf_domain_t::apply_unsigned(NumAbsDomain& inv, crab::binop_t op, variable_t xs, variable_t xu, variable_t y,
-                                   const number_t& z, int finite_width) {
-    inv.apply(op, xu, y, z, finite_width);
-    if (finite_width) {
-        inv.assign(xs, xu);
-        overflow_signed(inv, xs, finite_width);
-        overflow_unsigned(inv, xu, finite_width);
-    }
-}
-
-void ebpf_domain_t::apply_signed(NumAbsDomain& inv, crab::binop_t op, variable_t xs, variable_t xu, variable_t y,
-                                 variable_t z, int finite_width) {
-    inv.apply(op, xs, y, z, finite_width);
-    if (finite_width) {
-        inv.assign(xu, xs);
-        overflow_signed(inv, xs, finite_width);
-        overflow_unsigned(inv, xu, finite_width);
-    }
-}
-
-void ebpf_domain_t::apply_unsigned(NumAbsDomain& inv, crab::binop_t op, variable_t xs, variable_t xu, variable_t y,
-                                   variable_t z, int finite_width) {
-    inv.apply(op, xu, y, z, finite_width);
-    if (finite_width) {
-        inv.assign(xs, xu);
-        overflow_signed(inv, xs, finite_width);
-        overflow_unsigned(inv, xu, finite_width);
-    }
-}
-
-void ebpf_domain_t::apply(NumAbsDomain& inv, crab::binop_t op, variable_t x, variable_t y, variable_t z) {
-    inv.apply(op, x, y, z, 0);
-}
-
-void ebpf_domain_t::add(variable_t lhs, variable_t op2) {
-    apply_signed(m_inv, crab::arith_binop_t::ADD, lhs, lhs, lhs, op2, 0);
-}
-void ebpf_domain_t::add(variable_t lhs, const number_t& op2) {
-    apply_signed(m_inv, crab::arith_binop_t::ADD, lhs, lhs, lhs, op2, 0);
-}
-void ebpf_domain_t::sub(variable_t lhs, variable_t op2) {
-    apply_signed(m_inv, crab::arith_binop_t::SUB, lhs, lhs, lhs, op2, 0);
-}
-void ebpf_domain_t::sub(variable_t lhs, const number_t& op2) {
-    apply_signed(m_inv, crab::arith_binop_t::SUB, lhs, lhs, lhs, op2, 0);
-}
-
-// Add/subtract with overflow are both signed and unsigned. We can use either one of the two to compute the
-// result before adjusting for overflow, though if one is top we want to use the other to retain precision.
-void ebpf_domain_t::add_overflow(variable_t lhss, variable_t lhsu, variable_t op2, int finite_width) {
-    apply_signed(m_inv, crab::arith_binop_t::ADD, lhss, lhsu, ((!m_inv.eval_interval(lhss).is_top()) ? lhss : lhsu),
-                 op2, finite_width);
-}
-void ebpf_domain_t::add_overflow(variable_t lhss, variable_t lhsu, const number_t& op2, int finite_width) {
-    apply_signed(m_inv, crab::arith_binop_t::ADD, lhss, lhsu, ((!m_inv.eval_interval(lhss).is_top()) ? lhss : lhsu),
-                 op2, finite_width);
-}
-void ebpf_domain_t::sub_overflow(variable_t lhss, variable_t lhsu, variable_t op2, int finite_width) {
-    apply_signed(m_inv, crab::arith_binop_t::SUB, lhss, lhsu, ((!m_inv.eval_interval(lhss).is_top()) ? lhss : lhsu),
-                 op2, finite_width);
-}
-void ebpf_domain_t::sub_overflow(variable_t lhss, variable_t lhsu, const number_t& op2, int finite_width) {
-    apply_signed(m_inv, crab::arith_binop_t::SUB, lhss, lhsu, ((!m_inv.eval_interval(lhss).is_top()) ? lhss : lhsu),
-                 op2, finite_width);
-}
-
-void ebpf_domain_t::neg(variable_t lhss, variable_t lhsu, int finite_width) {
-    apply_signed(m_inv, crab::arith_binop_t::MUL, lhss, lhsu, lhss, (number_t)-1, finite_width);
-}
-void ebpf_domain_t::mul(variable_t lhss, variable_t lhsu, variable_t op2, int finite_width) {
-    apply_signed(m_inv, crab::arith_binop_t::MUL, lhss, lhsu, lhss, op2, finite_width);
-}
-void ebpf_domain_t::mul(variable_t lhss, variable_t lhsu, const number_t& op2, int finite_width) {
-    apply_signed(m_inv, crab::arith_binop_t::MUL, lhss, lhsu, lhss, op2, finite_width);
-}
-void ebpf_domain_t::sdiv(variable_t lhss, variable_t lhsu, variable_t op2, int finite_width) {
-    apply_signed(m_inv, crab::arith_binop_t::SDIV, lhss, lhsu, lhss, op2, finite_width);
-}
-void ebpf_domain_t::sdiv(variable_t lhss, variable_t lhsu, const number_t& op2, int finite_width) {
-    apply_signed(m_inv, crab::arith_binop_t::SDIV, lhss, lhsu, lhss, op2, finite_width);
-}
-void ebpf_domain_t::udiv(variable_t lhss, variable_t lhsu, variable_t op2, int finite_width) {
-    apply_unsigned(m_inv, crab::arith_binop_t::UDIV, lhss, lhsu, lhsu, op2, finite_width);
-}
-void ebpf_domain_t::udiv(variable_t lhss, variable_t lhsu, const number_t& op2, int finite_width) {
-    apply_unsigned(m_inv, crab::arith_binop_t::UDIV, lhss, lhsu, lhsu, op2, finite_width);
-}
-void ebpf_domain_t::srem(variable_t lhss, variable_t lhsu, variable_t op2, int finite_width) {
-    apply_signed(m_inv, crab::arith_binop_t::SREM, lhss, lhsu, lhss, op2, finite_width);
-}
-void ebpf_domain_t::srem(variable_t lhss, variable_t lhsu, const number_t& op2, int finite_width) {
-    apply_signed(m_inv, crab::arith_binop_t::SREM, lhss, lhsu, lhss, op2, finite_width);
-}
-void ebpf_domain_t::urem(variable_t lhss, variable_t lhsu, variable_t op2, int finite_width) {
-    apply_unsigned(m_inv, crab::arith_binop_t::UREM, lhss, lhsu, lhsu, op2, finite_width);
-}
-void ebpf_domain_t::urem(variable_t lhss, variable_t lhsu, const number_t& op2, int finite_width) {
-    apply_unsigned(m_inv, crab::arith_binop_t::UREM, lhss, lhsu, lhsu, op2, finite_width);
-}
-
-void ebpf_domain_t::bitwise_and(variable_t lhss, variable_t lhsu, variable_t op2, int finite_width) {
-    apply_unsigned(m_inv, crab::bitwise_binop_t::AND, lhss, lhsu, lhsu, op2, finite_width);
-}
-void ebpf_domain_t::bitwise_and(variable_t lhss, variable_t lhsu, const number_t& op2) {
-    // Use finite width 64 to make the svalue be set as well as the uvalue.
-    apply_unsigned(m_inv, crab::bitwise_binop_t::AND, lhss, lhsu, lhsu, op2, 64);
-}
-void ebpf_domain_t::bitwise_or(variable_t lhss, variable_t lhsu, variable_t op2, int finite_width) {
-    apply_unsigned(m_inv, crab::bitwise_binop_t::OR, lhss, lhsu, lhsu, op2, finite_width);
-}
-void ebpf_domain_t::bitwise_or(variable_t lhss, variable_t lhsu, const number_t& op2) {
-    apply_unsigned(m_inv, crab::bitwise_binop_t::OR, lhss, lhsu, lhsu, op2, 64);
-}
-void ebpf_domain_t::bitwise_xor(variable_t lhss, variable_t lhsu, variable_t op2, int finite_width) {
-    apply_unsigned(m_inv, crab::bitwise_binop_t::XOR, lhss, lhsu, lhsu, op2, finite_width);
-}
-void ebpf_domain_t::bitwise_xor(variable_t lhss, variable_t lhsu, const number_t& op2) {
-    apply_unsigned(m_inv, crab::bitwise_binop_t::XOR, lhss, lhsu, lhsu, op2, 64);
-}
-void ebpf_domain_t::shl_overflow(variable_t lhss, variable_t lhsu, variable_t op2) {
-    apply_unsigned(m_inv, crab::bitwise_binop_t::SHL, lhss, lhsu, lhsu, op2, 64);
-}
-void ebpf_domain_t::shl_overflow(variable_t lhss, variable_t lhsu, const number_t& op2) {
-    apply_unsigned(m_inv, crab::bitwise_binop_t::SHL, lhss, lhsu, lhsu, op2, 64);
 }
 
 static void assume(NumAbsDomain& inv, const linear_constraint_t& cst) { inv += cst; }
@@ -1203,28 +455,6 @@ void ebpf_domain_t::require(NumAbsDomain& inv, const linear_constraint_t& cst, c
         crab::assume(inv, cst);
     }
 }
-
-/// Forget everything we know about the value of a variable.
-void ebpf_domain_t::havoc(variable_t v) { m_inv -= v; }
-void ebpf_domain_t::havoc_offsets(NumAbsDomain& inv, const Reg& reg) {
-    reg_pack_t r = reg_pack(reg);
-    inv -= r.ctx_offset;
-    inv -= r.map_fd;
-    inv -= r.packet_offset;
-    inv -= r.shared_offset;
-    inv -= r.shared_region_size;
-    inv -= r.stack_offset;
-    inv -= r.stack_numeric_size;
-}
-void ebpf_domain_t::havoc_offsets(const Reg& reg) { havoc_offsets(m_inv, reg); }
-void ebpf_domain_t::havoc_register(NumAbsDomain& inv, const Reg& reg) {
-    reg_pack_t r = reg_pack(reg);
-    havoc_offsets(inv, reg);
-    inv -= r.svalue;
-    inv -= r.uvalue;
-}
-
-void ebpf_domain_t::assign(variable_t lhs, variable_t rhs) { m_inv.assign(lhs, rhs); }
 
 static linear_constraint_t type_is_pointer(const reg_pack_t& r) {
     using namespace crab::dsl_syntax;
@@ -1243,7 +473,7 @@ static linear_constraint_t type_is_not_stack(const reg_pack_t& r) {
     return r.type != T_STACK;
 }
 
-void ebpf_domain_t::TypeDomain::assign_type(NumAbsDomain& inv, const Reg& lhs, type_encoding_t t) {
+void ebpf_domain_t::TypeDomain::assign_type(NumAbsDomain& inv, const Reg& lhs, const type_encoding_t t) {
     inv.assign(reg_pack(lhs).type, t);
 }
 
@@ -1251,11 +481,12 @@ void ebpf_domain_t::TypeDomain::assign_type(NumAbsDomain& inv, const Reg& lhs, c
     inv.assign(reg_pack(lhs).type, reg_pack(rhs).type);
 }
 
-void ebpf_domain_t::TypeDomain::assign_type(NumAbsDomain& inv, std::optional<variable_t> lhs, const Reg& rhs) {
+void ebpf_domain_t::TypeDomain::assign_type(NumAbsDomain& inv, const std::optional<variable_t> lhs, const Reg& rhs) {
     inv.assign(lhs, reg_pack(rhs).type);
 }
 
-void ebpf_domain_t::TypeDomain::assign_type(NumAbsDomain& inv, std::optional<variable_t> lhs, const number_t& rhs) {
+void ebpf_domain_t::TypeDomain::assign_type(NumAbsDomain& inv, const std::optional<variable_t> lhs,
+                                            const number_t& rhs) {
     inv.assign(lhs, rhs);
 }
 
@@ -1267,48 +498,51 @@ void ebpf_domain_t::TypeDomain::assign_type(NumAbsDomain& inv, const Reg& lhs,
 void ebpf_domain_t::TypeDomain::havoc_type(NumAbsDomain& inv, const Reg& r) { inv -= reg_pack(r).type; }
 
 int ebpf_domain_t::TypeDomain::get_type(const NumAbsDomain& inv, const Reg& r) const {
-    auto res = inv[reg_pack(r).type].singleton();
+    const auto res = inv[reg_pack(r).type].singleton();
     if (!res) {
         return T_UNINIT;
     }
-    return (int)*res;
+    return static_cast<int>(*res);
 }
 
-int ebpf_domain_t::TypeDomain::get_type(const NumAbsDomain& inv, variable_t v) const {
-    auto res = inv[v].singleton();
+int ebpf_domain_t::TypeDomain::get_type(const NumAbsDomain& inv, const variable_t v) const {
+    const auto res = inv[v].singleton();
     if (!res) {
         return T_UNINIT;
     }
-    return (int)*res;
+    return static_cast<int>(*res);
 }
 
-int ebpf_domain_t::TypeDomain::get_type(const NumAbsDomain& inv, const number_t& t) const { return (int)t; }
+int ebpf_domain_t::TypeDomain::get_type(const NumAbsDomain& inv, const number_t& t) const {
+    return static_cast<int>(t);
+}
 
 // Check whether a given type value is within the range of a given type variable's value.
-bool ebpf_domain_t::TypeDomain::has_type(const NumAbsDomain& inv, const Reg& r, type_encoding_t type) const {
-    crab::interval_t interval = inv[reg_pack(r).type];
+bool ebpf_domain_t::TypeDomain::has_type(const NumAbsDomain& inv, const Reg& r, const type_encoding_t type) const {
+    const interval_t interval = inv[reg_pack(r).type];
     if (interval.is_top()) {
         return true;
     }
     return (interval.lb().number().value_or(INT_MIN) <= type) && (interval.ub().number().value_or(INT_MAX) >= type);
 }
 
-bool ebpf_domain_t::TypeDomain::has_type(const NumAbsDomain& inv, variable_t v, type_encoding_t type) const {
-    crab::interval_t interval = inv[v];
+bool ebpf_domain_t::TypeDomain::has_type(const NumAbsDomain& inv, const variable_t v,
+                                         const type_encoding_t type) const {
+    const interval_t interval = inv[v];
     if (interval.is_top()) {
         return true;
     }
     return (interval.lb().number().value_or(INT_MIN) <= type) && (interval.ub().number().value_or(INT_MAX) >= type);
 }
 
-bool ebpf_domain_t::TypeDomain::has_type(const NumAbsDomain& inv, const number_t& t, type_encoding_t type) const {
+bool ebpf_domain_t::TypeDomain::has_type(const NumAbsDomain& inv, const number_t& t, const type_encoding_t type) const {
     return t == number_t{type};
 }
 
 NumAbsDomain ebpf_domain_t::TypeDomain::join_over_types(
     const NumAbsDomain& inv, const Reg& reg,
     const std::function<void(NumAbsDomain&, type_encoding_t)>& transition) const {
-    crab::interval_t types = inv.eval_interval(reg_pack(reg).type);
+    interval_t types = inv.eval_interval(reg_pack(reg).type);
     if (types.is_bottom()) {
         return NumAbsDomain::bottom();
     }
@@ -1318,9 +552,11 @@ NumAbsDomain ebpf_domain_t::TypeDomain::join_over_types(
         return res;
     }
     NumAbsDomain res = NumAbsDomain::bottom();
-    auto lb = types.lb().is_finite() ? (type_encoding_t)(int)(types.lb().number().value()) : T_MAP_PROGRAMS;
-    auto ub = types.ub().is_finite() ? (type_encoding_t)(int)(types.ub().number().value()) : T_SHARED;
-    for (type_encoding_t type = lb; type <= ub; type = (type_encoding_t)((int)type + 1)) {
+    auto lb = types.lb().is_finite() ? static_cast<type_encoding_t>(static_cast<int>(types.lb().number().value()))
+                                     : T_MAP_PROGRAMS;
+    auto ub =
+        types.ub().is_finite() ? static_cast<type_encoding_t>(static_cast<int>(types.ub().number().value())) : T_SHARED;
+    for (type_encoding_t type = lb; type <= ub; type = static_cast<type_encoding_t>(static_cast<int>(type) + 1)) {
         NumAbsDomain tmp(inv);
         transition(tmp, type);
         selectively_join_based_on_type(res, tmp); // res |= tmp;
@@ -1349,9 +585,9 @@ bool ebpf_domain_t::TypeDomain::implies_type(const NumAbsDomain& inv, const line
     return inv.when(a).entail(b);
 }
 
-bool ebpf_domain_t::TypeDomain::is_in_group(const NumAbsDomain& inv, const Reg& r, TypeGroup group) const {
+bool ebpf_domain_t::TypeDomain::is_in_group(const NumAbsDomain& inv, const Reg& r, const TypeGroup group) const {
     using namespace crab::dsl_syntax;
-    variable_t t = reg_pack(r).type;
+    const variable_t t = reg_pack(r).type;
     switch (group) {
     case TypeGroup::number: return inv.entail(t == T_NUM);
     case TypeGroup::map_fd: return inv.entail(t == T_MAP);
@@ -1372,58 +608,10 @@ bool ebpf_domain_t::TypeDomain::is_in_group(const NumAbsDomain& inv, const Reg& 
     return false;
 }
 
-void ebpf_domain_t::overflow_bounds(NumAbsDomain& inv, variable_t lhs, number_t span, int finite_width, bool issigned) {
-    using namespace crab::dsl_syntax;
-    auto interval = inv[lhs];
-    if (interval.ub() - interval.lb() >= span) {
-        // Interval covers the full space.
-        inv -= lhs;
-        return;
-    }
-    if (interval.is_bottom()) {
-        inv -= lhs;
-        return;
-    }
-    number_t lb_value = interval.lb().number().value();
-    number_t ub_value = interval.ub().number().value();
-
-    // Compute the interval, taking overflow into account.
-    // For a signed result, we need to ensure the signed and unsigned results match
-    // so for a 32-bit operation, 0x80000000 should be a positive 64-bit number not
-    // a sign extended negative one.
-    number_t lb = lb_value.truncate_to_unsigned_finite_width(finite_width);
-    number_t ub = ub_value.truncate_to_unsigned_finite_width(finite_width);
-    if (issigned) {
-        lb = lb.truncate_to_sint64();
-        ub = ub.truncate_to_sint64();
-    }
-    if (lb > ub) {
-        // Range wraps in the middle, so we cannot represent as an unsigned interval.
-        inv -= lhs;
-        return;
-    }
-    auto new_interval = crab::interval_t{lb, ub};
-    if (new_interval != interval) {
-        // Update the variable, which will lose any relationships to other variables.
-        inv.set(lhs, new_interval);
-    }
-}
-
-void ebpf_domain_t::overflow_signed(NumAbsDomain& inv, variable_t lhs, int finite_width) {
-    auto span{finite_width == 64   ? crab::z_number{std::numeric_limits<uint64_t>::max()}
-              : finite_width == 32 ? crab::z_number{std::numeric_limits<uint32_t>::max()}
-                                   : throw std::exception()};
-    overflow_bounds(inv, lhs, span, finite_width, true);
-}
-
-void ebpf_domain_t::overflow_unsigned(NumAbsDomain& inv, variable_t lhs, int finite_width) {
-    auto span{finite_width == 64   ? crab::z_number{std::numeric_limits<uint64_t>::max()}
-              : finite_width == 32 ? crab::z_number{std::numeric_limits<uint32_t>::max()}
-                                   : throw std::exception()};
-    overflow_bounds(inv, lhs, span, finite_width, false);
-}
-
 void ebpf_domain_t::operator()(const basic_block_t& bb) {
+    if (!m_inv) {
+        return;
+    }
     for (const Instruction& statement : bb) {
         std::visit(*this, statement);
     }
@@ -1446,7 +634,7 @@ void ebpf_domain_t::check_access_context(NumAbsDomain& inv, const linear_express
 }
 
 void ebpf_domain_t::check_access_packet(NumAbsDomain& inv, const linear_expression_t& lb, const linear_expression_t& ub,
-                                        std::optional<variable_t> packet_size) {
+                                        const std::optional<variable_t> packet_size) {
     using namespace crab::dsl_syntax;
     require(inv, lb >= variable_t::meta_offset(), "Lower bound must be at least meta_offset");
     if (packet_size) {
@@ -1458,20 +646,23 @@ void ebpf_domain_t::check_access_packet(NumAbsDomain& inv, const linear_expressi
 }
 
 void ebpf_domain_t::check_access_shared(NumAbsDomain& inv, const linear_expression_t& lb, const linear_expression_t& ub,
-                                        variable_t region_size) {
+                                        const variable_t region_size) {
     using namespace crab::dsl_syntax;
     require(inv, lb >= 0, "Lower bound must be at least 0");
     require(inv, ub <= region_size, std::string("Upper bound must be at most ") + region_size.name());
 }
 
 void ebpf_domain_t::operator()(const Assume& s) {
-    Condition cond = s.cond;
-    auto dst = reg_pack(cond.left);
+    if (!m_inv) {
+        return;
+    }
+    const Condition cond = s.cond;
+    const auto dst = reg_pack(cond.left);
     if (std::holds_alternative<Reg>(cond.right)) {
-        auto src_reg = std::get<Reg>(cond.right);
-        auto src = reg_pack(src_reg);
+        const auto src_reg = std::get<Reg>(cond.right);
+        const auto src = reg_pack(src_reg);
         if (type_inv.same_type(m_inv, cond.left, std::get<Reg>(cond.right))) {
-            m_inv = type_inv.join_over_types(m_inv, cond.left, [&](NumAbsDomain& inv, type_encoding_t type) {
+            m_inv = type_inv.join_over_types(m_inv, cond.left, [&](NumAbsDomain& inv, const type_encoding_t type) {
                 if (type == T_NUM) {
                     for (const linear_constraint_t& cst :
                          assume_cst_reg(m_inv, cond.op, cond.is64, dst.svalue, dst.uvalue, src.svalue, src.uvalue)) {
@@ -1480,8 +671,8 @@ void ebpf_domain_t::operator()(const Assume& s) {
                 } else {
                     // Either pointers to a singleton region,
                     // or an equality comparison on map descriptors/pointers to non-singleton locations
-                    if (auto dst_offset = get_type_offset_variable(cond.left, type)) {
-                        if (auto src_offset = get_type_offset_variable(src_reg, type)) {
+                    if (const auto dst_offset = get_type_offset_variable(cond.left, type)) {
+                        if (const auto src_offset = get_type_offset_variable(src_reg, type)) {
                             inv += assume_cst_offsets_reg(cond.op, cond.is64, dst_offset.value(), src_offset.value());
                         }
                     }
@@ -1494,7 +685,7 @@ void ebpf_domain_t::operator()(const Assume& s) {
             m_inv.set_to_top();
         }
     } else {
-        int64_t imm = static_cast<int64_t>(std::get<Imm>(cond.right).v);
+        const int64_t imm = static_cast<int64_t>(std::get<Imm>(cond.right).v);
         for (const linear_constraint_t& cst : assume_cst_imm(m_inv, cond.op, cond.is64, dst.svalue, dst.uvalue, imm)) {
             assume(cst);
         }
@@ -1510,15 +701,18 @@ BOOST_CONSTEXPR T truncate(T x) BOOST_NOEXCEPT {
 }
 
 void ebpf_domain_t::operator()(const Un& stmt) {
-    auto dst = reg_pack(stmt.dst);
-    auto swap_endianness = [&](variable_t v, auto input, const auto& be_or_le) {
-        if (m_inv.entail(type_is_number(stmt.dst))) {
-            auto interval = m_inv.eval_interval(v);
-            if (std::optional<number_t> n = interval.singleton()) {
+    if (!m_inv) {
+        return;
+    }
+    const auto dst = reg_pack(stmt.dst);
+    auto swap_endianness = [&]<typename T>(const variable_t v, T input, const auto& be_or_le) {
+        if (m_inv->entail(type_is_number(stmt.dst))) {
+            const auto interval = m_inv->eval_interval(v);
+            if (const std::optional<number_t> n = interval.singleton()) {
                 if (n->fits_cast_to_int64()) {
-                    input = (decltype(input))n.value().cast_to_sint64();
-                    decltype(input) output = be_or_le(input);
-                    m_inv.set(v, crab::interval_t(number_t(output), number_t(output)));
+                    input = static_cast<T>(n.value().cast_to_sint64());
+                    T output = be_or_le(input);
+                    m_inv.set(v, interval_t(number_t(output), number_t(output)));
                     return;
                 }
             }
@@ -1532,66 +726,66 @@ void ebpf_domain_t::operator()(const Un& stmt) {
     switch (stmt.op) {
     case Un::Op::BE16:
         if (!thread_local_options.big_endian) {
-            swap_endianness(dst.svalue, uint16_t(0), boost::endian::endian_reverse<uint16_t>);
-            swap_endianness(dst.uvalue, uint16_t(0), boost::endian::endian_reverse<uint16_t>);
+            swap_endianness(dst.svalue, static_cast<uint16_t>(0), boost::endian::endian_reverse<uint16_t>);
+            swap_endianness(dst.uvalue, static_cast<uint16_t>(0), boost::endian::endian_reverse<uint16_t>);
         } else {
-            swap_endianness(dst.svalue, uint16_t(0), truncate<uint16_t>);
-            swap_endianness(dst.uvalue, uint16_t(0), truncate<uint16_t>);
+            swap_endianness(dst.svalue, static_cast<uint16_t>(0), truncate<uint16_t>);
+            swap_endianness(dst.uvalue, static_cast<uint16_t>(0), truncate<uint16_t>);
         }
         break;
     case Un::Op::BE32:
         if (!thread_local_options.big_endian) {
-            swap_endianness(dst.svalue, uint32_t(0), boost::endian::endian_reverse<uint32_t>);
-            swap_endianness(dst.uvalue, uint32_t(0), boost::endian::endian_reverse<uint32_t>);
+            swap_endianness(dst.svalue, static_cast<uint32_t>(0), boost::endian::endian_reverse<uint32_t>);
+            swap_endianness(dst.uvalue, static_cast<uint32_t>(0), boost::endian::endian_reverse<uint32_t>);
         } else {
-            swap_endianness(dst.svalue, uint32_t(0), truncate<uint32_t>);
-            swap_endianness(dst.uvalue, uint32_t(0), truncate<uint32_t>);
+            swap_endianness(dst.svalue, static_cast<uint32_t>(0), truncate<uint32_t>);
+            swap_endianness(dst.uvalue, static_cast<uint32_t>(0), truncate<uint32_t>);
         }
         break;
     case Un::Op::BE64:
         if (!thread_local_options.big_endian) {
-            swap_endianness(dst.svalue, int64_t(0), boost::endian::endian_reverse<int64_t>);
-            swap_endianness(dst.uvalue, uint64_t(0), boost::endian::endian_reverse<uint64_t>);
+            swap_endianness(dst.svalue, static_cast<int64_t>(0), boost::endian::endian_reverse<int64_t>);
+            swap_endianness(dst.uvalue, static_cast<uint64_t>(0), boost::endian::endian_reverse<uint64_t>);
         }
         break;
     case Un::Op::LE16:
         if (thread_local_options.big_endian) {
-            swap_endianness(dst.svalue, uint16_t(0), boost::endian::endian_reverse<uint16_t>);
-            swap_endianness(dst.uvalue, uint16_t(0), boost::endian::endian_reverse<uint16_t>);
+            swap_endianness(dst.svalue, static_cast<uint16_t>(0), boost::endian::endian_reverse<uint16_t>);
+            swap_endianness(dst.uvalue, static_cast<uint16_t>(0), boost::endian::endian_reverse<uint16_t>);
         } else {
-            swap_endianness(dst.svalue, uint16_t(0), truncate<uint16_t>);
-            swap_endianness(dst.uvalue, uint16_t(0), truncate<uint16_t>);
+            swap_endianness(dst.svalue, static_cast<uint16_t>(0), truncate<uint16_t>);
+            swap_endianness(dst.uvalue, static_cast<uint16_t>(0), truncate<uint16_t>);
         }
         break;
     case Un::Op::LE32:
         if (thread_local_options.big_endian) {
-            swap_endianness(dst.svalue, uint32_t(0), boost::endian::endian_reverse<uint32_t>);
-            swap_endianness(dst.uvalue, uint32_t(0), boost::endian::endian_reverse<uint32_t>);
+            swap_endianness(dst.svalue, static_cast<uint32_t>(0), boost::endian::endian_reverse<uint32_t>);
+            swap_endianness(dst.uvalue, static_cast<uint32_t>(0), boost::endian::endian_reverse<uint32_t>);
         } else {
-            swap_endianness(dst.svalue, uint32_t(0), truncate<uint32_t>);
-            swap_endianness(dst.uvalue, uint32_t(0), truncate<uint32_t>);
+            swap_endianness(dst.svalue, static_cast<uint32_t>(0), truncate<uint32_t>);
+            swap_endianness(dst.uvalue, static_cast<uint32_t>(0), truncate<uint32_t>);
         }
         break;
     case Un::Op::LE64:
         if (thread_local_options.big_endian) {
-            swap_endianness(dst.svalue, int64_t(0), boost::endian::endian_reverse<int64_t>);
-            swap_endianness(dst.uvalue, uint64_t(0), boost::endian::endian_reverse<uint64_t>);
+            swap_endianness(dst.svalue, static_cast<int64_t>(0), boost::endian::endian_reverse<int64_t>);
+            swap_endianness(dst.uvalue, static_cast<uint64_t>(0), boost::endian::endian_reverse<uint64_t>);
         }
         break;
     case Un::Op::SWAP16:
-        swap_endianness(dst.svalue, uint16_t(0), boost::endian::endian_reverse<uint16_t>);
-        swap_endianness(dst.uvalue, uint16_t(0), boost::endian::endian_reverse<uint16_t>);
+        swap_endianness(dst.svalue, static_cast<uint16_t>(0), boost::endian::endian_reverse<uint16_t>);
+        swap_endianness(dst.uvalue, static_cast<uint16_t>(0), boost::endian::endian_reverse<uint16_t>);
         break;
     case Un::Op::SWAP32:
-        swap_endianness(dst.svalue, uint32_t(0), boost::endian::endian_reverse<uint32_t>);
-        swap_endianness(dst.uvalue, uint32_t(0), boost::endian::endian_reverse<uint32_t>);
+        swap_endianness(dst.svalue, static_cast<uint32_t>(0), boost::endian::endian_reverse<uint32_t>);
+        swap_endianness(dst.uvalue, static_cast<uint32_t>(0), boost::endian::endian_reverse<uint32_t>);
         break;
     case Un::Op::SWAP64:
-        swap_endianness(dst.svalue, int64_t(0), boost::endian::endian_reverse<int64_t>);
-        swap_endianness(dst.uvalue, uint64_t(0), boost::endian::endian_reverse<uint64_t>);
+        swap_endianness(dst.svalue, static_cast<int64_t>(0), boost::endian::endian_reverse<int64_t>);
+        swap_endianness(dst.uvalue, static_cast<uint64_t>(0), boost::endian::endian_reverse<uint64_t>);
         break;
     case Un::Op::NEG:
-        neg(dst.svalue, dst.uvalue, stmt.is64 ? 64 : 32);
+        m_inv->neg(dst.svalue, dst.uvalue, stmt.is64 ? 64 : 32);
         havoc_offsets(stmt.dst);
         break;
     }
@@ -1599,7 +793,7 @@ void ebpf_domain_t::operator()(const Un& stmt) {
 
 void ebpf_domain_t::operator()(const Exit& a) {
     // Clean up any state for the current stack frame.
-    std::string prefix = a.stack_frame_prefix;
+    const std::string prefix = a.stack_frame_prefix;
     if (prefix.empty()) {
         return;
     }
@@ -1610,6 +804,9 @@ void ebpf_domain_t::operator()(const Jmp& a) {}
 
 void ebpf_domain_t::operator()(const Comparable& s) {
     using namespace crab::dsl_syntax;
+    if (!m_inv) {
+        return;
+    }
     if (type_inv.same_type(m_inv, s.r1, s.r2)) {
         // Same type. If both are numbers, that's okay. Otherwise:
         auto inv = m_inv.when(reg_pack(s.r2).type != T_NUM);
@@ -1630,6 +827,9 @@ void ebpf_domain_t::operator()(const Comparable& s) {
 }
 
 void ebpf_domain_t::operator()(const Addable& s) {
+    if (!m_inv) {
+        return;
+    }
     if (!type_inv.implies_type(m_inv, type_is_pointer(reg_pack(s.ptr)), type_is_number(s.num))) {
         require(m_inv, linear_constraint_t::false_const(), "Only numbers can be added to pointers");
     }
@@ -1637,29 +837,41 @@ void ebpf_domain_t::operator()(const Addable& s) {
 
 void ebpf_domain_t::operator()(const ValidDivisor& s) {
     using namespace crab::dsl_syntax;
-    auto reg = reg_pack(s.reg);
+    if (!m_inv) {
+        return;
+    }
+    const auto reg = reg_pack(s.reg);
     if (!type_inv.implies_type(m_inv, type_is_pointer(reg), type_is_number(s.reg))) {
         require(m_inv, linear_constraint_t::false_const(), "Only numbers can be used as divisors");
     }
     if (!thread_local_options.allow_division_by_zero) {
-        auto v = s.is_signed ? reg.svalue : reg.uvalue;
+        const auto v = s.is_signed ? reg.svalue : reg.uvalue;
         require(m_inv, v != 0, "Possible division by zero");
     }
 }
 
 void ebpf_domain_t::operator()(const ValidStore& s) {
+    if (!m_inv) {
+        return;
+    }
     if (!type_inv.implies_type(m_inv, type_is_not_stack(reg_pack(s.mem)), type_is_number(s.val))) {
         require(m_inv, linear_constraint_t::false_const(), "Only numbers can be stored to externally-visible regions");
     }
 }
 
 void ebpf_domain_t::operator()(const TypeConstraint& s) {
+    if (!m_inv) {
+        return;
+    }
     if (!type_inv.is_in_group(m_inv, s.reg, s.types)) {
         require(m_inv, linear_constraint_t::false_const(), "Invalid type");
     }
 }
 
 void ebpf_domain_t::operator()(const FuncConstraint& s) {
+    if (!m_inv) {
+        return;
+    }
     // Look up the helper function id.
     const reg_pack_t& reg = reg_pack(s.reg);
     auto src_interval = m_inv.eval_interval(reg.svalue);
@@ -1683,7 +895,10 @@ void ebpf_domain_t::operator()(const FuncConstraint& s) {
 
 void ebpf_domain_t::operator()(const ValidSize& s) {
     using namespace crab::dsl_syntax;
-    auto r = reg_pack(s.reg);
+    if (!m_inv) {
+        return;
+    }
+    const auto r = reg_pack(s.reg);
     require(m_inv, s.can_be_zero ? r.svalue >= 0 : r.svalue > 0, "Invalid size");
 }
 
@@ -1691,17 +906,17 @@ void ebpf_domain_t::operator()(const ValidSize& s) {
 // In the future, it would be cleaner to use a set rather than an interval
 // for map fds.
 bool ebpf_domain_t::get_map_fd_range(const Reg& map_fd_reg, int32_t* start_fd, int32_t* end_fd) const {
-    const crab::interval_t& map_fd_interval = m_inv[reg_pack(map_fd_reg).map_fd];
-    auto lb = map_fd_interval.lb().number();
-    auto ub = map_fd_interval.ub().number();
+    const interval_t& map_fd_interval = m_inv[reg_pack(map_fd_reg).map_fd];
+    const auto lb = map_fd_interval.lb().number();
+    const auto ub = map_fd_interval.ub().number();
     if (!lb || !lb->fits_sint32() || !ub || !ub->fits_sint32()) {
         return false;
     }
-    *start_fd = (int32_t)lb.value();
-    *end_fd = (int32_t)ub.value();
+    *start_fd = static_cast<int32_t>(lb.value());
+    *end_fd = static_cast<int32_t>(ub.value());
 
     // Cap the maximum range we'll check.
-    const int max_range = 32;
+    constexpr int max_range = 32;
     return (*map_fd_interval.finite_size() < max_range);
 }
 
@@ -1750,62 +965,65 @@ std::optional<uint32_t> ebpf_domain_t::get_map_inner_map_fd(const Reg& map_fd_re
 }
 
 // We can deal with a range of key sizes.
-crab::interval_t ebpf_domain_t::get_map_key_size(const Reg& map_fd_reg) const {
+interval_t ebpf_domain_t::get_map_key_size(const Reg& map_fd_reg) const {
     int start_fd, end_fd;
     if (!get_map_fd_range(map_fd_reg, &start_fd, &end_fd)) {
-        return crab::interval_t::top();
+        return interval_t::top();
     }
 
-    crab::interval_t result = crab::interval_t::bottom();
+    interval_t result = interval_t::bottom();
     for (int map_fd = start_fd; map_fd <= end_fd; map_fd++) {
-        if (EbpfMapDescriptor* map = &global_program_info->platform->get_map_descriptor(map_fd)) {
-            result = result | crab::interval_t(number_t(map->key_size));
+        if (const EbpfMapDescriptor* map = &global_program_info->platform->get_map_descriptor(map_fd)) {
+            result = result | interval_t(number_t(map->key_size));
         } else {
-            return crab::interval_t::top();
+            return interval_t::top();
         }
     }
     return result;
 }
 
 // We can deal with a range of value sizes.
-crab::interval_t ebpf_domain_t::get_map_value_size(const Reg& map_fd_reg) const {
+interval_t ebpf_domain_t::get_map_value_size(const Reg& map_fd_reg) const {
     int start_fd, end_fd;
     if (!get_map_fd_range(map_fd_reg, &start_fd, &end_fd)) {
-        return crab::interval_t::top();
+        return interval_t::top();
     }
 
-    crab::interval_t result = crab::interval_t::bottom();
+    interval_t result = interval_t::bottom();
     for (int map_fd = start_fd; map_fd <= end_fd; map_fd++) {
-        if (EbpfMapDescriptor* map = &global_program_info->platform->get_map_descriptor(map_fd)) {
-            result = result | crab::interval_t(number_t(map->value_size));
+        if (const EbpfMapDescriptor* map = &global_program_info->platform->get_map_descriptor(map_fd)) {
+            result = result | interval_t(number_t(map->value_size));
         } else {
-            return crab::interval_t::top();
+            return interval_t::top();
         }
     }
     return result;
 }
 
 // We can deal with a range of max_entries values.
-crab::interval_t ebpf_domain_t::get_map_max_entries(const Reg& map_fd_reg) const {
+interval_t ebpf_domain_t::get_map_max_entries(const Reg& map_fd_reg) const {
     int start_fd, end_fd;
     if (!get_map_fd_range(map_fd_reg, &start_fd, &end_fd)) {
-        return crab::interval_t::top();
+        return interval_t::top();
     }
 
-    crab::interval_t result = crab::interval_t::bottom();
+    interval_t result = interval_t::bottom();
     for (int map_fd = start_fd; map_fd <= end_fd; map_fd++) {
-        if (EbpfMapDescriptor* map = &global_program_info->platform->get_map_descriptor(map_fd)) {
-            result = result | crab::interval_t(number_t(map->max_entries));
+        if (const EbpfMapDescriptor* map = &global_program_info->platform->get_map_descriptor(map_fd)) {
+            result = result | interval_t(number_t(map->max_entries));
         } else {
-            return crab::interval_t::top();
+            return interval_t::top();
         }
     }
     return result;
 }
 
 void ebpf_domain_t::operator()(const ValidCall& s) {
+    if (!m_inv) {
+        return;
+    }
     if (!s.stack_frame_prefix.empty()) {
-        EbpfHelperPrototype proto = global_program_info->platform->get_helper_prototype(s.func);
+        const EbpfHelperPrototype proto = global_program_info->platform->get_helper_prototype(s.func);
         if (proto.return_type == EBPF_RETURN_TYPE_INTEGER_OR_NO_RETURN_IF_SUCCEED) {
             require(m_inv, linear_constraint_t::false_const(), "tail call not supported in subprogram");
             return;
@@ -1815,25 +1033,28 @@ void ebpf_domain_t::operator()(const ValidCall& s) {
 
 void ebpf_domain_t::operator()(const ValidMapKeyValue& s) {
     using namespace crab::dsl_syntax;
+    if (!m_inv) {
+        return;
+    }
 
-    auto fd_type = get_map_type(s.map_fd_reg);
+    const auto fd_type = get_map_type(s.map_fd_reg);
 
-    auto access_reg = reg_pack(s.access_reg);
+    const auto access_reg = reg_pack(s.access_reg);
     int width;
     if (s.key) {
-        auto key_size = get_map_key_size(s.map_fd_reg).singleton();
+        const auto key_size = get_map_key_size(s.map_fd_reg).singleton();
         if (!key_size.has_value()) {
             require(m_inv, linear_constraint_t::false_const(), "Map key size is not singleton");
             return;
         }
-        width = (int)key_size.value();
+        width = static_cast<int>(key_size.value());
     } else {
-        auto value_size = get_map_value_size(s.map_fd_reg).singleton();
+        const auto value_size = get_map_value_size(s.map_fd_reg).singleton();
         if (!value_size.has_value()) {
             require(m_inv, linear_constraint_t::false_const(), "Map value size is not singleton");
             return;
         }
-        width = (int)value_size.value();
+        width = static_cast<int>(value_size.value());
     }
 
     m_inv = type_inv.join_over_types(m_inv, s.access_reg, [&](NumAbsDomain& inv, type_encoding_t access_reg_type) {
@@ -1842,9 +1063,9 @@ void ebpf_domain_t::operator()(const ValidMapKeyValue& s) {
             linear_expression_t ub = lb + width;
             if (!stack.all_num(inv, lb, ub)) {
                 auto lb_is = inv[lb].lb().number();
-                std::string lb_s = lb_is && lb_is->fits_sint32() ? std::to_string((int32_t)*lb_is) : "-oo";
+                std::string lb_s = lb_is && lb_is->fits_sint32() ? std::to_string(static_cast<int32_t>(*lb_is)) : "-oo";
                 auto ub_is = inv.eval_interval(ub).ub().number();
-                std::string ub_s = ub_is && ub_is->fits_sint32() ? std::to_string((int32_t)*ub_is) : "oo";
+                std::string ub_s = ub_is && ub_is->fits_sint32() ? std::to_string(static_cast<int32_t>(*ub_is)) : "oo";
                 require(inv, linear_constraint_t::false_const(),
                         "Illegal map update with a non-numerical value [" + lb_s + "-" + ub_s + ")");
             } else if (thread_local_options.strict && fd_type.has_value()) {
@@ -1888,10 +1109,13 @@ void ebpf_domain_t::operator()(const ValidMapKeyValue& s) {
 
 void ebpf_domain_t::operator()(const ValidAccess& s) {
     using namespace crab::dsl_syntax;
+    if (!m_inv) {
+        return;
+    }
 
-    bool is_comparison_check = s.width == (Value)Imm{0};
+    const bool is_comparison_check = s.width == static_cast<Value>(Imm{0});
 
-    auto reg = reg_pack(s.reg);
+    const auto reg = reg_pack(s.reg);
     // join_over_types instead of simple iteration is only needed for assume-assert
     m_inv = type_inv.join_over_types(m_inv, s.reg, [&](NumAbsDomain& inv, type_encoding_t type) {
         switch (type) {
@@ -1919,7 +1143,8 @@ void ebpf_domain_t::operator()(const ValidAccess& s) {
                     if (s.offset < 0) {
                         require(inv, linear_constraint_t::false_const(), "Stack content is not numeric");
                     } else if (std::holds_alternative<Imm>(s.width)) {
-                        if (!inv.entail(((int)std::get<Imm>(s.width).v) <= reg.stack_numeric_size - s.offset)) {
+                        if (!inv.entail(static_cast<int>(std::get<Imm>(s.width).v) <=
+                                        reg.stack_numeric_size - s.offset)) {
                             require(inv, linear_constraint_t::false_const(), "Stack content is not numeric");
                         }
                     } else {
@@ -1974,12 +1199,18 @@ void ebpf_domain_t::operator()(const ValidAccess& s) {
 }
 
 void ebpf_domain_t::operator()(const ZeroCtxOffset& s) {
+    if (!m_inv) {
+        return;
+    }
     using namespace crab::dsl_syntax;
-    auto reg = reg_pack(s.reg);
+    const auto reg = reg_pack(s.reg);
     require(m_inv, reg.ctx_offset == 0, "Nonzero context offset");
 }
 
 void ebpf_domain_t::operator()(const Assert& stmt) {
+    if (!m_inv) {
+        return;
+    }
     if (check_require || thread_local_options.assume_assertions) {
         this->current_assertion = to_string(stmt.cst);
         std::visit(*this, stmt.cst);
@@ -1988,8 +1219,11 @@ void ebpf_domain_t::operator()(const Assert& stmt) {
 }
 
 void ebpf_domain_t::operator()(const Packet& a) {
-    auto reg = reg_pack(R0_RETURN_VALUE);
-    Reg r0_reg{(uint8_t)R0_RETURN_VALUE};
+    if (!m_inv) {
+        return;
+    }
+    const auto reg = reg_pack(R0_RETURN_VALUE);
+    constexpr Reg r0_reg{R0_RETURN_VALUE};
     type_inv.assign_type(m_inv, r0_reg, T_NUM);
     havoc_offsets(r0_reg);
     havoc(reg.svalue);
@@ -1997,8 +1231,8 @@ void ebpf_domain_t::operator()(const Packet& a) {
     scratch_caller_saved_registers();
 }
 
-void ebpf_domain_t::do_load_stack(NumAbsDomain& inv, const Reg& target_reg, const linear_expression_t& addr, int width,
-                                  const Reg& src_reg) {
+void ebpf_domain_t::do_load_stack(NumAbsDomain& inv, const Reg& target_reg, const linear_expression_t& addr,
+                                  const int width, const Reg& src_reg) {
     type_inv.assign_type(inv, target_reg, stack.load(inv, data_kind_t::types, addr, width));
     using namespace crab::dsl_syntax;
     if (inv.entail(width <= reg_pack(src_reg).stack_numeric_size)) {
@@ -2009,8 +1243,8 @@ void ebpf_domain_t::do_load_stack(NumAbsDomain& inv, const Reg& target_reg, cons
     if (width == 1 || width == 2 || width == 4 || width == 8) {
         // Use the addr before we havoc the destination register since we might be getting the
         // addr from that same register.
-        std::optional<linear_expression_t> sresult = stack.load(inv, data_kind_t::svalues, addr, width);
-        std::optional<linear_expression_t> uresult = stack.load(inv, data_kind_t::uvalues, addr, width);
+        const std::optional<linear_expression_t> sresult = stack.load(inv, data_kind_t::svalues, addr, width);
+        const std::optional<linear_expression_t> uresult = stack.load(inv, data_kind_t::uvalues, addr, width);
         havoc_register(inv, target_reg);
         inv.assign(target.svalue, sresult);
         inv.assign(target.uvalue, uresult);
@@ -2038,7 +1272,7 @@ void ebpf_domain_t::do_load_stack(NumAbsDomain& inv, const Reg& target_reg, cons
 }
 
 void ebpf_domain_t::do_load_ctx(NumAbsDomain& inv, const Reg& target_reg, const linear_expression_t& addr_vague,
-                                int width) {
+                                const int width) {
     using namespace crab::dsl_syntax;
     if (inv.is_bottom()) {
         return;
@@ -2054,11 +1288,11 @@ void ebpf_domain_t::do_load_ctx(NumAbsDomain& inv, const Reg& target_reg, const 
         return;
     }
 
-    crab::interval_t interval = inv.eval_interval(addr_vague);
-    std::optional<number_t> maybe_addr = interval.singleton();
+    const interval_t interval = inv.eval_interval(addr_vague);
+    const std::optional<number_t> maybe_addr = interval.singleton();
     havoc_register(inv, target_reg);
 
-    bool may_touch_ptr = interval[desc->data] || interval[desc->meta] || interval[desc->end];
+    const bool may_touch_ptr = interval[desc->data] || interval[desc->meta] || interval[desc->end];
 
     if (!maybe_addr) {
         if (may_touch_ptr) {
@@ -2069,13 +1303,13 @@ void ebpf_domain_t::do_load_ctx(NumAbsDomain& inv, const Reg& target_reg, const 
         return;
     }
 
-    number_t addr = *maybe_addr;
+    const number_t addr = *maybe_addr;
 
     // We use offsets for packet data, data_end, and meta during verification,
     // but at runtime they will be 64-bit pointers.  We can use the offset values
     // for verification like we use map_fd's as a proxy for maps which
     // at runtime are actually 64-bit memory pointers.
-    int offset_width = desc->end - desc->data;
+    const int offset_width = desc->end - desc->data;
     if (addr == desc->data) {
         if (width == offset_width) {
             inv.assign(target.packet_offset, 0);
@@ -2104,7 +1338,7 @@ void ebpf_domain_t::do_load_ctx(NumAbsDomain& inv, const Reg& target_reg, const 
 }
 
 void ebpf_domain_t::do_load_packet_or_shared(NumAbsDomain& inv, const Reg& target_reg, const linear_expression_t& addr,
-                                             int width) {
+                                             const int width) {
     if (inv.is_bottom()) {
         return;
     }
@@ -2115,23 +1349,23 @@ void ebpf_domain_t::do_load_packet_or_shared(NumAbsDomain& inv, const Reg& targe
 
     // A 1 or 2 byte copy results in a limited range of values that may be used as array indices.
     if (width == 1) {
-        inv.set(target.svalue, crab::interval_t(number_t{0}, number_t{UINT8_MAX}));
-        inv.set(target.uvalue, crab::interval_t(number_t{0}, number_t{UINT8_MAX}));
+        inv.set(target.svalue, interval_t(number_t{0}, number_t{UINT8_MAX}));
+        inv.set(target.uvalue, interval_t(number_t{0}, number_t{UINT8_MAX}));
     } else if (width == 2) {
-        inv.set(target.svalue, crab::interval_t(number_t{0}, number_t{UINT16_MAX}));
-        inv.set(target.uvalue, crab::interval_t(number_t{0}, number_t{UINT16_MAX}));
+        inv.set(target.svalue, interval_t(number_t{0}, number_t{UINT16_MAX}));
+        inv.set(target.uvalue, interval_t(number_t{0}, number_t{UINT16_MAX}));
     }
 }
 
 void ebpf_domain_t::do_load(const Mem& b, const Reg& target_reg) {
     using namespace crab::dsl_syntax;
 
-    auto mem_reg = reg_pack(b.access.basereg);
-    int width = b.access.width;
-    int offset = b.access.offset;
+    const auto mem_reg = reg_pack(b.access.basereg);
+    const int width = b.access.width;
+    const int offset = b.access.offset;
 
     if (b.access.basereg.v == R10_STACK_POINTER) {
-        linear_expression_t addr = mem_reg.stack_offset + (number_t)offset;
+        const linear_expression_t addr = mem_reg.stack_offset + (number_t)offset;
         do_load_stack(m_inv, target_reg, addr, width, b.access.basereg);
         return;
     }
@@ -2238,12 +1472,13 @@ void ebpf_domain_t::do_store_stack(NumAbsDomain& inv, const number_t& width, con
     // stack_numeric_size holds the number of continuous bytes starting from stack_offset that are known to be numeric.
     auto updated_lb = m_inv.eval_interval(addr).lb();
     auto updated_ub = m_inv.eval_interval(addr).ub() + width;
-    for (variable_t type_variable : variable_t::get_type_variables()) {
+    for (const variable_t type_variable : variable_t::get_type_variables()) {
         if (!type_inv.has_type(inv, type_variable, T_STACK)) {
             continue;
         }
-        variable_t stack_offset_variable = variable_t::kind_var(data_kind_t::stack_offsets, type_variable);
-        variable_t stack_numeric_size_variable = variable_t::kind_var(data_kind_t::stack_numeric_sizes, type_variable);
+        const variable_t stack_offset_variable = variable_t::kind_var(data_kind_t::stack_offsets, type_variable);
+        const variable_t stack_numeric_size_variable =
+            variable_t::kind_var(data_kind_t::stack_numeric_sizes, type_variable);
 
         using namespace crab::dsl_syntax;
         // See if the variable's numeric interval overlaps with changed bytes.
@@ -2256,20 +1491,20 @@ void ebpf_domain_t::do_store_stack(NumAbsDomain& inv, const number_t& width, con
 }
 
 void ebpf_domain_t::operator()(const Mem& b) {
-    if (m_inv.is_bottom()) {
+    if (!m_inv) {
         return;
     }
     if (std::holds_alternative<Reg>(b.value)) {
         if (b.is_load) {
             do_load(b, std::get<Reg>(b.value));
         } else {
-            auto data = std::get<Reg>(b.value);
+            const auto data = std::get<Reg>(b.value);
             auto data_reg = reg_pack(data);
             do_mem_store(b, data, data_reg.svalue, data_reg.uvalue, data_reg);
         }
     } else {
-        do_mem_store(b, number_t{T_NUM}, number_t{(int64_t)std::get<Imm>(b.value).v},
-                     number_t{(uint64_t)std::get<Imm>(b.value).v}, {});
+        do_mem_store(b, number_t{T_NUM}, number_t{static_cast<int64_t>(std::get<Imm>(b.value).v)},
+                     number_t{static_cast<uint64_t>(std::get<Imm>(b.value).v)}, {});
     }
 }
 
@@ -2280,15 +1515,15 @@ void ebpf_domain_t::do_mem_store(const Mem& b, Type val_type, SValue val_svalue,
         return;
     }
     int width = b.access.width;
-    number_t offset{b.access.offset};
+    const number_t offset{b.access.offset};
     if (b.access.basereg.v == R10_STACK_POINTER) {
-        number_t base_addr{EBPF_STACK_SIZE};
+        const number_t base_addr{EBPF_STACK_SIZE};
         do_store_stack(m_inv, width, base_addr + offset, val_type, val_svalue, val_uvalue, val_reg);
         return;
     }
-    m_inv = type_inv.join_over_types(m_inv, b.access.basereg, [&](NumAbsDomain& inv, type_encoding_t type) {
+    m_inv = type_inv.join_over_types(m_inv, b.access.basereg, [&](NumAbsDomain& inv, const type_encoding_t type) {
         if (type == T_STACK) {
-            linear_expression_t base_addr =
+            const linear_expression_t base_addr =
                 linear_expression_t(get_type_offset_variable(b.access.basereg, type).value());
             do_store_stack(inv, width, crab::dsl_syntax::operator+(base_addr, offset), val_type, val_svalue, val_uvalue,
                            val_reg);
@@ -2332,7 +1567,7 @@ void ebpf_domain_t::operator()(const Atomic& a) {
     }
 
     // Fetch the current value into the R11 pseudo-register.
-    const Reg r11{R11_ATOMIC_SCRATCH};
+    constexpr Reg r11{R11_ATOMIC_SCRATCH};
     (*this)(Mem{.access = a.access, .value = r11, .is_load = true});
 
     // Compute the new value in R11.
@@ -2398,7 +1633,7 @@ void ebpf_domain_t::operator()(const Call& call) {
             variable_t addr = variable.value();
             variable_t width = reg_pack(param.size).svalue;
 
-            m_inv = type_inv.join_over_types(m_inv, param.mem, [&](NumAbsDomain& inv, type_encoding_t type) {
+            m_inv = type_inv.join_over_types(m_inv, param.mem, [&](NumAbsDomain& inv, const type_encoding_t type) {
                 if (type == T_STACK) {
                     // Pointer to a memory region that the called function may change,
                     // so we must havoc.
@@ -2424,28 +1659,28 @@ void ebpf_domain_t::operator()(const Call& call) {
         }
     }
 
-    Reg r0_reg{(uint8_t)R0_RETURN_VALUE};
-    auto r0_pack = reg_pack(r0_reg);
+    constexpr Reg r0_reg{(uint8_t)R0_RETURN_VALUE};
+    const auto r0_pack = reg_pack(r0_reg);
     havoc(r0_pack.stack_numeric_size);
     if (call.is_map_lookup) {
         // This is the only way to get a null pointer
         if (maybe_fd_reg) {
-            if (auto map_type = get_map_type(*maybe_fd_reg)) {
+            if (const auto map_type = get_map_type(*maybe_fd_reg)) {
                 if (global_program_info->platform->get_map_type(*map_type).value_type == EbpfMapValueType::MAP) {
-                    if (auto inner_map_fd = get_map_inner_map_fd(*maybe_fd_reg)) {
-                        do_load_mapfd(r0_reg, (int)*inner_map_fd, true);
+                    if (const auto inner_map_fd = get_map_inner_map_fd(*maybe_fd_reg)) {
+                        do_load_mapfd(r0_reg, static_cast<int>(*inner_map_fd), true);
                         goto out;
                     }
                 } else {
                     assign_valid_ptr(r0_reg, true);
-                    assign(r0_pack.shared_offset, 0);
+                    m_inv.assign(r0_pack.shared_offset, 0);
                     m_inv.set(r0_pack.shared_region_size, get_map_value_size(*maybe_fd_reg));
                     type_inv.assign_type(m_inv, r0_reg, T_SHARED);
                 }
             }
         }
         assign_valid_ptr(r0_reg, true);
-        assign(r0_pack.shared_offset, 0);
+        m_inv->assign(r0_pack.shared_offset, 0);
         type_inv.assign_type(m_inv, r0_reg, T_SHARED);
     } else {
         havoc(r0_pack.svalue);
@@ -2477,22 +1712,22 @@ void ebpf_domain_t::operator()(const Callx& callx) {
 
     // Look up the helper function id.
     const reg_pack_t& reg = reg_pack(callx.func);
-    auto src_interval = m_inv.eval_interval(reg.svalue);
-    if (auto sn = src_interval.singleton()) {
+    const auto src_interval = m_inv.eval_interval(reg.svalue);
+    if (const auto sn = src_interval.singleton()) {
         if (sn->fits_sint32()) {
             // We can now process it as if the id was immediate.
-            int32_t imm = sn->cast_to_sint32();
+            const int32_t imm = sn->cast_to_sint32();
             if (!global_program_info->platform->is_helper_usable(imm)) {
                 return;
             }
-            Call call = make_call(imm, *global_program_info->platform);
+            const Call call = make_call(imm, *global_program_info->platform);
             (*this)(call);
             return;
         }
     }
 }
 
-void ebpf_domain_t::do_load_mapfd(const Reg& dst_reg, int mapfd, bool maybe_null) {
+void ebpf_domain_t::do_load_mapfd(const Reg& dst_reg, const int mapfd, const bool maybe_null) {
     const EbpfMapDescriptor& desc = global_program_info->platform->get_map_descriptor(mapfd);
     const EbpfMapType& type = global_program_info->platform->get_map_type(desc.type);
     if (type.value_type == EbpfMapValueType::PROGRAM) {
@@ -2501,13 +1736,18 @@ void ebpf_domain_t::do_load_mapfd(const Reg& dst_reg, int mapfd, bool maybe_null
         type_inv.assign_type(m_inv, dst_reg, T_MAP);
     }
     const reg_pack_t& dst = reg_pack(dst_reg);
-    assign(dst.map_fd, mapfd);
+    m_inv->assign(dst.map_fd, mapfd);
     assign_valid_ptr(dst_reg, maybe_null);
 }
 
-void ebpf_domain_t::operator()(const LoadMapFd& ins) { do_load_mapfd(ins.dst, ins.mapfd, false); }
+void ebpf_domain_t::operator()(const LoadMapFd& ins) {
+    if (!m_inv) {
+        return;
+    }
+    do_load_mapfd(ins.dst, ins.mapfd, false);
+}
 
-void ebpf_domain_t::assign_valid_ptr(const Reg& dst_reg, bool maybe_null) {
+void ebpf_domain_t::assign_valid_ptr(const Reg& dst_reg, const bool maybe_null) {
     using namespace crab::dsl_syntax;
     const reg_pack_t& reg = reg_pack(dst_reg);
     havoc(reg.svalue);
@@ -2518,40 +1758,42 @@ void ebpf_domain_t::assign_valid_ptr(const Reg& dst_reg, bool maybe_null) {
         m_inv += 0 < reg.svalue;
     }
     m_inv += reg.svalue <= PTR_MAX;
-    assign(reg.uvalue, reg.svalue);
+    m_inv->assign(reg.uvalue, reg.svalue);
 }
 
 // If nothing is known of the stack_numeric_size,
 // try to recompute the stack_numeric_size.
-void ebpf_domain_t::recompute_stack_numeric_size(NumAbsDomain& inv, variable_t type_variable) {
-    variable_t stack_numeric_size_variable = variable_t::kind_var(data_kind_t::stack_numeric_sizes, type_variable);
+void ebpf_domain_t::recompute_stack_numeric_size(NumAbsDomain& inv, const variable_t type_variable) const {
+    const variable_t stack_numeric_size_variable =
+        variable_t::kind_var(data_kind_t::stack_numeric_sizes, type_variable);
 
     if (!inv.eval_interval(stack_numeric_size_variable).is_top()) {
         return;
     }
 
     if (type_inv.has_type(inv, type_variable, T_STACK)) {
-        int numeric_size = stack.min_all_num_size(inv, variable_t::kind_var(data_kind_t::stack_offsets, type_variable));
+        const int numeric_size =
+            stack.min_all_num_size(inv, variable_t::kind_var(data_kind_t::stack_offsets, type_variable));
         if (numeric_size > 0) {
             inv.assign(stack_numeric_size_variable, numeric_size);
         }
     }
 }
 
-void ebpf_domain_t::recompute_stack_numeric_size(NumAbsDomain& inv, const Reg& reg) {
+void ebpf_domain_t::recompute_stack_numeric_size(NumAbsDomain& inv, const Reg& reg) const {
     recompute_stack_numeric_size(inv, reg_pack(reg).type);
 }
 
-void ebpf_domain_t::add(const Reg& reg, int imm, int finite_width) {
-    auto dst = reg_pack(reg);
-    auto offset = get_type_offset_variable(reg);
-    add_overflow(dst.svalue, dst.uvalue, imm, finite_width);
+void ebpf_domain_t::add(const Reg& reg, const int imm, const int finite_width) {
+    const auto dst = reg_pack(reg);
+    const auto offset = get_type_offset_variable(reg);
+    m_inv->add_overflow(dst.svalue, dst.uvalue, imm, finite_width);
     if (offset.has_value()) {
-        add(offset.value(), imm);
+        m_inv->add(offset.value(), imm);
         if (imm > 0) {
             // Since the start offset is increasing but
             // the end offset is not, the numeric size decreases.
-            sub(dst.stack_numeric_size, imm);
+            m_inv->sub(dst.stack_numeric_size, imm);
         } else if (imm < 0) {
             havoc(dst.stack_numeric_size);
         }
@@ -2559,87 +1801,31 @@ void ebpf_domain_t::add(const Reg& reg, int imm, int finite_width) {
     }
 }
 
-void ebpf_domain_t::shl(const Reg& dst_reg, int imm, int finite_width) {
-    reg_pack_t dst = reg_pack(dst_reg);
-
-    // The BPF ISA requires masking the imm.
-    imm &= finite_width - 1;
+void ebpf_domain_t::shl(const Reg& dst_reg, int imm, const int finite_width) {
+    const reg_pack_t dst = reg_pack(dst_reg);
 
     if (m_inv.entail(type_is_number(dst))) {
-        auto interval = m_inv.eval_interval(dst.uvalue);
-        if (interval.finite_size()) {
-            number_t lb = interval.lb().number().value();
-            number_t ub = interval.ub().number().value();
-            uint64_t lb_n = lb.cast_to_uint64();
-            uint64_t ub_n = ub.cast_to_uint64();
-            uint64_t uint_max = (finite_width == 64) ? UINT64_MAX : UINT32_MAX;
-            if ((lb_n >> (finite_width - imm)) != (ub_n >> (finite_width - imm))) {
-                // The bits that will be shifted out to the left are different,
-                // which means all combinations of remaining bits are possible.
-                lb_n = 0;
-                ub_n = (uint_max << imm) & uint_max;
-            } else {
-                // The bits that will be shifted out to the left are identical
-                // for all values in the interval, so we can safely shift left
-                // to get a new interval.
-                lb_n = (lb_n << imm) & uint_max;
-                ub_n = (ub_n << imm) & uint_max;
-            }
-            m_inv.set(dst.uvalue, crab::interval_t{number_t(lb_n), number_t(ub_n)});
-            if ((int64_t)ub_n >= (int64_t)lb_n) {
-                m_inv.assign(dst.svalue, dst.uvalue);
-            } else {
-                havoc(dst.svalue);
-            }
-            return;
-        }
+        m_inv->shl(dst.svalue, dst.uvalue, imm, finite_width);
+    } else {
+        // The BPF ISA requires masking the imm.
+        imm &= finite_width - 1;
+        m_inv->shl_overflow(dst.svalue, dst.uvalue, imm);
     }
-    shl_overflow(dst.svalue, dst.uvalue, imm);
     havoc_offsets(dst_reg);
 }
 
-void ebpf_domain_t::lshr(const Reg& dst_reg, int imm, int finite_width) {
-    reg_pack_t dst = reg_pack(dst_reg);
-
-    // The BPF ISA requires masking the imm.
-    imm &= finite_width - 1;
-
+void ebpf_domain_t::lshr(const Reg& dst_reg, const int imm, const int finite_width) {
+    const reg_pack_t dst = reg_pack(dst_reg);
     if (m_inv.entail(type_is_number(dst))) {
-        auto interval = m_inv.eval_interval(dst.uvalue);
-        number_t lb_n{0};
-        number_t ub_n{UINT64_MAX >> imm};
-        if (interval.finite_size()) {
-            number_t lb = interval.lb().number().value();
-            number_t ub = interval.ub().number().value();
-            if (finite_width == 64) {
-                lb_n = lb.cast_to_uint64() >> imm;
-                ub_n = ub.cast_to_uint64() >> imm;
-            } else {
-                number_t lb_w = lb.cast_to_signed_finite_width(finite_width);
-                number_t ub_w = ub.cast_to_signed_finite_width(finite_width);
-                lb_n = lb_w.cast_to_uint32() >> imm;
-                ub_n = ub_w.cast_to_uint32() >> imm;
-
-                // The interval must be valid since a signed range crossing 0
-                // was earlier converted to a full unsigned range.
-                assert(lb_n <= ub_n);
-            }
-        }
-        m_inv.set(dst.uvalue, crab::interval_t{lb_n, ub_n});
-        if ((int64_t)ub_n >= (int64_t)lb_n) {
-            // ? m_inv.set(dst.svalue, crab::interval_t{number_t{(int64_t)lb_n}, number_t{(int64_t)ub_n}});
-            m_inv.assign(dst.svalue, dst.uvalue);
-        } else {
-            havoc(dst.svalue);
-        }
-        return;
+        m_inv->lshr(dst.svalue, dst.uvalue, imm, finite_width);
+    } else {
+        havoc(dst.svalue);
+        havoc(dst.uvalue);
+        havoc_offsets(dst_reg);
     }
-    havoc(dst.svalue);
-    havoc(dst.uvalue);
-    havoc_offsets(dst_reg);
 }
 
-static inline int _movsx_bits(Bin::Op op) {
+static int _movsx_bits(const Bin::Op op) {
     switch (op) {
     case Bin::Op::MOVSX8: return 8;
     case Bin::Op::MOVSX16: return 16;
@@ -2648,94 +1834,26 @@ static inline int _movsx_bits(Bin::Op op) {
     }
 }
 
-void ebpf_domain_t::sign_extend(const Reg& dst_reg, const linear_expression_t& right_svalue, int finite_width,
-                                Bin::Op op) {
+void ebpf_domain_t::ashr(const Reg& dst_reg, const linear_expression_t& right_svalue, const int finite_width) {
     using namespace crab;
 
-    int bits = _movsx_bits(op);
-    reg_pack_t dst = reg_pack(dst_reg);
-    interval_t right_interval = m_inv.eval_interval(right_svalue);
-    type_inv.assign_type(m_inv, dst_reg, T_NUM);
-    havoc_offsets(dst_reg);
-    int64_t span = 1ULL << bits;
-    if (right_interval.ub() - right_interval.lb() >= number_t{span}) {
-        // Interval covers the full space.
-        if (bits == 64) {
-            havoc(dst.svalue);
-            return;
-        }
-        right_interval = interval_t::signed_int(bits);
-    }
-    int64_t mask = 1ULL << (bits - 1);
-
-    // Sign extend each bound.
-    int64_t lb = right_interval.lb().number().value().cast_to_sint64();
-    lb &= (span - 1);
-    lb = (lb ^ mask) - mask;
-    int64_t ub = right_interval.ub().number().value().cast_to_sint64();
-    ub &= (span - 1);
-    ub = (ub ^ mask) - mask;
-    m_inv.set(dst.svalue, crab::interval_t{number_t{lb}, number_t{ub}});
-
-    if (finite_width) {
-        m_inv.assign(dst.uvalue, dst.svalue);
-        overflow_signed(m_inv, dst.svalue, finite_width);
-        overflow_unsigned(m_inv, dst.uvalue, finite_width);
-    }
-}
-
-void ebpf_domain_t::ashr(const Reg& dst_reg, const linear_expression_t& right_svalue, int finite_width) {
-    using namespace crab;
-
-    reg_pack_t dst = reg_pack(dst_reg);
-    if (m_inv.entail(type_is_number(dst))) {
-        interval_t left_interval = interval_t::bottom();
-        interval_t right_interval = interval_t::bottom();
-        interval_t left_interval_positive = interval_t::bottom();
-        interval_t left_interval_negative = interval_t::bottom();
-        get_signed_intervals(m_inv, (finite_width == 64), dst.svalue, dst.uvalue, right_svalue, left_interval,
-                             right_interval, left_interval_positive, left_interval_negative);
-        if (auto sn = right_interval.singleton()) {
-            // The BPF ISA requires masking the imm.
-            int64_t imm = sn->cast_to_sint64() & (finite_width - 1);
-
-            int64_t lb_n = INT64_MIN >> imm;
-            int64_t ub_n = INT64_MAX >> imm;
-            if (left_interval.finite_size()) {
-                number_t lb = left_interval.lb().number().value();
-                number_t ub = left_interval.ub().number().value();
-                if (finite_width == 64) {
-                    lb_n = lb.cast_to_sint64() >> imm;
-                    ub_n = ub.cast_to_sint64() >> imm;
-                } else {
-                    number_t lb_w = lb.cast_to_signed_finite_width(finite_width) >> (int)imm;
-                    number_t ub_w = ub.cast_to_signed_finite_width(finite_width) >> (int)imm;
-                    if (lb_w.cast_to_uint32() <= ub_w.cast_to_uint32()) {
-                        lb_n = lb_w.cast_to_uint32();
-                        ub_n = ub_w.cast_to_uint32();
-                    }
-                }
-            }
-            m_inv.set(dst.svalue, crab::interval_t{number_t{lb_n}, number_t{ub_n}});
-            if ((uint64_t)ub_n >= (uint64_t)lb_n) {
-                m_inv.assign(dst.uvalue, dst.svalue);
-            } else {
-                havoc(dst.uvalue);
-            }
+    const reg_pack_t dst = reg_pack(dst_reg);
+    if (m_inv->entail(type_is_number(dst))) {
+        if (m_inv->ashr(dst.svalue, dst.uvalue, right_svalue, finite_width)) {
             return;
         }
     }
-    havoc(dst.svalue);
-    havoc(dst.uvalue);
     havoc_offsets(dst_reg);
 }
 
 void ebpf_domain_t::operator()(const Bin& bin) {
     using namespace crab::dsl_syntax;
+    if (!m_inv) {
+        return;
+    }
 
     auto dst = reg_pack(bin.dst);
-    int finite_width = (bin.is64) ? 64 : 32;
-
+    int finite_width = bin.is64 ? 64 : 32;
     if (std::holds_alternative<Imm>(bin.v)) {
         // dst += K
         int64_t imm;
@@ -2745,13 +1863,13 @@ void ebpf_domain_t::operator()(const Bin& bin) {
         } else {
             // Use only the low 32 bits of the value.
             imm = static_cast<int>(std::get<Imm>(bin.v).v);
-            bitwise_and(dst.svalue, dst.uvalue, UINT32_MAX);
+            m_inv->bitwise_and(dst.svalue, dst.uvalue, UINT32_MAX);
         }
         switch (bin.op) {
         case Bin::Op::MOV:
-            assign(dst.svalue, imm);
-            assign(dst.uvalue, imm);
-            overflow_unsigned(m_inv, dst.uvalue, (bin.is64) ? 64 : 32);
+            m_inv->assign(dst.svalue, imm);
+            m_inv->assign(dst.uvalue, imm);
+            m_inv->overflow_unsigned(dst.uvalue, (bin.is64) ? 64 : 32);
             type_inv.assign_type(m_inv, bin.dst, T_NUM);
             havoc_offsets(bin.dst);
             break;
@@ -2759,42 +1877,42 @@ void ebpf_domain_t::operator()(const Bin& bin) {
             if (imm == 0) {
                 return;
             }
-            add(bin.dst, (int)imm, finite_width);
+            add(bin.dst, static_cast<int>(imm), finite_width);
             break;
         case Bin::Op::SUB:
             if (imm == 0) {
                 return;
             }
-            add(bin.dst, (int)-imm, finite_width);
+            add(bin.dst, static_cast<int>(-imm), finite_width);
             break;
         case Bin::Op::MUL:
-            mul(dst.svalue, dst.uvalue, imm, finite_width);
+            m_inv->mul(dst.svalue, dst.uvalue, imm, finite_width);
             havoc_offsets(bin.dst);
             break;
         case Bin::Op::UDIV:
-            udiv(dst.svalue, dst.uvalue, imm, finite_width);
+            m_inv->udiv(dst.svalue, dst.uvalue, imm, finite_width);
             havoc_offsets(bin.dst);
             break;
         case Bin::Op::UMOD:
-            urem(dst.svalue, dst.uvalue, imm, finite_width);
+            m_inv->urem(dst.svalue, dst.uvalue, imm, finite_width);
             havoc_offsets(bin.dst);
             break;
         case Bin::Op::SDIV:
-            sdiv(dst.svalue, dst.uvalue, imm, finite_width);
+            m_inv->sdiv(dst.svalue, dst.uvalue, imm, finite_width);
             havoc_offsets(bin.dst);
             break;
         case Bin::Op::SMOD:
-            srem(dst.svalue, dst.uvalue, imm, finite_width);
+            m_inv->srem(dst.svalue, dst.uvalue, imm, finite_width);
             havoc_offsets(bin.dst);
             break;
         case Bin::Op::OR:
-            bitwise_or(dst.svalue, dst.uvalue, imm);
+            m_inv->bitwise_or(dst.svalue, dst.uvalue, imm);
             havoc_offsets(bin.dst);
             break;
         case Bin::Op::AND:
             // FIX: what to do with ptr&-8 as in counter/simple_loop_unrolled?
-            bitwise_and(dst.svalue, dst.uvalue, imm);
-            if ((int32_t)imm > 0) {
+            m_inv->bitwise_and(dst.svalue, dst.uvalue, imm);
+            if (static_cast<int32_t>(imm) > 0) {
                 // AND with immediate is only a 32-bit operation so svalue and uvalue are the same.
                 assume(dst.svalue <= imm);
                 assume(dst.uvalue <= imm);
@@ -2803,11 +1921,11 @@ void ebpf_domain_t::operator()(const Bin& bin) {
             }
             havoc_offsets(bin.dst);
             break;
-        case Bin::Op::LSH: shl(bin.dst, (int32_t)imm, finite_width); break;
-        case Bin::Op::RSH: lshr(bin.dst, (int32_t)imm, finite_width); break;
-        case Bin::Op::ARSH: ashr(bin.dst, number_t{(int32_t)imm}, finite_width); break;
+        case Bin::Op::LSH: shl(bin.dst, static_cast<int32_t>(imm), finite_width); break;
+        case Bin::Op::RSH: lshr(bin.dst, static_cast<int32_t>(imm), finite_width); break;
+        case Bin::Op::ARSH: ashr(bin.dst, number_t{static_cast<int32_t>(imm)}, finite_width); break;
         case Bin::Op::XOR:
-            bitwise_xor(dst.svalue, dst.uvalue, imm);
+            m_inv->bitwise_xor(dst.svalue, dst.uvalue, imm);
             havoc_offsets(bin.dst);
             break;
         }
@@ -2819,80 +1937,83 @@ void ebpf_domain_t::operator()(const Bin& bin) {
         case Bin::Op::ADD: {
             if (type_inv.same_type(m_inv, bin.dst, std::get<Reg>(bin.v))) {
                 // both must be numbers
-                add_overflow(dst.svalue, dst.uvalue, src.svalue, finite_width);
+                m_inv->add_overflow(dst.svalue, dst.uvalue, src.svalue, finite_width);
             } else {
                 // Here we're not sure that lhs and rhs are the same type; they might be.
                 // But previous assertions should fail unless we know that exactly one of lhs or rhs is a pointer.
-                m_inv = type_inv.join_over_types(m_inv, bin.dst, [&](NumAbsDomain& inv, type_encoding_t dst_type) {
-                    inv = type_inv.join_over_types(inv, src_reg, [&](NumAbsDomain& inv, type_encoding_t src_type) {
-                        if (dst_type == T_NUM && src_type != T_NUM) {
-                            // num += ptr
-                            type_inv.assign_type(inv, bin.dst, src_type);
-                            if (auto dst_offset = get_type_offset_variable(bin.dst, src_type)) {
-                                apply(inv, crab::arith_binop_t::ADD, dst_offset.value(), dst.svalue,
-                                      get_type_offset_variable(src_reg, src_type).value());
-                            }
-                            if (src_type == T_SHARED) {
-                                inv.assign(dst.shared_region_size, src.shared_region_size);
-                            }
-                        } else if (dst_type != T_NUM && src_type == T_NUM) {
-                            // ptr += num
-                            type_inv.assign_type(inv, bin.dst, dst_type);
-                            if (auto dst_offset = get_type_offset_variable(bin.dst, dst_type)) {
-                                apply(inv, crab::arith_binop_t::ADD, dst_offset.value(), dst_offset.value(),
-                                      src.svalue);
-                                if (dst_type == T_STACK) {
-                                    // Reduce the numeric size.
-                                    using namespace crab::dsl_syntax;
-                                    if (m_inv.intersect(src.svalue < 0)) {
-                                        inv -= dst.stack_numeric_size;
-                                        recompute_stack_numeric_size(inv, dst.type);
-                                    } else {
-                                        apply_signed(inv, crab::arith_binop_t::SUB, dst.stack_numeric_size,
-                                                     dst.stack_numeric_size, dst.stack_numeric_size, src.svalue, 0);
+                m_inv =
+                    type_inv.join_over_types(m_inv, bin.dst, [&](NumAbsDomain& inv, const type_encoding_t dst_type) {
+                        inv = type_inv.join_over_types(
+                            inv, src_reg, [&](NumAbsDomain& inv, const type_encoding_t src_type) {
+                                if (dst_type == T_NUM && src_type != T_NUM) {
+                                    // num += ptr
+                                    type_inv.assign_type(inv, bin.dst, src_type);
+                                    if (const auto dst_offset = get_type_offset_variable(bin.dst, src_type)) {
+                                        inv->apply(arith_binop_t::ADD, dst_offset.value(), dst.svalue,
+                                                   get_type_offset_variable(src_reg, src_type).value());
                                     }
+                                    if (src_type == T_SHARED) {
+                                        inv.assign(dst.shared_region_size, src.shared_region_size);
+                                    }
+                                } else if (dst_type != T_NUM && src_type == T_NUM) {
+                                    // ptr += num
+                                    type_inv.assign_type(inv, bin.dst, dst_type);
+                                    if (const auto dst_offset = get_type_offset_variable(bin.dst, dst_type)) {
+                                        inv->add(dst_offset.value(), src.svalue);
+                                        if (dst_type == T_STACK) {
+                                            // Reduce the numeric size.
+                                            using namespace crab::dsl_syntax;
+                                            if (m_inv.intersect(src.svalue < 0)) {
+                                                inv -= dst.stack_numeric_size;
+                                                recompute_stack_numeric_size(inv, dst.type);
+                                            } else {
+                                                inv->sub(dst.stack_numeric_size, src.svalue);
+                                            }
+                                        }
+                                    }
+                                } else if (dst_type == T_NUM && src_type == T_NUM) {
+                                    // dst and src don't necessarily have the same type, but among the possibilities
+                                    // enumerated is the case where they are both numbers.
+                                    inv->add_overflow(dst.svalue, dst.uvalue, src.svalue, finite_width);
+                                } else {
+                                    // We ignore the cases here that do not match the assumption described
+                                    // above.  Joining bottom with another results will leave the other
+                                    // results unchanged.
+                                    inv.set_to_bottom();
                                 }
-                            }
-                        } else if (dst_type == T_NUM && src_type == T_NUM) {
-                            // dst and src don't necessarily have the same type, but among the possibilities
-                            // enumerated is the case where they are both numbers.
-                            apply_signed(inv, crab::arith_binop_t::ADD, dst.svalue, dst.uvalue, dst.svalue, src.svalue,
-                                         finite_width);
-                        } else {
-                            // We ignore the cases here that do not match the assumption described
-                            // above.  Joining bottom with another results will leave the other
-                            // results unchanged.
-                            inv.set_to_bottom();
-                        }
+                            });
                     });
-                });
                 // careful: change dst.value only after dealing with offset
-                apply_signed(m_inv, crab::arith_binop_t::ADD, dst.svalue, dst.uvalue, dst.svalue, src.svalue,
-                             finite_width);
+                m_inv->add_overflow(dst.svalue, dst.uvalue, src.svalue, finite_width);
             }
             break;
         }
         case Bin::Op::SUB: {
-            if (type_inv.same_type(m_inv, bin.dst, std::get<Reg>(bin.v))) {
+            if (bin.dst == src_reg) {
+                type_inv.assign_type(m_inv, bin.dst, T_NUM);
+                m_inv->assign(dst.svalue, 0);
+                m_inv->assign(dst.uvalue, 0);
+                crab::havoc_offsets(m_inv, bin.dst);
+                break;
+            }
+            if (type_inv.same_type(m_inv, bin.dst, src_reg)) {
                 // src and dest have the same type.
-                m_inv = type_inv.join_over_types(m_inv, bin.dst, [&](NumAbsDomain& inv, type_encoding_t type) {
+                m_inv = type_inv.join_over_types(m_inv, bin.dst, [&](NumAbsDomain& inv, const type_encoding_t type) {
                     switch (type) {
                     case T_NUM:
-                        // This is: sub_overflow(inv, dst.value, src.value, finite_width);
-                        apply_signed(inv, crab::arith_binop_t::SUB, dst.svalue, dst.uvalue, dst.svalue, src.svalue,
-                                     finite_width);
+                        inv->sub_overflow(dst.svalue, dst.uvalue, src.svalue, finite_width);
                         type_inv.assign_type(inv, bin.dst, T_NUM);
-                        havoc_offsets(inv, bin.dst);
+                        crab::havoc_offsets(inv, bin.dst);
                         break;
                     default:
                         // ptr -= ptr
                         // Assertions should make sure we only perform this on non-shared pointers.
-                        if (auto dst_offset = get_type_offset_variable(bin.dst, type)) {
-                            apply_signed(inv, crab::arith_binop_t::SUB, dst.svalue, dst.uvalue, dst_offset.value(),
-                                         get_type_offset_variable(src_reg, type).value(), finite_width);
+                        if (const auto dst_offset = get_type_offset_variable(bin.dst, type)) {
+                            inv->apply_signed(arith_binop_t::SUB, dst.svalue, dst.uvalue, dst_offset.value(),
+                                              get_type_offset_variable(src_reg, type).value(), finite_width);
                             inv -= dst_offset.value();
                         }
-                        havoc_offsets(inv, bin.dst);
+                        crab::havoc_offsets(inv, bin.dst);
                         type_inv.assign_type(inv, bin.dst, T_NUM);
                         break;
                     }
@@ -2900,15 +2021,15 @@ void ebpf_domain_t::operator()(const Bin& bin) {
             } else {
                 // We're not sure that lhs and rhs are the same type.
                 // Either they're different, or at least one is not a singleton.
-                if (type_inv.get_type(m_inv, std::get<Reg>(bin.v)) != T_NUM) {
+                if (type_inv.get_type(m_inv, src_reg) != T_NUM) {
                     type_inv.havoc_type(m_inv, bin.dst);
                     havoc(dst.svalue);
                     havoc(dst.uvalue);
                     havoc_offsets(bin.dst);
                 } else {
-                    sub_overflow(dst.svalue, dst.uvalue, src.svalue, finite_width);
+                    m_inv->sub_overflow(dst.svalue, dst.uvalue, src.svalue, finite_width);
                     if (auto dst_offset = get_type_offset_variable(bin.dst)) {
-                        sub(dst_offset.value(), src.svalue);
+                        m_inv->sub(dst_offset.value(), src.svalue);
                         if (type_inv.has_type(m_inv, dst.type, T_STACK)) {
                             // Reduce the numeric size.
                             using namespace crab::dsl_syntax;
@@ -2916,8 +2037,7 @@ void ebpf_domain_t::operator()(const Bin& bin) {
                                 m_inv -= dst.stack_numeric_size;
                                 recompute_stack_numeric_size(m_inv, dst.type);
                             } else {
-                                apply(m_inv, crab::arith_binop_t::ADD, dst.stack_numeric_size, dst.stack_numeric_size,
-                                      src.svalue);
+                                m_inv->add(dst.stack_numeric_size, src.svalue);
                             }
                         }
                     }
@@ -2926,62 +2046,62 @@ void ebpf_domain_t::operator()(const Bin& bin) {
             break;
         }
         case Bin::Op::MUL:
-            mul(dst.svalue, dst.uvalue, src.svalue, finite_width);
+            m_inv->mul(dst.svalue, dst.uvalue, src.svalue, finite_width);
             havoc_offsets(bin.dst);
             break;
         case Bin::Op::UDIV:
-            udiv(dst.svalue, dst.uvalue, src.uvalue, finite_width);
+            m_inv->udiv(dst.svalue, dst.uvalue, src.uvalue, finite_width);
             havoc_offsets(bin.dst);
             break;
         case Bin::Op::UMOD:
-            urem(dst.svalue, dst.uvalue, src.uvalue, finite_width);
+            m_inv->urem(dst.svalue, dst.uvalue, src.uvalue, finite_width);
             havoc_offsets(bin.dst);
             break;
         case Bin::Op::SDIV:
-            sdiv(dst.svalue, dst.uvalue, src.svalue, finite_width);
+            m_inv->sdiv(dst.svalue, dst.uvalue, src.svalue, finite_width);
             havoc_offsets(bin.dst);
             break;
         case Bin::Op::SMOD:
-            srem(dst.svalue, dst.uvalue, src.svalue, finite_width);
+            m_inv->srem(dst.svalue, dst.uvalue, src.svalue, finite_width);
             havoc_offsets(bin.dst);
             break;
         case Bin::Op::OR:
-            bitwise_or(dst.svalue, dst.uvalue, src.uvalue, finite_width);
+            m_inv->bitwise_or(dst.svalue, dst.uvalue, src.uvalue, finite_width);
             havoc_offsets(bin.dst);
             break;
         case Bin::Op::AND:
-            bitwise_and(dst.svalue, dst.uvalue, src.uvalue, finite_width);
+            m_inv->bitwise_and(dst.svalue, dst.uvalue, src.uvalue, finite_width);
             havoc_offsets(bin.dst);
             break;
         case Bin::Op::LSH:
-            if (m_inv.entail(type_is_number(src_reg))) {
-                auto src_interval = m_inv.eval_interval(src.uvalue);
+            if (m_inv->entail(type_is_number(src_reg))) {
+                auto src_interval = m_inv->eval_interval(src.uvalue);
                 if (std::optional<number_t> sn = src_interval.singleton()) {
                     uint64_t imm = sn->cast_to_uint64() & (bin.is64 ? 63 : 31);
                     if (imm <= INT32_MAX) {
                         if (!bin.is64) {
                             // Use only the low 32 bits of the value.
-                            bitwise_and(dst.svalue, dst.uvalue, UINT32_MAX);
+                            m_inv->bitwise_and(dst.svalue, dst.uvalue, UINT32_MAX);
                         }
-                        shl(bin.dst, (int32_t)imm, finite_width);
+                        shl(bin.dst, static_cast<int32_t>(imm), finite_width);
                         break;
                     }
                 }
             }
-            shl_overflow(dst.svalue, dst.uvalue, src.uvalue);
+            m_inv->shl_overflow(dst.svalue, dst.uvalue, src.uvalue);
             havoc_offsets(bin.dst);
             break;
         case Bin::Op::RSH:
-            if (m_inv.entail(type_is_number(src_reg))) {
-                auto src_interval = m_inv.eval_interval(src.uvalue);
+            if (m_inv->entail(type_is_number(src_reg))) {
+                auto src_interval = m_inv->eval_interval(src.uvalue);
                 if (std::optional<number_t> sn = src_interval.singleton()) {
                     uint64_t imm = sn->cast_to_uint64() & (bin.is64 ? 63 : 31);
                     if (imm <= INT32_MAX) {
                         if (!bin.is64) {
                             // Use only the low 32 bits of the value.
-                            bitwise_and(dst.svalue, dst.uvalue, UINT32_MAX);
+                            m_inv->bitwise_and(dst.svalue, dst.uvalue, UINT32_MAX);
                         }
-                        lshr(bin.dst, (int32_t)imm, finite_width);
+                        lshr(bin.dst, static_cast<int32_t>(imm), finite_width);
                         break;
                     }
                 }
@@ -2991,7 +2111,7 @@ void ebpf_domain_t::operator()(const Bin& bin) {
             havoc_offsets(bin.dst);
             break;
         case Bin::Op::ARSH:
-            if (m_inv.entail(type_is_number(src_reg))) {
+            if (m_inv->entail(type_is_number(src_reg))) {
                 ashr(bin.dst, src.svalue, finite_width);
                 break;
             }
@@ -3000,7 +2120,7 @@ void ebpf_domain_t::operator()(const Bin& bin) {
             havoc_offsets(bin.dst);
             break;
         case Bin::Op::XOR:
-            bitwise_xor(dst.svalue, dst.uvalue, src.uvalue, finite_width);
+            m_inv->bitwise_xor(dst.svalue, dst.uvalue, src.uvalue, finite_width);
             havoc_offsets(bin.dst);
             break;
         case Bin::Op::MOVSX8:
@@ -3008,11 +2128,13 @@ void ebpf_domain_t::operator()(const Bin& bin) {
         case Bin::Op::MOVSX32:
             // Keep relational information if operation is a no-op.
             if ((dst.svalue == src.svalue) &&
-                (m_inv.eval_interval(dst.svalue) <= interval_t::signed_int(_movsx_bits(bin.op)))) {
+                (m_inv->eval_interval(dst.svalue) <= interval_t::signed_int(_movsx_bits(bin.op)))) {
                 return;
             }
-            if (m_inv.entail(type_is_number(src_reg))) {
-                sign_extend(bin.dst, src.svalue, finite_width, bin.op);
+            if (m_inv->entail(type_is_number(src_reg))) {
+                type_inv.assign_type(m_inv, bin.dst, T_NUM);
+                havoc_offsets(bin.dst);
+                m_inv->sign_extend(dst.svalue, dst.uvalue, src.svalue, finite_width, _movsx_bits(bin.op));
                 break;
             }
             havoc(dst.svalue);
@@ -3021,48 +2143,49 @@ void ebpf_domain_t::operator()(const Bin& bin) {
             break;
         case Bin::Op::MOV:
             // Keep relational information if operation is a no-op.
-            if ((dst.svalue == src.svalue) && (m_inv.eval_interval(dst.uvalue) <= interval_t::unsigned_int(bin.is64))) {
+            if ((dst.svalue == src.svalue) &&
+                (m_inv->eval_interval(dst.uvalue) <= interval_t::unsigned_int(bin.is64))) {
                 return;
             }
-            assign(dst.svalue, src.svalue);
-            assign(dst.uvalue, src.uvalue);
+            m_inv->assign(dst.svalue, src.svalue);
+            m_inv->assign(dst.uvalue, src.uvalue);
             havoc_offsets(bin.dst);
-            m_inv = type_inv.join_over_types(m_inv, src_reg, [&](NumAbsDomain& inv, type_encoding_t type) {
+            m_inv = type_inv.join_over_types(m_inv, src_reg, [&](NumAbsDomain& inv, const type_encoding_t type) {
                 switch (type) {
                 case T_CTX:
                     if (bin.is64) {
-                        inv.assign(dst.type, type);
-                        inv.assign(dst.ctx_offset, src.ctx_offset);
+                        inv->assign(dst.type, type);
+                        inv->assign(dst.ctx_offset, src.ctx_offset);
                     }
                     break;
                 case T_MAP:
                 case T_MAP_PROGRAMS:
                     if (bin.is64) {
-                        inv.assign(dst.type, type);
-                        inv.assign(dst.map_fd, src.map_fd);
+                        inv->assign(dst.type, type);
+                        inv->assign(dst.map_fd, src.map_fd);
                     }
                     break;
                 case T_PACKET:
                     if (bin.is64) {
-                        inv.assign(dst.type, type);
-                        inv.assign(dst.packet_offset, src.packet_offset);
+                        inv->assign(dst.type, type);
+                        inv->assign(dst.packet_offset, src.packet_offset);
                     }
                     break;
                 case T_SHARED:
                     if (bin.is64) {
-                        inv.assign(dst.type, type);
-                        inv.assign(dst.shared_region_size, src.shared_region_size);
-                        inv.assign(dst.shared_offset, src.shared_offset);
+                        inv->assign(dst.type, type);
+                        inv->assign(dst.shared_region_size, src.shared_region_size);
+                        inv->assign(dst.shared_offset, src.shared_offset);
                     }
                     break;
                 case T_STACK:
                     if (bin.is64) {
-                        inv.assign(dst.type, type);
-                        inv.assign(dst.stack_offset, src.stack_offset);
-                        inv.assign(dst.stack_numeric_size, src.stack_numeric_size);
+                        inv->assign(dst.type, type);
+                        inv->assign(dst.stack_offset, src.stack_offset);
+                        inv->assign(dst.stack_numeric_size, src.stack_numeric_size);
                     }
                     break;
-                default: inv.assign(dst.type, type); break;
+                default: inv->assign(dst.type, type); break;
                 }
             });
             if (bin.is64) {
@@ -3078,11 +2201,11 @@ void ebpf_domain_t::operator()(const Bin& bin) {
         }
     }
     if (!bin.is64) {
-        bitwise_and(dst.svalue, dst.uvalue, UINT32_MAX);
+        m_inv->bitwise_and(dst.svalue, dst.uvalue, UINT32_MAX);
     }
 }
 
-string_invariant ebpf_domain_t::to_set() { return this->m_inv.to_set() + this->stack.to_set(); }
+string_invariant ebpf_domain_t::to_set() const { return this->m_inv.to_set() + this->stack.to_set(); }
 
 std::ostream& operator<<(std::ostream& o, const ebpf_domain_t& dom) {
     if (dom.is_bottom()) {
@@ -3096,57 +2219,57 @@ std::ostream& operator<<(std::ostream& o, const ebpf_domain_t& dom) {
 void ebpf_domain_t::initialize_packet(ebpf_domain_t& inv) {
     using namespace crab::dsl_syntax;
 
-    inv -= variable_t::packet_size();
-    inv -= variable_t::meta_offset();
+    inv.m_inv -= variable_t::packet_size();
+    inv.m_inv -= variable_t::meta_offset();
 
-    inv += 0 <= variable_t::packet_size();
-    inv += variable_t::packet_size() < MAX_PACKET_SIZE;
-    auto info = *global_program_info;
+    inv.m_inv += 0 <= variable_t::packet_size();
+    inv.m_inv += variable_t::packet_size() < MAX_PACKET_SIZE;
+    const auto info = *global_program_info;
     if (info.type.context_descriptor->meta >= 0) {
-        inv += variable_t::meta_offset() <= 0;
-        inv += variable_t::meta_offset() >= -4098;
+        inv.m_inv += variable_t::meta_offset() <= 0;
+        inv.m_inv += variable_t::meta_offset() >= -4098;
     } else {
-        inv.assign(variable_t::meta_offset(), 0);
+        inv.m_inv->assign(variable_t::meta_offset(), 0);
     }
 }
 
-ebpf_domain_t ebpf_domain_t::from_constraints(const std::set<std::string>& constraints, bool setup_constraints) {
+ebpf_domain_t ebpf_domain_t::from_constraints(const std::set<std::string>& constraints, const bool setup_constraints) {
     ebpf_domain_t inv;
     if (setup_constraints) {
-        inv = ebpf_domain_t::setup_entry(false);
+        inv = setup_entry(false);
     }
-    auto numeric_ranges = std::vector<crab::interval_t>();
+    auto numeric_ranges = std::vector<interval_t>();
     for (const auto& cst : parse_linear_constraints(constraints, numeric_ranges)) {
-        inv += cst;
+        inv.m_inv += cst;
     }
-    for (const crab::interval_t& range : numeric_ranges) {
-        int start = (int)range.lb().number().value();
-        int width = 1 + (int)range.finite_size().value();
+    for (const interval_t& range : numeric_ranges) {
+        const int start = static_cast<int>(range.lb().number().value());
+        const int width = 1 + static_cast<int>(range.finite_size().value());
         inv.stack.initialize_numbers(start, width);
     }
     // TODO: handle other stack type constraints
     return inv;
 }
 
-ebpf_domain_t ebpf_domain_t::setup_entry(bool init_r1) {
+ebpf_domain_t ebpf_domain_t::setup_entry(const bool init_r1) {
     using namespace crab::dsl_syntax;
 
     ebpf_domain_t inv;
-    auto r10 = reg_pack(R10_STACK_POINTER);
-    Reg r10_reg{(uint8_t)R10_STACK_POINTER};
-    inv += EBPF_STACK_SIZE <= r10.svalue;
-    inv += r10.svalue <= PTR_MAX;
-    inv.assign(r10.stack_offset, EBPF_STACK_SIZE);
+    const auto r10 = reg_pack(R10_STACK_POINTER);
+    constexpr Reg r10_reg{(uint8_t)R10_STACK_POINTER};
+    inv.m_inv += EBPF_STACK_SIZE <= r10.svalue;
+    inv.m_inv += r10.svalue <= PTR_MAX;
+    inv.m_inv->assign(r10.stack_offset, EBPF_STACK_SIZE);
     // stack_numeric_size would be 0, but TOP has the same result
     // so no need to assign it.
     inv.type_inv.assign_type(inv.m_inv, r10_reg, T_STACK);
 
     if (init_r1) {
-        auto r1 = reg_pack(R1_ARG);
-        Reg r1_reg{(uint8_t)R1_ARG};
-        inv += 1 <= r1.svalue;
-        inv += r1.svalue <= PTR_MAX;
-        inv.assign(r1.ctx_offset, 0);
+        const auto r1 = reg_pack(R1_ARG);
+        constexpr Reg r1_reg{(uint8_t)R1_ARG};
+        inv.m_inv += 1 <= r1.svalue;
+        inv.m_inv += r1.svalue <= PTR_MAX;
+        inv.m_inv->assign(r1.ctx_offset, 0);
         inv.type_inv.assign_type(inv.m_inv, r1_reg, T_CTX);
     }
 
@@ -3154,19 +2277,22 @@ ebpf_domain_t ebpf_domain_t::setup_entry(bool init_r1) {
     return inv;
 }
 
-void ebpf_domain_t::initialize_loop_counter(const label_t label) {
+void ebpf_domain_t::initialize_loop_counter(const label_t& label) {
     m_inv.assign(variable_t::loop_counter(to_string(label)), 0);
 }
 
-bound_t ebpf_domain_t::get_loop_count_upper_bound() {
-    crab::bound_t ub{number_t{0}};
-    for (variable_t counter : variable_t::get_loop_counters()) {
+bound_t ebpf_domain_t::get_loop_count_upper_bound() const {
+    bound_t ub{number_t{0}};
+    for (const variable_t counter : variable_t::get_loop_counters()) {
         ub = std::max(ub, m_inv[counter].ub());
     }
     return ub;
 }
 
 void ebpf_domain_t::operator()(const IncrementLoopCounter& ins) {
-    this->add(variable_t::loop_counter(to_string(ins.name)), 1);
+    if (!m_inv) {
+        return;
+    }
+    m_inv->add(variable_t::loop_counter(to_string(ins.name)), 1);
 }
 } // namespace crab

--- a/src/crab/ebpf_domain.hpp
+++ b/src/crab/ebpf_domain.hpp
@@ -6,7 +6,6 @@
 
 #include <functional>
 #include <optional>
-#include <vector>
 
 #include "crab/array_domain.hpp"
 #include "crab/split_dbm.hpp"
@@ -24,7 +23,7 @@ class ebpf_domain_t final {
 
   public:
     ebpf_domain_t();
-    ebpf_domain_t(crab::domains::NumAbsDomain inv, crab::domains::array_domain_t stack);
+    ebpf_domain_t(domains::NumAbsDomain inv, const domains::array_domain_t& stack);
 
     // Generic abstract domain operations
     static ebpf_domain_t top();
@@ -35,7 +34,7 @@ class ebpf_domain_t final {
     bool is_bottom() const;
     [[nodiscard]]
     bool is_top() const;
-    bool operator<=(const ebpf_domain_t& other);
+    bool operator<=(const ebpf_domain_t& other) const;
     bool operator==(const ebpf_domain_t& other) const;
     void operator|=(ebpf_domain_t&& other);
     void operator|=(const ebpf_domain_t& other);
@@ -43,17 +42,17 @@ class ebpf_domain_t final {
     ebpf_domain_t operator|(const ebpf_domain_t& other) const&;
     ebpf_domain_t operator|(const ebpf_domain_t& other) &&;
     ebpf_domain_t operator&(const ebpf_domain_t& other) const;
-    ebpf_domain_t widen(const ebpf_domain_t& other, bool to_constants);
-    ebpf_domain_t widening_thresholds(const ebpf_domain_t& other, const crab::iterators::thresholds_t& ts);
-    ebpf_domain_t narrow(const ebpf_domain_t& other);
+    ebpf_domain_t widen(const ebpf_domain_t& other, bool to_constants) const;
+    ebpf_domain_t widening_thresholds(const ebpf_domain_t& other, const thresholds_t& ts);
+    ebpf_domain_t narrow(const ebpf_domain_t& other) const;
 
     typedef bool check_require_func_t(NumAbsDomain&, const linear_constraint_t&, std::string);
     void set_require_check(std::function<check_require_func_t> f);
-    bound_t get_loop_count_upper_bound();
+    bound_t get_loop_count_upper_bound() const;
     static ebpf_domain_t setup_entry(bool init_r1);
 
     static ebpf_domain_t from_constraints(const std::set<std::string>& constraints, bool setup_constraints);
-    string_invariant to_set();
+    string_invariant to_set() const;
 
     // abstract transformers
     void operator()(const basic_block_t& bb);
@@ -85,68 +84,16 @@ class ebpf_domain_t final {
     void operator()(const ZeroCtxOffset&);
     void operator()(const IncrementLoopCounter&);
 
-    void initialize_loop_counter(label_t label);
+    void initialize_loop_counter(const label_t& label);
     static ebpf_domain_t calculate_constant_limits();
 
   private:
     // private generic domain functions
-    void operator+=(const linear_constraint_t& cst);
-    void operator-=(variable_t var);
-
-    void assign(variable_t lhs, variable_t rhs);
-    void assign(variable_t x, const linear_expression_t& e);
-    void assign(variable_t x, int64_t e);
-
-    void apply(crab::arith_binop_t op, variable_t x, variable_t y, const number_t& z, int finite_width);
-    void apply(crab::arith_binop_t op, variable_t x, variable_t y, variable_t z, int finite_width);
-    void apply(crab::bitwise_binop_t op, variable_t x, variable_t y, variable_t z, int finite_width);
-    void apply(crab::bitwise_binop_t op, variable_t x, variable_t y, const number_t& k, int finite_width);
-    void apply(crab::binop_t op, variable_t x, variable_t y, const number_t& z, int finite_width);
-    void apply(crab::binop_t op, variable_t x, variable_t y, variable_t z, int finite_width);
-
-    void apply(crab::domains::NumAbsDomain& inv, crab::binop_t op, variable_t x, variable_t y, variable_t z);
-    void apply_signed(crab::domains::NumAbsDomain& inv, crab::binop_t op, variable_t xs, variable_t xu, variable_t y,
-                      const number_t& z, int finite_width);
-    void apply_unsigned(crab::domains::NumAbsDomain& inv, crab::binop_t op, variable_t xs, variable_t xu, variable_t y,
-                        const number_t& z, int finite_width);
-    void apply_signed(crab::domains::NumAbsDomain& inv, crab::binop_t op, variable_t xs, variable_t xu, variable_t y,
-                      variable_t z, int finite_width);
-    void apply_unsigned(crab::domains::NumAbsDomain& inv, crab::binop_t op, variable_t xs, variable_t xu, variable_t y,
-                        variable_t z, int finite_width);
 
     void add(const Reg& reg, int imm, int finite_width);
-    void add(variable_t lhs, variable_t op2);
-    void add(variable_t lhs, const number_t& op2);
-    void sub(variable_t lhs, variable_t op2);
-    void sub(variable_t lhs, const number_t& op2);
-    void add_overflow(variable_t lhss, variable_t lhsu, variable_t op2, int finite_width);
-    void add_overflow(variable_t lhss, variable_t lhsu, const number_t& op2, int finite_width);
-    void sub_overflow(variable_t lhss, variable_t lhsu, variable_t op2, int finite_width);
-    void sub_overflow(variable_t lhss, variable_t lhsu, const number_t& op2, int finite_width);
-    void neg(variable_t lhss, variable_t lhsu, int finite_width);
-    void mul(variable_t lhss, variable_t lhsu, variable_t op2, int finite_width);
-    void mul(variable_t lhss, variable_t lhsu, const number_t& op2, int finite_width);
-    void sdiv(variable_t lhss, variable_t lhsu, variable_t op2, int finite_width);
-    void sdiv(variable_t lhss, variable_t lhsu, const number_t& op2, int finite_width);
-    void udiv(variable_t lhss, variable_t lhsu, variable_t op2, int finite_width);
-    void udiv(variable_t lhss, variable_t lhsu, const number_t& op2, int finite_width);
-    void srem(variable_t lhss, variable_t lhsu, variable_t op2, int finite_width);
-    void srem(variable_t lhss, variable_t lhsu, const number_t& op2, int finite_width);
-    void urem(variable_t lhss, variable_t lhsu, variable_t op2, int finite_width);
-    void urem(variable_t lhss, variable_t lhsu, const number_t& op2, int finite_width);
-
-    void bitwise_and(variable_t lhss, variable_t lhsu, variable_t op2, int finite_width);
-    void bitwise_and(variable_t lhss, variable_t lhsu, const number_t& op2);
-    void bitwise_or(variable_t lhss, variable_t lhsu, variable_t op2, int finite_width);
-    void bitwise_or(variable_t lhss, variable_t lhsu, const number_t& op2);
-    void bitwise_xor(variable_t lhsss, variable_t lhsu, variable_t op2, int finite_width);
-    void bitwise_xor(variable_t lhss, variable_t lhsu, const number_t& op2);
     void shl(const Reg& reg, int imm, int finite_width);
-    void shl_overflow(variable_t lhss, variable_t lhsu, variable_t op2);
-    void shl_overflow(variable_t lhss, variable_t lhsu, const number_t& op2);
     void lshr(const Reg& reg, int imm, int finite_width);
     void ashr(const Reg& reg, const linear_expression_t& right_svalue, int finite_width);
-    void sign_extend(const Reg& dst_reg, const linear_expression_t& right_svalue, int finite_width, Bin::Op op);
 
     void assume(const linear_constraint_t& cst);
 
@@ -155,7 +102,6 @@ class ebpf_domain_t final {
 
     /// Forget everything about all offset variables for a given register.
     void havoc_offsets(const Reg& reg);
-    void havoc_offsets(NumAbsDomain& inv, const Reg& reg);
 
     static std::optional<variable_t> get_type_offset_variable(const Reg& reg, int type);
     [[nodiscard]]
@@ -171,22 +117,17 @@ class ebpf_domain_t final {
     [[nodiscard]]
     std::optional<uint32_t> get_map_inner_map_fd(const Reg& map_fd_reg) const;
     [[nodiscard]]
-    crab::interval_t get_map_key_size(const Reg& map_fd_reg) const;
+    interval_t get_map_key_size(const Reg& map_fd_reg) const;
     [[nodiscard]]
-    crab::interval_t get_map_value_size(const Reg& map_fd_reg) const;
+    interval_t get_map_value_size(const Reg& map_fd_reg) const;
     [[nodiscard]]
-    crab::interval_t get_map_max_entries(const Reg& map_fd_reg) const;
+    interval_t get_map_max_entries(const Reg& map_fd_reg) const;
     void forget_packet_pointers();
-    void havoc_register(NumAbsDomain& inv, const Reg& reg);
     void do_load_mapfd(const Reg& dst_reg, int mapfd, bool maybe_null);
-
-    static void overflow_signed(NumAbsDomain& inv, variable_t lhs, int finite_width);
-    static void overflow_unsigned(NumAbsDomain& inv, variable_t lhs, int finite_width);
-    static void overflow_bounds(NumAbsDomain& inv, variable_t lhs, number_t span, int finite_width, bool issigned);
 
     void assign_valid_ptr(const Reg& dst_reg, bool maybe_null);
 
-    void require(crab::domains::NumAbsDomain& inv, const linear_constraint_t& cst, const std::string& s);
+    void require(domains::NumAbsDomain& inv, const linear_constraint_t& cst, const std::string& s);
 
     // memory check / load / store
     void check_access_stack(NumAbsDomain& inv, const linear_expression_t& lb, const linear_expression_t& ub);
@@ -196,8 +137,8 @@ class ebpf_domain_t final {
     void check_access_shared(NumAbsDomain& inv, const linear_expression_t& lb, const linear_expression_t& ub,
                              variable_t shared_region_size);
 
-    void recompute_stack_numeric_size(NumAbsDomain& inv, const Reg& reg);
-    void recompute_stack_numeric_size(NumAbsDomain& inv, variable_t type_variable);
+    void recompute_stack_numeric_size(NumAbsDomain& inv, const Reg& reg) const;
+    void recompute_stack_numeric_size(NumAbsDomain& inv, variable_t type_variable) const;
     void do_load_stack(NumAbsDomain& inv, const Reg& target_reg, const linear_expression_t& addr, int width,
                        const Reg& src_reg);
     void do_load_ctx(NumAbsDomain& inv, const Reg& target_reg, const linear_expression_t& addr_vague, int width);
@@ -205,8 +146,8 @@ class ebpf_domain_t final {
     void do_load(const Mem& b, const Reg& target_reg);
 
     template <typename X, typename Y, typename Z>
-    void do_store_stack(crab::domains::NumAbsDomain& inv, const number_t& width, const linear_expression_t& addr,
-                        X val_type, Y val_svalue, Z val_uvalue, const std::optional<reg_pack_t>& opt_val_reg);
+    void do_store_stack(domains::NumAbsDomain& inv, const number_t& width, const linear_expression_t& addr, X val_type,
+                        Y val_svalue, Z val_uvalue, const std::optional<reg_pack_t>& opt_val_reg);
 
     template <typename Type, typename SValue, typename UValue>
     void do_mem_store(const Mem& b, Type val_type, SValue val_svalue, UValue val_uvalue,
@@ -220,12 +161,12 @@ class ebpf_domain_t final {
     /// Mapping from variables (including registers, types, offsets,
     /// memory locations, etc.) to numeric intervals or relationships
     /// to other variables.
-    crab::domains::NumAbsDomain m_inv;
+    domains::NumAbsDomain m_inv;
 
     /// Represents the stack as a memory region, i.e., an array of bytes,
     /// allowing mapping to variable in the m_inv numeric domains
     /// while dealing with overlapping byte ranges.
-    crab::domains::array_domain_t stack;
+    domains::array_domain_t stack;
 
     std::function<check_require_func_t> check_require{};
     bool get_map_fd_range(const Reg& map_fd_reg, int32_t* start_fd, int32_t* end_fd) const;
@@ -266,8 +207,8 @@ class ebpf_domain_t final {
                                      const std::function<void(NumAbsDomain&)>& if_true,
                                      const std::function<void(NumAbsDomain&)>& if_false) const;
         void selectively_join_based_on_type(NumAbsDomain& dst, NumAbsDomain& src) const;
-        void add_extra_invariant(NumAbsDomain& dst, std::map<crab::variable_t, crab::interval_t>& extra_invariants,
-                                 variable_t type_variable, type_encoding_t type, crab::data_kind_t kind,
+        void add_extra_invariant(const NumAbsDomain& dst, std::map<variable_t, interval_t>& extra_invariants,
+                                 variable_t type_variable, type_encoding_t type, data_kind_t kind,
                                  const NumAbsDomain& other) const;
 
         [[nodiscard]]

--- a/src/crab/finite_domain.cpp
+++ b/src/crab/finite_domain.cpp
@@ -1,0 +1,796 @@
+// Copyright (c) Prevail Verifier contributors.
+// SPDX-License-Identifier: MIT
+
+#include <optional>
+#include <utility>
+
+#include "crab/dsl_syntax.hpp"
+#include "crab/finite_domain.hpp"
+#include "crab/interval.hpp"
+#include "crab/linear_constraint.hpp"
+#include "crab/split_dbm.hpp"
+#include "crab/variable.hpp"
+#include "string_constraints.hpp"
+
+namespace crab::domains {
+
+static std::vector<linear_constraint_t>
+assume_unsigned_64bit_gt(const bool strict, const variable_t left_svalue, const variable_t left_uvalue,
+                         const interval_t& left_interval_low, const interval_t& left_interval_high,
+                         const linear_expression_t& right_svalue, const linear_expression_t& right_uvalue,
+                         const interval_t& right_interval) {
+    using namespace dsl_syntax;
+
+    const auto rlb = right_interval.lb();
+    const auto llub = left_interval_low.truncate_to_uint(true).ub();
+    const auto lhlb = left_interval_high.truncate_to_uint(true).lb();
+
+    if ((right_interval <= interval_t::nonnegative_int(true)) && (strict ? (llub <= rlb) : (llub < rlb))) {
+        // The low interval is out of range.
+        return {(strict) ? (left_uvalue > right_uvalue) : (left_uvalue >= right_uvalue),
+                (*lhlb.number() == number_t(std::numeric_limits<uint64_t>::max())) ? (left_uvalue == *lhlb.number())
+                                                                                   : (left_uvalue >= *lhlb.number()),
+                left_svalue < 0};
+    } else if (right_interval <= interval_t::unsigned_high(true)) {
+        // Interval can be represented as both an svalue and a uvalue since it fits in [INT_MAX+1, UINT_MAX].
+        return {number_t{0} <= left_uvalue, strict ? (left_uvalue > right_uvalue) : (left_uvalue >= right_uvalue),
+                strict ? (left_svalue > right_svalue) : (left_svalue >= right_svalue)};
+    } else if ((left_interval_low | left_interval_high) <= interval_t::nonnegative_int(true) &&
+               right_interval <= interval_t::nonnegative_int(true)) {
+        // Interval can be represented as both an svalue and a uvalue since it fits in [0, INT_MAX].
+        return {number_t{0} <= left_uvalue, strict ? (left_uvalue > right_uvalue) : (left_uvalue >= right_uvalue),
+                strict ? (left_svalue > right_svalue) : (left_svalue >= right_svalue)};
+    } else {
+        // Interval can only be represented as a uvalue.
+        return {number_t{0} <= left_uvalue, strict ? (left_uvalue > right_uvalue) : (left_uvalue >= right_uvalue)};
+    }
+}
+
+static std::vector<linear_constraint_t>
+assume_signed_64bit_lt(const bool strict, const variable_t left_svalue, const variable_t left_uvalue,
+                       const interval_t& left_interval_positive, const interval_t& left_interval_negative,
+                       const linear_expression_t& right_svalue, const linear_expression_t& right_uvalue,
+                       const interval_t& right_interval) {
+
+    using namespace crab::dsl_syntax;
+
+    if (right_interval <= interval_t::negative_int(true)) {
+        // Interval can be represented as both an svalue and a uvalue since it fits in [INT_MIN, -1].
+        return {strict ? (left_svalue < right_svalue) : (left_svalue <= right_svalue), number_t{0} <= left_uvalue,
+                strict ? (left_uvalue < right_uvalue) : (left_uvalue <= right_uvalue)};
+    } else if ((left_interval_negative | left_interval_positive) <= interval_t::nonnegative_int(true) &&
+               right_interval <= interval_t::nonnegative_int(true)) {
+        // Interval can be represented as both an svalue and a uvalue since it fits in [0, INT_MAX].
+        return {strict ? (left_svalue < right_svalue) : (left_svalue <= right_svalue), number_t{0} <= left_uvalue,
+                strict ? (left_uvalue < right_uvalue) : (left_uvalue <= right_uvalue)};
+    } else {
+        // Interval can only be represented as an svalue.
+        return {strict ? (left_svalue < right_svalue) : (left_svalue <= right_svalue)};
+    }
+}
+
+void FiniteDomain::overflow_bounds(variable_t lhs, number_t span, int finite_width, bool is_signed) {
+    using namespace crab::dsl_syntax;
+    auto interval = (*this)[lhs];
+    if (interval.ub() - interval.lb() >= span) {
+        // Interval covers the full space.
+        (*this) -= lhs;
+        return;
+    }
+    if (interval.is_bottom()) {
+        (*this) -= lhs;
+        return;
+    }
+    number_t lb_value = interval.lb().number().value();
+    number_t ub_value = interval.ub().number().value();
+
+    // Compute the interval, taking overflow into account.
+    // For a signed result, we need to ensure the signed and unsigned results match
+    // so for a 32-bit operation, 0x80000000 should be a positive 64-bit number not
+    // a sign extended negative one.
+    number_t lb = lb_value.truncate_to_unsigned_finite_width(finite_width);
+    number_t ub = ub_value.truncate_to_unsigned_finite_width(finite_width);
+    if (is_signed) {
+        lb = lb.truncate_to_sint64();
+        ub = ub.truncate_to_sint64();
+    }
+    if (lb > ub) {
+        // Range wraps in the middle, so we cannot represent as an unsigned interval.
+        (*this) -= lhs;
+        return;
+    }
+    auto new_interval = crab::interval_t{lb, ub};
+    if (new_interval != interval) {
+        // Update the variable, which will lose any relationships to other variables.
+        set(lhs, new_interval);
+    }
+}
+
+void FiniteDomain::sign_extend(const variable_t svalue, const variable_t uvalue,
+                               const linear_expression_t& right_svalue, const int finite_width, const int bits) {
+    using namespace crab;
+
+    interval_t right_interval = eval_interval(right_svalue);
+    const int64_t span = 1ULL << bits;
+    if (right_interval.ub() - right_interval.lb() >= number_t{span}) {
+        // Interval covers the full space.
+        if (bits == 64) {
+            dom -= svalue;
+            return;
+        }
+        right_interval = interval_t::signed_int(bits);
+    }
+    const int64_t mask = 1ULL << (bits - 1);
+
+    // Sign extend each bound.
+    int64_t lb = right_interval.lb().number().value().cast_to_sint64();
+    lb &= span - 1;
+    lb = (lb ^ mask) - mask;
+    int64_t ub = right_interval.ub().number().value().cast_to_sint64();
+    ub &= span - 1;
+    ub = (ub ^ mask) - mask;
+    set(svalue, interval_t{number_t{lb}, number_t{ub}});
+
+    if (finite_width) {
+        assign(uvalue, svalue);
+        overflow_signed(svalue, finite_width);
+        overflow_unsigned(uvalue, finite_width);
+    }
+}
+
+void FiniteDomain::shl(const variable_t svalue, const variable_t uvalue, int imm, const int finite_width) {
+    // The BPF ISA requires masking the imm.
+    imm &= finite_width - 1;
+
+    const auto interval = eval_interval(uvalue);
+    if (interval.finite_size()) {
+        const number_t lb = interval.lb().number().value();
+        const number_t ub = interval.ub().number().value();
+        uint64_t lb_n = lb.cast_to_uint64();
+        uint64_t ub_n = ub.cast_to_uint64();
+        const uint64_t uint_max = (finite_width == 64) ? UINT64_MAX : UINT32_MAX;
+        if ((lb_n >> (finite_width - imm)) != (ub_n >> (finite_width - imm))) {
+            // The bits that will be shifted out to the left are different,
+            // which means all combinations of remaining bits are possible.
+            lb_n = 0;
+            ub_n = (uint_max << imm) & uint_max;
+        } else {
+            // The bits that will be shifted out to the left are identical
+            // for all values in the interval, so we can safely shift left
+            // to get a new interval.
+            lb_n = (lb_n << imm) & uint_max;
+            ub_n = (ub_n << imm) & uint_max;
+        }
+        set(uvalue, interval_t{number_t(lb_n), number_t(ub_n)});
+        if (static_cast<int64_t>(ub_n) >= static_cast<int64_t>(lb_n)) {
+            assign(svalue, uvalue);
+        } else {
+            dom -= svalue;
+        }
+        return;
+    }
+    shl_overflow(svalue, uvalue, imm);
+}
+
+void FiniteDomain::lshr(const variable_t svalue, const variable_t uvalue, int imm, int finite_width) {
+    // The BPF ISA requires masking the imm.
+    imm &= finite_width - 1;
+
+    auto interval = eval_interval(uvalue);
+    number_t lb_n{0};
+    number_t ub_n{UINT64_MAX >> imm};
+    if (interval.finite_size()) {
+        number_t lb = interval.lb().number().value();
+        number_t ub = interval.ub().number().value();
+        if (finite_width == 64) {
+            lb_n = lb.cast_to_uint64() >> imm;
+            ub_n = ub.cast_to_uint64() >> imm;
+        } else {
+            number_t lb_w = lb.cast_to_signed_finite_width(finite_width);
+            number_t ub_w = ub.cast_to_signed_finite_width(finite_width);
+            lb_n = lb_w.cast_to_uint32() >> imm;
+            ub_n = ub_w.cast_to_uint32() >> imm;
+
+            // The interval must be valid since a signed range crossing 0
+            // was earlier converted to a full unsigned range.
+            assert(lb_n <= ub_n);
+        }
+    }
+    set(uvalue, interval_t{lb_n, ub_n});
+    if (static_cast<int64_t>(ub_n) >= static_cast<int64_t>(lb_n)) {
+        // ? m_inv.set(dst.svalue, crab::interval_t{number_t{(int64_t)lb_n}, number_t{(int64_t)ub_n}});
+        assign(svalue, uvalue);
+    } else {
+        dom -= svalue;
+    }
+}
+
+bool FiniteDomain::ashr(const variable_t svalue, const variable_t uvalue, const linear_expression_t& right_svalue,
+                        int finite_width) {
+    using namespace crab;
+
+    interval_t left_interval = interval_t::bottom();
+    interval_t right_interval = interval_t::bottom();
+    interval_t left_interval_positive = interval_t::bottom();
+    interval_t left_interval_negative = interval_t::bottom();
+    get_signed_intervals(finite_width == 64, svalue, uvalue, right_svalue, left_interval, right_interval,
+                         left_interval_positive, left_interval_negative);
+    if (auto sn = right_interval.singleton()) {
+        // The BPF ISA requires masking the imm.
+        int64_t imm = sn->cast_to_sint64() & (finite_width - 1);
+
+        int64_t lb_n = INT64_MIN >> imm;
+        int64_t ub_n = INT64_MAX >> imm;
+        if (left_interval.finite_size()) {
+            number_t lb = left_interval.lb().number().value();
+            number_t ub = left_interval.ub().number().value();
+            if (finite_width == 64) {
+                lb_n = lb.cast_to_sint64() >> imm;
+                ub_n = ub.cast_to_sint64() >> imm;
+            } else {
+                number_t lb_w = lb.cast_to_signed_finite_width(finite_width) >> static_cast<int>(imm);
+                number_t ub_w = ub.cast_to_signed_finite_width(finite_width) >> static_cast<int>(imm);
+                if (lb_w.cast_to_uint32() <= ub_w.cast_to_uint32()) {
+                    lb_n = lb_w.cast_to_uint32();
+                    ub_n = ub_w.cast_to_uint32();
+                }
+            }
+        }
+        set(svalue, crab::interval_t{number_t{lb_n}, number_t{ub_n}});
+        if (static_cast<uint64_t>(ub_n) >= static_cast<uint64_t>(lb_n)) {
+            assign(uvalue, svalue);
+        } else {
+            dom -= uvalue;
+        }
+        return true;
+    } else {
+        dom -= svalue;
+        dom -= uvalue;
+        return false;
+    }
+}
+
+std::vector<linear_constraint_t>
+FiniteDomain::assume_unsigned_64bit_lt(const bool strict, variable_t left_svalue, variable_t left_uvalue,
+                                       const interval_t& left_interval_low, const interval_t& left_interval_high,
+                                       const linear_expression_t& right_svalue, const linear_expression_t& right_uvalue,
+                                       const interval_t& right_interval) const {
+    using namespace dsl_syntax;
+
+    auto rub = right_interval.ub();
+    auto lllb = left_interval_low.truncate_to_uint(true).lb();
+    if ((right_interval <= interval_t::nonnegative_int(true)) && (strict ? (lllb >= rub) : (lllb > rub))) {
+        // The high interval is out of range.
+        if (auto lsubn = eval_interval(left_svalue).ub().number()) {
+            return {left_uvalue >= 0, ((strict) ? left_uvalue < right_uvalue : left_uvalue <= right_uvalue),
+                    left_uvalue <= *lsubn, left_svalue >= 0};
+        } else {
+            return {left_uvalue >= 0, ((strict) ? left_uvalue < right_uvalue : left_uvalue <= right_uvalue),
+                    left_svalue >= 0};
+        }
+    }
+    auto lhlb = left_interval_high.truncate_to_uint(true).lb();
+    if ((right_interval <= interval_t::unsigned_high(true)) && (strict ? (lhlb >= rub) : (lhlb > rub))) {
+        // The high interval is out of range.
+        if (auto lsubn = eval_interval(left_svalue).ub().number()) {
+            return {left_uvalue >= 0, ((strict) ? left_uvalue < *rub.number() : left_uvalue <= *rub.number()),
+                    left_uvalue <= *lsubn, left_svalue >= 0};
+        } else {
+            return {left_uvalue >= 0, ((strict) ? left_uvalue < *rub.number() : left_uvalue <= *rub.number()),
+                    left_svalue >= 0};
+        }
+    }
+    if (right_interval <= interval_t::signed_int(true)) {
+        // Interval can be represented as both an svalue and a uvalue since it fits in [0, INT_MAX].
+        auto llub = left_interval_low.truncate_to_uint(true).ub();
+        return {number_t{0} <= left_uvalue, strict ? (left_uvalue < right_uvalue) : (left_uvalue <= right_uvalue),
+                left_uvalue <= *llub.number(), number_t{0} <= left_svalue,
+                strict ? (left_svalue < right_svalue) : (left_svalue <= right_svalue)};
+    } else if (left_interval_low.is_bottom() && right_interval <= interval_t::unsigned_high(true)) {
+        // Interval can be represented as both an svalue and a uvalue since it fits in [INT_MAX+1, UINT_MAX].
+        return {number_t{0} <= left_uvalue, strict ? (left_uvalue < right_uvalue) : (left_uvalue <= right_uvalue),
+                strict ? (left_svalue < right_svalue) : (left_svalue <= right_svalue)};
+    } else if ((left_interval_low | left_interval_high) == interval_t::unsigned_int(true)) {
+        // Interval can only be represented as a uvalue, and was TOP before.
+        return {strict ? (left_uvalue < right_uvalue) : (left_uvalue <= right_uvalue)};
+    } else {
+        // Interval can only be represented as a uvalue.
+        return {number_t{0} <= left_uvalue, strict ? (left_uvalue < right_uvalue) : (left_uvalue <= right_uvalue)};
+    }
+}
+
+std::vector<linear_constraint_t> FiniteDomain::assume_unsigned_32bit_lt(const bool strict, variable_t left_svalue,
+                                                                        variable_t left_uvalue,
+                                                                        const linear_expression_t& right_svalue,
+                                                                        const linear_expression_t& right_uvalue,
+                                                                        const interval_t& right_interval) const {
+    using namespace dsl_syntax;
+    auto left_uinterval = eval_interval(left_uvalue);
+    auto right_uinterval = eval_interval(right_uvalue);
+    auto left_sinterval = eval_interval(left_svalue);
+    auto right_sinterval = eval_interval(right_svalue);
+    if (left_uinterval <= interval_t::nonnegative_int(false) && right_interval <= interval_t::nonnegative_int(false)) {
+        // Interval can be represented as both an svalue and a uvalue since it fits in [0, INT32_MAX].
+        return {number_t{0} <= left_uvalue, strict ? (left_uvalue < right_uvalue) : (left_uvalue <= right_uvalue),
+                strict ? (left_svalue < right_svalue) : (left_svalue <= right_svalue)};
+    } else if (left_sinterval <= interval_t::negative_int(false) &&
+               right_sinterval <= interval_t::negative_int(false)) {
+        // Interval can be represented as both an svalue and a uvalue since it fits in [INT32_MIN, -1].
+        return {number_t{0} <= left_uvalue, strict ? (left_uvalue < right_uvalue) : (left_uvalue <= right_uvalue),
+                strict ? (left_svalue < right_svalue) : (left_svalue <= right_svalue)};
+    } else if (left_uinterval <= interval_t::unsigned_int(false) &&
+               right_uinterval <= interval_t::unsigned_int(false)) {
+        // Interval can only be represented as a uvalue.
+        return {number_t{0} <= left_uvalue, strict ? (left_uvalue < right_uvalue) : (left_uvalue <= right_uvalue)};
+    } else {
+        // We can't directly compare the uvalues since they may differ in high order bits.
+        return {};
+    }
+}
+
+std::vector<linear_constraint_t> FiniteDomain::assume_unsigned_32bit_gt(const bool strict, const variable_t left_svalue,
+                                                                        const variable_t left_uvalue,
+                                                                        const linear_expression_t& right_svalue,
+                                                                        const linear_expression_t& right_uvalue,
+                                                                        const interval_t& right_interval) const {
+    using namespace dsl_syntax;
+
+    if (right_interval <= interval_t::unsigned_high(false)) {
+        // Interval can be represented as both an svalue and a uvalue since it fits in [INT32_MAX+1, UINT32_MAX].
+        return {number_t{0} <= left_uvalue, strict ? (left_uvalue > right_uvalue) : (left_uvalue >= right_uvalue),
+                strict ? (left_svalue > right_svalue) : (left_svalue >= right_svalue)};
+    } else if (eval_interval(left_uvalue) <= interval_t::unsigned_int(false) &&
+               eval_interval(right_uvalue) <= interval_t::unsigned_int(false)) {
+        // Interval can only be represented as a uvalue.
+        return {number_t{0} <= left_uvalue, strict ? (left_uvalue > right_uvalue) : (left_uvalue >= right_uvalue)};
+    } else {
+        // We can't directly compare the uvalues since they may differ in high order bits.
+        return {};
+    };
+}
+
+// Given left and right values, get the left and right intervals, and also split
+// the left interval into separate low and high intervals.
+void FiniteDomain::get_unsigned_intervals(bool is64, const variable_t left_svalue, const variable_t left_uvalue,
+                                          const linear_expression_t& right_uvalue, interval_t& left_interval,
+                                          interval_t& right_interval, interval_t& left_interval_low,
+                                          interval_t& left_interval_high) const {
+    using namespace crab::dsl_syntax;
+
+    // Get intervals as 32-bit or 64-bit as appropriate.
+    left_interval = eval_interval(left_uvalue);
+    right_interval = eval_interval(right_uvalue);
+    if (!is64) {
+        if ((left_interval <= interval_t::nonnegative_int(false) &&
+             right_interval <= interval_t::nonnegative_int(false)) ||
+            (left_interval <= interval_t::unsigned_high(false) && right_interval <= interval_t::unsigned_high(false))) {
+            is64 = true;
+            // fallthrough as 64bit, including deduction of relational information
+        } else {
+            for (interval_t* interval : {&left_interval, &right_interval}) {
+                if (!(*interval <= interval_t::unsigned_int(false))) {
+                    *interval = interval->truncate_to_uint(false);
+                }
+            }
+            // continue as 32bit
+        }
+    }
+
+    if (!left_interval.is_top()) {
+        left_interval_low = left_interval & interval_t::nonnegative_int(true);
+        left_interval_high = left_interval & interval_t::unsigned_high(true);
+    } else {
+        left_interval = eval_interval(left_svalue);
+        if (!left_interval.is_top()) {
+            // The interval is TOP as an unsigned interval but is represented precisely as a signed interval,
+            // so split into two unsigned intervals that can be treated separately.
+            left_interval_low = interval_t(number_t{0}, left_interval.ub()).truncate_to_uint(true);
+            left_interval_high = interval_t(left_interval.lb(), number_t{-1}).truncate_to_uint(true);
+        } else {
+            left_interval_low = interval_t::nonnegative_int(true);
+            left_interval_high = interval_t::unsigned_high(true);
+        }
+    }
+
+    for (interval_t* interval : {&left_interval, &right_interval}) {
+        if (!(*interval <= interval_t::unsigned_int(true))) {
+            *interval = interval->truncate_to_uint(true);
+        }
+    }
+}
+
+static std::vector<linear_constraint_t>
+assume_signed_64bit_eq(const variable_t left_svalue, const variable_t left_uvalue, const interval_t& right_interval,
+                       const linear_expression_t& right_svalue, const linear_expression_t& right_uvalue) {
+    using namespace crab::dsl_syntax;
+    if (right_interval <= interval_t::nonnegative_int(true) && !right_interval.is_singleton()) {
+        return {(left_svalue == right_svalue), (left_uvalue == right_uvalue), eq(left_svalue, left_uvalue)};
+    } else {
+        return {(left_svalue == right_svalue), (left_uvalue == right_uvalue)};
+    }
+}
+
+static std::vector<linear_constraint_t> assume_signed_32bit_eq(const variable_t left_svalue,
+                                                               const variable_t left_uvalue,
+                                                               const interval_t& right_interval,
+                                                               const interval_t& left_interval) {
+    using namespace crab::dsl_syntax;
+    if (const auto rn = right_interval.singleton()) {
+        if (auto size = left_interval.finite_size()) {
+            // Find the lowest 64-bit svalue whose low 32 bits match the singleton.
+
+            // Get lower bound as a 64-bit value.
+            int64_t lb = left_interval.lb().number()->cast_to_sint64();
+
+            // Use the high 32-bits from the left lower bound and the low 32-bits from the right singleton.
+            // The result might be lower than the lower bound.
+            const int64_t lb_match = ((lb & 0xFFFFFFFF00000000) | (rn->cast_to_sint64() & 0xFFFFFFFF));
+            if (lb_match < lb) {
+                // The result is lower than the left interval, so try the next higher matching 64-bit value.
+                // It's ok if this goes higher than the left upper bound.
+                lb += 0x100000000;
+            }
+
+            // Find the highest 64-bit svalue whose low 32 bits match the singleton.
+
+            // Get upper bound as a 64-bit value.
+            const int64_t ub = left_interval.ub().number()->cast_to_sint64();
+
+            // Use the high 32-bits from the left upper bound and the low 32-bits from the right singleton.
+            // The result might be higher than the upper bound.
+            const int64_t ub_match = ((ub & 0xFFFFFFFF00000000) | (rn->cast_to_sint64() & 0xFFFFFFFF));
+            if (ub_match > ub) {
+                // The result is higher than the left interval, so try the next lower matching 64-bit value.
+                // It's ok if this goes lower than the left lower bound.
+                lb -= 0x100000000;
+            }
+
+            if (static_cast<uint64_t>(lb_match) <= static_cast<uint64_t>(ub_match)) {
+                // The interval is also valid when cast to a uvalue, meaning
+                // both bounds are positive or both are negative.
+                return {left_svalue >= lb_match, left_svalue <= ub_match,
+                        left_uvalue >= number_t(static_cast<uint64_t>(lb_match)),
+                        left_uvalue <= number_t(static_cast<uint64_t>(ub_match))};
+            } else {
+                // The interval can only be represented as an svalue.
+                return {left_svalue >= lb_match, left_svalue <= ub_match};
+            }
+        }
+    }
+    return {};
+}
+
+// Given left and right values, get the left and right intervals, and also split
+// the left interval into separate negative and positive intervals.
+void FiniteDomain::get_signed_intervals(bool is64, const variable_t left_svalue, const variable_t left_uvalue,
+                                        const linear_expression_t& right_svalue, interval_t& left_interval,
+                                        interval_t& right_interval, interval_t& left_interval_positive,
+                                        interval_t& left_interval_negative) const {
+
+    using namespace crab::dsl_syntax;
+
+    // Get intervals as 32-bit or 64-bit as appropriate.
+    left_interval = eval_interval(left_svalue);
+    right_interval = eval_interval(right_svalue);
+    if (!is64) {
+        if ((left_interval <= interval_t::nonnegative_int(false) &&
+             right_interval <= interval_t::nonnegative_int(false)) ||
+            (left_interval <= interval_t::negative_int(false) && right_interval <= interval_t::negative_int(false))) {
+            is64 = true;
+            // fallthrough as 64bit, including deduction of relational information
+        } else {
+            for (interval_t* interval : {&left_interval, &right_interval}) {
+                if (!(*interval <= interval_t::signed_int(false))) {
+                    *interval = interval->truncate_to_sint(false);
+                }
+            }
+            // continue as 32bit
+        }
+    }
+
+    if (!left_interval.is_top()) {
+        left_interval_positive = left_interval & interval_t::nonnegative_int(true);
+        left_interval_negative = left_interval & interval_t::negative_int(true);
+    } else {
+        left_interval = eval_interval(left_uvalue);
+        if (!left_interval.is_top()) {
+            // The interval is TOP as a signed interval but is represented precisely as an unsigned interval,
+            // so split into two signed intervals that can be treated separately.
+            left_interval_positive = left_interval & interval_t::nonnegative_int(true);
+            const number_t lih_ub =
+                left_interval.ub().number() ? left_interval.ub().number()->truncate_to_sint64() : -1;
+            left_interval_negative = interval_t(number_t{std::numeric_limits<int64_t>::min()}, lih_ub);
+        } else {
+            left_interval_positive = interval_t::nonnegative_int(true);
+            left_interval_negative = interval_t::negative_int(true);
+        }
+    }
+
+    for (interval_t* interval : {&left_interval, &right_interval}) {
+        if (!(*interval <= interval_t::signed_int(true))) {
+            *interval = interval->truncate_to_sint(true);
+        }
+    }
+}
+
+std::vector<linear_constraint_t>
+FiniteDomain::assume_signed_32bit_lt(const bool strict, const variable_t left_svalue, const variable_t left_uvalue,
+                                     const interval_t& left_interval_positive, const interval_t& left_interval_negative,
+                                     const linear_expression_t& right_svalue, const linear_expression_t& right_uvalue,
+                                     const interval_t& right_interval) const {
+
+    using namespace crab::dsl_syntax;
+
+    if (right_interval <= interval_t::negative_int(false)) {
+        // Interval can be represented as both an svalue and a uvalue since it fits in [INT_MIN, -1],
+        // aka [INT_MAX+1, UINT_MAX].
+        return {left_uvalue >= (number_t{INT32_MAX} + 1),
+                strict ? (left_uvalue < right_uvalue) : (left_uvalue <= right_uvalue),
+                strict ? (left_svalue < right_svalue) : (left_svalue <= right_svalue)};
+    } else if ((left_interval_negative | left_interval_positive) <= interval_t::nonnegative_int(false) &&
+               right_interval <= interval_t::nonnegative_int(false)) {
+        // Interval can be represented as both an svalue and a uvalue since it fits in [0, INT_MAX]
+        const auto lpub = left_interval_positive.truncate_to_sint(false).ub();
+        return {left_svalue >= 0,
+                strict ? left_svalue < right_svalue : left_svalue <= right_svalue,
+                left_svalue <= left_uvalue,
+                left_svalue >= left_uvalue,
+                left_uvalue >= 0,
+                strict ? left_uvalue < right_uvalue : left_uvalue <= right_uvalue,
+                left_uvalue <= *lpub.number()};
+    } else if (eval_interval(left_svalue) <= interval_t::signed_int(false) &&
+               eval_interval(right_svalue) <= interval_t::signed_int(false)) {
+        // Interval can only be represented as an svalue.
+        return {strict ? (left_svalue < right_svalue) : (left_svalue <= right_svalue)};
+    } else {
+        // We can't directly compare the svalues since they may differ in high order bits.
+        return {};
+    }
+}
+
+std::vector<linear_constraint_t>
+assume_signed_64bit_gt(const bool strict, const variable_t left_svalue, const variable_t left_uvalue,
+                       const interval_t& left_interval_positive, const interval_t& left_interval_negative,
+                       const linear_expression_t& right_svalue, const linear_expression_t& right_uvalue,
+                       const interval_t& right_interval) {
+
+    using namespace crab::dsl_syntax;
+
+    if (right_interval <= interval_t::nonnegative_int(true)) {
+        // Interval can be represented as both an svalue and a uvalue since it fits in [0, INT_MAX].
+        const auto lpub = left_interval_positive.truncate_to_sint(true).ub();
+        return {left_svalue >= 0,
+                strict ? left_svalue > right_svalue : left_svalue >= right_svalue,
+                left_svalue <= left_uvalue,
+                left_svalue >= left_uvalue,
+                left_uvalue >= 0,
+                strict ? left_uvalue > right_uvalue : left_uvalue >= right_uvalue,
+                left_uvalue <= *lpub.number()};
+    } else if ((left_interval_negative | left_interval_positive) <= interval_t::negative_int(true) &&
+               right_interval <= interval_t::negative_int(true)) {
+        // Interval can be represented as both an svalue and a uvalue since it fits in [INT_MIN, -1],
+        // aka [INT_MAX+1, UINT_MAX].
+        return {left_uvalue >= (number_t{INT64_MAX} + 1),
+                strict ? (left_uvalue > right_uvalue) : (left_uvalue >= right_uvalue),
+                strict ? (left_svalue > right_svalue) : (left_svalue >= right_svalue)};
+    } else {
+        // Interval can only be represented as an svalue.
+        return {strict ? (left_svalue > right_svalue) : (left_svalue >= right_svalue)};
+    }
+}
+
+std::vector<linear_constraint_t>
+FiniteDomain::assume_signed_32bit_gt(const bool strict, const variable_t left_svalue, const variable_t left_uvalue,
+                                     const interval_t& left_interval_positive, const interval_t& left_interval_negative,
+                                     const linear_expression_t& right_svalue, const linear_expression_t& right_uvalue,
+                                     const interval_t& right_interval) const {
+
+    using namespace crab::dsl_syntax;
+
+    if (right_interval <= interval_t::nonnegative_int(false)) {
+        // Interval can be represented as both an svalue and a uvalue since it fits in [0, INT_MAX].
+        const auto lpub = left_interval_positive.truncate_to_sint(false).ub();
+        return {left_svalue >= 0,
+                strict ? left_svalue > right_svalue : left_svalue >= right_svalue,
+                left_svalue <= left_uvalue,
+                left_svalue >= left_uvalue,
+                left_uvalue >= 0,
+                strict ? left_uvalue > right_uvalue : left_uvalue >= right_uvalue,
+                left_uvalue <= *lpub.number()};
+    } else if ((left_interval_negative | left_interval_positive) <= interval_t::negative_int(false) &&
+               right_interval <= interval_t::negative_int(false)) {
+        // Interval can be represented as both an svalue and a uvalue since it fits in [INT_MIN, -1],
+        // aka [INT_MAX+1, UINT_MAX].
+        return {left_uvalue >= (number_t{INT32_MAX} + 1),
+                strict ? (left_uvalue > right_uvalue) : (left_uvalue >= right_uvalue),
+                strict ? (left_svalue > right_svalue) : (left_svalue >= right_svalue)};
+    } else if (eval_interval(left_svalue) <= interval_t::signed_int(false) &&
+               eval_interval(right_svalue) <= interval_t::signed_int(false)) {
+        // Interval can only be represented as an svalue.
+        return {strict ? (left_svalue > right_svalue) : (left_svalue >= right_svalue)};
+    } else {
+        // We can't directly compare the svalues since they may differ in high order bits.
+        return {};
+    }
+}
+
+std::vector<linear_constraint_t> FiniteDomain::assume_bit_cst_interval(Condition::Op op, bool is64,
+                                                                       variable_t dst_uvalue,
+                                                                       interval_t src_interval) const {
+    using namespace crab::dsl_syntax;
+    using Op = Condition::Op;
+
+    auto dst_interval = eval_interval(dst_uvalue);
+    std::optional<number_t> dst_n = dst_interval.singleton();
+    if (!dst_n || !dst_n.value().fits_cast_to_int64()) {
+        return {};
+    }
+
+    std::optional<number_t> src_n = src_interval.singleton();
+    if (!src_n || !src_n->fits_cast_to_int64()) {
+        return {};
+    }
+    uint64_t src_int_value = src_n.value().cast_to_uint64();
+    if (!is64) {
+        src_int_value = static_cast<uint32_t>(src_int_value);
+    }
+
+    bool result;
+    switch (op) {
+    case Op::SET: result = ((dst_n.value().cast_to_uint64() & src_int_value) != 0); break;
+    case Op::NSET: result = ((dst_n.value().cast_to_uint64() & src_int_value) == 0); break;
+    default: throw std::exception();
+    }
+
+    return {result ? linear_constraint_t::true_const() : linear_constraint_t::false_const()};
+}
+
+std::vector<linear_constraint_t>
+FiniteDomain::assume_signed_cst_interval(Condition::Op op, bool is64, variable_t left_svalue, variable_t left_uvalue,
+                                         const linear_expression_t& right_svalue,
+                                         const linear_expression_t& right_uvalue) const {
+
+    using namespace crab::dsl_syntax;
+
+    interval_t left_interval = interval_t::bottom();
+    interval_t right_interval = interval_t::bottom();
+    interval_t left_interval_positive = interval_t::bottom();
+    interval_t left_interval_negative = interval_t::bottom();
+    get_signed_intervals(is64, left_svalue, left_uvalue, right_svalue, left_interval, right_interval,
+                         left_interval_positive, left_interval_negative);
+
+    if (op == Condition::Op::EQ) {
+        // Handle svalue == right.
+        if (is64) {
+            return assume_signed_64bit_eq(left_svalue, left_uvalue, right_interval, right_svalue, right_uvalue);
+        } else {
+            return assume_signed_32bit_eq(left_svalue, left_uvalue, right_interval, eval_interval(left_svalue));
+        }
+    }
+
+    const bool is_lt = op == Condition::Op::SLT || op == Condition::Op::SLE;
+    bool strict = op == Condition::Op::SLT || op == Condition::Op::SGT;
+
+    auto llb = left_interval.lb();
+    auto lub = left_interval.ub();
+    auto rlb = right_interval.lb();
+    auto rub = right_interval.ub();
+    if (!is_lt && (strict ? (lub <= rlb) : (lub < rlb))) {
+        // Left signed interval is lower than right signed interval.
+        return {linear_constraint_t::false_const()};
+    } else if (is_lt && (strict ? (llb >= rub) : (llb > rub))) {
+        // Left signed interval is higher than right signed interval.
+        return {linear_constraint_t::false_const()};
+    }
+    if (is_lt && (strict ? (lub < rlb) : (lub <= rlb))) {
+        // Left signed interval is lower than right signed interval.
+        return {linear_constraint_t::true_const()};
+    } else if (!is_lt && (strict ? (llb > rub) : (llb >= rub))) {
+        // Left signed interval is higher than right signed interval.
+        return {linear_constraint_t::true_const()};
+    }
+
+    if (is64) {
+        if (is_lt) {
+            return assume_signed_64bit_lt(strict, left_svalue, left_uvalue, left_interval_positive,
+                                          left_interval_negative, right_svalue, right_uvalue, right_interval);
+        } else {
+            return assume_signed_64bit_gt(strict, left_svalue, left_uvalue, left_interval_positive,
+                                          left_interval_negative, right_svalue, right_uvalue, right_interval);
+        }
+    } else {
+        // 32-bit compare.
+        if (is_lt) {
+            return assume_signed_32bit_lt(strict, left_svalue, left_uvalue, left_interval_positive,
+                                          left_interval_negative, right_svalue, right_uvalue, right_interval);
+        } else {
+            return assume_signed_32bit_gt(strict, left_svalue, left_uvalue, left_interval_positive,
+                                          left_interval_negative, right_svalue, right_uvalue, right_interval);
+        }
+    }
+}
+
+std::vector<linear_constraint_t>
+FiniteDomain::assume_unsigned_cst_interval(Condition::Op op, bool is64, variable_t left_svalue, variable_t left_uvalue,
+                                           const linear_expression_t& right_svalue,
+                                           const linear_expression_t& right_uvalue) const {
+    using namespace dsl_syntax;
+
+    interval_t left_interval = interval_t::bottom();
+    interval_t right_interval = interval_t::bottom();
+    interval_t left_interval_low = interval_t::bottom();
+    interval_t left_interval_high = interval_t::bottom();
+    get_unsigned_intervals(is64, left_svalue, left_uvalue, right_uvalue, left_interval, right_interval,
+                           left_interval_low, left_interval_high);
+
+    // Handle uvalue != right.
+    if (op == Condition::Op::NE) {
+        if (auto rn = right_interval.singleton()) {
+            if (rn == left_interval.truncate_to_uint(is64).lb().number()) {
+                // "NE lower bound" is equivalent to "GT lower bound".
+                op = Condition::Op::GT;
+                right_interval = interval_t{left_interval.lb()};
+            } else if (rn == left_interval.ub().number()) {
+                // "NE upper bound" is equivalent to "LT upper bound".
+                op = Condition::Op::LT;
+                right_interval = interval_t{left_interval.ub()};
+            } else {
+                return {};
+            }
+        } else {
+            return {};
+        }
+    }
+
+    const bool is_lt = op == Condition::Op::LT || op == Condition::Op::LE;
+    bool strict = op == Condition::Op::LT || op == Condition::Op::GT;
+
+    auto llb = left_interval.lb();
+    auto lub = left_interval.ub();
+    auto rlb = right_interval.lb();
+    auto rub = right_interval.ub();
+    if (!is_lt && (strict ? (lub <= rlb) : (lub < rlb))) {
+        // Left unsigned interval is lower than right unsigned interval.
+        return {linear_constraint_t::false_const()};
+    } else if (is_lt && (strict ? (llb >= rub) : (llb > rub))) {
+        // Left unsigned interval is higher than right unsigned interval.
+        return {linear_constraint_t::false_const()};
+    }
+    if (is_lt && (strict ? (lub < rlb) : (lub <= rlb))) {
+        // Left unsigned interval is lower than right unsigned interval. We still add a
+        // relationship for use when widening, such as is used in the prime conformance test.
+        if (is64) {
+            return {strict ? left_uvalue < right_uvalue : left_uvalue <= right_uvalue};
+        } else {
+            return {linear_constraint_t::true_const()};
+        }
+    } else if (!is_lt && (strict ? (llb > rub) : (llb >= rub))) {
+        // Left unsigned interval is higher than right unsigned interval. We still add a
+        // relationship for use when widening, such as is used in the prime conformance test.
+        if (is64) {
+            return {strict ? left_uvalue > right_uvalue : left_uvalue >= right_uvalue};
+        } else {
+            return {linear_constraint_t::true_const()};
+        }
+    }
+
+    if (is64) {
+        if (is_lt) {
+            return assume_unsigned_64bit_lt(strict, left_svalue, left_uvalue, left_interval_low, left_interval_high,
+                                            right_svalue, right_uvalue, right_interval);
+        } else {
+            return assume_unsigned_64bit_gt(strict, left_svalue, left_uvalue, left_interval_low, left_interval_high,
+                                            right_svalue, right_uvalue, right_interval);
+        }
+    } else {
+        if (is_lt) {
+            return assume_unsigned_32bit_lt(strict, left_svalue, left_uvalue, right_svalue, right_uvalue,
+                                            right_interval);
+        } else {
+            return assume_unsigned_32bit_gt(strict, left_svalue, left_uvalue, right_svalue, right_uvalue,
+                                            right_interval);
+        }
+    }
+}
+
+} // namespace crab::domains

--- a/src/crab/finite_domain.hpp
+++ b/src/crab/finite_domain.hpp
@@ -1,0 +1,364 @@
+// Copyright (c) Prevail Verifier contributors.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include <optional>
+#include <utility>
+
+#include "crab/interval.hpp"
+#include "crab/linear_constraint.hpp"
+#include "crab/split_dbm.hpp"
+#include "crab/thresholds.hpp"
+#include "crab/variable.hpp"
+#include "string_constraints.hpp"
+
+namespace crab::domains {
+
+class FiniteDomain final {
+    SplitDBM dom;
+
+    explicit FiniteDomain(const SplitDBM& dom) : dom{dom} {}
+
+  public:
+    explicit FiniteDomain() = default;
+
+    FiniteDomain(const FiniteDomain& o) = default;
+    FiniteDomain(FiniteDomain&& o) = default;
+
+    FiniteDomain& operator=(const FiniteDomain& o) = default;
+    FiniteDomain& operator=(FiniteDomain&& o) = default;
+
+    void operator+=(const linear_constraint_t& cst) { dom.add_constraint(cst); }
+
+    void operator-=(const variable_t v) { dom -= v; }
+
+    void assign(const variable_t x, const linear_expression_t& e) { dom.assign(x, e); }
+    void assign(const variable_t x, const int64_t e) { dom.set(x, crab::interval_t(number_t(e))); }
+
+    void apply(const arith_binop_t op, const variable_t x, const variable_t y, const number_t& z,
+               const int finite_width) {
+        dom.apply(op, x, y, z, finite_width);
+    }
+
+    void apply(const arith_binop_t op, const variable_t x, const variable_t y, const variable_t z,
+               const int finite_width) {
+        dom.apply(op, x, y, z, finite_width);
+    }
+
+    void apply(const bitwise_binop_t op, const variable_t x, const variable_t y, const variable_t z,
+               const int finite_width) {
+        dom.apply(op, x, y, z, finite_width);
+    }
+
+    void apply(const bitwise_binop_t op, const variable_t x, const variable_t y, const number_t& k,
+               const int finite_width) {
+        dom.apply(op, x, y, k, finite_width);
+    }
+
+    void apply(binop_t op, variable_t x, variable_t y, const number_t& z, int finite_width) {
+        std::visit([&](auto top) { apply(top, x, y, z, finite_width); }, op);
+    }
+
+    void apply(binop_t op, variable_t x, variable_t y, variable_t z, int finite_width) {
+        std::visit([&](auto top) { apply(top, x, y, z, finite_width); }, op);
+    }
+
+    void overflow_bounds(variable_t lhs, number_t span, int finite_width, bool is_signed);
+
+    void overflow_signed(const variable_t lhs, const int finite_width) {
+        const auto span{finite_width == 64   ? z_number{std::numeric_limits<uint64_t>::max()}
+                        : finite_width == 32 ? z_number{std::numeric_limits<uint32_t>::max()}
+                                             : throw std::exception()};
+        overflow_bounds(lhs, span, finite_width, true);
+    }
+
+    void overflow_unsigned(const variable_t lhs, const int finite_width) {
+        const auto span{finite_width == 64   ? z_number{std::numeric_limits<uint64_t>::max()}
+                        : finite_width == 32 ? z_number{std::numeric_limits<uint32_t>::max()}
+                                             : throw std::exception()};
+        overflow_bounds(lhs, span, finite_width, false);
+    }
+
+    void apply_signed(const binop_t& op, const variable_t xs, const variable_t xu, const variable_t y,
+                      const number_t& z, const int finite_width) {
+        apply(op, xs, y, z, finite_width);
+        if (finite_width) {
+            assign(xu, xs);
+            overflow_signed(xs, finite_width);
+            overflow_unsigned(xu, finite_width);
+        }
+    }
+
+    void apply_unsigned(const binop_t& op, const variable_t xs, const variable_t xu, const variable_t y,
+                        const number_t& z, const int finite_width) {
+        apply(op, xu, y, z, finite_width);
+        if (finite_width) {
+            assign(xs, xu);
+            overflow_signed(xs, finite_width);
+            overflow_unsigned(xu, finite_width);
+        }
+    }
+
+    void apply_signed(const binop_t& op, const variable_t xs, const variable_t xu, const variable_t y,
+                      const variable_t z, const int finite_width) {
+        apply(op, xs, y, z, finite_width);
+        if (finite_width) {
+            assign(xu, xs);
+            overflow_signed(xs, finite_width);
+            overflow_unsigned(xu, finite_width);
+        }
+    }
+
+    void apply_unsigned(const binop_t& op, const variable_t xs, const variable_t xu, const variable_t y,
+                        const variable_t z, const int finite_width = 0) {
+        apply(op, xu, y, z, finite_width);
+        if (finite_width) {
+            assign(xs, xu);
+            overflow_signed(xs, finite_width);
+            overflow_unsigned(xu, finite_width);
+        }
+    }
+
+    void sign_extend(variable_t svalue, variable_t uvalue, const linear_expression_t& right_svalue, int finite_width,
+                     int bits);
+    void add(const variable_t lhs, const variable_t op2) { apply_signed(arith_binop_t::ADD, lhs, lhs, lhs, op2, 0); }
+    void add(const variable_t lhs, const number_t& op2) { apply_signed(arith_binop_t::ADD, lhs, lhs, lhs, op2, 0); }
+    void sub(const variable_t lhs, const variable_t op2) { apply_signed(arith_binop_t::SUB, lhs, lhs, lhs, op2, 0); }
+    void sub(const variable_t lhs, const number_t& op2) { apply_signed(arith_binop_t::SUB, lhs, lhs, lhs, op2, 0); }
+
+    // Add/subtract with overflow are both signed and unsigned. We can use either one of the two to compute the
+    // result before adjusting for overflow, though if one is top we want to use the other to retain precision.
+    void add_overflow(const variable_t lhss, const variable_t lhsu, const variable_t op2, const int finite_width) {
+        apply_signed(arith_binop_t::ADD, lhss, lhsu, ((!dom.eval_interval(lhss).is_top()) ? lhss : lhsu), op2,
+                     finite_width);
+    }
+    void add_overflow(const variable_t lhss, const variable_t lhsu, const number_t& op2, const int finite_width) {
+        apply_signed(arith_binop_t::ADD, lhss, lhsu, ((!dom.eval_interval(lhss).is_top()) ? lhss : lhsu), op2,
+                     finite_width);
+    }
+    void sub_overflow(const variable_t lhss, const variable_t lhsu, const variable_t op2, const int finite_width) {
+        apply_signed(arith_binop_t::SUB, lhss, lhsu, ((!dom.eval_interval(lhss).is_top()) ? lhss : lhsu), op2,
+                     finite_width);
+    }
+    void sub_overflow(const variable_t lhss, const variable_t lhsu, const number_t& op2, const int finite_width) {
+        apply_signed(arith_binop_t::SUB, lhss, lhsu, ((!dom.eval_interval(lhss).is_top()) ? lhss : lhsu), op2,
+                     finite_width);
+    }
+
+    void neg(const variable_t lhss, const variable_t lhsu, const int finite_width) {
+        apply_signed(arith_binop_t::MUL, lhss, lhsu, lhss, (number_t)-1, finite_width);
+    }
+    void mul(const variable_t lhss, const variable_t lhsu, const variable_t op2, const int finite_width) {
+        apply_signed(arith_binop_t::MUL, lhss, lhsu, lhss, op2, finite_width);
+    }
+    void mul(const variable_t lhss, const variable_t lhsu, const number_t& op2, const int finite_width) {
+        apply_signed(arith_binop_t::MUL, lhss, lhsu, lhss, op2, finite_width);
+    }
+    void sdiv(const variable_t lhss, const variable_t lhsu, const variable_t op2, const int finite_width) {
+        apply_signed(arith_binop_t::SDIV, lhss, lhsu, lhss, op2, finite_width);
+    }
+    void sdiv(const variable_t lhss, const variable_t lhsu, const number_t& op2, const int finite_width) {
+        apply_signed(arith_binop_t::SDIV, lhss, lhsu, lhss, op2, finite_width);
+    }
+    void udiv(const variable_t lhss, const variable_t lhsu, const variable_t op2, const int finite_width) {
+        apply_unsigned(arith_binop_t::UDIV, lhss, lhsu, lhsu, op2, finite_width);
+    }
+    void udiv(const variable_t lhss, const variable_t lhsu, const number_t& op2, const int finite_width) {
+        apply_unsigned(arith_binop_t::UDIV, lhss, lhsu, lhsu, op2, finite_width);
+    }
+    void srem(const variable_t lhss, const variable_t lhsu, const variable_t op2, const int finite_width) {
+        apply_signed(arith_binop_t::SREM, lhss, lhsu, lhss, op2, finite_width);
+    }
+    void srem(const variable_t lhss, const variable_t lhsu, const number_t& op2, const int finite_width) {
+        apply_signed(arith_binop_t::SREM, lhss, lhsu, lhss, op2, finite_width);
+    }
+    void urem(const variable_t lhss, const variable_t lhsu, const variable_t op2, const int finite_width) {
+        apply_unsigned(arith_binop_t::UREM, lhss, lhsu, lhsu, op2, finite_width);
+    }
+    void urem(const variable_t lhss, const variable_t lhsu, const number_t& op2, const int finite_width) {
+        apply_unsigned(arith_binop_t::UREM, lhss, lhsu, lhsu, op2, finite_width);
+    }
+
+    void bitwise_and(const variable_t lhss, const variable_t lhsu, const variable_t op2, const int finite_width) {
+        apply_unsigned(bitwise_binop_t::AND, lhss, lhsu, lhsu, op2, finite_width);
+    }
+    void bitwise_and(const variable_t lhss, const variable_t lhsu, const number_t& op2) {
+        // Use finite width 64 to make the svalue be set as well as the uvalue.
+        apply_unsigned(bitwise_binop_t::AND, lhss, lhsu, lhsu, op2, 64);
+    }
+    void bitwise_or(const variable_t lhss, const variable_t lhsu, const variable_t op2, const int finite_width) {
+        apply_unsigned(bitwise_binop_t::OR, lhss, lhsu, lhsu, op2, finite_width);
+    }
+    void bitwise_or(const variable_t lhss, const variable_t lhsu, const number_t& op2) {
+        apply_unsigned(bitwise_binop_t::OR, lhss, lhsu, lhsu, op2, 64);
+    }
+    void bitwise_xor(const variable_t lhss, const variable_t lhsu, const variable_t op2, const int finite_width) {
+        apply_unsigned(bitwise_binop_t::XOR, lhss, lhsu, lhsu, op2, finite_width);
+    }
+    void bitwise_xor(const variable_t lhss, const variable_t lhsu, const number_t& op2) {
+        apply_unsigned(bitwise_binop_t::XOR, lhss, lhsu, lhsu, op2, 64);
+    }
+    void shl_overflow(const variable_t lhss, const variable_t lhsu, const variable_t op2) {
+        apply_unsigned(bitwise_binop_t::SHL, lhss, lhsu, lhsu, op2, 64);
+    }
+    void shl_overflow(const variable_t lhss, const variable_t lhsu, const number_t& op2) {
+        apply_unsigned(bitwise_binop_t::SHL, lhss, lhsu, lhsu, op2, 64);
+    }
+
+    void shl(variable_t svalue, variable_t uvalue, int imm, int finite_width);
+
+    void lshr(variable_t svalue, variable_t uvalue, int imm, int finite_width);
+
+    bool ashr(variable_t svalue, variable_t uvalue, const linear_expression_t& right_svalue, int finite_width);
+
+  private:
+    std::vector<linear_constraint_t>
+    assume_unsigned_64bit_lt(bool strict, variable_t left_svalue, variable_t left_uvalue,
+                             const interval_t& left_interval_low, const interval_t& left_interval_high,
+                             const linear_expression_t& right_svalue, const linear_expression_t& right_uvalue,
+                             const interval_t& right_interval) const;
+
+    std::vector<linear_constraint_t> assume_unsigned_32bit_lt(bool strict, variable_t left_svalue,
+                                                              variable_t left_uvalue,
+                                                              const linear_expression_t& right_svalue,
+                                                              const linear_expression_t& right_uvalue,
+                                                              const interval_t& right_interval) const;
+
+    std::vector<linear_constraint_t> assume_unsigned_32bit_gt(bool strict, variable_t left_svalue,
+                                                              variable_t left_uvalue,
+                                                              const linear_expression_t& right_svalue,
+                                                              const linear_expression_t& right_uvalue,
+                                                              const interval_t& right_interval) const;
+
+    // Given left and right values, get the left and right intervals, and also split
+    // the left interval into separate low and high intervals.
+    void get_unsigned_intervals(bool is64, variable_t left_svalue, variable_t left_uvalue,
+                                const linear_expression_t& right_uvalue, interval_t& left_interval,
+                                interval_t& right_interval, interval_t& left_interval_low,
+                                interval_t& left_interval_high) const;
+
+    // Given left and right values, get the left and right intervals, and also split
+    // the left interval into separate negative and positive intervals.
+    void get_signed_intervals(bool is64, variable_t left_svalue, variable_t left_uvalue,
+                              const linear_expression_t& right_svalue, interval_t& left_interval,
+                              interval_t& right_interval, interval_t& left_interval_positive,
+                              interval_t& left_interval_negative) const;
+    std::vector<linear_constraint_t> assume_signed_32bit_lt(bool strict, variable_t left_svalue, variable_t left_uvalue,
+                                                            const interval_t& left_interval_positive,
+                                                            const interval_t& left_interval_negative,
+                                                            const linear_expression_t& right_svalue,
+                                                            const linear_expression_t& right_uvalue,
+                                                            const interval_t& right_interval) const;
+
+    std::vector<linear_constraint_t> assume_signed_32bit_gt(bool strict, variable_t left_svalue, variable_t left_uvalue,
+                                                            const interval_t& left_interval_positive,
+                                                            const interval_t& left_interval_negative,
+                                                            const linear_expression_t& right_svalue,
+                                                            const linear_expression_t& right_uvalue,
+                                                            const interval_t& right_interval) const;
+
+  public:
+    std::vector<linear_constraint_t> assume_bit_cst_interval(Condition::Op op, bool is64, variable_t dst_uvalue,
+                                                             interval_t src_interval) const;
+
+    std::vector<linear_constraint_t> assume_signed_cst_interval(Condition::Op op, bool is64, variable_t left_svalue,
+                                                                variable_t left_uvalue,
+                                                                const linear_expression_t& right_svalue,
+                                                                const linear_expression_t& right_uvalue) const;
+
+    std::vector<linear_constraint_t> assume_unsigned_cst_interval(Condition::Op op, bool is64, variable_t left_svalue,
+                                                                  variable_t left_uvalue,
+                                                                  const linear_expression_t& right_svalue,
+                                                                  const linear_expression_t& right_uvalue) const;
+    void set_to_top() { dom.set_to_top(); }
+
+    static FiniteDomain top() { return FiniteDomain(); }
+
+    [[nodiscard]]
+    bool is_top() const {
+        return dom.is_top();
+    }
+
+    bool operator<=(const FiniteDomain& o) const { return dom <= o.dom; }
+
+    // FIXME: can be done more efficient
+    void operator|=(const FiniteDomain& o) { *this = *this | o; }
+    void operator|=(FiniteDomain&& o) { *this = *this | std::move(o); }
+
+    FiniteDomain operator|(const FiniteDomain& o) const& { return FiniteDomain{dom | o.dom}; }
+
+    FiniteDomain operator|(FiniteDomain&& o) && { return FiniteDomain{std::move(dom) | o.dom}; }
+
+    FiniteDomain operator|(const FiniteDomain& o) && { return FiniteDomain{std::move(dom) | o.dom}; }
+
+    FiniteDomain operator|(FiniteDomain&& o) const& { return FiniteDomain{dom | o.dom}; }
+
+    [[nodiscard]]
+    FiniteDomain widen(const FiniteDomain& o) const {
+        return FiniteDomain{dom.widen(o.dom)};
+    }
+
+    [[nodiscard]]
+    FiniteDomain widening_thresholds(const FiniteDomain& o, const thresholds_t& ts) const {
+        // TODO: use thresholds
+        return this->widen(o);
+    }
+
+    std::optional<FiniteDomain> meet(const FiniteDomain& o) const {
+        const auto res = dom.meet(o.dom);
+        if (!res) {
+            return {};
+        }
+        return FiniteDomain{*res};
+    }
+
+    [[nodiscard]]
+    FiniteDomain narrow(const FiniteDomain& o) const {
+        return FiniteDomain{dom.narrow(o.dom)};
+    }
+    void assign(auto lhs, auto e) { dom.assign(lhs, e); }
+
+    void apply(auto op, auto x, auto y, auto z, int finite_width = 0) { dom.apply(op, x, y, z, finite_width); }
+
+    bool add_constraint(const linear_constraint_t& cst) { return dom.add_constraint(cst); }
+
+    [[nodiscard]]
+    interval_t eval_interval(const linear_expression_t& e) const {
+        return dom.eval_interval(e);
+    }
+
+    interval_t operator[](const variable_t x) const { return dom[x]; }
+
+    void set(const variable_t x, const interval_t& intv) { dom.set(x, intv); }
+
+    void forget(auto variables) { dom.forget(variables); }
+
+    [[nodiscard]]
+    std::pair<std::size_t, std::size_t> size() const {
+        return dom.size();
+    }
+
+    // Return true if inv intersects with cst.
+    [[nodiscard]]
+    bool intersect(const linear_constraint_t& cst) const {
+        return dom.intersect(cst);
+    }
+
+    // Return true if entails rhs.
+    [[nodiscard]]
+    bool entail(const linear_constraint_t& rhs) const {
+        return dom.entail(rhs);
+    }
+
+    friend std::ostream& operator<<(std::ostream& o, const FiniteDomain& dom) { return o << dom.dom; }
+
+    [[nodiscard]]
+    string_invariant to_set() const {
+        return dom.to_set();
+    }
+
+    static void clear_thread_local_state() { SplitDBM::clear_thread_local_state(); }
+}; // class FiniteDomain
+
+} // namespace crab::domains

--- a/test-data/subtract.yaml
+++ b/test-data/subtract.yaml
@@ -43,7 +43,7 @@ post:
 ---
 test-case: subtract unknown register from itself
 
-pre: [ ]
+pre: []
 
 code:
   <start>: |

--- a/test-data/subtract.yaml
+++ b/test-data/subtract.yaml
@@ -28,9 +28,22 @@ post:
   - r0.uvalue=[2147483645, 2147483647]
   - r0.svalue=r0.uvalue
 ---
-test-case: subtract a register from itself
+test-case: subtract a number from itself
 
 pre: ["r1.type=number"]
+
+code:
+  <start>: |
+    r1 -= r1
+
+post:
+  - r1.type=number
+  - r1.svalue=0
+  - r1.uvalue=0
+---
+test-case: subtract unknown register from itself
+
+pre: [ ]
 
 code:
   <start>: |


### PR DESCRIPTION
Move numerical operations that deal with signedness and overflow from ebpf_domain_t to FiniteDomain, with its own cpp and hpp.

Also: always allow `rx -= rx`.

