### PR TITLE
Use gsl::narrow in ebpf_domain.cpp

### DIFF
--- a/src/crab/array_domain.cpp
+++ b/src/crab/array_domain.cpp
@@ -15,6 +15,7 @@
 #include "config.hpp"
 #include "crab/array_domain.hpp"
 #include "crab/dsl_syntax.hpp"
+#include "crab_utils/num_safety.hpp"
 #include "spec_type_descriptors.hpp"
 
 namespace crab::domains {
@@ -109,7 +110,8 @@ class cell_t final {
     cell_t(const offset_t offset, const unsigned size) : _offset(offset), _size(size) {}
 
     static interval_t to_interval(const offset_t o, const unsigned size) {
-        return {gsl::narrow<int>(o), number_t{gsl::narrow<int>(o)} + size - 1};
+        const number_t lb{gsl::narrow<int>(o)};
+        return {lb, lb + size - 1};
     }
 
   public:
@@ -646,7 +648,7 @@ std::optional<linear_expression_t> array_domain_t::load(const NumAbsDomain& inv,
             }
         }
         offset_t o(k);
-        unsigned size = gsl::narrow<unsigned>(width);
+        unsigned size = to_unsigned(width);
         if (auto cell = lookup_array_map(kind).get_cell(o, size)) {
             return cell->get_scalar(kind);
         }
@@ -705,7 +707,7 @@ std::optional<linear_expression_t> array_domain_t::load(const NumAbsDomain& inv,
                     } else {
                         b = boost::endian::native_to_little<index_t>(b);
                     }
-                    return kind == data_kind_t::uvalues ? number_t(b) : number_t(gsl::narrow_cast<int64_t>(b));
+                    return kind == data_kind_t::uvalues ? number_t(b) : number_t(to_signed(b));
                 }
             }
         }

--- a/src/crab/type_domain.cpp
+++ b/src/crab/type_domain.cpp
@@ -17,14 +17,31 @@
 
 namespace crab {
 
-static void operator++(type_encoding_t& t) { t = static_cast<type_encoding_t>(1 + static_cast<int>(t)); }
+template <is_enum T>
+static void operator++(T& t) {
+    t = static_cast<T>(1 + static_cast<std::underlying_type_t<T>>(t));
+}
+
+std::vector<data_kind_t> iterate_kinds(const data_kind_t lb, const data_kind_t ub) {
+    if (lb > ub) {
+        CRAB_ERROR("lower bound ", lb, " is greater than upper bound ", ub);
+    }
+    if (lb < KIND_MIN || ub > KIND_MAX) {
+        CRAB_ERROR("bounds ", lb, " and ", ub, " are out of range");
+    }
+    std::vector<data_kind_t> res;
+    for (data_kind_t i = lb; i <= ub; ++i) {
+        res.push_back(i);
+    }
+    return res;
+}
 
 std::vector<type_encoding_t> iterate_types(const type_encoding_t lb, const type_encoding_t ub) {
     if (lb > ub) {
-        CRAB_ERROR("iterate_types: lower bound ", lb, " is greater than upper bound ", ub);
+        CRAB_ERROR("lower bound ", lb, " is greater than upper bound ", ub);
     }
     if (lb < T_MIN || ub > T_MAX) {
-        CRAB_ERROR("iterate_types: bounds ", lb, " and ", ub, " are out of range");
+        CRAB_ERROR("bounds ", lb, " and ", ub, " are out of range");
     }
     std::vector<type_encoding_t> res;
     for (type_encoding_t i = lb; i <= ub; ++i) {

--- a/src/crab/type_encoding.hpp
+++ b/src/crab/type_encoding.hpp
@@ -20,9 +20,12 @@ enum class data_kind_t {
     shared_region_sizes,
     stack_numeric_sizes
 };
+constexpr auto KIND_MIN = data_kind_t::types;
+constexpr auto KIND_MAX = data_kind_t::stack_numeric_sizes;
 
 std::string name_of(data_kind_t kind);
 data_kind_t regkind(const std::string& s);
+std::vector<data_kind_t> iterate_kinds(data_kind_t lb = KIND_MIN, data_kind_t ub = KIND_MAX);
 std::ostream& operator<<(std::ostream& o, const data_kind_t& s);
 
 // The exact numbers are taken advantage of in ebpf_domain_t

--- a/src/crab_utils/num_big.hpp
+++ b/src/crab_utils/num_big.hpp
@@ -9,16 +9,11 @@
 
 #include <boost/multiprecision/cpp_int.hpp>
 
+#include "crab_utils/num_safety.hpp"
 #include "debug.hpp"
 using boost::multiprecision::cpp_int;
 
 namespace crab {
-
-template <typename T>
-concept is_enum = std::is_enum_v<T>;
-
-template <std::integral T>
-using swap_signedness = std::conditional_t<std::is_signed_v<T>, std::make_unsigned_t<T>, std::make_signed_t<T>>;
 
 class number_t final {
     cpp_int _n{};

--- a/src/crab_utils/num_safety.hpp
+++ b/src/crab_utils/num_safety.hpp
@@ -18,7 +18,7 @@ constexpr auto to_signed(std::unsigned_integral auto x) -> std::make_signed_t<de
     return static_cast<std::make_signed_t<decltype(x)>>(x);
 }
 
-static auto to_unsigned(std::signed_integral auto x) -> std::make_unsigned_t<decltype(x)> {
+constexpr auto to_unsigned(std::signed_integral auto x) -> std::make_unsigned_t<decltype(x)> {
     return static_cast<std::make_unsigned_t<decltype(x)>>(x);
 }
 

--- a/src/crab_utils/num_safety.hpp
+++ b/src/crab_utils/num_safety.hpp
@@ -1,0 +1,25 @@
+// Copyright (c) Prevail Verifier contributors.
+// SPDX-License-Identifier: MIT
+#pragma once
+
+#include <concepts>
+
+#include <gsl/narrow>
+
+namespace crab {
+
+template <typename T>
+concept is_enum = std::is_enum_v<T>;
+
+template <std::integral T>
+using swap_signedness = std::conditional_t<std::is_signed_v<T>, std::make_unsigned_t<T>, std::make_signed_t<T>>;
+
+static auto to_signed(std::unsigned_integral auto x) -> std::make_signed_t<decltype(x)> {
+    return static_cast<std::make_signed_t<decltype(x)>>(x);
+}
+
+static auto to_unsigned(std::signed_integral auto x) -> std::make_unsigned_t<decltype(x)> {
+    return static_cast<std::make_unsigned_t<decltype(x)>>(x);
+}
+
+} // namespace crab

--- a/src/crab_utils/num_safety.hpp
+++ b/src/crab_utils/num_safety.hpp
@@ -14,7 +14,7 @@ concept is_enum = std::is_enum_v<T>;
 template <std::integral T>
 using swap_signedness = std::conditional_t<std::is_signed_v<T>, std::make_unsigned_t<T>, std::make_signed_t<T>>;
 
-static auto to_signed(std::unsigned_integral auto x) -> std::make_signed_t<decltype(x)> {
+constexpr auto to_signed(std::unsigned_integral auto x) -> std::make_signed_t<decltype(x)> {
     return static_cast<std::make_signed_t<decltype(x)>>(x);
 }
 

--- a/src/ebpf_vm_isa.hpp
+++ b/src/ebpf_vm_isa.hpp
@@ -87,7 +87,9 @@ enum {
     INST_ALU_OP_ARSH = 0xc0,
     INST_ALU_OP_END = 0xd0,
     INST_ALU_OP_MASK = 0xf0,
+};
 
+enum {
     R0_RETURN_VALUE = 0,
     R1_ARG = 1,
     R2_ARG = 2,


### PR DESCRIPTION
Also: introduce num_safety.hpp and two helpers: to_signed() and to_unsigned()

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced type handling and arithmetic operations for improved safety and clarity.\
	- Added utility functions for type safety in numeric operations.

- **Bug Fixes**
	- Improved error handling for arithmetic operations to prevent overflow and type mismatches.

- **Documentation**
	- Updated method signatures and added new methods for better clarity and usability.

- **Refactor**
	- Streamlined type handling and error reporting across various classes and methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->