### PR TITLE
Use get_if instead of holds_alternative to avoid repetition

### DIFF
--- a/src/asm_cfg.cpp
+++ b/src/asm_cfg.cpp
@@ -11,7 +11,6 @@
 
 #include "asm_syntax.hpp"
 #include "crab/cfg.hpp"
-#include "crab_utils/debug.hpp"
 
 using std::optional;
 using std::set;
@@ -20,19 +19,21 @@ using std::to_string;
 using std::vector;
 
 static optional<label_t> get_jump(Instruction ins) {
-    if (std::holds_alternative<Jmp>(ins)) {
-        return std::get<Jmp>(ins).target;
+    if (const auto pins = std::get_if<Jmp>(&ins)) {
+        return pins->target;
     }
     return {};
 }
 
-static bool has_fall(Instruction ins) {
+static bool has_fall(const Instruction& ins) {
     if (std::holds_alternative<Exit>(ins)) {
         return false;
     }
 
-    if (std::holds_alternative<Jmp>(ins) && !std::get<Jmp>(ins).cond) {
-        return false;
+    if (const auto pins = std::get_if<Jmp>(&ins)) {
+        if (!pins->cond) {
+            return false;
+        }
     }
 
     return true;
@@ -51,8 +52,8 @@ static void add_cfg_nodes(cfg_t& cfg, const label_t& caller_label, const label_t
     basic_block_t& caller_node = cfg.get_node(caller_label);
     std::string stack_frame_prefix = to_string(caller_label);
     for (auto& inst : caller_node) {
-        if (std::holds_alternative<CallLocal>(inst)) {
-            std::get<CallLocal>(inst).stack_frame_prefix = stack_frame_prefix;
+        if (const auto pcall = std::get_if<CallLocal>(&inst)) {
+            pcall->stack_frame_prefix = stack_frame_prefix;
         }
     }
 
@@ -72,10 +73,10 @@ static void add_cfg_nodes(cfg_t& cfg, const label_t& caller_label, const label_t
         const label_t label(macro_label.from, macro_label.to, stack_frame_prefix);
         auto& bb = cfg.insert(label);
         for (auto inst : cfg.get_node(macro_label)) {
-            if (std::holds_alternative<Exit>(inst)) {
-                std::get<Exit>(inst).stack_frame_prefix = label.stack_frame_prefix;
-            } else if (std::holds_alternative<Call>(inst)) {
-                std::get<Call>(inst).stack_frame_prefix = label.stack_frame_prefix;
+            if (const auto pins = std::get_if<Exit>(&inst)) {
+                pins->stack_frame_prefix = label.stack_frame_prefix;
+            } else if (const auto pins = std::get_if<Call>(&inst)) {
+                pins->stack_frame_prefix = label.stack_frame_prefix;
             }
             bb.insert(inst);
         }
@@ -121,18 +122,18 @@ static void add_cfg_nodes(cfg_t& cfg, const label_t& caller_label, const label_t
     for (auto& macro_label : seen_labels) {
         for (const label_t label(macro_label.from, macro_label.to, caller_label_str);
              const auto& inst : cfg.get_node(label)) {
-            if (std::holds_alternative<CallLocal>(inst)) {
+            if (const auto pins = std::get_if<CallLocal>(&inst)) {
                 if (stack_frame_depth >= MAX_CALL_STACK_FRAMES) {
                     throw std::runtime_error{"too many call stack frames"};
                 }
-                add_cfg_nodes(cfg, label, std::get<CallLocal>(inst).target);
+                add_cfg_nodes(cfg, label, pins->target);
             }
         }
     }
 }
 
 /// Convert an instruction sequence to a control-flow graph (CFG).
-static cfg_t instruction_seq_to_cfg(const InstructionSeq& insts, bool must_have_exit) {
+static cfg_t instruction_seq_to_cfg(const InstructionSeq& insts, const bool must_have_exit) {
     cfg_t cfg;
     std::optional<label_t> falling_from = {};
     bool first = true;
@@ -159,8 +160,7 @@ static cfg_t instruction_seq_to_cfg(const InstructionSeq& insts, bool must_have_
         if (has_fall(inst)) {
             falling_from = label;
         }
-        auto jump_target = get_jump(inst);
-        if (jump_target) {
+        if (auto jump_target = get_jump(inst)) {
             bb >> cfg.insert(*jump_target);
         }
 
@@ -180,8 +180,8 @@ static cfg_t instruction_seq_to_cfg(const InstructionSeq& insts, bool must_have_
     // we only add new nodes that are actually reachable, based on the
     // results of the first pass.
     for (auto& [label, inst, _] : insts) {
-        if (std::holds_alternative<CallLocal>(inst)) {
-            add_cfg_nodes(cfg, label, std::get<CallLocal>(inst).target);
+        if (const auto pins = std::get_if<CallLocal>(&inst)) {
+            add_cfg_nodes(cfg, label, pins->target);
         }
     }
 
@@ -189,7 +189,7 @@ static cfg_t instruction_seq_to_cfg(const InstructionSeq& insts, bool must_have_
 }
 
 /// Get the inverse of a given comparison operation.
-static Condition::Op reverse(Condition::Op op) {
+static Condition::Op reverse(const Condition::Op op) {
     switch (op) {
     case Condition::Op::EQ: return Condition::Op::NE;
     case Condition::Op::NE: return Condition::Op::EQ;
@@ -214,7 +214,7 @@ static Condition::Op reverse(Condition::Op op) {
 }
 
 /// Get the inverse of a given comparison condition.
-static Condition reverse(Condition cond) {
+static Condition reverse(const Condition& cond) {
     return {.op = reverse(cond.op), .left = cond.left, .right = cond.right, .is64 = cond.is64};
 }
 
@@ -274,31 +274,30 @@ static cfg_t to_nondet(const cfg_t& cfg) {
     return res;
 }
 
-/// Get the type of a given instruction.
+/// Get the type of given instruction.
 /// Most of these type names are also statistics header labels.
 static std::string instype(Instruction ins) {
-    if (std::holds_alternative<Call>(ins)) {
-        auto call = std::get<Call>(ins);
-        if (call.is_map_lookup) {
+    if (const auto pcall = std::get_if<Call>(&ins)) {
+        if (pcall->is_map_lookup) {
             return "call_1";
         }
-        if (call.pairs.empty()) {
-            if (std::all_of(call.singles.begin(), call.singles.end(),
-                            [](ArgSingle kr) { return kr.kind == ArgSingle::Kind::ANYTHING; })) {
+        if (pcall->pairs.empty()) {
+            if (std::ranges::all_of(pcall->singles,
+                                    [](const ArgSingle kr) { return kr.kind == ArgSingle::Kind::ANYTHING; })) {
                 return "call_nomem";
             }
         }
         return "call_mem";
     } else if (std::holds_alternative<Callx>(ins)) {
         return "callx";
-    } else if (std::holds_alternative<Mem>(ins)) {
-        return std::get<Mem>(ins).is_load ? "load" : "store";
+    } else if (const auto pimm = std::get_if<Mem>(&ins)) {
+        return pimm->is_load ? "load" : "store";
     } else if (std::holds_alternative<Atomic>(ins)) {
         return "load_store";
     } else if (std::holds_alternative<Packet>(ins)) {
         return "packet_access";
-    } else if (std::holds_alternative<Bin>(ins)) {
-        switch (std::get<Bin>(ins).op) {
+    } else if (const auto pins = std::get_if<Bin>(&ins)) {
+        switch (pins->op) {
         case Bin::Op::MOV:
         case Bin::Op::MOVSX8:
         case Bin::Op::MOVSX16:
@@ -334,20 +333,18 @@ std::map<std::string, int> collect_stats(const cfg_t& cfg) {
         basic_block_t const& bb = cfg.get_node(this_label);
 
         for (Instruction ins : bb) {
-            if (std::holds_alternative<LoadMapFd>(ins)) {
-                if (std::get<LoadMapFd>(ins).mapfd == -1) {
+            if (const auto pins = std::get_if<LoadMapFd>(&ins)) {
+                if (pins->mapfd == -1) {
                     res["map_in_map"] = 1;
                 }
             }
-            if (std::holds_alternative<Call>(ins)) {
-                auto call = std::get<Call>(ins);
-                if (call.reallocate_packet) {
+            if (const auto pins = std::get_if<Call>(&ins)) {
+                if (pins->reallocate_packet) {
                     res["reallocate"] = 1;
                 }
             }
-            if (std::holds_alternative<Bin>(ins)) {
-                auto const& bin = std::get<Bin>(ins);
-                res[bin.is64 ? "arith64" : "arith32"]++;
+            if (const auto pins = std::get_if<Bin>(&ins)) {
+                res[pins->is64 ? "arith64" : "arith32"]++;
             }
             res[instype(ins)]++;
         }

--- a/src/asm_ostream.hpp
+++ b/src/asm_ostream.hpp
@@ -29,7 +29,7 @@ inline std::function<int32_t(label_t)> label_to_offset32(pc_t pc) {
 
 std::ostream& operator<<(std::ostream& os, const btf_line_info_t& line_info);
 
-void print(const InstructionSeq& insts, std::ostream& out, std::optional<const label_t> label_to_print,
+void print(const InstructionSeq& insts, std::ostream& out, const std::optional<const label_t>& label_to_print,
            bool print_line_info = false);
 
 std::string to_string(label_t const& label);
@@ -43,8 +43,8 @@ std::ostream& operator<<(std::ostream& os, Condition::Op op);
 inline std::ostream& operator<<(std::ostream& os, Imm imm) { return os << (int64_t)imm.v; }
 inline std::ostream& operator<<(std::ostream& os, Reg const& a) { return os << "r" << (int)a.v; }
 inline std::ostream& operator<<(std::ostream& os, Value const& a) {
-    if (std::holds_alternative<Imm>(a)) {
-        return os << std::get<Imm>(a);
+    if (auto pa = std::get_if<Imm>(&a)) {
+        return os << *pa;
     }
     return os << std::get<Reg>(a);
 }

--- a/src/asm_unmarshal.cpp
+++ b/src/asm_unmarshal.cpp
@@ -5,14 +5,13 @@
 #include <string>
 #include <vector>
 
-#include "ebpf_vm_isa.hpp"
-
 #include "asm_unmarshal.hpp"
+#include "ebpf_vm_isa.hpp"
 
 using std::string;
 using std::vector;
 
-int opcode_to_width(uint8_t opcode) {
+int opcode_to_width(const uint8_t opcode) {
     switch (opcode & INST_SIZE_MASK) {
     case INST_SIZE_B: return 1;
     case INST_SIZE_H: return 2;
@@ -23,7 +22,7 @@ int opcode_to_width(uint8_t opcode) {
     return {};
 }
 
-uint8_t width_to_opcode(int width) {
+uint8_t width_to_opcode(const int width) {
     switch (width) {
     case 1: return INST_SIZE_B;
     case 2: return INST_SIZE_H;
@@ -37,21 +36,22 @@ uint8_t width_to_opcode(int width) {
 template <typename T>
 void compare(const string& field, T actual, T expected) {
     if (actual != expected) {
-        std::cerr << field << ": (actual) " << std::hex << (int)actual << " != " << (int)expected << " (expected)\n";
+        std::cerr << field << ": (actual) " << std::hex << static_cast<int>(actual)
+                  << " != " << static_cast<int>(expected) << " (expected)\n";
     }
 }
 
-static std::string make_opcode_message(const char* msg, uint8_t opcode) {
+static std::string make_opcode_message(const char* msg, const uint8_t opcode) {
     std::ostringstream oss;
-    oss << msg << " op 0x" << std::hex << (int)opcode;
+    oss << msg << " op 0x" << std::hex << static_cast<int>(opcode);
     return oss.str();
 }
 
 struct InvalidInstruction : std::invalid_argument {
     size_t pc;
-    explicit InvalidInstruction(size_t pc, const char* what) : std::invalid_argument{what}, pc{pc} {}
-    InvalidInstruction(size_t pc, std::string what) : std::invalid_argument{what}, pc{pc} {}
-    InvalidInstruction(size_t pc, uint8_t opcode)
+    explicit InvalidInstruction(const size_t pc, const char* what) : std::invalid_argument{what}, pc{pc} {}
+    InvalidInstruction(const size_t pc, const std::string& what) : std::invalid_argument{what}, pc{pc} {}
+    InvalidInstruction(const size_t pc, const uint8_t opcode)
         : std::invalid_argument{make_opcode_message("bad instruction", opcode)}, pc{pc} {}
 };
 
@@ -59,7 +59,7 @@ struct UnsupportedMemoryMode : std::invalid_argument {
     explicit UnsupportedMemoryMode(const char* what) : std::invalid_argument{what} {}
 };
 
-static auto getMemIsLoad(uint8_t opcode) -> bool {
+static auto getMemIsLoad(const uint8_t opcode) -> bool {
     switch (opcode & INST_CLS_MASK) {
     case INST_CLS_LD:
     case INST_CLS_LDX: return true;
@@ -69,7 +69,7 @@ static auto getMemIsLoad(uint8_t opcode) -> bool {
     return {};
 }
 
-static auto getMemWidth(uint8_t opcode) -> int {
+static auto getMemWidth(const uint8_t opcode) -> int {
     switch (opcode & INST_SIZE_MASK) {
     case INST_SIZE_B: return 1;
     case INST_SIZE_H: return 2;
@@ -89,8 +89,8 @@ static auto getMemWidth(uint8_t opcode) -> int {
 //     return {};
 // }
 
-static Instruction shift32(Reg dst, Bin::Op op) {
-    return (Instruction)Bin{.op = op, .dst = dst, .v = Imm{32}, .is64 = true, .lddw = false};
+static Instruction shift32(const Reg dst, const Bin::Op op) {
+    return Bin{.op = op, .dst = dst, .v = Imm{32}, .is64 = true, .lddw = false};
 }
 
 struct Unmarshaller {
@@ -102,9 +102,9 @@ struct Unmarshaller {
         note_next_pc();
     }
 
-    auto getAluOp(size_t pc, ebpf_inst inst) -> std::variant<Bin::Op, Un::Op> {
+    auto getAluOp(const size_t pc, const ebpf_inst inst) -> std::variant<Bin::Op, Un::Op> {
         // First handle instructions that support a non-zero offset.
-        bool is64 = (inst.opcode & INST_CLS_MASK) == INST_CLS_ALU64;
+        const bool is64 = (inst.opcode & INST_CLS_MASK) == INST_CLS_ALU64;
         switch (inst.opcode & INST_ALU_OP_MASK) {
         case INST_ALU_OP_DIV:
             if (!info.platform->supports_group(is64 ? bpf_conformance_groups_t::divmul64
@@ -226,9 +226,8 @@ struct Unmarshaller {
         return {};
     }
 
-    auto getAtomicOp(size_t pc, ebpf_inst inst) -> Atomic::Op {
-        Atomic::Op op = (Atomic::Op)(inst.imm & ~INST_FETCH);
-        switch (op) {
+    static auto getAtomicOp(const size_t pc, const ebpf_inst inst) -> Atomic::Op {
+        switch (const auto op = static_cast<Atomic::Op>(inst.imm & ~INST_FETCH)) {
         case Atomic::Op::XCHG:
         case Atomic::Op::CMPXCHG:
             if ((inst.imm & INST_FETCH) == 0) {
@@ -242,11 +241,11 @@ struct Unmarshaller {
         throw InvalidInstruction(pc, "unsupported immediate");
     }
 
-    uint64_t sign_extend(int32_t imm) { return (uint64_t)(int64_t)imm; }
+    static uint64_t sign_extend(const int32_t imm) { return static_cast<uint64_t>(static_cast<int64_t>(imm)); }
 
-    uint64_t zero_extend(int32_t imm) { return (uint64_t)(uint32_t)imm; }
+    static uint64_t zero_extend(const int32_t imm) { return static_cast<uint64_t>(static_cast<uint32_t>(imm)); }
 
-    auto getBinValue(pc_t pc, ebpf_inst inst) -> Value {
+    static auto getBinValue(const pc_t pc, const ebpf_inst inst) -> Value {
         if (inst.opcode & INST_SRC_REG) {
             if (inst.imm != 0) {
                 throw InvalidInstruction(pc, make_opcode_message("nonzero imm for", inst.opcode));
@@ -261,7 +260,7 @@ struct Unmarshaller {
         }
     }
 
-    static auto getJmpOp(size_t pc, uint8_t opcode) -> Condition::Op {
+    static auto getJmpOp(const size_t pc, const uint8_t opcode) -> Condition::Op {
         using Op = Condition::Op;
         switch ((opcode >> 4) & 0xF) {
         case 0x0: return {}; // goto
@@ -284,17 +283,17 @@ struct Unmarshaller {
         return {};
     }
 
-    auto makeMemOp(pc_t pc, ebpf_inst inst) -> Instruction {
+    auto makeMemOp(const pc_t pc, const ebpf_inst inst) -> Instruction {
         if (inst.dst > R10_STACK_POINTER || inst.src > R10_STACK_POINTER) {
             throw InvalidInstruction(pc, "bad register");
         }
 
-        int width = getMemWidth(inst.opcode);
+        const int width = getMemWidth(inst.opcode);
         if (!info.platform->supports_group((width == sizeof(uint64_t)) ? bpf_conformance_groups_t::base64
                                                                        : bpf_conformance_groups_t::base32)) {
             throw InvalidInstruction(pc, inst.opcode);
         }
-        bool isLD = (inst.opcode & INST_CLS_MASK) == INST_CLS_LD;
+        const bool isLD = (inst.opcode & INST_CLS_MASK) == INST_CLS_LD;
         switch (inst.opcode & INST_MODE_MASK) {
         case INST_MODE_IMM: throw InvalidInstruction(pc, inst.opcode);
 
@@ -332,11 +331,11 @@ struct Unmarshaller {
             if (isLD) {
                 throw InvalidInstruction(pc, inst.opcode);
             }
-            bool isLoad = getMemIsLoad(inst.opcode);
+            const bool isLoad = getMemIsLoad(inst.opcode);
             if (isLoad && inst.dst == R10_STACK_POINTER) {
                 throw InvalidInstruction(pc, "cannot modify r10");
             }
-            bool isImm = !(inst.opcode & 1);
+            const bool isImm = !(inst.opcode & 1);
             if (isImm && inst.src != 0) {
                 throw InvalidInstruction(pc, inst.opcode);
             }
@@ -345,7 +344,7 @@ struct Unmarshaller {
             }
 
             assert(!(isLoad && isImm));
-            uint8_t basereg = isLoad ? inst.src : inst.dst;
+            const uint8_t basereg = isLoad ? inst.src : inst.dst;
 
             if (basereg == R10_STACK_POINTER &&
                 (inst.offset + opcode_to_width(inst.opcode) > 0 || inst.offset < -EBPF_STACK_SIZE)) {
@@ -358,8 +357,9 @@ struct Unmarshaller {
                         .basereg = Reg{basereg},
                         .offset = inst.offset,
                     },
-                .value =
-                    isLoad ? (Value)Reg{inst.dst} : (isImm ? (Value)Imm{zero_extend(inst.imm)} : (Value)Reg{inst.src}),
+                .value = isLoad ? static_cast<Value>(Reg{inst.dst})
+                                : (isImm ? static_cast<Value>(Imm{zero_extend(inst.imm)})
+                                         : static_cast<Value>(Reg{inst.src})),
                 .is_load = isLoad,
             };
             return res;
@@ -388,11 +388,10 @@ struct Unmarshaller {
             };
         default: throw InvalidInstruction(pc, inst.opcode);
         }
-        return {};
     }
 
-    auto makeAluOp(size_t pc, ebpf_inst inst) -> Instruction {
-        bool is64 = (inst.opcode & INST_CLS_MASK) == INST_CLS_ALU64;
+    auto makeAluOp(const size_t pc, const ebpf_inst inst) -> Instruction {
+        const bool is64 = (inst.opcode & INST_CLS_MASK) == INST_CLS_ALU64;
         if (!info.platform->supports_group(is64 ? bpf_conformance_groups_t::base64
                                                 : bpf_conformance_groups_t::base32)) {
             throw InvalidInstruction(pc, inst.opcode);
@@ -404,8 +403,8 @@ struct Unmarshaller {
             throw InvalidInstruction(pc, "bad register");
         }
         return std::visit(
-            overloaded{[&](Un::Op op) -> Instruction { return Un{.op = op, .dst = Reg{inst.dst}, .is64 = is64}; },
-                       [&](Bin::Op op) -> Instruction {
+            overloaded{[&](const Un::Op op) -> Instruction { return Un{.op = op, .dst = Reg{inst.dst}, .is64 = is64}; },
+                       [&](const Bin::Op op) -> Instruction {
                            Bin res{
                                .op = op,
                                .dst = Reg{inst.dst},
@@ -414,8 +413,10 @@ struct Unmarshaller {
                            };
                            if (!thread_local_options.allow_division_by_zero &&
                                (op == Bin::Op::UDIV || op == Bin::Op::UMOD)) {
-                               if (std::holds_alternative<Imm>(res.v) && std::get<Imm>(res.v).v == 0) {
-                                   note("division by zero");
+                               if (const auto pimm = std::get_if<Imm>(&res.v)) {
+                                   if (pimm->v == 0) {
+                                       note("division by zero");
+                                   }
                                }
                            }
                            return res;
@@ -423,14 +424,15 @@ struct Unmarshaller {
             getAluOp(pc, inst));
     }
 
-    auto makeLddw(ebpf_inst inst, int32_t next_imm, const vector<ebpf_inst>& insts, pc_t pc) -> Instruction {
+    auto makeLddw(const ebpf_inst inst, const int32_t next_imm, const vector<ebpf_inst>& insts, const pc_t pc) const
+        -> Instruction {
         if (!info.platform->supports_group(bpf_conformance_groups_t::base64)) {
             throw InvalidInstruction{pc, inst.opcode};
         }
         if (pc >= insts.size() - 1) {
             throw InvalidInstruction(pc, "incomplete lddw");
         }
-        ebpf_inst next = insts[pc + 1];
+        const ebpf_inst next = insts[pc + 1];
         if (next.opcode != 0 || next.dst != 0 || next.src != 0 || next.offset != 0) {
             throw InvalidInstruction(pc, "invalid lddw");
         }
@@ -462,7 +464,7 @@ struct Unmarshaller {
         };
     }
 
-    static ArgSingle::Kind toArgSingleKind(ebpf_argument_type_t t) {
+    static ArgSingle::Kind toArgSingleKind(const ebpf_argument_type_t t) {
         switch (t) {
         case EBPF_ARGUMENT_TYPE_ANYTHING: return ArgSingle::Kind::ANYTHING;
         case EBPF_ARGUMENT_TYPE_PTR_TO_MAP: return ArgSingle::Kind::MAP_FD;
@@ -475,7 +477,7 @@ struct Unmarshaller {
         return {};
     }
 
-    static ArgPair::Kind toArgPairKind(ebpf_argument_type_t t) {
+    static ArgPair::Kind toArgPairKind(const ebpf_argument_type_t t) {
         switch (t) {
         case EBPF_ARGUMENT_TYPE_PTR_TO_READABLE_MEM_OR_NULL: return ArgPair::Kind::PTR_TO_READABLE_MEM_OR_NULL;
         case EBPF_ARGUMENT_TYPE_PTR_TO_READABLE_MEM: return ArgPair::Kind::PTR_TO_READABLE_MEM;
@@ -485,8 +487,8 @@ struct Unmarshaller {
         return {};
     }
 
-    auto makeCall(int32_t imm) const {
-        EbpfHelperPrototype proto = info.platform->get_helper_prototype(imm);
+    auto makeCall(const int32_t imm) const {
+        const EbpfHelperPrototype proto = info.platform->get_helper_prototype(imm);
         if (proto.return_type == EBPF_RETURN_TYPE_UNSUPPORTED) {
             throw std::runtime_error(std::string("unsupported function: ") + proto.name);
         }
@@ -495,7 +497,7 @@ struct Unmarshaller {
         res.name = proto.name;
         res.reallocate_packet = proto.reallocate_packet;
         res.is_map_lookup = proto.return_type == EBPF_RETURN_TYPE_PTR_TO_MAP_VALUE_OR_NULL;
-        std::array<ebpf_argument_type_t, 7> args = {
+        const std::array<ebpf_argument_type_t, 7> args = {
             {EBPF_ARGUMENT_TYPE_DONTCARE, proto.argument_type[0], proto.argument_type[1], proto.argument_type[2],
              proto.argument_type[3], proto.argument_type[4], EBPF_ARGUMENT_TYPE_DONTCARE}};
         for (size_t i = 1; i < args.size() - 1; i++) {
@@ -510,7 +512,7 @@ struct Unmarshaller {
             case EBPF_ARGUMENT_TYPE_PTR_TO_MAP_KEY:
             case EBPF_ARGUMENT_TYPE_PTR_TO_MAP_VALUE:
             case EBPF_ARGUMENT_TYPE_PTR_TO_CTX:
-                res.singles.push_back({toArgSingleKind(args[i]), Reg{(uint8_t)i}});
+                res.singles.push_back({toArgSingleKind(args[i]), Reg{static_cast<uint8_t>(i)}});
                 break;
             case EBPF_ARGUMENT_TYPE_CONST_SIZE: {
                 // Sanity check: This argument should never be seen in isolation.
@@ -542,8 +544,9 @@ struct Unmarshaller {
                                     "EBPF_ARGUMENT_TYPE_CONST_SIZE_OR_ZERO: ") +
                         proto.name);
                 }
-                bool can_be_zero = (args[i + 1] == EBPF_ARGUMENT_TYPE_CONST_SIZE_OR_ZERO);
-                res.pairs.push_back({toArgPairKind(args[i]), Reg{(uint8_t)i}, Reg{(uint8_t)(i + 1)}, can_be_zero});
+                const bool can_be_zero = (args[i + 1] == EBPF_ARGUMENT_TYPE_CONST_SIZE_OR_ZERO);
+                res.pairs.push_back({toArgPairKind(args[i]), Reg{static_cast<uint8_t>(i)},
+                                     Reg{static_cast<uint8_t>(i + 1)}, can_be_zero});
                 i++;
                 break;
             }
@@ -552,17 +555,17 @@ struct Unmarshaller {
     }
 
     /// Given a program counter and an offset, get the label of the target instruction.
-    label_t getJumpTarget(int32_t offset, const vector<ebpf_inst>& insts, pc_t pc) const {
-        pc_t new_pc = pc + 1 + offset;
+    static label_t getJumpTarget(const int32_t offset, const vector<ebpf_inst>& insts, const pc_t pc) {
+        const pc_t new_pc = pc + 1 + offset;
         if (new_pc >= insts.size()) {
             throw InvalidInstruction(pc, "jump out of bounds");
         } else if (insts[new_pc].opcode == 0) {
             throw InvalidInstruction(pc, "jump to middle of lddw");
         }
-        return label_t{(int)new_pc};
+        return label_t{static_cast<int>(new_pc)};
     }
 
-    auto makeCallLocal(ebpf_inst inst, const vector<ebpf_inst>& insts, pc_t pc) const {
+    static auto makeCallLocal(const ebpf_inst inst, const vector<ebpf_inst>& insts, const pc_t pc) {
         if (inst.opcode & INST_SRC_REG) {
             throw InvalidInstruction(pc, inst.opcode);
         }
@@ -572,7 +575,7 @@ struct Unmarshaller {
         return CallLocal{.target = getJumpTarget(inst.imm, insts, pc)};
     }
 
-    auto makeCallx(ebpf_inst inst, pc_t pc) const {
+    static auto makeCallx(const ebpf_inst inst, const pc_t pc) {
         // callx puts the register number in the 'dst' field rather than the 'src' field.
         if (inst.dst > R10_STACK_POINTER) {
             throw InvalidInstruction(pc, "bad register");
@@ -585,12 +588,12 @@ struct Unmarshaller {
             if (inst.imm < 0 || inst.imm > R10_STACK_POINTER) {
                 throw InvalidInstruction(pc, "bad register");
             }
-            return Callx{(uint8_t)inst.imm};
+            return Callx{static_cast<uint8_t>(inst.imm)};
         }
         return Callx{inst.dst};
     }
 
-    auto makeJmp(ebpf_inst inst, const vector<ebpf_inst>& insts, pc_t pc) -> Instruction {
+    auto makeJmp(const ebpf_inst inst, const vector<ebpf_inst>& insts, const pc_t pc) const -> Instruction {
         switch ((inst.opcode >> 4) & 0xF) {
         case INST_CALL:
             if ((inst.opcode & INST_CLS_MASK) != INST_CLS_JMP) {
@@ -662,12 +665,12 @@ struct Unmarshaller {
             }
         default: {
             // First validate the opcode, src, and imm.
-            auto is64 = (inst.opcode & INST_CLS_MASK) == INST_CLS_JMP;
+            const auto is64 = (inst.opcode & INST_CLS_MASK) == INST_CLS_JMP;
             if (!info.platform->supports_group(is64 ? bpf_conformance_groups_t::base64
                                                     : bpf_conformance_groups_t::base32)) {
                 throw InvalidInstruction(pc, inst.opcode);
             }
-            auto op = getJmpOp(pc, inst.opcode);
+            const auto op = getJmpOp(pc, inst.opcode);
             if (!(inst.opcode & INST_SRC_REG) && (inst.src != 0)) {
                 throw InvalidInstruction(pc, inst.opcode);
             }
@@ -675,8 +678,8 @@ struct Unmarshaller {
                 throw InvalidInstruction(pc, make_opcode_message("nonzero imm for", inst.opcode));
             }
 
-            int32_t offset = (inst.opcode == INST_OP_JA32) ? inst.imm : inst.offset;
-            label_t target = getJumpTarget(offset, insts, pc);
+            const int32_t offset = (inst.opcode == INST_OP_JA32) ? inst.imm : inst.offset;
+            const label_t target = getJumpTarget(offset, insts, pc);
             if (inst.opcode != INST_OP_JA16 && inst.opcode != INST_OP_JA32) {
                 if (inst.dst > R10_STACK_POINTER) {
                     throw InvalidInstruction(pc, "bad register");
@@ -686,13 +689,13 @@ struct Unmarshaller {
                 }
             }
 
-            auto cond = (inst.opcode == INST_OP_JA16 || inst.opcode == INST_OP_JA32)
-                            ? std::optional<Condition>{}
-                            : Condition{.op = op,
-                                        .left = Reg{inst.dst},
-                                        .right = (inst.opcode & INST_SRC_REG) ? (Value)Reg{inst.src}
-                                                                              : Imm{sign_extend(inst.imm)},
-                                        .is64 = ((inst.opcode & INST_CLS_MASK) == INST_CLS_JMP)};
+            const auto cond = (inst.opcode == INST_OP_JA16 || inst.opcode == INST_OP_JA32)
+                                  ? std::optional<Condition>{}
+                                  : Condition{.op = op,
+                                              .left = Reg{inst.dst},
+                                              .right = (inst.opcode & INST_SRC_REG) ? static_cast<Value>(Reg{inst.src})
+                                                                                    : Imm{sign_extend(inst.imm)},
+                                              .is64 = ((inst.opcode & INST_CLS_MASK) == INST_CLS_JMP)};
             return Jmp{.cond = cond, .target = target};
         }
         }
@@ -705,14 +708,14 @@ struct Unmarshaller {
             throw std::invalid_argument("Zero length programs are not allowed");
         }
         for (size_t pc = 0; pc < insts.size();) {
-            ebpf_inst inst = insts[pc];
+            const ebpf_inst inst = insts[pc];
             Instruction new_ins;
             bool skip_instruction = false;
             bool fallthrough = true;
             switch (inst.opcode & INST_CLS_MASK) {
             case INST_CLS_LD:
                 if (inst.opcode == INST_OP_LDDW_IMM) {
-                    int32_t next_imm = pc < insts.size() - 1 ? insts[pc + 1].imm : 0;
+                    const int32_t next_imm = pc < insts.size() - 1 ? insts[pc + 1].imm : 0;
                     new_ins = makeLddw(inst, next_imm, insts, static_cast<pc_t>(pc));
                     skip_instruction = true;
                     break;
@@ -731,7 +734,7 @@ struct Unmarshaller {
                 if (pc >= insts.size() - 1) {
                     break;
                 }
-                ebpf_inst next = insts[pc + 1];
+                const ebpf_inst next = insts[pc + 1];
                 auto dst = Reg{inst.dst};
 
                 if (new_ins != shift32(dst, Bin::Op::LSH)) {
@@ -755,13 +758,13 @@ struct Unmarshaller {
 
             case INST_CLS_JMP32:
             case INST_CLS_JMP: {
-                new_ins = makeJmp(inst, insts, static_cast<pc_t>(pc));
+                new_ins = makeJmp(inst, insts, pc);
                 if (std::holds_alternative<Exit>(new_ins)) {
                     fallthrough = false;
                     exit_count++;
                 }
-                if (std::holds_alternative<Jmp>(new_ins)) {
-                    if (!std::get<Jmp>(new_ins).cond) {
+                if (const auto pjmp = std::get_if<Jmp>(&new_ins)) {
+                    if (!pjmp->cond) {
                         fallthrough = false;
                     }
                 }
@@ -810,8 +813,8 @@ std::variant<InstructionSeq, std::string> unmarshal(const raw_program& raw_prog)
     return unmarshal(raw_prog, notes);
 }
 
-Call make_call(int imm, const ebpf_platform_t& platform) {
+Call make_call(const int imm, const ebpf_platform_t& platform) {
     vector<vector<string>> notes;
-    program_info info{.platform = &platform};
+    const program_info info{.platform = &platform};
     return Unmarshaller{notes, info}.makeCall(imm);
 }

--- a/src/crab/cfg.hpp
+++ b/src/crab/cfg.hpp
@@ -616,7 +616,7 @@ std::map<std::string, int> collect_stats(const cfg_t&);
 cfg_t prepare_cfg(const InstructionSeq& prog, const program_info& info, bool simplify, bool must_have_exit = true);
 
 void explicate_assertions(cfg_t& cfg, const program_info& info);
-std::vector<Assert> get_assertions(Instruction ins, const program_info& info, std::optional<label_t> label);
+std::vector<Assert> get_assertions(Instruction ins, const program_info& info, const std::optional<label_t>& label);
 
 void print_dot(const cfg_t& cfg, std::ostream& out);
 void print_dot(const cfg_t& cfg, const std::string& outfile);

--- a/src/ebpf_yaml.cpp
+++ b/src/ebpf_yaml.cpp
@@ -338,8 +338,8 @@ ConformanceTestResult run_conformance_test_case(const std::vector<uint8_t>& memo
 
     // Convert the raw program section to a set of instructions.
     std::variant<InstructionSeq, std::string> prog_or_error = unmarshal(raw_prog);
-    if (std::holds_alternative<string>(prog_or_error)) {
-        std::cerr << "unmarshaling error at " << std::get<string>(prog_or_error) << "\n";
+    if (auto prog = std::get_if<std::string>(&prog_or_error)) {
+        std::cerr << "unmarshaling error at " << *prog << "\n";
         return {};
     }
 

--- a/src/main/check.cpp
+++ b/src/main/check.cpp
@@ -220,8 +220,8 @@ int main(int argc, char** argv) {
 
     // Convert the raw program section to a set of instructions.
     std::variant<InstructionSeq, std::string> prog_or_error = unmarshal(raw_prog);
-    if (std::holds_alternative<string>(prog_or_error)) {
-        std::cout << "unmarshaling error at " << std::get<string>(prog_or_error) << "\n";
+    if (auto prog = std::get_if<string>(&prog_or_error)) {
+        std::cout << "unmarshaling error at " << *prog << "\n";
         return 1;
     }
 

--- a/src/test/test_marshal.cpp
+++ b/src/test/test_marshal.cpp
@@ -299,33 +299,33 @@ static void check_marshal_unmarshal_fail(const Instruction& ins, std::string exp
 static void check_unmarshal_fail(ebpf_inst inst, std::string expected_error_message,
                                  const ebpf_platform_t& platform = g_ebpf_platform_linux) {
     program_info info{.platform = &platform, .type = platform.get_program_type("unspec", "unspec")};
-    std::vector<ebpf_inst> insns = {inst};
+    std::vector insns = {inst};
     auto result = unmarshal(raw_program{"", "", 0, "", insns, info});
-    REQUIRE(std::holds_alternative<std::string>(result));
-    std::string error_message = std::get<std::string>(result);
-    REQUIRE(error_message == expected_error_message);
+    std::string* error_message = std::get_if<std::string>(&result);
+    REQUIRE(error_message != nullptr);
+    REQUIRE(*error_message == expected_error_message);
 }
 
 static void check_unmarshal_fail_goto(ebpf_inst inst, const std::string& expected_error_message,
                                       const ebpf_platform_t& platform = g_ebpf_platform_linux) {
     program_info info{.platform = &platform, .type = platform.get_program_type("unspec", "unspec")};
-    const ebpf_inst exit{.opcode = INST_OP_EXIT};
-    std::vector<ebpf_inst> insns{inst, exit, exit};
+    constexpr ebpf_inst exit{.opcode = INST_OP_EXIT};
+    std::vector insns{inst, exit, exit};
     auto result = unmarshal(raw_program{"", "", 0, "", insns, info});
-    REQUIRE(std::holds_alternative<std::string>(result));
-    std::string error_message = std::get<std::string>(result);
-    REQUIRE(error_message == expected_error_message);
+    std::string* error_message = std::get_if<std::string>(&result);
+    REQUIRE(error_message != nullptr);
+    REQUIRE(*error_message == expected_error_message);
 }
 
 // Check that unmarshaling a 64-bit immediate instruction fails.
 static void check_unmarshal_fail(ebpf_inst inst1, ebpf_inst inst2, std::string expected_error_message,
                                  const ebpf_platform_t& platform = g_ebpf_platform_linux) {
     program_info info{.platform = &platform, .type = platform.get_program_type("unspec", "unspec")};
-    std::vector<ebpf_inst> insns = {inst1, inst2};
+    std::vector insns{inst1, inst2};
     auto result = unmarshal(raw_program{"", "", 0, "", insns, info});
-    REQUIRE(std::holds_alternative<std::string>(result));
-    std::string error_message = std::get<std::string>(result);
-    REQUIRE(error_message == expected_error_message);
+    std::string* error_message = std::get_if<std::string>(&result);
+    REQUIRE(error_message != nullptr);
+    REQUIRE(*error_message == expected_error_message);
 }
 
 static const auto ws = {1, 2, 4, 8};

--- a/src/test/test_print.cpp
+++ b/src/test/test_print.cpp
@@ -26,9 +26,9 @@ void verify_printed_string(const std::string& file) {
         read_elf(std::string(TEST_OBJECT_FILE_DIRECTORY) + file + ".o", "", nullptr, &g_ebpf_platform_linux);
     const raw_program& raw_prog = raw_progs.back();
     std::variant<InstructionSeq, std::string> prog_or_error = unmarshal(raw_prog);
-    REQUIRE(std::holds_alternative<InstructionSeq>(prog_or_error));
-    auto& program = std::get<InstructionSeq>(prog_or_error);
-    print(program, generated_output, {});
+    auto program = std::get_if<InstructionSeq>(&prog_or_error);
+    REQUIRE(program != nullptr);
+    print(*program, generated_output, {});
     print_map_descriptors(raw_prog.info.map_descriptors, generated_output);
     std::ifstream expected_stream(std::string(TEST_ASM_FILE_DIRECTORY) + file + std::string(".asm"));
     REQUIRE(expected_stream);

--- a/src/test/test_verify.cpp
+++ b/src/test/test_verify.cpp
@@ -38,10 +38,10 @@ FAIL_UNMARSHAL("invalid", "invalid-lddw.o", ".text")
         auto raw_progs = read_elf("ebpf-samples/" dirname "/" filename, sectionname, nullptr, platform); \
         REQUIRE(raw_progs.size() == 1);                                                                  \
         raw_program raw_prog = raw_progs.back();                                                         \
-        std::variant<InstructionSeq, std::string> prog_or_error = unmarshal(raw_prog);                   \
-        REQUIRE(std::holds_alternative<InstructionSeq>(prog_or_error));                                  \
-        auto& prog = std::get<InstructionSeq>(prog_or_error);                                            \
-        bool res = ebpf_verify_program(std::cout, prog, raw_prog.info, options, nullptr);                \
+        auto prog_or_error = unmarshal(raw_prog);                                                        \
+        auto prog = std::get_if<InstructionSeq>(&prog_or_error);                                         \
+        REQUIRE(prog != nullptr);                                                                        \
+        bool res = ebpf_verify_program(std::cout, *prog, raw_prog.info, options, nullptr);               \
         if (pass)                                                                                        \
             REQUIRE(res);                                                                                \
         else                                                                                             \
@@ -54,10 +54,10 @@ FAIL_UNMARSHAL("invalid", "invalid-lddw.o", ".text")
         auto raw_progs = read_elf("ebpf-samples/" dirname "/" filename, section_name, nullptr, platform); \
         for (auto& raw_prog : raw_progs) {                                                                \
             if (raw_prog.function_name == program_name) {                                                 \
-                std::variant<InstructionSeq, std::string> prog_or_error = unmarshal(raw_prog);            \
-                REQUIRE(std::holds_alternative<InstructionSeq>(prog_or_error));                           \
-                auto& prog = std::get<InstructionSeq>(prog_or_error);                                     \
-                bool res = ebpf_verify_program(std::cout, prog, raw_prog.info, options, nullptr);         \
+                auto prog_or_error = unmarshal(raw_prog);                                                 \
+                auto prog = std::get_if<InstructionSeq>(&prog_or_error);                                  \
+                REQUIRE(prog != nullptr);                                                                 \
+                bool res = ebpf_verify_program(std::cout, *prog, raw_prog.info, options, nullptr);        \
                 if (pass)                                                                                 \
                     REQUIRE(res);                                                                         \
                 else                                                                                      \
@@ -598,18 +598,18 @@ TEST_CASE("multithreading", "[verify][multithreading]") {
     auto raw_progs1 = read_elf("ebpf-samples/bpf_cilium_test/bpf_netdev.o", "2/1", nullptr, &g_ebpf_platform_linux);
     REQUIRE(raw_progs1.size() == 1);
     raw_program raw_prog1 = raw_progs1.back();
-    std::variant<InstructionSeq, std::string> prog_or_error1 = unmarshal(raw_prog1);
-    REQUIRE(std::holds_alternative<InstructionSeq>(prog_or_error1));
-    auto& prog1 = std::get<InstructionSeq>(prog_or_error1);
-    cfg_t cfg1 = prepare_cfg(prog1, raw_prog1.info, true);
+    auto prog_or_error1 = unmarshal(raw_prog1);
+    auto prog1 = std::get_if<InstructionSeq>(&prog_or_error1);
+    REQUIRE(prog1 != nullptr);
+    cfg_t cfg1 = prepare_cfg(*prog1, raw_prog1.info, true);
 
     auto raw_progs2 = read_elf("ebpf-samples/bpf_cilium_test/bpf_netdev.o", "2/2", nullptr, &g_ebpf_platform_linux);
     REQUIRE(raw_progs2.size() == 1);
     raw_program raw_prog2 = raw_progs2.back();
-    std::variant<InstructionSeq, std::string> prog_or_error2 = unmarshal(raw_prog2);
-    REQUIRE(std::holds_alternative<InstructionSeq>(prog_or_error2));
-    auto& prog2 = std::get<InstructionSeq>(prog_or_error2);
-    cfg_t cfg2 = prepare_cfg(prog2, raw_prog2.info, true);
+    auto prog_or_error2 = unmarshal(raw_prog2);
+    auto prog2 = std::get_if<InstructionSeq>(&prog_or_error2);
+    REQUIRE(prog2 != nullptr);
+    cfg_t cfg2 = prepare_cfg(*prog2, raw_prog2.info, true);
 
     bool res1, res2;
     std::thread a(test_analyze_thread, &cfg1, &raw_prog1.info, &res1);


### PR DESCRIPTION
Also some more modernization, a-la #673.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Enhanced type safety and clarity in handling `Instruction` types across various components.
	- Introduced a new static function for calculating lower and upper bounds in memory access.

- **Bug Fixes**
	- Streamlined error handling in multiple locations to improve clarity and reduce complexity.

- **Refactor**
	- Updated function signatures to pass parameters by reference, enhancing performance.
	- Replaced `std::holds_alternative` with `std::get_if` for safer type checking across the codebase.

- **Documentation**
	- Improved comments and code structure for better maintainability and readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->