### PR TITLE
Use template for truncation

### DIFF
--- a/src/crab/array_domain.cpp
+++ b/src/crab/array_domain.cpp
@@ -132,7 +132,7 @@ class cell_t final {
 
     [[nodiscard]]
     variable_t get_scalar(data_kind_t kind) const {
-        return variable_t::cell_var(kind, number_t{_offset}, _size);
+        return variable_t::cell_var(kind, number_t{static_cast<index_t>(_offset)}, _size);
     }
 
     // ignore the scalar variable

--- a/src/crab/ebpf_domain.cpp
+++ b/src/crab/ebpf_domain.cpp
@@ -224,7 +224,7 @@ static void get_signed_intervals(const NumAbsDomain& inv, bool is64, variable_t 
             // The interval is TOP as a signed interval but is represented precisely as an unsigned interval,
             // so split into two signed intervals that can be treated separately.
             left_interval_positive = left_interval & interval_t::nonnegative_int(true);
-            number_t lih_ub = left_interval.ub().number() ? left_interval.ub().number()->truncate_to_sint64() : -1;
+            number_t lih_ub = left_interval.ub().number() ? left_interval.ub().number()->truncate_to_signed_finite_width(64) : -1;
             left_interval_negative = interval_t(number_t{std::numeric_limits<int64_t>::min()}, lih_ub);
         } else {
             left_interval_positive = interval_t::nonnegative_int(true);
@@ -1394,8 +1394,8 @@ void ebpf_domain_t::overflow_bounds(NumAbsDomain& inv, variable_t lhs, number_t 
     number_t lb = lb_value.truncate_to_unsigned_finite_width(finite_width);
     number_t ub = ub_value.truncate_to_unsigned_finite_width(finite_width);
     if (issigned) {
-        lb = lb.truncate_to_sint64();
-        ub = ub.truncate_to_sint64();
+        lb = lb.truncate_to_signed_finite_width(64);
+        ub = ub.truncate_to_signed_finite_width(64);
     }
     if (lb > ub) {
         // Range wraps in the middle, so we cannot represent as an unsigned interval.


### PR DESCRIPTION
This is related to #679 - not a fix, but I think it might help addressing it. Also somewhat cleaner.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced numeric handling in the `z_number` class with new template functions for truncation and fitting integral types.
	- Improved precision in numeric truncation methods within the `ebpf_domain`.

- **Bug Fixes**
	- Updated return handling in the `get_scalar` method to ensure proper type casting, enhancing value interpretation.

- **Refactor**
	- Streamlined constructors and methods in the `z_number` class to reduce redundancy and improve type safety.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->