### PR TITLE
Cleanup, modernize and silence compiler warnings

### DIFF
--- a/src/crab/ebpf_domain.cpp
+++ b/src/crab/ebpf_domain.cpp
@@ -2510,6 +2510,9 @@ void ebpf_domain_t::operator()(const Bin& bin) {
             type_inv.assign_type(m_inv, bin.dst, T_NUM);
             havoc_offsets(bin.dst);
             break;
+        case Bin::Op::MOVSX8:
+        case Bin::Op::MOVSX16:
+        case Bin::Op::MOVSX32: CRAB_ERROR("Unsupported operation");
         case Bin::Op::ADD:
             if (imm == 0) {
                 return;

--- a/src/crab/split_dbm.cpp
+++ b/src/crab/split_dbm.cpp
@@ -1168,7 +1168,7 @@ string_invariant SplitDBM::to_set() const {
 std::ostream& operator<<(std::ostream& o, const SplitDBM& dom) { return o << dom.to_set(); }
 
 bool SplitDBM::eval_expression_overflow(const linear_expression_t& e, Weight& out) const {
-    bool overflow = convert_NtoW_overflow(e.constant_term(), out);
+    [[maybe_unused]] bool overflow = convert_NtoW_overflow(e.constant_term(), out);
     assert(!overflow);
     for (const auto& [variable, coefficient] : e.variable_terms()) {
         Weight coef;

--- a/src/crab/variable.hpp
+++ b/src/crab/variable.hpp
@@ -11,10 +11,6 @@
 #include "crab_utils/lazy_allocator.hpp"
 #include "crab_utils/num_big.hpp"
 
-using index_t = uint64_t;
-
-/* Basic type definitions */
-
 namespace crab {
 
 std::vector<std::string> default_variable_names();
@@ -22,22 +18,22 @@ std::vector<std::string> default_variable_names();
 // Wrapper for typed variables used by the crab abstract domains and linear_constraints.
 // Being a class (instead of a type alias) enables overloading in dsl_syntax
 class variable_t final {
-    index_t _id;
+    uint64_t _id;
 
-    explicit variable_t(index_t id) : _id(id) {}
+    explicit variable_t(const uint64_t id) : _id(id) {}
 
   public:
     [[nodiscard]]
     std::size_t hash() const {
-        return (size_t)_id;
+        return _id;
     }
 
-    bool operator==(variable_t o) const { return _id == o._id; }
+    bool operator==(const variable_t o) const { return _id == o._id; }
 
-    bool operator!=(variable_t o) const { return (!(operator==(o))); }
+    bool operator!=(const variable_t o) const { return (!(operator==(o))); }
 
     // for flat_map
-    bool operator<(variable_t o) const { return _id < o._id; }
+    bool operator<(const variable_t o) const { return _id < o._id; }
 
     [[nodiscard]]
     std::string name() const {
@@ -54,7 +50,7 @@ class variable_t final {
         return names->at(_id).find(".uvalue") != std::string::npos;
     }
 
-    friend std::ostream& operator<<(std::ostream& o, variable_t v) { return o << names->at(v._id); }
+    friend std::ostream& operator<<(std::ostream& o, const variable_t v) { return o << names->at(v._id); }
 
     // var_factory portion.
     // This singleton is eBPF-specific, to avoid lifetime issues and/or passing factory explicitly everywhere:


### PR DESCRIPTION
also some more modernization

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Introduced handling for new operations (`MOVSX8`, `MOVSX16`, `MOVSX32`) in the EBPF domain, improving error management for unsupported operations.
	- Added a type alias `index_t` to enhance type clarity across various functions.

- **Bug Fixes**
	- Updated the `eval_expression_overflow` method to suppress compiler warnings for unused variables.

- **Refactor**
	- Enhanced the `variable_t` class by simplifying the `_id` member type and improving performance in operator overloads.

- **Documentation**
	- Improved code clarity and consistency by enforcing const-correctness in various functions and methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->