### PR TITLE
Prepare to use GSL, and particularly gsl::narrow

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,70 +1,81 @@
 # Copyright (c) Prevail Verifier contributors.
 # SPDX-License-Identifier: MIT
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.14)
 project(ebpf_verifier)
 
 include(FetchContent)
-FetchContent_Declare(
-  Catch2
-  GIT_REPOSITORY https://github.com/catchorg/Catch2.git
-  GIT_TAG        fa43b77429ba76c462b1898d6cd2f2d7a9416b14 # v3.7.1
+
+FetchContent_Declare(GSL
+        GIT_REPOSITORY "https://github.com/microsoft/GSL"
+        GIT_TAG "v4.0.0"
+        GIT_SHALLOW ON
+)
+FetchContent_MakeAvailable(GSL)
+get_target_property(GSL_INCLUDE_DIRS Microsoft.GSL::GSL INTERFACE_INCLUDE_DIRECTORIES)
+
+FetchContent_Declare(Catch2
+        GIT_REPOSITORY "https://github.com/catchorg/Catch2.git"
+        GIT_TAG "v3.7.1"
+        GIT_SHALLOW ON
 )
 FetchContent_MakeAvailable(Catch2)
 
 if (IS_DIRECTORY "${PROJECT_SOURCE_DIR}/.git")
-  # Install Git pre-commit hook
-  file(COPY scripts/pre-commit scripts/commit-msg
-       DESTINATION "${PROJECT_SOURCE_DIR}/.git/hooks")
+    # Install Git pre-commit hook
+    file(COPY scripts/pre-commit scripts/commit-msg
+            DESTINATION "${PROJECT_SOURCE_DIR}/.git/hooks")
 endif ()
 
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" OR
-    "${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
-  find_package(yaml-cpp REQUIRED)
-  find_package(Boost REQUIRED)
-  set(CMAKE_CXX_STANDARD 20)
+        "${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
+    find_package(yaml-cpp REQUIRED)
+    find_package(Boost REQUIRED)
+    set(CMAKE_CXX_STANDARD 20)
+    set(CMAKE_CXX_STANDARD_REQUIRED ON)
 elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
-  list(APPEND CMAKE_CONFIGURATION_TYPES FuzzerDebug)
-  list(REMOVE_DUPLICATES CMAKE_CONFIGURATION_TYPES)
-  set(CMAKE_CONFIGURATION_TYPES "${CMAKE_CONFIGURATION_TYPES}" CACHE STRING
-      "Add the configurations that we need"
-      FORCE)
-  set(CMAKE_EXE_LINKER_FLAGS_FUZZERDEBUG "${CMAKE_EXE_LINKER_FLAGS_DEBUG}")
-  set(CMAKE_SHARED_LINKER_FLAGS_FUZZERDEBUG "${CMAKE_SHARED_LINKER_FLAGS_DEBUG}")
-  set(CMAKE_C_FLAGS_FUZZERDEBUG "${CMAKE_C_FLAGS_DEBUG} /fsanitize=address /fsanitize=fuzzer /fsanitize-coverage=inline-bool-flag /fsanitize-coverage=edge /fsanitize-coverage=trace-cmp /fsanitize-coverage=trace-div /ZH:SHA_256")
-  set(CMAKE_CXX_FLAGS_FUZZERDEBUG "${CMAKE_CXX_FLAGS_DEBUG} /fsanitize=address /fsanitize=fuzzer /fsanitize-coverage=inline-bool-flag /fsanitize-coverage=edge /fsanitize-coverage=trace-cmp /fsanitize-coverage=trace-div /ZH:SHA_256")
+    list(APPEND CMAKE_CONFIGURATION_TYPES FuzzerDebug)
+    list(REMOVE_DUPLICATES CMAKE_CONFIGURATION_TYPES)
+    set(CMAKE_CONFIGURATION_TYPES "${CMAKE_CONFIGURATION_TYPES}" CACHE STRING
+            "Add the configurations that we need"
+            FORCE)
+    set(CMAKE_EXE_LINKER_FLAGS_FUZZERDEBUG "${CMAKE_EXE_LINKER_FLAGS_DEBUG}")
+    set(CMAKE_SHARED_LINKER_FLAGS_FUZZERDEBUG "${CMAKE_SHARED_LINKER_FLAGS_DEBUG}")
+    set(CMAKE_C_FLAGS_FUZZERDEBUG "${CMAKE_C_FLAGS_DEBUG} /fsanitize=address /fsanitize=fuzzer /fsanitize-coverage=inline-bool-flag /fsanitize-coverage=edge /fsanitize-coverage=trace-cmp /fsanitize-coverage=trace-div /ZH:SHA_256")
+    set(CMAKE_CXX_FLAGS_FUZZERDEBUG "${CMAKE_CXX_FLAGS_DEBUG} /fsanitize=address /fsanitize=fuzzer /fsanitize-coverage=inline-bool-flag /fsanitize-coverage=edge /fsanitize-coverage=trace-cmp /fsanitize-coverage=trace-div /ZH:SHA_256")
 
-  find_program(NUGET nuget)
-  if (NOT NUGET)
-    message("ERROR: You must first install nuget.exe from https://www.nuget.org/downloads")
-  else ()
-    execute_process(COMMAND ${NUGET} install "Boost" -Version 1.81.0 -ExcludeVersion -OutputDirectory ${CMAKE_BINARY_DIR}/packages)
-    set(BOOST_VERSION 1.81.0)
-  endif()
-  set(Boost_INCLUDE_DIRS ${CMAKE_BINARY_DIR}/packages/boost/lib/native/include)
-  set(Boost_LIBRARY_DIRS ${CMAKE_BINARY_DIR}/packages/boost_filesystem-vc143/lib/native)
+    find_program(NUGET nuget)
+    if (NOT NUGET)
+        message("ERROR: You must first install nuget.exe from https://www.nuget.org/downloads")
+    else ()
+        execute_process(COMMAND ${NUGET} install "Boost" -Version 1.81.0 -ExcludeVersion -OutputDirectory ${CMAKE_BINARY_DIR}/packages)
+        set(BOOST_VERSION 1.81.0)
+    endif ()
+    set(Boost_INCLUDE_DIRS ${CMAKE_BINARY_DIR}/packages/boost/lib/native/include)
+    set(Boost_LIBRARY_DIRS ${CMAKE_BINARY_DIR}/packages/boost_filesystem-vc143/lib/native)
 
-  # MSVC's "std:c++20" option is the current standard that supports all the C++17
-  # features we use. However, cmake can't deal with that here, so we set it below.
+    # MSVC's "std:c++20" option is the current standard that supports all the C++17
+    # features we use. However, cmake can't deal with that here, so we set it below.
 
-  set(EXTERNAL_INSTALL_LOCATION ${CMAKE_BINARY_DIR}/packages/yaml-cpp)
-  include(ExternalProject)
-  ExternalProject_Add(yaml-cpp
-          GIT_REPOSITORY https://github.com/jbeder/yaml-cpp.git
-          GIT_TAG "yaml-cpp-0.7.0"
-          GIT_SHALLOW true
-          CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${EXTERNAL_INSTALL_LOCATION}
-                     -DYAML_MSVC_SHARED_RT=ON
-                     -DYAML_CPP_BUILD_TESTS=OFF
-                     -DYAML_CPP_BUILD_TOOLS=OFF
-          )
-  set(YAML_CPP_LIBRARIES ${EXTERNAL_INSTALL_LOCATION}/lib/yaml-cpp$<$<CONFIG:DEBUG>:d>.lib)
-  set(YAML_CPP_INCLUDE_DIRS ${EXTERNAL_INSTALL_LOCATION}/include/)
+    set(EXTERNAL_INSTALL_LOCATION ${CMAKE_BINARY_DIR}/packages/yaml-cpp)
+    include(ExternalProject)
+    ExternalProject_Add(yaml-cpp
+            GIT_REPOSITORY https://github.com/jbeder/yaml-cpp.git
+            GIT_TAG "yaml-cpp-0.7.0"
+            GIT_SHALLOW true
+            CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${EXTERNAL_INSTALL_LOCATION}
+            -DYAML_MSVC_SHARED_RT=ON
+            -DYAML_CPP_BUILD_TESTS=OFF
+            -DYAML_CPP_BUILD_TOOLS=OFF
+    )
+    set(YAML_CPP_LIBRARIES ${EXTERNAL_INSTALL_LOCATION}/lib/yaml-cpp$<$<CONFIG:DEBUG>:d>.lib)
+    set(YAML_CPP_INCLUDE_DIRS ${EXTERNAL_INSTALL_LOCATION}/include/)
 endif ()
 
 include_directories(./external)
 include_directories(./external/bpf_conformance/external/elfio)
 include_directories(./src)
 include_directories(./external/libbtf)
+include_directories(${GSL_INCLUDE_DIRS})
 include_directories(${Boost_INCLUDE_DIRS})
 include_directories(${YAML_CPP_INCLUDE_DIRS})
 link_directories(${Boost_LIBRARY_DIRS})
@@ -73,31 +84,30 @@ file(GLOB LIB_SRC
         "./src/*.cpp"
         "./src/crab/*.cpp"
         "./src/crab_utils/*.cpp"
-        "./src/linux/gpl/*.cpp"
+        "./src/linux/gpl/spec_prototypes.cpp"
         "./src/linux/linux_platform.cpp"
-        )
+)
 
 file(GLOB ALL_TEST
-        "./src/test/test.cpp"
         "./src/test/test_conformance.cpp"
         "./src/test/test_marshal.cpp"
         "./src/test/test_print.cpp"
         "./src/test/test_verify.cpp"
         "./src/test/test_wto.cpp"
         "./src/test/test_yaml.cpp"
-        )
+)
 
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" OR
-    "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-  set(COMMON_FLAGS -Wall -Wfatal-errors -DSIZEOF_VOID_P=8 -DSIZEOF_LONG=8)
+        "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+    set(COMMON_FLAGS -Wall -Wfatal-errors -DSIZEOF_VOID_P=8 -DSIZEOF_LONG=8)
 
-  set(RELEASE_FLAGS -O2 -flto=auto -ffat-lto-objects)
+    set(RELEASE_FLAGS -O2 -flto=auto -ffat-lto-objects)
 
-  set(DEBUG_FLAGS -O0 -g3 -fno-omit-frame-pointer)
+    set(DEBUG_FLAGS -O0 -g3 -fno-omit-frame-pointer)
 
-  set(SANITIZE_FLAGS -fsanitize=address -O1 -fno-omit-frame-pointer)
+    set(SANITIZE_FLAGS -fsanitize=address -O1 -fno-omit-frame-pointer)
 elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /std:c++20")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /std:c++20")
 endif ()
 
 add_library(ebpfverifier ${LIB_SRC})
@@ -106,6 +116,8 @@ add_executable(check src/main/check.cpp src/main/linux_verifier.cpp)
 add_executable(tests ${ALL_TEST})
 add_executable(run_yaml src/main/run_yaml.cpp)
 add_executable(conformance_check src/test/conformance_check.cpp)
+
+target_include_directories(ebpfverifier PRIVATE ${GSL_INCLUDE_DIRS})
 
 set_target_properties(check
         PROPERTIES
@@ -141,6 +153,14 @@ add_subdirectory("external/libbtf")
 set(ebpfverifier_GUID_CMAKE "7d5b4e68-c0fa-3f86-9405-f6400219b440" CACHE INTERNAL "Project GUID")
 set(yaml-cpp_GUID_CMAKE "98d56b8a-d8eb-3d98-b8ee-c83696b4d58a" CACHE INTERNAL "Project GUID")
 
+set(THREADS_PREFER_PTHREAD_FLAG ON)
+find_package(Threads REQUIRED)
+
+target_link_libraries(ebpfverifier PRIVATE ${YAML_CPP_LIBRARIES})
+target_link_libraries(ebpfverifier PRIVATE libbtf)
+target_link_libraries(ebpfverifier PRIVATE Microsoft.GSL::GSL)
+target_compile_options(ebpfverifier PRIVATE ${COMMON_FLAGS})
+
 target_compile_options(check PRIVATE ${COMMON_FLAGS})
 target_compile_options(check PUBLIC "$<$<CONFIG:DEBUG>:${DEBUG_FLAGS}>")
 target_compile_options(check PUBLIC "$<$<CONFIG:RELEASE>:${RELEASE_FLAGS}>")
@@ -155,16 +175,9 @@ target_compile_options(tests PUBLIC "$<$<CONFIG:SANITIZE>:${SANITIZE_FLAGS}>")
 target_link_libraries(tests PRIVATE ebpfverifier)
 target_link_libraries(tests PRIVATE bpf_conformance)
 target_link_libraries(tests PRIVATE ${CMAKE_DL_LIBS})
-
-set(THREADS_PREFER_PTHREAD_FLAG ON)
-find_package(Threads REQUIRED)
-
 target_link_libraries(tests PRIVATE Threads::Threads)
 target_link_libraries(tests PRIVATE Catch2::Catch2WithMain)
 
-target_link_libraries(ebpfverifier PRIVATE ${YAML_CPP_LIBRARIES})
-target_link_libraries(ebpfverifier PRIVATE libbtf)
-target_compile_options(ebpfverifier PRIVATE ${COMMON_FLAGS})
-
 target_link_libraries(run_yaml PRIVATE ebpfverifier)
+
 target_link_libraries(conformance_check PRIVATE ebpfverifier)

--- a/src/crab/array_domain.cpp
+++ b/src/crab/array_domain.cpp
@@ -495,8 +495,8 @@ void array_domain_t::split_number_var(NumAbsDomain& inv, data_kind_t kind, const
     std::vector<cell_t> cells = offset_map.get_overlap_cells(o, size);
     for (cell_t const& c : cells) {
         interval_t intv = c.to_interval();
-        int cell_start_index = intv.lb().number()->narrow<int>();
-        int cell_end_index = intv.ub().number()->narrow<int>();
+        int cell_start_index = intv.lb().narrow<int>();
+        int cell_end_index = intv.ub().narrow<int>();
 
         if (!this->num_bytes.all_num(cell_start_index, cell_end_index + 1) ||
             cell_end_index + 1UL < cell_start_index + sizeof(int64_t)) {

--- a/src/crab/cfg.hpp
+++ b/src/crab/cfg.hpp
@@ -20,14 +20,12 @@
 
 #include <boost/iterator/transform_iterator.hpp>
 #include <boost/lexical_cast.hpp>
-#include <boost/range/iterator_range.hpp>
-
-#include "crab/variable.hpp"
-#include "crab_utils/debug.hpp"
-#include "crab_utils/num_big.hpp"
+#include <gsl/gsl>
 
 #include "asm_ostream.hpp"
 #include "asm_syntax.hpp"
+#include "crab_utils/debug.hpp"
+#include "crab_utils/num_big.hpp"
 #include "spec_type_descriptors.hpp"
 
 namespace crab {
@@ -100,7 +98,7 @@ class basic_block_t final {
 
     [[nodiscard]]
     size_t size() const {
-        return static_cast<size_t>(std::distance(begin(), end()));
+        return gsl::narrow<size_t>(std::distance(begin(), end()));
     }
 
     [[nodiscard]]
@@ -195,7 +193,7 @@ class basic_block_rev_t final {
 
     [[nodiscard]]
     std::size_t size() const {
-        return static_cast<size_t>(std::distance(begin(), end()));
+        return gsl::narrow<size_t>(std::distance(begin(), end()));
     }
 
     [[nodiscard]]
@@ -382,7 +380,7 @@ class cfg_t final {
 
     [[nodiscard]]
     size_t size() const {
-        return static_cast<size_t>(std::distance(begin(), end()));
+        return gsl::narrow<size_t>(std::distance(begin(), end()));
     }
 
     void simplify() {

--- a/src/crab/ebpf_domain.cpp
+++ b/src/crab/ebpf_domain.cpp
@@ -2451,8 +2451,7 @@ void ebpf_domain_t::ashr(const Reg& dst_reg, const linear_expression_t& right_sv
             int64_t lb_n = std::numeric_limits<int64_t>::min() >> imm;
             int64_t ub_n = std::numeric_limits<int64_t>::max() >> imm;
             if (left_interval.finite_size()) {
-                number_t lb = left_interval.lb().number().value();
-                number_t ub = left_interval.ub().number().value();
+                const auto [lb, ub] = left_interval.pair_number();
                 if (finite_width == 64) {
                     lb_n = lb.cast_to<int64_t>() >> imm;
                     ub_n = ub.cast_to<int64_t>() >> imm;
@@ -2880,7 +2879,7 @@ ebpf_domain_t ebpf_domain_t::from_constraints(const std::set<std::string>& const
         inv += cst;
     }
     for (const interval_t& range : numeric_ranges) {
-        const int start = range.lb().number()->narrow<int>();
+        const int start = range.lb().narrow<int>();
         const int width = 1 + range.finite_size()->narrow<int>();
         inv.stack.initialize_numbers(start, width);
     }

--- a/src/crab/interval.hpp
+++ b/src/crab/interval.hpp
@@ -88,12 +88,18 @@ class interval_t final {
 
     template <std::integral T>
     [[nodiscard]]
+    std::tuple<T, T> pair() const {
+        return {_lb.number()->narrow<T>(), _ub.number()->narrow<T>()};
+    }
+
+    template <std::integral T>
+    [[nodiscard]]
     std::tuple<T, T> bound(T lb, T ub) const {
-        interval_t b = interval_t(lb, ub) & *this;
+        const interval_t b = interval_t(lb, ub) & *this;
         if (b.is_bottom()) {
             CRAB_ERROR("Cannot convert bottom to tuple");
         }
-        return {static_cast<T>(*b._lb.number()), static_cast<T>(*b._ub.number())};
+        return {b._lb.number()->narrow<T>(), _ub.number()->narrow<T>()};
     }
 
     template <is_enum T>

--- a/src/crab/linear_constraint.hpp
+++ b/src/crab/linear_constraint.hpp
@@ -34,12 +34,12 @@ class linear_constraint_t final {
         if (!_expression.is_constant()) {
             return false;
         }
-        number_t constant = _expression.constant_term();
+        const number_t constant = _expression.constant_term();
         switch (_constraint_kind) {
-        case constraint_kind_t::EQUALS_ZERO: return (constant == 0);
-        case constraint_kind_t::LESS_THAN_OR_EQUALS_ZERO: return (constant <= 0);
-        case constraint_kind_t::LESS_THAN_ZERO: return (constant < 0);
-        case constraint_kind_t::NOT_ZERO: return (constant != 0);
+        case constraint_kind_t::EQUALS_ZERO: return constant == 0;
+        case constraint_kind_t::LESS_THAN_OR_EQUALS_ZERO: return constant <= 0;
+        case constraint_kind_t::LESS_THAN_ZERO: return constant < 0;
+        case constraint_kind_t::NOT_ZERO: return constant != 0;
         default: throw std::exception();
         }
     }
@@ -90,9 +90,9 @@ inline std::ostream& operator<<(std::ostream& o, const linear_constraint_t& cons
         const auto& expression = constraint.expression();
         expression.output_variable_terms(o);
 
-        const char* constraint_kind_label[] = {" == ", " <= ", " < ", " != "};
-        int kind = (int)constraint.kind();
-        if (kind < 0 || kind >= (int)(sizeof(constraint_kind_label) / sizeof(*constraint_kind_label))) {
+        constexpr std::array constraint_kind_label{" == ", " <= ", " < ", " != "};
+        const size_t kind = static_cast<size_t>(constraint.kind());
+        if (kind >= std::size(constraint_kind_label)) {
             throw std::exception();
         }
         o << constraint_kind_label[kind] << -expression.constant_term();

--- a/src/crab/linear_constraint.hpp
+++ b/src/crab/linear_constraint.hpp
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: MIT
 #pragma once
 
+#include <gsl/narrow>
+
 #include "linear_expression.hpp"
 
 // A linear constraint is of the form:
@@ -91,7 +93,7 @@ inline std::ostream& operator<<(std::ostream& o, const linear_constraint_t& cons
         expression.output_variable_terms(o);
 
         constexpr std::array constraint_kind_label{" == ", " <= ", " < ", " != "};
-        const size_t kind = static_cast<size_t>(constraint.kind());
+        const size_t kind = gsl::narrow<size_t>(constraint.kind());
         if (kind >= std::size(constraint_kind_label)) {
             throw std::exception();
         }

--- a/src/crab/split_dbm.cpp
+++ b/src/crab/split_dbm.cpp
@@ -466,7 +466,7 @@ SplitDBM SplitDBM::operator|(const SplitDBM& o) const& {
     for (auto [v, n] : vert_map) {
         if (auto y = try_at(o.vert_map, v)) {
             // Variable exists in both
-            out_vmap.emplace(v, static_cast<vert_id>(perm_x.size()));
+            out_vmap.emplace(v, gsl::narrow<vert_id>(perm_x.size()));
             out_revmap.push_back(v);
 
             pot_rx.push_back(potential[n] - potential[0]);
@@ -629,7 +629,7 @@ SplitDBM SplitDBM::widen(const SplitDBM& o) const {
     for (auto [v, n] : vert_map) {
         if (auto y = try_at(o.vert_map, v)) {
             // Variable exists in both
-            out_vmap.emplace(v, static_cast<vert_id>(perm_x.size()));
+            out_vmap.emplace(v, gsl::narrow<vert_id>(perm_x.size()));
             out_revmap.push_back(v);
 
             widen_pot.push_back(potential[n] - potential[0]);
@@ -684,7 +684,7 @@ std::optional<SplitDBM> SplitDBM::meet(const SplitDBM& o) const {
     meet_pi.emplace_back(0);
     meet_rev.push_back(std::nullopt);
     for (auto [v, n] : vert_map) {
-        vert_id vv = static_cast<vert_id>(perm_x.size());
+        vert_id vv = gsl::narrow<vert_id>(perm_x.size());
         meet_verts.emplace(v, vv);
         meet_rev.push_back(v);
 
@@ -698,7 +698,7 @@ std::optional<SplitDBM> SplitDBM::meet(const SplitDBM& o) const {
         auto it = meet_verts.find(v);
 
         if (it == meet_verts.end()) {
-            vert_id vv = static_cast<vert_id>(perm_y.size());
+            vert_id vv = gsl::narrow<vert_id>(perm_y.size());
             meet_rev.push_back(v);
 
             perm_y.push_back(n);

--- a/src/crab/type_domain.cpp
+++ b/src/crab/type_domain.cpp
@@ -209,7 +209,7 @@ type_encoding_t TypeDomain::get_type(const NumAbsDomain& inv, const Reg& r) cons
     if (!res) {
         return T_UNINIT;
     }
-    return static_cast<type_encoding_t>(*res);
+    return res->narrow<type_encoding_t>();
 }
 
 type_encoding_t TypeDomain::get_type(const NumAbsDomain& inv, const variable_t v) const {
@@ -217,11 +217,11 @@ type_encoding_t TypeDomain::get_type(const NumAbsDomain& inv, const variable_t v
     if (!res) {
         return T_UNINIT;
     }
-    return static_cast<type_encoding_t>(*res);
+    return res->narrow<type_encoding_t>();
 }
 
 type_encoding_t TypeDomain::get_type(const NumAbsDomain& inv, const number_t& t) const {
-    return static_cast<type_encoding_t>(t);
+    return t.narrow<type_encoding_t>();
 }
 
 // Check whether a given type value is within the range of a given type variable's value.

--- a/src/crab/var_factory.cpp
+++ b/src/crab/var_factory.cpp
@@ -11,13 +11,12 @@
 namespace crab {
 
 variable_t variable_t::make(const std::string& name) {
-    auto it = std::find(names->begin(), names->end(), name);
+    const auto it = std::find(names->begin(), names->end(), name);
     if (it == names->end()) {
         names->emplace_back(name);
         return variable_t(names->size() - 1);
-    } else {
-        return variable_t(std::distance(names->begin(), it));
     }
+    return variable_t(std::distance(names->begin(), it));
 }
 
 std::vector<std::string> default_variable_names() {
@@ -141,11 +140,13 @@ thread_local lazy_allocator<std::vector<std::string>, default_variable_names> va
 
 void variable_t::clear_thread_local_state() { names.clear(); }
 
-variable_t variable_t::reg(data_kind_t kind, int i) { return make("r" + std::to_string(i) + "." + name_of(kind)); }
+variable_t variable_t::reg(const data_kind_t kind, const int i) {
+    return make("r" + std::to_string(i) + "." + name_of(kind));
+}
 
 std::ostream& operator<<(std::ostream& o, const data_kind_t& s) { return o << name_of(s); }
 
-static std::string mk_scalar_name(data_kind_t kind, const number_t& o, const number_t& size) {
+static std::string mk_scalar_name(const data_kind_t kind, const number_t& o, const number_t& size) {
     std::stringstream os;
     os << "s"
        << "[" << o;
@@ -156,17 +157,17 @@ static std::string mk_scalar_name(data_kind_t kind, const number_t& o, const num
     return os.str();
 }
 
-variable_t variable_t::stack_frame_var(data_kind_t kind, int i, std::string prefix) {
+variable_t variable_t::stack_frame_var(const data_kind_t kind, const int i, const std::string& prefix) {
     return make(prefix + STACK_FRAME_DELIMITER + "r" + std::to_string(i) + "." + name_of(kind));
 }
 
-variable_t variable_t::cell_var(data_kind_t array, const number_t& offset, const number_t& size) {
+variable_t variable_t::cell_var(const data_kind_t array, const number_t& offset, const number_t& size) {
     return make(mk_scalar_name(array, offset.cast_to<uint64_t>(), size));
 }
 
 // Given a type variable, get the associated variable of a given kind.
-variable_t variable_t::kind_var(data_kind_t kind, variable_t type_variable) {
-    std::string name = type_variable.name();
+variable_t variable_t::kind_var(const data_kind_t kind, const variable_t type_variable) {
+    const std::string name = type_variable.name();
     return make(name.substr(0, name.rfind('.') + 1) + name_of(kind));
 }
 

--- a/src/crab/variable.hpp
+++ b/src/crab/variable.hpp
@@ -69,7 +69,7 @@ class variable_t final {
 
     static std::vector<variable_t> get_type_variables();
     static variable_t reg(data_kind_t, int);
-    static variable_t stack_frame_var(data_kind_t kind, int i, std::string prefix);
+    static variable_t stack_frame_var(data_kind_t kind, int i, const std::string& prefix);
     static variable_t cell_var(data_kind_t array, const number_t& offset, const number_t& size);
     static variable_t kind_var(data_kind_t kind, variable_t type_variable);
     static variable_t meta_offset();

--- a/src/crab_utils/num_big.hpp
+++ b/src/crab_utils/num_big.hpp
@@ -31,7 +31,7 @@ class number_t final {
     explicit number_t(const std::string& s) { _n = cpp_int(s); }
 
     template <std::integral T>
-    explicit operator T() const {
+    T narrow() const {
         if (!fits<T>()) {
             CRAB_ERROR("number_t ", _n, " does not fit into ", typeid(T).name());
         }
@@ -39,7 +39,7 @@ class number_t final {
     }
 
     template <is_enum T>
-    explicit operator T() const {
+    T narrow() const {
         return static_cast<T>(static_cast<std::underlying_type_t<T>>(_n));
     }
 
@@ -241,7 +241,7 @@ class number_t final {
         if (!x.fits<int32_t>()) {
             CRAB_ERROR("number_t ", x._n, " does not fit into an int32");
         }
-        return number_t(_n << static_cast<int32_t>(x));
+        return number_t(_n << x.narrow<int32_t>());
     }
 
     number_t operator>>(const number_t& x) const {
@@ -251,7 +251,7 @@ class number_t final {
         if (!x.fits<int32_t>()) {
             CRAB_ERROR("number_t ", x._n, " does not fit into an int32");
         }
-        return number_t(_n >> static_cast<int32_t>(x));
+        return number_t(_n >> x.narrow<int32_t>());
     }
 
     [[nodiscard]]

--- a/src/crab_utils/num_extended.hpp
+++ b/src/crab_utils/num_extended.hpp
@@ -49,6 +49,19 @@ class extended_number final {
 
     extended_number(extended_number&&) noexcept = default;
 
+    template <std::integral T>
+    T narrow() const {
+        if (_is_infinite) {
+            CRAB_ERROR("Bound: cannot narrow infinite value");
+        }
+        return _n.narrow<T>();
+    }
+
+    template <is_enum T>
+    T narrow() const {
+        return static_cast<T>(narrow<std::underlying_type_t<T>>(_n));
+    }
+
     extended_number& operator=(extended_number&&) noexcept = default;
 
     extended_number& operator=(const extended_number& o) {

--- a/src/crab_utils/num_extended.hpp
+++ b/src/crab_utils/num_extended.hpp
@@ -59,7 +59,7 @@ class extended_number final {
 
     template <is_enum T>
     T narrow() const {
-        return static_cast<T>(narrow<std::underlying_type_t<T>>(_n));
+        return static_cast<T>(narrow<std::underlying_type_t<T>>());
     }
 
     extended_number& operator=(extended_number&&) noexcept = default;

--- a/src/crab_utils/num_safeint.hpp
+++ b/src/crab_utils/num_safeint.hpp
@@ -39,30 +39,30 @@ class safe_i64 {
         return std::numeric_limits<int64_t>::min();
     }
 
-    static std::optional<int64_t> checked_add(int64_t a, int64_t b) {
-        wideint_t lr = (wideint_t)a + (wideint_t)b;
+    static std::optional<int64_t> checked_add(const int64_t a, const int64_t b) {
+        const wideint_t lr = static_cast<wideint_t>(a) + static_cast<wideint_t>(b);
         if (lr > get_max() || lr < get_min()) {
             return {};
         }
         return static_cast<int64_t>(lr);
     }
 
-    static std::optional<int64_t> checked_sub(int64_t a, int64_t b) {
-        wideint_t lr = (wideint_t)a - (wideint_t)b;
+    static std::optional<int64_t> checked_sub(const int64_t a, const int64_t b) {
+        const wideint_t lr = static_cast<wideint_t>(a) - static_cast<wideint_t>(b);
         if (lr > get_max() || lr < get_min()) {
             return {};
         }
         return static_cast<int64_t>(lr);
     }
-    static std::optional<int64_t> checked_mul(int64_t a, int64_t b) {
-        wideint_t lr = (wideint_t)a * (wideint_t)b;
+    static std::optional<int64_t> checked_mul(const int64_t a, const int64_t b) {
+        const wideint_t lr = static_cast<wideint_t>(a) * static_cast<wideint_t>(b);
         if (lr > get_max() || lr < get_min()) {
             return {};
         }
         return static_cast<int64_t>(lr);
     }
-    static std::optional<int64_t> checked_div(int64_t a, int64_t b) {
-        wideint_t lr = (wideint_t)a / (wideint_t)b;
+    static std::optional<int64_t> checked_div(const int64_t a, const int64_t b) {
+        const wideint_t lr = static_cast<wideint_t>(a) / static_cast<wideint_t>(b);
         if (lr > get_max() || lr < get_min()) {
             return {};
         }
@@ -72,39 +72,39 @@ class safe_i64 {
   public:
     safe_i64() : m_num(0) {}
 
-    safe_i64(int64_t num) : m_num(num) {}
+    safe_i64(const int64_t num) : m_num(num) {}
 
-    safe_i64(const number_t& n) : m_num((int64_t)n) {}
+    safe_i64(const number_t& n) : m_num(n.narrow<int64_t>()) {}
 
     operator int64_t() const { return (int64_t)m_num; }
 
     // TODO: output parameters whether operation overflows
-    safe_i64 operator+(safe_i64 x) const {
-        if (auto z = checked_add(m_num, x.m_num)) {
+    safe_i64 operator+(const safe_i64 x) const {
+        if (const auto z = checked_add(m_num, x.m_num)) {
             return safe_i64(*z);
         }
         CRAB_ERROR("Integer overflow during addition");
     }
 
     // TODO: output parameters whether operation overflows
-    safe_i64 operator-(safe_i64 x) const {
-        if (auto z = checked_sub(m_num, x.m_num)) {
+    safe_i64 operator-(const safe_i64 x) const {
+        if (const auto z = checked_sub(m_num, x.m_num)) {
             return safe_i64(*z);
         }
         CRAB_ERROR("Integer overflow during subtraction");
     }
 
     // TODO: output parameters whether operation overflows
-    safe_i64 operator*(safe_i64 x) const {
-        if (auto z = checked_mul(m_num, x.m_num)) {
+    safe_i64 operator*(const safe_i64 x) const {
+        if (const auto z = checked_mul(m_num, x.m_num)) {
             return safe_i64(*z);
         }
         CRAB_ERROR("Integer overflow during multiplication");
     }
 
     // TODO: output parameters whether operation overflows
-    safe_i64 operator/(safe_i64 x) const {
-        if (auto z = checked_div(m_num, x.m_num)) {
+    safe_i64 operator/(const safe_i64 x) const {
+        if (const auto z = checked_div(m_num, x.m_num)) {
             return safe_i64(*z);
         }
         CRAB_ERROR("Integer overflow during division");
@@ -114,22 +114,22 @@ class safe_i64 {
     safe_i64 operator-() const { return safe_i64(0) - *this; }
 
     // TODO: output parameters whether operation overflows
-    safe_i64& operator+=(safe_i64 x) { return *this = *this + x; }
+    safe_i64& operator+=(const safe_i64 x) { return *this = *this + x; }
 
     // TODO: output parameters whether operation overflows
-    safe_i64& operator-=(safe_i64 x) { return *this = *this - x; }
+    safe_i64& operator-=(const safe_i64 x) { return *this = *this - x; }
 
-    bool operator==(safe_i64 x) const { return m_num == x.m_num; }
+    bool operator==(const safe_i64 x) const { return m_num == x.m_num; }
 
-    bool operator!=(safe_i64 x) const { return m_num != x.m_num; }
+    bool operator!=(const safe_i64 x) const { return m_num != x.m_num; }
 
-    bool operator<(safe_i64 x) const { return m_num < x.m_num; }
+    bool operator<(const safe_i64 x) const { return m_num < x.m_num; }
 
-    bool operator<=(safe_i64 x) const { return m_num <= x.m_num; }
+    bool operator<=(const safe_i64 x) const { return m_num <= x.m_num; }
 
-    bool operator>(safe_i64 x) const { return m_num > x.m_num; }
+    bool operator>(const safe_i64 x) const { return m_num > x.m_num; }
 
-    bool operator>=(safe_i64 x) const { return m_num >= x.m_num; }
+    bool operator>=(const safe_i64 x) const { return m_num >= x.m_num; }
 
     friend std::ostream& operator<<(std::ostream& o, const safe_i64& n) { return o << n.m_num; }
 


### PR DESCRIPTION
[gsl::narrow](https://github.com/microsoft/GSL/blob/main/docs/headers.md#user-content-H-narrow-narrow) is a checked cast, which I believe can greatly help in ensuring correctness of the verifier. 

Since the existing cast in number_t is already a checked one, I think it should be renamed narrow(). This should also help locate unchecked narrowing (search for static_cast<>()). 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added support for Microsoft GSL and YAML-CPP dependencies.
	- Introduced new `narrow` methods for safer type conversions in numeric operations.

- **Improvements**
	- Enhanced type safety and handling of numeric values across various components.
	- Improved error handling and memory access checks in the eBPF domain.
	- Streamlined method signatures for clarity and const-correctness in multiple classes.
	- Added methods for retrieving bounds in the `interval_t` class.

- **Bug Fixes**
	- Resolved potential overflow issues in arithmetic operations.

- **Documentation**
	- Updated comments and formatting for better code clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->