### PR TITLE
Use gsl::narrow in asm_marshal.cpp

### DIFF
--- a/src/asm_ostream.cpp
+++ b/src/asm_ostream.cpp
@@ -120,7 +120,7 @@ std::ostream& operator<<(std::ostream& os, ValidAccess const& a) {
         os << a.offset;
     }
 
-    if (a.width == static_cast<Value>(Imm{0})) {
+    if (a.width == Value{Imm{0}}) {
         // a.width == 0, meaning we only care it's an in-bound pointer,
         // so it can be compared with another pointer to the same region.
         os << ") for comparison/subtraction";

--- a/src/crab_utils/graph_ops.hpp
+++ b/src/crab_utils/graph_ops.hpp
@@ -741,7 +741,7 @@ class GraphOps {
                 ++qtail;
             }
 
-            for (vert_id v : scc) {
+            for (vert_id _ : scc) {
                 while (qtail != qhead) {
                     vert_id s = *--qtail;
                     // If it _was_ on the queue, it must be in the SCC

--- a/src/crab_utils/num_safeint.hpp
+++ b/src/crab_utils/num_safeint.hpp
@@ -17,7 +17,6 @@
 namespace crab {
 
 class safe_i64 {
-
     // Current implementation is based on
     // https://blog.regehr.org/archives/1139 using wider integers.
 
@@ -70,13 +69,13 @@ class safe_i64 {
     }
 
   public:
-    safe_i64() : m_num(0) {}
+    safe_i64() : m_num{0} {}
 
-    safe_i64(const int64_t num) : m_num(num) {}
+    safe_i64(const int64_t num) : m_num{num} {}
 
-    safe_i64(const number_t& n) : m_num(n.narrow<int64_t>()) {}
+    safe_i64(const number_t& n) : m_num{n.narrow<int64_t>()} {}
 
-    operator int64_t() const { return (int64_t)m_num; }
+    operator int64_t() const { return m_num; }
 
     // TODO: output parameters whether operation overflows
     safe_i64 operator+(const safe_i64 x) const {

--- a/src/crab_utils/stats.cpp
+++ b/src/crab_utils/stats.cpp
@@ -30,7 +30,8 @@ long Stopwatch::systemTime() const {
     }
 
     // Convert from 100ns intervals to microseconds.
-    uint64_t total_us = (((uint64_t)user_time.dwHighDateTime << 32) | (uint64_t)user_time.dwLowDateTime) / 10;
+    uint64_t total_us =
+        ((static_cast<uint64_t>(user_time.dwHighDateTime) << 32) | static_cast<uint64_t>(user_time.dwLowDateTime)) / 10;
 
     return (long)total_us;
 #else


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved type safety in various components by replacing unsafe type casts with safer alternatives.
	- Enhanced the output formatting for the `ValidAccess` structure to ensure consistent representation of attributes.

- **Refactor**
	- Updated initialization styles for member variables in the `safe_i64` class for improved clarity.
	- Enhanced readability in the `GraphOps` class by indicating unused loop variables.

- **Style**
	- Changed casting style in the `Stopwatch` class for better type safety.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->