### PR TITLE
Fail verification on infinite calllocal recursion

### DIFF
--- a/src/asm_cfg.cpp
+++ b/src/asm_cfg.cpp
@@ -57,12 +57,16 @@ static void add_cfg_nodes(cfg_t& cfg, const label_t& caller_label, const label_t
     }
 
     // Walk the transitive closure of CFG nodes starting at entry_label and ending at
-    // any exit instruction,
+    // any exit instruction.
     std::queue<label_t> macro_labels{{entry_label}};
     std::set seen_labels{entry_label};
     while (!macro_labels.empty()) {
         label_t macro_label = macro_labels.front();
         macro_labels.pop();
+
+        if (stack_frame_prefix == macro_label.stack_frame_prefix) {
+            throw std::runtime_error{stack_frame_prefix + ": illegal recursion"};
+        }
 
         // Clone the macro block into a new block with the new stack frame prefix.
         const label_t label(macro_label.from, macro_label.to, stack_frame_prefix);

--- a/test-data/calllocal.yaml
+++ b/test-data/calllocal.yaml
@@ -279,3 +279,34 @@ post:
   - r0.svalue=0
   - r0.uvalue=0
   - r6.type=packet
+---
+test-case: fail infinite self-recursion
+
+pre: []
+
+code:
+  <start>: |
+    call <start>
+    exit
+
+post: []
+
+messages:
+  - "0: illegal recursion"
+---
+test-case: fail infinite recursion with subprogram
+
+pre: []
+
+code:
+  <start>: |
+    call <sub>
+    exit
+  <sub>: |
+    call <start>
+    exit
+
+post: []
+
+messages:
+  - "0/2: illegal recursion"


### PR DESCRIPTION
Previously the code would simply throw an exception. This change adds an error message and test cases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Implemented a check to prevent illegal recursion during function calls, enhancing error handling.
	- Introduced test cases to validate the system's response to illegal recursion scenarios.

- **Bug Fixes**
	- Added runtime error handling for cases of infinite self-recursion and recursion involving subprograms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->