### PR TITLE
Cleanup and modernize ebpf_domain

### DIFF
--- a/src/crab/array_domain.cpp
+++ b/src/crab/array_domain.cpp
@@ -20,7 +20,7 @@
 
 namespace crab::domains {
 
-static bool maybe_between(const NumAbsDomain& dom, const bound_t& x, const linear_expression_t& symb_lb,
+static bool maybe_between(const NumAbsDomain& dom, const extended_number& x, const linear_expression_t& symb_lb,
                           const linear_expression_t& symb_ub) {
     using namespace dsl_syntax;
     assert(x.is_finite());

--- a/src/crab/dsl_syntax.hpp
+++ b/src/crab/dsl_syntax.hpp
@@ -17,77 +17,28 @@ inline linear_expression_t operator+(const linear_expression_t& e1, const linear
     return e1.plus(e2);
 }
 
-inline linear_expression_t operator+(const linear_expression_t& e, const number_t& n) { return e.plus(n); }
-
-inline linear_expression_t operator+(const number_t& n, const linear_expression_t& e) { return e.plus(n); }
-
 inline linear_expression_t operator-(const linear_expression_t& e1, const linear_expression_t& e2) {
     return e1.subtract(e2);
 }
 
-inline linear_expression_t operator-(const number_t& n, const linear_expression_t& e) {
-    return linear_expression_t(n).subtract(e);
-}
-
-inline linear_expression_t operator-(const linear_expression_t& e, const number_t& n) { return e.subtract(n); }
-
 inline linear_constraint_t operator<=(const linear_expression_t& e1, const linear_expression_t& e2) {
     return linear_constraint_t(e1 - e2, constraint_kind_t::LESS_THAN_OR_EQUALS_ZERO);
-}
-
-inline linear_constraint_t operator<=(const linear_expression_t& e, const number_t& n) {
-    return linear_constraint_t(e - n, constraint_kind_t::LESS_THAN_OR_EQUALS_ZERO);
-}
-
-inline linear_constraint_t operator<=(const number_t& n, const linear_expression_t& e) {
-    return linear_constraint_t(n - e, constraint_kind_t::LESS_THAN_OR_EQUALS_ZERO);
 }
 
 inline linear_constraint_t operator<(const linear_expression_t& e1, const linear_expression_t& e2) {
     return linear_constraint_t(e1 - e2, constraint_kind_t::LESS_THAN_ZERO);
 }
 
-inline linear_constraint_t operator<(const linear_expression_t& e, const number_t& n) {
-    return linear_constraint_t(e - n, constraint_kind_t::LESS_THAN_ZERO);
-}
-
-inline linear_constraint_t operator<(const number_t& n, const linear_expression_t& e) {
-    return linear_constraint_t(n - e, constraint_kind_t::LESS_THAN_ZERO);
-}
-
 inline linear_constraint_t operator>=(const linear_expression_t& e1, const linear_expression_t& e2) { return e2 <= e1; }
-
-inline linear_constraint_t operator>=(const linear_expression_t& e, const number_t& n) { return n <= e; }
-
-inline linear_constraint_t operator>=(const number_t& n, const linear_expression_t& e) { return e <= n; }
 
 inline linear_constraint_t operator>(const linear_expression_t& e1, const linear_expression_t& e2) { return e2 < e1; }
 
-inline linear_constraint_t operator>(const linear_expression_t& e, const number_t& n) { return n < e; }
-
-inline linear_constraint_t operator>(const number_t& n, const linear_expression_t& e) { return e < n; }
-
 inline linear_constraint_t operator==(const linear_expression_t& e1, const linear_expression_t& e2) {
     return linear_constraint_t(e1 - e2, constraint_kind_t::EQUALS_ZERO);
-}
-
-inline linear_constraint_t operator==(const linear_expression_t& e, const number_t& n) {
-    return linear_constraint_t(e - n, constraint_kind_t::EQUALS_ZERO);
-}
-
-inline linear_constraint_t operator==(const number_t& n, const linear_expression_t& e) {
-    return linear_constraint_t(e - n, constraint_kind_t::EQUALS_ZERO);
 }
 
 inline linear_constraint_t operator!=(const linear_expression_t& e1, const linear_expression_t& e2) {
     return linear_constraint_t(e1 - e2, constraint_kind_t::NOT_ZERO);
 }
 
-inline linear_constraint_t operator!=(const linear_expression_t& e, const number_t& n) {
-    return linear_constraint_t(e - n, constraint_kind_t::NOT_ZERO);
-}
-
-inline linear_constraint_t operator!=(const number_t& n, const linear_expression_t& e) {
-    return linear_constraint_t(e - n, constraint_kind_t::NOT_ZERO);
-}
 } // end namespace crab::dsl_syntax

--- a/src/crab/ebpf_domain.cpp
+++ b/src/crab/ebpf_domain.cpp
@@ -3182,8 +3182,8 @@ void ebpf_domain_t::initialize_loop_counter(const label_t& label) {
     m_inv.assign(variable_t::loop_counter(to_string(label)), 0);
 }
 
-bound_t ebpf_domain_t::get_loop_count_upper_bound() const {
-    bound_t ub{0};
+extended_number ebpf_domain_t::get_loop_count_upper_bound() const {
+    extended_number ub{0};
     for (const variable_t counter : variable_t::get_loop_counters()) {
         ub = std::max(ub, m_inv[counter].ub());
     }

--- a/src/crab/ebpf_domain.hpp
+++ b/src/crab/ebpf_domain.hpp
@@ -49,7 +49,7 @@ class ebpf_domain_t final {
 
     typedef bool check_require_func_t(NumAbsDomain&, const linear_constraint_t&, std::string);
     void set_require_check(std::function<check_require_func_t> f);
-    bound_t get_loop_count_upper_bound() const;
+    extended_number get_loop_count_upper_bound() const;
     static ebpf_domain_t setup_entry(bool init_r1);
 
     static ebpf_domain_t from_constraints(const std::set<std::string>& constraints, bool setup_constraints);

--- a/src/crab/ebpf_domain.hpp
+++ b/src/crab/ebpf_domain.hpp
@@ -24,7 +24,7 @@ class ebpf_domain_t final {
 
   public:
     ebpf_domain_t();
-    ebpf_domain_t(crab::domains::NumAbsDomain inv, crab::domains::array_domain_t stack);
+    ebpf_domain_t(domains::NumAbsDomain inv, domains::array_domain_t stack);
 
     // Generic abstract domain operations
     static ebpf_domain_t top();
@@ -35,7 +35,7 @@ class ebpf_domain_t final {
     bool is_bottom() const;
     [[nodiscard]]
     bool is_top() const;
-    bool operator<=(const ebpf_domain_t& other);
+    bool operator<=(const ebpf_domain_t& other) const;
     bool operator==(const ebpf_domain_t& other) const;
     void operator|=(ebpf_domain_t&& other);
     void operator|=(const ebpf_domain_t& other);
@@ -43,17 +43,17 @@ class ebpf_domain_t final {
     ebpf_domain_t operator|(const ebpf_domain_t& other) const&;
     ebpf_domain_t operator|(const ebpf_domain_t& other) &&;
     ebpf_domain_t operator&(const ebpf_domain_t& other) const;
-    ebpf_domain_t widen(const ebpf_domain_t& other, bool to_constants);
-    ebpf_domain_t widening_thresholds(const ebpf_domain_t& other, const crab::iterators::thresholds_t& ts);
-    ebpf_domain_t narrow(const ebpf_domain_t& other);
+    ebpf_domain_t widen(const ebpf_domain_t& other, bool to_constants) const;
+    ebpf_domain_t widening_thresholds(const ebpf_domain_t& other, const thresholds_t& ts);
+    ebpf_domain_t narrow(const ebpf_domain_t& other) const;
 
     typedef bool check_require_func_t(NumAbsDomain&, const linear_constraint_t&, std::string);
     void set_require_check(std::function<check_require_func_t> f);
-    bound_t get_loop_count_upper_bound();
+    bound_t get_loop_count_upper_bound() const;
     static ebpf_domain_t setup_entry(bool init_r1);
 
     static ebpf_domain_t from_constraints(const std::set<std::string>& constraints, bool setup_constraints);
-    string_invariant to_set();
+    string_invariant to_set() const;
 
     // abstract transformers
     void operator()(const basic_block_t& bb);
@@ -85,7 +85,7 @@ class ebpf_domain_t final {
     void operator()(const ZeroCtxOffset&);
     void operator()(const IncrementLoopCounter&);
 
-    void initialize_loop_counter(label_t label);
+    void initialize_loop_counter(const label_t& label);
     static ebpf_domain_t calculate_constant_limits();
 
   private:
@@ -97,22 +97,12 @@ class ebpf_domain_t final {
     void assign(variable_t x, const linear_expression_t& e);
     void assign(variable_t x, int64_t e);
 
-    void apply(crab::arith_binop_t op, variable_t x, variable_t y, const number_t& z, int finite_width);
-    void apply(crab::arith_binop_t op, variable_t x, variable_t y, variable_t z, int finite_width);
-    void apply(crab::bitwise_binop_t op, variable_t x, variable_t y, variable_t z, int finite_width);
-    void apply(crab::bitwise_binop_t op, variable_t x, variable_t y, const number_t& k, int finite_width);
-    void apply(crab::binop_t op, variable_t x, variable_t y, const number_t& z, int finite_width);
-    void apply(crab::binop_t op, variable_t x, variable_t y, variable_t z, int finite_width);
-
-    void apply(crab::domains::NumAbsDomain& inv, crab::binop_t op, variable_t x, variable_t y, variable_t z);
-    void apply_signed(crab::domains::NumAbsDomain& inv, crab::binop_t op, variable_t xs, variable_t xu, variable_t y,
-                      const number_t& z, int finite_width);
-    void apply_unsigned(crab::domains::NumAbsDomain& inv, crab::binop_t op, variable_t xs, variable_t xu, variable_t y,
-                        const number_t& z, int finite_width);
-    void apply_signed(crab::domains::NumAbsDomain& inv, crab::binop_t op, variable_t xs, variable_t xu, variable_t y,
-                      variable_t z, int finite_width);
-    void apply_unsigned(crab::domains::NumAbsDomain& inv, crab::binop_t op, variable_t xs, variable_t xu, variable_t y,
-                        variable_t z, int finite_width);
+    void apply(arith_binop_t op, variable_t x, variable_t y, const number_t& z, int finite_width);
+    void apply(arith_binop_t op, variable_t x, variable_t y, variable_t z, int finite_width);
+    void apply(bitwise_binop_t op, variable_t x, variable_t y, variable_t z, int finite_width);
+    void apply(bitwise_binop_t op, variable_t x, variable_t y, const number_t& k, int finite_width);
+    void apply(binop_t op, variable_t x, variable_t y, const number_t& z, int finite_width);
+    void apply(binop_t op, variable_t x, variable_t y, variable_t z, int finite_width);
 
     void add(const Reg& reg, int imm, int finite_width);
     void add(variable_t lhs, variable_t op2);
@@ -145,7 +135,7 @@ class ebpf_domain_t final {
     void shl_overflow(variable_t lhss, variable_t lhsu, variable_t op2);
     void shl_overflow(variable_t lhss, variable_t lhsu, const number_t& op2);
     void lshr(const Reg& reg, int imm, int finite_width);
-    void ashr(const Reg& reg, const linear_expression_t& right_svalue, int finite_width);
+    void ashr(const Reg& dst_reg, const linear_expression_t& right_svalue, int finite_width);
     void sign_extend(const Reg& dst_reg, const linear_expression_t& right_svalue, int finite_width, Bin::Op op);
 
     void assume(const linear_constraint_t& cst);
@@ -155,7 +145,6 @@ class ebpf_domain_t final {
 
     /// Forget everything about all offset variables for a given register.
     void havoc_offsets(const Reg& reg);
-    void havoc_offsets(NumAbsDomain& inv, const Reg& reg);
 
     static std::optional<variable_t> get_type_offset_variable(const Reg& reg, int type);
     [[nodiscard]]
@@ -171,33 +160,28 @@ class ebpf_domain_t final {
     [[nodiscard]]
     std::optional<uint32_t> get_map_inner_map_fd(const Reg& map_fd_reg) const;
     [[nodiscard]]
-    crab::interval_t get_map_key_size(const Reg& map_fd_reg) const;
+    interval_t get_map_key_size(const Reg& map_fd_reg) const;
     [[nodiscard]]
-    crab::interval_t get_map_value_size(const Reg& map_fd_reg) const;
+    interval_t get_map_value_size(const Reg& map_fd_reg) const;
     [[nodiscard]]
-    crab::interval_t get_map_max_entries(const Reg& map_fd_reg) const;
+    interval_t get_map_max_entries(const Reg& map_fd_reg) const;
     void forget_packet_pointers();
-    void havoc_register(NumAbsDomain& inv, const Reg& reg);
     void do_load_mapfd(const Reg& dst_reg, int mapfd, bool maybe_null);
-
-    static void overflow_signed(NumAbsDomain& inv, variable_t lhs, int finite_width);
-    static void overflow_unsigned(NumAbsDomain& inv, variable_t lhs, int finite_width);
-    static void overflow_bounds(NumAbsDomain& inv, variable_t lhs, number_t span, int finite_width, bool issigned);
 
     void assign_valid_ptr(const Reg& dst_reg, bool maybe_null);
 
-    void require(crab::domains::NumAbsDomain& inv, const linear_constraint_t& cst, const std::string& s);
+    void require(domains::NumAbsDomain& inv, const linear_constraint_t& cst, const std::string& s) const;
 
     // memory check / load / store
-    void check_access_stack(NumAbsDomain& inv, const linear_expression_t& lb, const linear_expression_t& ub);
-    void check_access_context(NumAbsDomain& inv, const linear_expression_t& lb, const linear_expression_t& ub);
+    void check_access_stack(NumAbsDomain& inv, const linear_expression_t& lb, const linear_expression_t& ub) const;
+    void check_access_context(NumAbsDomain& inv, const linear_expression_t& lb, const linear_expression_t& ub) const;
     void check_access_packet(NumAbsDomain& inv, const linear_expression_t& lb, const linear_expression_t& ub,
-                             std::optional<variable_t> shared_region_size);
+                             std::optional<variable_t> shared_region_size) const;
     void check_access_shared(NumAbsDomain& inv, const linear_expression_t& lb, const linear_expression_t& ub,
-                             variable_t shared_region_size);
+                             variable_t shared_region_size) const;
 
-    void recompute_stack_numeric_size(NumAbsDomain& inv, const Reg& reg);
-    void recompute_stack_numeric_size(NumAbsDomain& inv, variable_t type_variable);
+    void recompute_stack_numeric_size(NumAbsDomain& inv, const Reg& reg) const;
+    void recompute_stack_numeric_size(NumAbsDomain& inv, variable_t type_variable) const;
     void do_load_stack(NumAbsDomain& inv, const Reg& target_reg, const linear_expression_t& addr, int width,
                        const Reg& src_reg);
     void do_load_ctx(NumAbsDomain& inv, const Reg& target_reg, const linear_expression_t& addr_vague, int width);
@@ -205,8 +189,8 @@ class ebpf_domain_t final {
     void do_load(const Mem& b, const Reg& target_reg);
 
     template <typename X, typename Y, typename Z>
-    void do_store_stack(crab::domains::NumAbsDomain& inv, const number_t& width, const linear_expression_t& addr,
-                        X val_type, Y val_svalue, Z val_uvalue, const std::optional<reg_pack_t>& opt_val_reg);
+    void do_store_stack(domains::NumAbsDomain& inv, const number_t& width, const linear_expression_t& addr, X val_type,
+                        Y val_svalue, Z val_uvalue, const std::optional<reg_pack_t>& opt_val_reg);
 
     template <typename Type, typename SValue, typename UValue>
     void do_mem_store(const Mem& b, Type val_type, SValue val_svalue, UValue val_uvalue,
@@ -220,12 +204,12 @@ class ebpf_domain_t final {
     /// Mapping from variables (including registers, types, offsets,
     /// memory locations, etc.) to numeric intervals or relationships
     /// to other variables.
-    crab::domains::NumAbsDomain m_inv;
+    domains::NumAbsDomain m_inv;
 
     /// Represents the stack as a memory region, i.e., an array of bytes,
     /// allowing mapping to variable in the m_inv numeric domains
     /// while dealing with overlapping byte ranges.
-    crab::domains::array_domain_t stack;
+    domains::array_domain_t stack;
 
     std::function<check_require_func_t> check_require{};
     bool get_map_fd_range(const Reg& map_fd_reg, int32_t* start_fd, int32_t* end_fd) const;
@@ -266,8 +250,8 @@ class ebpf_domain_t final {
                                      const std::function<void(NumAbsDomain&)>& if_true,
                                      const std::function<void(NumAbsDomain&)>& if_false) const;
         void selectively_join_based_on_type(NumAbsDomain& dst, NumAbsDomain& src) const;
-        void add_extra_invariant(NumAbsDomain& dst, std::map<crab::variable_t, crab::interval_t>& extra_invariants,
-                                 variable_t type_variable, type_encoding_t type, crab::data_kind_t kind,
+        void add_extra_invariant(const NumAbsDomain& dst, std::map<variable_t, interval_t>& extra_invariants,
+                                 variable_t type_variable, type_encoding_t type, data_kind_t kind,
                                  const NumAbsDomain& other) const;
 
         [[nodiscard]]

--- a/src/crab/interval.hpp
+++ b/src/crab/interval.hpp
@@ -56,6 +56,7 @@ class interval_t final {
         : _lb(b.is_infinite() ? bound_t{number_t{0}} : b), _ub(b.is_infinite() ? bound_t{-1} : b) {}
 
     explicit interval_t(const number_t& n) : _lb(n), _ub(n) {}
+    explicit interval_t(std::integral auto n) : _lb(n), _ub(n) {}
 
     interval_t(const interval_t& i) = default;
 

--- a/src/crab/interval.hpp
+++ b/src/crab/interval.hpp
@@ -17,6 +17,8 @@
 
 namespace crab {
 
+using bound_t = extended_number;
+
 class interval_t final {
     bound_t _lb;
     bound_t _ub;

--- a/src/crab/linear_expression.hpp
+++ b/src/crab/linear_expression.hpp
@@ -34,6 +34,8 @@ class linear_expression_t final {
   public:
     linear_expression_t(number_t coefficient) : _constant_term(std::move(coefficient)) {}
 
+    linear_expression_t(std::integral auto coefficient) : _constant_term(coefficient) {}
+    linear_expression_t(is_enum auto coefficient) : _constant_term(coefficient) {}
     linear_expression_t(variable_t variable) { _variable_terms[variable] = 1; }
 
     linear_expression_t(const number_t& coefficient, const variable_t& variable) {
@@ -69,7 +71,7 @@ class linear_expression_t final {
 
     // Multiply a linear expression by a constant.
     [[nodiscard]]
-    linear_expression_t multiply(const number_t& constant) const {
+    linear_expression_t multiply(const finite_integral auto& constant) const {
         variable_terms_t variable_terms;
         for (const auto& [variable, coefficient] : _variable_terms) {
             variable_terms.emplace(variable, coefficient * constant);
@@ -79,7 +81,7 @@ class linear_expression_t final {
 
     // Add a constant to a linear expression.
     [[nodiscard]]
-    linear_expression_t plus(const number_t& constant) const {
+    linear_expression_t plus(const finite_integral auto& constant) const {
         return linear_expression_t(variable_terms_t(_variable_terms), _constant_term + constant);
     }
 
@@ -109,7 +111,7 @@ class linear_expression_t final {
 
     // Subtract a constant from a linear expression.
     [[nodiscard]]
-    linear_expression_t subtract(const number_t& constant) const {
+    linear_expression_t subtract(const finite_integral auto& constant) const {
         return linear_expression_t(variable_terms_t(_variable_terms), _constant_term - constant);
     }
 

--- a/src/crab/linear_expression.hpp
+++ b/src/crab/linear_expression.hpp
@@ -4,7 +4,8 @@
 
 #include <map>
 
-#include "variable.hpp"
+#include "crab/variable.hpp"
+#include "crab_utils/num_big.hpp"
 
 namespace crab {
 // A linear expression is of the form: Ax + By + Cz + ... + N.

--- a/src/crab/split_dbm.cpp
+++ b/src/crab/split_dbm.cpp
@@ -1096,8 +1096,8 @@ string_invariant SplitDBM::to_set() const {
             continue;
         }
         interval_t v_out =
-            interval_t(this->g.elem(v, 0) ? -number_t(this->g.edge_val(v, 0)) : bound_t::minus_infinity(),
-                       this->g.elem(0, v) ? number_t(this->g.edge_val(0, v)) : bound_t::plus_infinity());
+            interval_t(this->g.elem(v, 0) ? -number_t(this->g.edge_val(v, 0)) : extended_number::minus_infinity(),
+                       this->g.elem(0, v) ? number_t(this->g.edge_val(0, v)) : extended_number::plus_infinity());
         assert(!v_out.is_bottom());
 
         variable_t variable = *(this->rev_map[v]);
@@ -1279,8 +1279,8 @@ static interval_t get_interval(const SplitDBM::vert_map_t& m, const SplitDBM::gr
         return interval_t::top();
     }
     SplitDBM::vert_id v = it->second;
-    bound_t lb = bound_t::minus_infinity();
-    bound_t ub = bound_t::plus_infinity();
+    extended_number lb = extended_number::minus_infinity();
+    extended_number ub = extended_number::plus_infinity();
     if (r.elem(v, 0)) {
         lb = x.is_unsigned() ? (-number_t(r.edge_val(v, 0))).truncate_to_uint(finite_width)
                              : (-number_t(r.edge_val(v, 0))).truncate_to_sint(finite_width);

--- a/src/crab/thresholds.cpp
+++ b/src/crab/thresholds.cpp
@@ -7,9 +7,9 @@ namespace crab {
 
 inline namespace iterators {
 
-void thresholds_t::add(bound_t v1) {
+void thresholds_t::add(extended_number v1) {
     if (m_thresholds.size() < m_size) {
-        bound_t v = (v1);
+        extended_number v = (v1);
         if (std::find(m_thresholds.begin(), m_thresholds.end(), v) == m_thresholds.end()) {
             auto ub = std::upper_bound(m_thresholds.begin(), m_thresholds.end(), v);
 
@@ -37,9 +37,9 @@ void thresholds_t::add(bound_t v1) {
 
 std::ostream& operator<<(std::ostream& o, const thresholds_t& t) {
     o << "{";
-    for (typename std::vector<bound_t>::const_iterator it = t.m_thresholds.begin(), et = t.m_thresholds.end();
+    for (typename std::vector<extended_number>::const_iterator it = t.m_thresholds.begin(), et = t.m_thresholds.end();
          it != et;) {
-        bound_t b(*it);
+        extended_number b(*it);
         o << b;
         ++it;
         if (it != t.m_thresholds.end()) {

--- a/src/crab/thresholds.hpp
+++ b/src/crab/thresholds.hpp
@@ -24,14 +24,14 @@ inline namespace iterators {
 class thresholds_t final {
 
   private:
-    std::vector<bound_t> m_thresholds;
+    std::vector<extended_number> m_thresholds;
     size_t m_size;
 
   public:
     explicit thresholds_t(size_t size = UINT_MAX) : m_size(size) {
-        m_thresholds.push_back(bound_t::minus_infinity());
+        m_thresholds.push_back(extended_number::minus_infinity());
         m_thresholds.emplace_back(number_t{0});
-        m_thresholds.push_back(bound_t::plus_infinity());
+        m_thresholds.push_back(extended_number::plus_infinity());
     }
 
     [[nodiscard]]
@@ -39,7 +39,7 @@ class thresholds_t final {
         return m_thresholds.size();
     }
 
-    void add(bound_t v1);
+    void add(extended_number v1);
 
     friend std::ostream& operator<<(std::ostream& o, const thresholds_t& t);
 };

--- a/src/crab_utils/num_big.hpp
+++ b/src/crab_utils/num_big.hpp
@@ -259,4 +259,10 @@ class number_t final {
 };
 // class number_t
 
+bool operator<=(std::integral auto left, const number_t& rhs) { return rhs >= left; }
+bool operator<=(is_enum auto left, const number_t& rhs) { return rhs >= left; }
+
+template <typename T>
+concept finite_integral = std::integral<T> || std::is_same_v<T, number_t>;
+
 } // namespace crab

--- a/src/crab_utils/num_extended.hpp
+++ b/src/crab_utils/num_extended.hpp
@@ -43,6 +43,7 @@ class extended_number final {
     }
 
     extended_number(number_t n) : _is_infinite(false), _n(std::move(n)) {}
+    extended_number(std::integral auto n) : _is_infinite(false), _n{n} {}
 
     extended_number(const extended_number& o) = default;
 

--- a/src/crab_utils/num_extended.hpp
+++ b/src/crab_utils/num_extended.hpp
@@ -223,6 +223,4 @@ class extended_number final {
 
 }; // class extended_number
 
-using bound_t = extended_number;
-
 } // namespace crab

--- a/src/crab_verifier.cpp
+++ b/src/crab_verifier.cpp
@@ -31,7 +31,7 @@ struct checks_db final {
     std::map<label_t, std::vector<std::string>> m_db{};
     int total_warnings{};
     int total_unreachable{};
-    crab::bound_t max_loop_count{crab::number_t{0}};
+    crab::extended_number max_loop_count{crab::number_t{0}};
 
     void add(const label_t& label, const std::string& msg) { m_db[label].emplace_back(msg); }
 


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Added support for creating `interval_t`, `extended_number`, and `linear_expression_t` instances using integral types.
	- Introduced operator overloads for comparisons between integral types and `number_t`.

- **Bug Fixes**
	- Removed unnecessary operator overloads for `linear_expression_t` and `number_t`, simplifying interactions.

- **Documentation**
	- Updated method signatures to include `const` qualifiers for better clarity and understanding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->