### PR TITLE
Use explicit width for finite width parameters

### DIFF
--- a/src/crab/array_domain.cpp
+++ b/src/crab/array_domain.cpp
@@ -583,7 +583,7 @@ static std::optional<std::pair<offset_t, unsigned>> kill_and_find_var(NumAbsDoma
 bool array_domain_t::all_num(NumAbsDomain& inv, const linear_expression_t& lb, const linear_expression_t& ub) {
     auto min_lb = inv.eval_interval(lb).lb().number();
     auto max_ub = inv.eval_interval(ub).ub().number();
-    if (!min_lb || !max_ub || !min_lb->fits_sint32() || !max_ub->fits_sint32()) {
+    if (!min_lb || !max_ub || !min_lb->fits<int32_t>() || !max_ub->fits<int32_t>()) {
         return false;
     }
 
@@ -601,7 +601,7 @@ bool array_domain_t::all_num(NumAbsDomain& inv, const linear_expression_t& lb, c
 int array_domain_t::min_all_num_size(const NumAbsDomain& inv, variable_t offset) const {
     auto min_lb = inv.eval_interval(offset).lb().number();
     auto max_ub = inv.eval_interval(offset).ub().number();
-    if (!min_lb || !max_ub || !min_lb->fits_sint32() || !max_ub->fits_sint32()) {
+    if (!min_lb || !max_ub || !min_lb->fits<int32_t>() || !max_ub->fits<int32_t>()) {
         return 0;
     }
     auto lb = (int)min_lb.value();
@@ -616,7 +616,7 @@ std::optional<uint8_t> get_value_byte(NumAbsDomain& inv, offset_t o, int width) 
     if (!t) {
         return {};
     }
-    uint64_t n = t->cast_to_uint64();
+    uint64_t n = t->cast_to<uint64_t>();
 
     // Convert value to bytes of the appropriate endian-ness.
     switch (width) {
@@ -751,7 +751,7 @@ std::optional<linear_expression_t> array_domain_t::load(NumAbsDomain& inv, data_
         auto ub = ii.ub().number();
         if (lb.has_value() && ub.has_value()) {
             z_number fullwidth = ub.value() - lb.value() + width;
-            if (lb.value().fits_uint32() && fullwidth.fits_uint32()) {
+            if (lb.value().fits<uint32_t>() && fullwidth.fits<uint32_t>()) {
                 auto [only_num, only_non_num] = num_bytes.uniformity((uint32_t)lb.value(), (uint32_t)fullwidth);
                 if (only_num) {
                     return number_t{T_NUM};

--- a/src/crab/ebpf_domain.cpp
+++ b/src/crab/ebpf_domain.cpp
@@ -2057,7 +2057,7 @@ void ebpf_domain_t::do_load_ctx(NumAbsDomain& inv, const Reg& target_reg, const 
     std::optional<number_t> maybe_addr = interval.singleton();
     havoc_register(inv, target_reg);
 
-    bool may_touch_ptr = interval[desc->data] || interval[desc->meta] || interval[desc->end];
+    bool may_touch_ptr = interval.contains(desc->data) || interval.contains(desc->meta) || interval.contains(desc->end);
 
     if (!maybe_addr) {
         if (may_touch_ptr) {

--- a/src/crab/interval.cpp
+++ b/src/crab/interval.cpp
@@ -29,13 +29,13 @@ interval_t interval_t::operator/(const interval_t& x) const {
         using z_interval = interval_t;
         if (x[0]) {
             // The divisor contains 0.
-            z_interval l(x._lb, z_bound(-1));
-            z_interval u(z_bound(1), x._ub);
+            z_interval l(x._lb, bound_t(-1));
+            z_interval u(bound_t(1), x._ub);
             return (operator/(l) | operator/(u) | z_interval(number_t(0)));
         } else if (operator[](0)) {
             // The dividend contains 0.
-            z_interval l(_lb, z_bound(-1));
-            z_interval u(z_bound(1), _ub);
+            z_interval l(_lb, bound_t(-1));
+            z_interval u(bound_t(1), _ub);
             return ((l / x) | (u / x) | z_interval(number_t(0)));
         } else {
             // Neither the dividend nor the divisor contains 0
@@ -47,7 +47,7 @@ interval_t interval_t::operator/(const interval_t& x) const {
             bound_t lu = a._lb / x._ub;
             bound_t ul = a._ub / x._lb;
             bound_t uu = a._ub / x._ub;
-            return interval_t(bound_t::min(ll, lu, ul, uu), bound_t::max(ll, lu, ul, uu));
+            return interval_t(std::min({ll, lu, ul, uu}), std::max({ll, lu, ul, uu}));
         }
     }
 }
@@ -76,13 +76,13 @@ interval_t interval_t::SDiv(const interval_t& x) const {
         using z_interval = interval_t;
         if (x[0]) {
             // The divisor contains 0.
-            z_interval l(x._lb, z_bound(-1));
-            z_interval u(z_bound(1), x._ub);
+            z_interval l(x._lb, bound_t(-1));
+            z_interval u(bound_t(1), x._ub);
             return (SDiv(l) | SDiv(u) | z_interval(number_t(0)));
         } else if (operator[](0)) {
             // The dividend contains 0.
-            z_interval l(_lb, z_bound(-1));
-            z_interval u(z_bound(1), _ub);
+            z_interval l(_lb, bound_t(-1));
+            z_interval u(bound_t(1), _ub);
             return (l.SDiv(x) | u.SDiv(x) | z_interval(number_t(0)));
         } else {
             // Neither the dividend nor the divisor contains 0
@@ -94,7 +94,7 @@ interval_t interval_t::SDiv(const interval_t& x) const {
             bound_t lu = a._lb / x._ub;
             bound_t ul = a._ub / x._lb;
             bound_t uu = a._ub / x._ub;
-            return interval_t(bound_t::min(ll, lu, ul, uu), bound_t::max(ll, lu, ul, uu));
+            return interval_t(std::min({ll, lu, ul, uu}), std::max({ll, lu, ul, uu}));
         }
     }
 }
@@ -123,13 +123,13 @@ interval_t interval_t::UDiv(const interval_t& x) const {
         using z_interval = interval_t;
         if (x[0]) {
             // The divisor contains 0.
-            z_interval l(x._lb, z_bound(-1));
-            z_interval u(z_bound(1), x._ub);
+            z_interval l(x._lb, bound_t(-1));
+            z_interval u(bound_t(1), x._ub);
             return (UDiv(l) | UDiv(u) | z_interval(number_t(0)));
         } else if (operator[](0)) {
             // The dividend contains 0.
-            z_interval l(_lb, z_bound(-1));
-            z_interval u(z_bound(1), _ub);
+            z_interval l(_lb, bound_t(-1));
+            z_interval u(bound_t(1), _ub);
             return (l.UDiv(x) | u.UDiv(x) | z_interval(number_t(0)));
         } else {
             // Neither the dividend nor the divisor contains 0
@@ -141,7 +141,7 @@ interval_t interval_t::UDiv(const interval_t& x) const {
             bound_t lu = a._lb.UDiv(x._ub);
             bound_t ul = a._ub.UDiv(x._lb);
             bound_t uu = a._ub.UDiv(x._ub);
-            return interval_t(bound_t::min(ll, lu, ul, uu), bound_t::max(ll, lu, ul, uu));
+            return interval_t(std::min({ll, lu, ul, uu}), std::max({ll, lu, ul, uu}));
         }
     }
 }
@@ -163,8 +163,8 @@ interval_t interval_t::SRem(const interval_t& x) const {
         return interval_t(dividend % divisor);
     } else if (x[0]) {
         // The divisor contains 0.
-        interval_t l(x._lb, z_bound(-1));
-        interval_t u(z_bound(1), x._ub);
+        interval_t l(x._lb, bound_t(-1));
+        interval_t u(bound_t(1), x._ub);
         return SRem(l) | SRem(u) | *this;
     } else if (x.ub().is_finite() && x.lb().is_finite()) {
         number_t min_divisor = min(abs(*x.lb().number()), abs(*x.ub().number()));
@@ -212,13 +212,13 @@ interval_t interval_t::URem(const interval_t& x) const {
         using z_interval = interval_t;
         if (x[0]) {
             // The divisor contains 0.
-            z_interval l(x._lb, z_bound(-1));
-            z_interval u(z_bound(1), x._ub);
+            z_interval l(x._lb, bound_t(-1));
+            z_interval u(bound_t(1), x._ub);
             return (URem(l) | URem(u) | *this);
         } else if (operator[](0)) {
             // The dividend contains 0.
-            z_interval l(_lb, z_bound(-1));
-            z_interval u(z_bound(1), _ub);
+            z_interval l(_lb, bound_t(-1));
+            z_interval u(bound_t(1), _ub);
             return (l.URem(x) | u.URem(x) | *this);
         } else {
             // Neither the dividend nor the divisor contains 0
@@ -266,7 +266,7 @@ interval_t interval_t::And(const interval_t& x) const {
             // avoid setting other bits via sign extension.
             return interval_t{number_t{0}, number_t{UINT32_MAX}};
         } else if (!is_top() && !x.is_top()) {
-            return interval_t(number_t{0}, bound_t::min(ub(), x.ub()));
+            return interval_t(number_t{0}, std::min(ub(), x.ub()));
         } else if (!x.is_top()) {
             return interval_t(number_t{0}, x.ub());
         } else if (!is_top()) {

--- a/src/crab/interval.cpp
+++ b/src/crab/interval.cpp
@@ -55,11 +55,11 @@ interval_t interval_t::SDiv(const interval_t& x) const {
         return bottom();
     }
     if (const auto n = x.singleton()) {
-        if (n->fits_cast_to_int64()) {
+        if (n->fits_cast_to<int64_t>()) {
             // Divisor is a singleton:
             //   the linear interval solver can perform many divisions where
             //   the divisor is a singleton interval. We optimize for this case.
-            number_t c{n->cast_to_sint64()};
+            number_t c{n->cast_to<int64_t>()};
             if (c == 1) {
                 return *this;
             } else if (c != 0) {
@@ -100,11 +100,11 @@ interval_t interval_t::UDiv(const interval_t& x) const {
         return bottom();
     }
     if (const auto n = x.singleton()) {
-        if (n->fits_cast_to_int64()) {
+        if (n->fits_cast_to<int64_t>()) {
             // Divisor is a singleton:
             //   the linear interval solver can perform many divisions where
             //   the divisor is a singleton interval. We optimize for this case.
-            number_t c{n->cast_to_uint64()};
+            number_t c{n->cast_to<uint64_t>()};
             if (c == 1) {
                 return *this;
             } else if (c > number_t{0}) {
@@ -215,11 +215,11 @@ interval_t interval_t::URem(const interval_t& x) const {
             // a value between the upper bound and 0, so set to top.  A "positive" dividend
             // could result in anything between 0 and the dividend - 1.
             return (_ub < number_t{0}) ? top() : ((*this - interval_t(number_t{1})) | interval_t(number_t(0)));
-        } else if (_ub.is_finite() && (_ub.number()->cast_to_uint64() < x._lb.number()->cast_to_uint64())) {
+        } else if (_ub.is_finite() && (_ub.number()->cast_to<uint64_t>() < x._lb.number()->cast_to<uint64_t>())) {
             // Dividend lower than divisor, so the dividend is the remainder.
             return *this;
         } else {
-            number_t max_divisor{x._ub.number()->cast_to_uint64()};
+            number_t max_divisor{x._ub.number()->cast_to<uint64_t>()};
             return interval_t(number_t{0}, max_divisor - 1);
         }
     }
@@ -243,7 +243,7 @@ interval_t interval_t::And(const interval_t& x) const {
         if (const auto width = finite_size()) {
             const number_t lb32_n = lb().number()->truncate_to<uint32_t>();
             const number_t ub32_n = ub().number()->truncate_to<uint32_t>();
-            if (width->fits_uint32() && lb32_n < ub32_n && lb32_n + width->truncate_to<uint32_t>() == ub32_n) {
+            if (width->fits<uint32_t>() && lb32_n < ub32_n && lb32_n + width->truncate_to<uint32_t>() == ub32_n) {
                 return interval_t{lb32_n, ub32_n};
             }
         }

--- a/src/crab/interval.cpp
+++ b/src/crab/interval.cpp
@@ -8,47 +8,44 @@ namespace crab {
 interval_t interval_t::operator/(const interval_t& x) const {
     if (is_bottom() || x.is_bottom()) {
         return bottom();
-    } else {
+    }
+    if (const auto n = x.singleton()) {
         // Divisor is a singleton:
         //   the linear interval solver can perform many divisions where
         //   the divisor is a singleton interval. We optimize for this case.
-        if (std::optional<number_t> n = x.singleton()) {
-            number_t c = *n;
-            if (c == number_t{1}) {
-                return *this;
-            } else if (c > number_t{0}) {
-                return interval_t(_lb / bound_t{c}, _ub / bound_t{c});
-            } else if (c < number_t{0}) {
-                return interval_t(_ub / bound_t{c}, _lb / bound_t{c});
-            } else {
-                // The eBPF ISA defines division by 0 as resulting in 0.
-                return interval_t(number_t(0));
-            }
-        }
-        // Divisor is not a singleton
-        using z_interval = interval_t;
-        if (x[0]) {
-            // The divisor contains 0.
-            z_interval l(x._lb, bound_t(-1));
-            z_interval u(bound_t(1), x._ub);
-            return (operator/(l) | operator/(u) | z_interval(number_t(0)));
-        } else if (operator[](0)) {
-            // The dividend contains 0.
-            z_interval l(_lb, bound_t(-1));
-            z_interval u(bound_t(1), _ub);
-            return ((l / x) | (u / x) | z_interval(number_t(0)));
+        number_t c = *n;
+        if (c == number_t{1}) {
+            return *this;
+        } else if (c > number_t{0}) {
+            return interval_t(_lb / bound_t{c}, _ub / bound_t{c});
+        } else if (c < number_t{0}) {
+            return interval_t(_ub / bound_t{c}, _lb / bound_t{c});
         } else {
-            // Neither the dividend nor the divisor contains 0
-            z_interval a =
-                (_ub < number_t{0})
-                    ? (*this + ((x._ub < number_t{0}) ? (x + z_interval(number_t(1))) : (z_interval(number_t(1)) - x)))
-                    : *this;
-            bound_t ll = a._lb / x._lb;
-            bound_t lu = a._lb / x._ub;
-            bound_t ul = a._ub / x._lb;
-            bound_t uu = a._ub / x._ub;
-            return interval_t(std::min({ll, lu, ul, uu}), std::max({ll, lu, ul, uu}));
+            // The eBPF ISA defines division by 0 as resulting in 0.
+            return interval_t(number_t(0));
         }
+    }
+    if (x.contains(0)) {
+        // The divisor contains 0.
+        interval_t l(x._lb, bound_t(-1));
+        interval_t u(bound_t(1), x._ub);
+        return (operator/(l) | operator/(u) | interval_t(number_t(0)));
+    } else if (contains(0)) {
+        // The dividend contains 0.
+        interval_t l(_lb, bound_t(-1));
+        interval_t u(bound_t(1), _ub);
+        return ((l / x) | (u / x) | interval_t(number_t(0)));
+    } else {
+        // Neither the dividend nor the divisor contains 0
+        interval_t a =
+            (_ub < number_t{0})
+                ? (*this + ((x._ub < number_t{0}) ? (x + interval_t(number_t(1))) : (interval_t(number_t(1)) - x)))
+                : *this;
+        bound_t ll = a._lb / x._lb;
+        bound_t lu = a._lb / x._ub;
+        bound_t ul = a._ub / x._lb;
+        bound_t uu = a._ub / x._ub;
+        return interval_t(std::min({ll, lu, ul, uu}), std::max({ll, lu, ul, uu}));
     }
 }
 
@@ -56,12 +53,12 @@ interval_t interval_t::operator/(const interval_t& x) const {
 interval_t interval_t::SDiv(const interval_t& x) const {
     if (is_bottom() || x.is_bottom()) {
         return bottom();
-    } else {
-        // Divisor is a singleton:
-        //   the linear interval solver can perform many divisions where
-        //   the divisor is a singleton interval. We optimize for this case.
-        std::optional<number_t> n = x.singleton();
-        if (n && n->fits_cast_to_int64()) {
+    }
+    if (const auto n = x.singleton()) {
+        if (n->fits_cast_to_int64()) {
+            // Divisor is a singleton:
+            //   the linear interval solver can perform many divisions where
+            //   the divisor is a singleton interval. We optimize for this case.
             number_t c{n->cast_to_sint64()};
             if (c == 1) {
                 return *this;
@@ -72,30 +69,28 @@ interval_t interval_t::SDiv(const interval_t& x) const {
                 return interval_t(number_t(0));
             }
         }
-        // Divisor is not a singleton
-        using z_interval = interval_t;
-        if (x[0]) {
-            // The divisor contains 0.
-            z_interval l(x._lb, bound_t(-1));
-            z_interval u(bound_t(1), x._ub);
-            return (SDiv(l) | SDiv(u) | z_interval(number_t(0)));
-        } else if (operator[](0)) {
-            // The dividend contains 0.
-            z_interval l(_lb, bound_t(-1));
-            z_interval u(bound_t(1), _ub);
-            return (l.SDiv(x) | u.SDiv(x) | z_interval(number_t(0)));
-        } else {
-            // Neither the dividend nor the divisor contains 0
-            z_interval a =
-                (_ub < number_t{0})
-                    ? (*this + ((x._ub < number_t{0}) ? (x + z_interval(number_t(1))) : (z_interval(number_t(1)) - x)))
-                    : *this;
-            bound_t ll = a._lb / x._lb;
-            bound_t lu = a._lb / x._ub;
-            bound_t ul = a._ub / x._lb;
-            bound_t uu = a._ub / x._ub;
-            return interval_t(std::min({ll, lu, ul, uu}), std::max({ll, lu, ul, uu}));
-        }
+    }
+    if (x.contains(0)) {
+        // The divisor contains 0.
+        interval_t l(x._lb, bound_t(-1));
+        interval_t u(bound_t(1), x._ub);
+        return (SDiv(l) | SDiv(u) | interval_t(number_t(0)));
+    } else if (contains(0)) {
+        // The dividend contains 0.
+        interval_t l(_lb, bound_t(-1));
+        interval_t u(bound_t(1), _ub);
+        return (l.SDiv(x) | u.SDiv(x) | interval_t(number_t(0)));
+    } else {
+        // Neither the dividend nor the divisor contains 0
+        interval_t a =
+            (_ub < number_t{0})
+                ? (*this + ((x._ub < number_t{0}) ? (x + interval_t(number_t(1))) : (interval_t(number_t(1)) - x)))
+                : *this;
+        bound_t ll = a._lb / x._lb;
+        bound_t lu = a._lb / x._ub;
+        bound_t ul = a._ub / x._lb;
+        bound_t uu = a._ub / x._ub;
+        return interval_t(std::min({ll, lu, ul, uu}), std::max({ll, lu, ul, uu}));
     }
 }
 
@@ -103,12 +98,12 @@ interval_t interval_t::SDiv(const interval_t& x) const {
 interval_t interval_t::UDiv(const interval_t& x) const {
     if (is_bottom() || x.is_bottom()) {
         return bottom();
-    } else {
-        // Divisor is a singleton:
-        //   the linear interval solver can perform many divisions where
-        //   the divisor is a singleton interval. We optimize for this case.
-        std::optional<number_t> n = x.singleton();
-        if (n && n->fits_cast_to_int64()) {
+    }
+    if (const auto n = x.singleton()) {
+        if (n->fits_cast_to_int64()) {
+            // Divisor is a singleton:
+            //   the linear interval solver can perform many divisions where
+            //   the divisor is a singleton interval. We optimize for this case.
             number_t c{n->cast_to_uint64()};
             if (c == 1) {
                 return *this;
@@ -119,31 +114,29 @@ interval_t interval_t::UDiv(const interval_t& x) const {
                 return interval_t(number_t(0));
             }
         }
-        // Divisor is not a singleton
-        using z_interval = interval_t;
-        if (x[0]) {
-            // The divisor contains 0.
-            z_interval l(x._lb, bound_t(-1));
-            z_interval u(bound_t(1), x._ub);
-            return (UDiv(l) | UDiv(u) | z_interval(number_t(0)));
-        } else if (operator[](0)) {
-            // The dividend contains 0.
-            z_interval l(_lb, bound_t(-1));
-            z_interval u(bound_t(1), _ub);
-            return (l.UDiv(x) | u.UDiv(x) | z_interval(number_t(0)));
-        } else {
-            // Neither the dividend nor the divisor contains 0
-            z_interval a =
-                (_ub < number_t{0})
-                    ? (*this + ((x._ub < number_t{0}) ? (x + z_interval(number_t(1))) : (z_interval(number_t(1)) - x)))
-                    : *this;
-            bound_t ll = a._lb.UDiv(x._lb);
-            bound_t lu = a._lb.UDiv(x._ub);
-            bound_t ul = a._ub.UDiv(x._lb);
-            bound_t uu = a._ub.UDiv(x._ub);
-            return interval_t(std::min({ll, lu, ul, uu}), std::max({ll, lu, ul, uu}));
-        }
     }
+    if (x.contains(0)) {
+        // The divisor contains 0.
+        interval_t l(x._lb, bound_t(-1));
+        interval_t u(bound_t(1), x._ub);
+        return UDiv(l) | UDiv(u) | interval_t(number_t(0));
+    }
+    if (contains(0)) {
+        // The dividend contains 0.
+        interval_t l(_lb, bound_t(-1));
+        interval_t u(bound_t(1), _ub);
+        return l.UDiv(x) | u.UDiv(x) | interval_t(number_t(0));
+    }
+    // Neither the dividend nor the divisor contains 0
+    interval_t a =
+        (_ub < number_t{0})
+            ? (*this + ((x._ub < number_t{0}) ? (x + interval_t(number_t(1))) : (interval_t(number_t(1)) - x)))
+            : *this;
+    bound_t ll = a._lb.UDiv(x._lb);
+    bound_t lu = a._lb.UDiv(x._ub);
+    bound_t ul = a._ub.UDiv(x._lb);
+    bound_t uu = a._ub.UDiv(x._ub);
+    return interval_t(std::min({ll, lu, ul, uu}), std::max({ll, lu, ul, uu}));
 }
 
 // Signed remainder (modulo).
@@ -152,21 +145,22 @@ interval_t interval_t::SRem(const interval_t& x) const {
 
     if (is_bottom() || x.is_bottom()) {
         return bottom();
-    } else if (singleton() && x.singleton()) {
-        number_t dividend = *singleton();
-        number_t divisor = *x.singleton();
-
-        if (divisor == 0) {
-            return interval_t(dividend);
+    }
+    if (const auto dividend = singleton()) {
+        if (const auto divisor = x.singleton()) {
+            if (*divisor == 0) {
+                return interval_t(*dividend);
+            }
+            return interval_t(*dividend % *divisor);
         }
-
-        return interval_t(dividend % divisor);
-    } else if (x[0]) {
+    }
+    if (x.contains(0)) {
         // The divisor contains 0.
         interval_t l(x._lb, bound_t(-1));
         interval_t u(bound_t(1), x._ub);
         return SRem(l) | SRem(u) | *this;
-    } else if (x.ub().is_finite() && x.lb().is_finite()) {
+    }
+    if (x.ub().is_finite() && x.lb().is_finite()) {
         number_t min_divisor = min(abs(*x.lb().number()), abs(*x.ub().number()));
         number_t max_divisor = max(abs(*x.lb().number()), abs(*x.ub().number()));
 
@@ -181,59 +175,52 @@ interval_t interval_t::SRem(const interval_t& x) const {
             } else {
                 return interval_t(-(max_divisor - 1), number_t{0});
             }
-        } else {
-            return interval_t(number_t{0}, max_divisor - 1);
         }
-    } else {
-        // Divisor has infinite range, so result can be anything between the dividend and zero.
-        return *this | interval_t(number_t(0));
+        return interval_t(number_t{0}, max_divisor - 1);
     }
+    // Divisor has infinite range, so result can be anything between the dividend and zero.
+    return *this | interval_t(number_t(0));
 }
 
 // Unsigned remainder (modulo).
 interval_t interval_t::URem(const interval_t& x) const {
-
     if (is_bottom() || x.is_bottom()) {
         return bottom();
-    } else {
+    }
+    if (const auto n = x.singleton()) {
         // Divisor is a singleton:
         //   the linear interval solver can perform many divisions where
         //   the divisor is a singleton interval. We optimize for this case.
-        if (std::optional<number_t> n = x.singleton()) {
-            number_t c = *n;
-            if (c > number_t{0}) {
-                return interval_t(_lb.UMod(bound_t{c}), _ub.UMod(bound_t{c}));
-            } else {
-                // The eBPF ISA defines modulo 0 as being unchanged.
-                return *this;
-            }
+        number_t c = *n;
+        if (c > number_t{0}) {
+            return interval_t(_lb.URem(bound_t{c}), _ub.URem(bound_t{c}));
         }
-        // Divisor is not a singleton
-        using z_interval = interval_t;
-        if (x[0]) {
-            // The divisor contains 0.
-            z_interval l(x._lb, bound_t(-1));
-            z_interval u(bound_t(1), x._ub);
-            return (URem(l) | URem(u) | *this);
-        } else if (operator[](0)) {
-            // The dividend contains 0.
-            z_interval l(_lb, bound_t(-1));
-            z_interval u(bound_t(1), _ub);
-            return (l.URem(x) | u.URem(x) | *this);
+        // The eBPF ISA defines modulo 0 as being unchanged.
+        return *this;
+    }
+    if (x.contains(0)) {
+        // The divisor contains 0.
+        interval_t l(x._lb, bound_t(-1));
+        interval_t u(bound_t(1), x._ub);
+        return URem(l) | URem(u) | *this;
+    } else if (contains(0)) {
+        // The dividend contains 0.
+        interval_t l(_lb, bound_t(-1));
+        interval_t u(bound_t(1), _ub);
+        return l.URem(x) | u.URem(x) | *this;
+    } else {
+        // Neither the dividend nor the divisor contains 0
+        if (x._lb.is_infinite() || x._ub.is_infinite()) {
+            // Divisor is infinite. A "negative" dividend could result in anything except
+            // a value between the upper bound and 0, so set to top.  A "positive" dividend
+            // could result in anything between 0 and the dividend - 1.
+            return (_ub < number_t{0}) ? top() : ((*this - interval_t(number_t{1})) | interval_t(number_t(0)));
+        } else if (_ub.is_finite() && (_ub.number()->cast_to_uint64() < x._lb.number()->cast_to_uint64())) {
+            // Dividend lower than divisor, so the dividend is the remainder.
+            return *this;
         } else {
-            // Neither the dividend nor the divisor contains 0
-            if (x._lb.is_infinite() || x._ub.is_infinite()) {
-                // Divisor is infinite. A "negative" dividend could result in anything except
-                // a value between the upper bound and 0, so set to top.  A "positive" dividend
-                // could result in anything between 0 and the dividend - 1.
-                return (_ub < number_t{0}) ? top() : ((*this - interval_t(number_t{1})) | interval_t(number_t(0)));
-            } else if (_ub.is_finite() && (_ub.number()->cast_to_uint64() < x._lb.number()->cast_to_uint64())) {
-                // Dividend lower than divisor, so the dividend is the remainder.
-                return *this;
-            } else {
-                number_t max_divisor{x._ub.number()->cast_to_uint64()};
-                return interval_t(number_t{0}, max_divisor - 1);
-            }
+            number_t max_divisor{x._ub.number()->cast_to_uint64()};
+            return interval_t(number_t{0}, max_divisor - 1);
         }
     }
 }
@@ -242,154 +229,142 @@ interval_t interval_t::URem(const interval_t& x) const {
 interval_t interval_t::And(const interval_t& x) const {
     if (is_bottom() || x.is_bottom()) {
         return bottom();
-    } else {
-        std::optional<number_t> left_op = singleton();
-        std::optional<number_t> right_op = x.singleton();
+    }
+    assert(is_top() || (lb() >= number_t{0}));
+    assert(x.is_top() || (x.lb() >= number_t{0}));
 
-        assert(is_top() || (lb() >= number_t{0}));
-        assert(x.is_top() || (x.lb() >= number_t{0}));
-
-        if (left_op && right_op) {
-            return interval_t((*left_op) & (*right_op));
-        } else if (right_op && right_op.value().fits_uint32() && right_op.value().cast_to_uint32() == UINT32_MAX) {
-            // Handle bitwise-AND with UINT32_MAX, which we do for 32-bit operations.
-            if (auto width = finite_size()) {
-                number_t lb32_n = (uint32_t)lb().number()->cast_to_uint64();
-                number_t ub32_n = (uint32_t)ub().number()->cast_to_uint64();
-                number_t width32_n = (uint32_t)width->cast_to_uint64();
-                if ((width->cast_to_uint64() <= UINT32_MAX) && (lb32_n < ub32_n) && (lb32_n + width32_n == ub32_n)) {
-                    return interval_t{lb32_n, ub32_n};
-                }
-            }
-
-            // Return the full range of all 32-bit numbers.  Use unsigned bounds to
-            // avoid setting other bits via sign extension.
-            return interval_t{number_t{0}, number_t{UINT32_MAX}};
-        } else if (!is_top() && !x.is_top()) {
-            return interval_t(number_t{0}, std::min(ub(), x.ub()));
-        } else if (!x.is_top()) {
-            return interval_t(number_t{0}, x.ub());
-        } else if (!is_top()) {
-            return interval_t(number_t{0}, ub());
-        } else {
-            return top();
+    if (const auto left = singleton()) {
+        if (const auto right = x.singleton()) {
+            return interval_t(*left & *right);
         }
+    }
+    if (x == interval_t{std::numeric_limits<uint32_t>::max()}) {
+        // Handle bitwise-AND with UINT32_MAX, which we do for 32-bit operations.
+        if (const auto width = finite_size()) {
+            const number_t lb32_n = lb().number()->truncate_to<uint32_t>();
+            const number_t ub32_n = ub().number()->truncate_to<uint32_t>();
+            if (width->fits_uint32() && lb32_n < ub32_n && lb32_n + width->truncate_to<uint32_t>() == ub32_n) {
+                return interval_t{lb32_n, ub32_n};
+            }
+        }
+        return full<uint32_t>();
+    }
+    if (x.contains(std::numeric_limits<uint64_t>::max())) {
+        return truncate_to<uint64_t>();
+    } else if (!is_top() && !x.is_top()) {
+        return interval_t(number_t{0}, std::min(ub(), x.ub()));
+    } else if (!x.is_top()) {
+        return interval_t(number_t{0}, x.ub());
+    } else if (!is_top()) {
+        return interval_t(number_t{0}, ub());
+    } else {
+        return top();
     }
 }
 
 interval_t interval_t::Or(const interval_t& x) const {
     if (is_bottom() || x.is_bottom()) {
         return bottom();
-    } else {
-        std::optional<number_t> left_op = singleton();
-        std::optional<number_t> right_op = x.singleton();
-
-        if (left_op && right_op) {
-            return interval_t((*left_op) | (*right_op));
-        } else if (lb() >= number_t{0} && x.lb() >= number_t{0}) {
-            std::optional<number_t> left_ub = ub().number();
-            std::optional<number_t> right_ub = x.ub().number();
-
-            if (left_ub && right_ub) {
-                number_t m = (*left_ub > *right_ub ? *left_ub : *right_ub);
-                return interval_t(number_t{0}, m.fill_ones());
-            } else {
-                return interval_t(number_t{0}, bound_t::plus_infinity());
-            }
-        } else {
-            return top();
+    }
+    if (const auto left_op = singleton()) {
+        if (const auto right_op = x.singleton()) {
+            return interval_t(*left_op | *right_op);
         }
     }
+    if (lb() >= number_t{0} && x.lb() >= number_t{0}) {
+        if (const auto left_ub = ub().number()) {
+            if (const auto right_ub = x.ub().number()) {
+                const number_t m = *left_ub > *right_ub ? *left_ub : *right_ub;
+                return interval_t(number_t{0}, m.fill_ones());
+            }
+        }
+        return interval_t(number_t{0}, bound_t::plus_infinity());
+    }
+    return top();
 }
 
 interval_t interval_t::Xor(const interval_t& x) const {
     if (is_bottom() || x.is_bottom()) {
         return bottom();
-    } else {
-        std::optional<number_t> left_op = singleton();
-        std::optional<number_t> right_op = x.singleton();
-
-        if (left_op && right_op) {
-            return interval_t((*left_op) ^ (*right_op));
-        } else {
-            return Or(x);
+    }
+    if (const auto left_op = singleton()) {
+        if (const auto right_op = x.singleton()) {
+            return interval_t(*left_op ^ *right_op);
         }
     }
+    return Or(x);
 }
 
 interval_t interval_t::Shl(const interval_t& x) const {
     if (is_bottom() || x.is_bottom()) {
         return bottom();
-    } else {
-        if (std::optional<number_t> shift = x.singleton()) {
-            number_t k = *shift;
-            if (k < number_t{0}) {
-                // CRAB_ERROR("lshr shift operand cannot be negative");
-                return top();
-            }
-            // Some crazy linux drivers generate shl instructions with
-            // huge shifts.  We limit the number of times the loop is run
-            // to avoid wasting too much time on it.
-            if (k <= 128) {
-                number_t factor = 1;
-                for (int i = 0; k > i; i++) {
-                    factor *= 2;
-                }
-                return this->operator*(interval_t{factor});
-            }
-        }
-        return top();
     }
+    if (const auto shift = x.singleton()) {
+        const number_t k = *shift;
+        if (k < number_t{0}) {
+            // CRAB_ERROR("lshr shift operand cannot be negative");
+            return top();
+        }
+        // Some crazy linux drivers generate shl instructions with
+        // huge shifts.  We limit the number of times the loop is run
+        // to avoid wasting too much time on it.
+        if (k <= 128) {
+            number_t factor = 1;
+            for (int i = 0; k > i; i++) {
+                factor *= 2;
+            }
+            return this->operator*(interval_t{factor});
+        }
+    }
+    return top();
 }
 
 interval_t interval_t::AShr(const interval_t& x) const {
     if (is_bottom() || x.is_bottom()) {
         return bottom();
-    } else {
-        if (std::optional<number_t> shift = x.singleton()) {
-            number_t k = *shift;
-            if (k < number_t{0}) {
-                // CRAB_ERROR("ashr shift operand cannot be negative");
-                return top();
-            }
-            // Some crazy linux drivers generate ashr instructions with
-            // huge shifts.  We limit the number of times the loop is run
-            // to avoid wasting too much time on it.
-            if (k <= 128) {
-                number_t factor = 1;
-                for (int i = 0; k > i; i++) {
-                    factor *= 2;
-                }
-                return this->operator/(interval_t{factor});
-            }
-        }
-        return top();
     }
+    if (const auto shift = x.singleton()) {
+        const number_t k = *shift;
+        if (k < number_t{0}) {
+            // CRAB_ERROR("ashr shift operand cannot be negative");
+            return top();
+        }
+        // Some crazy linux drivers generate ashr instructions with
+        // huge shifts.  We limit the number of times the loop is run
+        // to avoid wasting too much time on it.
+        if (k <= 128) {
+            number_t factor = 1;
+            for (int i = 0; k > i; i++) {
+                factor *= 2;
+            }
+            return this->operator/(interval_t{factor});
+        }
+    }
+    return top();
 }
 
 interval_t interval_t::LShr(const interval_t& x) const {
     if (is_bottom() || x.is_bottom()) {
         return bottom();
-    } else {
-        if (std::optional<number_t> shift = x.singleton()) {
-            number_t k = *shift;
-            if (k < number_t{0}) {
-                // CRAB_ERROR("lshr shift operand cannot be negative");
-                return top();
-            }
-            // Some crazy linux drivers generate lshr instructions with
-            // huge shifts.  We limit the number of times the loop is run
-            // to avoid wasting too much time on it.
-            if (k <= 128) {
-                if (lb() >= number_t{0} && ub().is_finite() && shift) {
-                    number_t lb = *this->lb().number();
-                    number_t ub = *this->ub().number();
-                    return interval_t(lb >> k, ub >> k);
-                }
+    }
+    if (const auto shift = x.singleton()) {
+        const number_t k = *shift;
+        if (k < number_t{0}) {
+            // CRAB_ERROR("lshr shift operand cannot be negative");
+            return top();
+        }
+        // Some crazy linux drivers generate lshr instructions with
+        // huge shifts.  We limit the number of times the loop is run
+        // to avoid wasting too much time on it.
+        if (k <= 128) {
+            if (lb() >= number_t{0} && ub().is_finite() && shift) {
+                const number_t lb = *this->lb().number();
+                const number_t ub = *this->ub().number();
+                return interval_t(lb >> k, ub >> k);
             }
         }
-        return top();
     }
+    return top();
 }
 
 } // namespace crab

--- a/src/crab/interval.hpp
+++ b/src/crab/interval.hpp
@@ -511,12 +511,14 @@ class interval_t final {
         if (*this <= full<T>()) {
             return *this;
         }
-        if (finite_size()->fits<T>()) {
-            T llb = lb().number()->truncate_to<T>();
-            T lub = ub().number()->truncate_to<T>();
-            if (llb <= lub) {
-                // Interval can be accurately represented in 64 width.
-                return interval_t(llb, lub);
+        if (const auto size = finite_size()) {
+            if (size->fits<T>()) {
+                T llb = lb().number()->truncate_to<T>();
+                T lub = ub().number()->truncate_to<T>();
+                if (llb <= lub) {
+                    // Interval can be accurately represented in 64 width.
+                    return interval_t(llb, lub);
+                }
             }
         }
         return full<T>();
@@ -562,7 +564,7 @@ class interval_t final {
     }
 
     interval_t negative(bool is64) const = delete;
-    // Return a non-negative interval in the range [0, INT_MAX],
+    // Return a negative interval in the range [INT_MIN, -1],
     // which can be represented as both an svalue and a uvalue.
     static interval_t negative(const int width) {
         switch (width) {

--- a/src/crab/interval.hpp
+++ b/src/crab/interval.hpp
@@ -489,9 +489,7 @@ class interval_t final {
         case 16: return truncate_to<int16_t>();
         case 32: return truncate_to<int32_t>();
         case 64: return truncate_to<int64_t>();
-        default: {
-            CRAB_ERROR("invalid width");
-        }
+        default: CRAB_ERROR("Invalid width ", width);
         }
     }
 
@@ -503,9 +501,7 @@ class interval_t final {
         case 16: return truncate_to<uint16_t>();
         case 32: return truncate_to<uint32_t>();
         case 64: return truncate_to<uint64_t>();
-        default: {
-            CRAB_ERROR("invalid width");
-        }
+        default: CRAB_ERROR("Invalid width ", width);
         }
     }
 
@@ -535,7 +531,7 @@ class interval_t final {
         case 16: return full<int16_t>();
         case 32: return full<int32_t>();
         case 64: return full<int64_t>();
-        default: throw std::exception();
+        default: CRAB_ERROR("Invalid width ", width);
         }
     }
 
@@ -545,10 +541,10 @@ class interval_t final {
     static interval_t unsigned_int(const int width) {
         switch (width) {
         case 8: return full<uint8_t>();
-        case 32: return full<uint32_t>();
         case 16: return full<uint16_t>();
+        case 32: return full<uint32_t>();
         case 64: return full<uint64_t>();
-        default: throw std::exception();
+        default: CRAB_ERROR("Invalid width ", width);
         }
     }
 
@@ -561,7 +557,7 @@ class interval_t final {
         case 16: return nonnegative<int16_t>();
         case 32: return nonnegative<int32_t>();
         case 64: return nonnegative<int64_t>();
-        default: throw std::exception();
+        default: CRAB_ERROR("Invalid width ", width);
         }
     }
 
@@ -574,7 +570,7 @@ class interval_t final {
         case 16: return negative<int16_t>();
         case 32: return negative<int32_t>();
         case 64: return negative<int64_t>();
-        default: throw std::exception();
+        default: CRAB_ERROR("Invalid width ", width);
         }
     }
 
@@ -601,15 +597,15 @@ class interval_t final {
 
     interval_t unsigned_high(bool is64) const = delete;
     // Return an interval in the range [INT_MAX+1, UINT_MAX], which can only
-    // be represented as a uvalue.  The svalue equivalent using the same
-    // width would be negative_int().
+    // be represented as a uvalue.
+    // The svalue equivalent using the same width would be negative_int().
     static interval_t unsigned_high(const int width) {
         switch (width) {
-        case 8: return high<uint8_t>(); ;
+        case 8: return high<uint8_t>();
         case 16: return high<uint16_t>();
         case 32: return high<uint32_t>();
         case 64: return high<uint64_t>();
-        default: throw std::exception();
+        default: CRAB_ERROR("Invalid width ", width);
         }
     }
 

--- a/src/crab/split_dbm.cpp
+++ b/src/crab/split_dbm.cpp
@@ -47,7 +47,7 @@ SplitDBM::vert_id SplitDBM::get_vert(variable_t v) {
  **/
 SafeInt64DefaultParams::Weight SafeInt64DefaultParams::convert_NtoW(const z_number& n, bool& overflow) {
     overflow = false;
-    if (!n.fits_sint64()) {
+    if (!n.fits<int64_t>()) {
         overflow = true;
         return 0;
     }
@@ -1031,7 +1031,7 @@ void SplitDBM::apply(bitwise_binop_t op, variable_t x, variable_t y, const numbe
     // Convert to intervals and perform the operation
     normalize();
     interval_t yi = this->operator[](y);
-    interval_t zi(number_t(k.cast_to_uint64()));
+    interval_t zi(number_t(k.cast_to<uint64_t>()));
     interval_t xi = interval_t::bottom();
 
     switch (op) {

--- a/src/crab/var_factory.cpp
+++ b/src/crab/var_factory.cpp
@@ -176,7 +176,7 @@ variable_t variable_t::stack_frame_var(data_kind_t kind, int i, std::string pref
 }
 
 variable_t variable_t::cell_var(data_kind_t array, const number_t& offset, const number_t& size) {
-    return make(mk_scalar_name(array, offset.cast_to_uint64(), size));
+    return make(mk_scalar_name(array, offset.cast_to<uint64_t>(), size));
 }
 
 // Given a type variable, get the associated variable of a given kind.

--- a/src/crab_utils/bignums.hpp
+++ b/src/crab_utils/bignums.hpp
@@ -161,7 +161,7 @@ class z_number final {
     }
 
     [[nodiscard]]
-    uint64_t cast_to_uint32() const {
+    uint32_t cast_to_uint32() const {
         if (fits_uint32()) {
             return (uint32_t)_n;
         } else if (fits_sint32()) {

--- a/src/crab_verifier.cpp
+++ b/src/crab_verifier.cpp
@@ -48,8 +48,8 @@ struct checks_db final {
     [[nodiscard]]
     int get_max_loop_count() const {
         auto m = this->max_loop_count.number();
-        if (m && m->fits_sint32()) {
-            return m->cast_to_sint32();
+        if (m && m->fits<int32_t>()) {
+            return m->cast_to<int32_t>();
         } else {
             return std::numeric_limits<int>::max();
         }

--- a/src/test/conformance_check.cpp
+++ b/src/test/conformance_check.cpp
@@ -81,8 +81,8 @@ int main(int argc, char** argv) {
     }
 
     // Print output so the conformance test suite can check it.
-    if (result.r0_value.singleton() && result.r0_value.singleton().value().fits_cast_to_int64()) {
-        std::cout << std::hex << result.r0_value.singleton().value().cast_to_uint64() << std::endl;
+    if (result.r0_value.singleton() && result.r0_value.singleton().value().fits_cast_to<int64_t>()) {
+        std::cout << std::hex << result.r0_value.singleton().value().cast_to<uint64_t>() << std::endl;
     } else {
         std::cout << result.r0_value << std::endl;
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced interval handling with support for 64-bit integer evaluations.
	- Introduced new template methods in the `z_number` class for improved type casting and fitting checks.

- **Bug Fixes**
	- Improved precision and correctness in interval arithmetic and relational checks.

- **Refactor**
	- Streamlined the `bound_t` and `interval_t` classes by simplifying method signatures and enhancing type safety.
	- Updated the `z_number` class to utilize templates for integral type handling, improving readability and usability.
	- Standardized type checking and casting methods across various components for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->