### PR TITLE
Shorten test names

### DIFF
--- a/src/test/test_verify.cpp
+++ b/src/test/test_verify.cpp
@@ -66,49 +66,47 @@ FAIL_UNMARSHAL("invalid", "invalid-lddw.o", ".text")
         }                                                                                                 \
     } while (0)
 
-#define TEST_SECTION(project, filename, section)                                                            \
-    TEST_CASE("./check ebpf-samples/" project "/" filename " " section, "[verify][samples][" project "]") { \
-        VERIFY_SECTION(project, filename, section, nullptr, &g_ebpf_platform_linux, true);                  \
-    }
-
-#define TEST_PROGRAM(project, filename, section_name, program_name)                                              \
-    TEST_CASE("./check ebpf-samples/" project "/" filename " " program_name, "[verify][samples][" project "]") { \
-        VERIFY_PROGRAM(project, filename, section_name, program_name, nullptr, &g_ebpf_platform_linux, true);    \
-    }
-
-#define TEST_PROGRAM_REJECT(project, filename, section_name, program_name)                                       \
-    TEST_CASE("./check ebpf-samples/" project "/" filename " " program_name, "[verify][samples][" project "]") { \
-        VERIFY_PROGRAM(project, filename, section_name, program_name, nullptr, &g_ebpf_platform_linux, false);   \
-    }
-
-#define TEST_SECTION_REJECT(project, filename, section)                                                     \
-    TEST_CASE("./check ebpf-samples/" project "/" filename " " section, "[verify][samples][" project "]") { \
-        VERIFY_SECTION(project, filename, section, nullptr, &g_ebpf_platform_linux, false);                 \
-    }
-
-#define TEST_SECTION_REJECT_IF_STRICT(project, filename, section)                                           \
-    TEST_CASE("./check ebpf-samples/" project "/" filename " " section, "[verify][samples][" project "]") { \
-        ebpf_verifier_options_t options = ebpf_verifier_default_options;                                    \
-        VERIFY_SECTION(project, filename, section, &options, &g_ebpf_platform_linux, true);                 \
-        options.strict = true;                                                                              \
-        VERIFY_SECTION(project, filename, section, &options, &g_ebpf_platform_linux, false);                \
-    }
-
-#define TEST_SECTION_FAIL(project, filename, section)                                      \
-    TEST_CASE("expect failure ebpf-samples/" project "/" filename " " section,             \
-              "[!shouldfail][verify][samples][" project "]") {                             \
+#define TEST_SECTION(project, filename, section)                                           \
+    TEST_CASE(project "/" filename " " section, "[verify][samples][" project "]") {        \
         VERIFY_SECTION(project, filename, section, nullptr, &g_ebpf_platform_linux, true); \
     }
 
-#define TEST_SECTION_REJECT_FAIL(project, filename, section)                                \
-    TEST_CASE("expect failure ebpf-samples/" project "/" filename " " section,              \
-              "[!shouldfail][verify][samples][" project "]") {                              \
+#define TEST_PROGRAM(project, filename, section_name, program_name)                                           \
+    TEST_CASE(project "/" filename " " program_name, "[verify][samples][" project "]") {                      \
+        VERIFY_PROGRAM(project, filename, section_name, program_name, nullptr, &g_ebpf_platform_linux, true); \
+    }
+
+#define TEST_PROGRAM_REJECT(project, filename, section_name, program_name)                                     \
+    TEST_CASE(project "/" filename " " program_name, "[verify][samples][" project "]") {                       \
+        VERIFY_PROGRAM(project, filename, section_name, program_name, nullptr, &g_ebpf_platform_linux, false); \
+    }
+
+#define TEST_SECTION_REJECT(project, filename, section)                                     \
+    TEST_CASE(project "/" filename " " section, "[verify][samples][" project "]") {         \
         VERIFY_SECTION(project, filename, section, nullptr, &g_ebpf_platform_linux, false); \
+    }
+
+#define TEST_SECTION_REJECT_IF_STRICT(project, filename, section)                            \
+    TEST_CASE(project "/" filename " " section, "[verify][samples][" project "]") {          \
+        ebpf_verifier_options_t options = ebpf_verifier_default_options;                     \
+        VERIFY_SECTION(project, filename, section, &options, &g_ebpf_platform_linux, true);  \
+        options.strict = true;                                                               \
+        VERIFY_SECTION(project, filename, section, &options, &g_ebpf_platform_linux, false); \
+    }
+
+#define TEST_SECTION_FAIL(project, filename, section)                                                              \
+    TEST_CASE("expect failure " project "/" filename " " section, "[!shouldfail][verify][samples][" project "]") { \
+        VERIFY_SECTION(project, filename, section, nullptr, &g_ebpf_platform_linux, true);                         \
+    }
+
+#define TEST_SECTION_REJECT_FAIL(project, filename, section)                                                       \
+    TEST_CASE("expect failure " project "/" filename " " section, "[!shouldfail][verify][samples][" project "]") { \
+        VERIFY_SECTION(project, filename, section, nullptr, &g_ebpf_platform_linux, false);                        \
     }
 
 #define TEST_SECTION_LEGACY(dirname, filename, sectionname)                                               \
     TEST_SECTION(dirname, filename, sectionname)                                                          \
-    TEST_CASE("Try unmarshalling bad program: " dirname "/" filename " " sectionname, "[unmarshal]") {    \
+    TEST_CASE("Fail unmarshalling: " dirname "/" filename " " sectionname, "[unmarshal]") {               \
         ebpf_platform_t platform = g_ebpf_platform_linux;                                                 \
         platform.supported_conformance_groups &= ~bpf_conformance_groups_t::packet;                       \
         auto raw_progs = read_elf("ebpf-samples/" dirname "/" filename, sectionname, nullptr, &platform); \


### PR DESCRIPTION
Catch2 shows inconsistent number of tests. It may be only due to my Clion setup, but it shows many "not found" tests. I believe the issue has something to do with the length of the test's name, so this PR shorten it. The issue does not reproduce again, but it might not be compeletly solved either.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Simplified the formatting of test case strings for better readability.
	- Updated legacy test case strings for clarity.

These changes enhance the overall clarity of test definitions, contributing to a more streamlined testing process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->