### PR TITLE
Put bpf2bpf caller in a named section

### DIFF
--- a/src/asm_files.cpp
+++ b/src/asm_files.cpp
@@ -419,8 +419,7 @@ vector<raw_program> read_elf(std::istream& input_stream, const std::string& path
                     auto [symbol_name, symbol_section_index] = get_symbol_name_and_section_index(symbols, index);
 
                     // Queue up relocation for function symbols.
-                    if (inst.opcode == INST_OP_CALL && inst.src == INST_CALL_LOCAL &&
-                        reader.sections[symbol_section_index] == section.get()) {
+                    if (inst.opcode == INST_OP_CALL && inst.src == INST_CALL_LOCAL) {
                         function_relocation fr{.prog_index = res.size(),
                                                .source_offset = offset / sizeof(ebpf_inst),
                                                .relocation_entry_index = index,

--- a/src/test/test_verify.cpp
+++ b/src/test/test_verify.cpp
@@ -501,7 +501,7 @@ TEST_SECTION("raw_tracepoint/filler/proc_startupdate_2")
 TEST_SECTION("raw_tracepoint/filler/sys_recvfrom_x")
 */
 TEST_PROGRAM_REJECT("build", "bpf2bpf.o", ".text", "plus1"); // Subprogram will fail verification.
-TEST_PROGRAM("build", "bpf2bpf.o", ".text", "func");         // Subprogram can be called from main program.
+TEST_PROGRAM("build", "bpf2bpf.o", "test", "func");         // Subprogram can be called from main program.
 TEST_SECTION("build", "byteswap.o", ".text")
 TEST_SECTION("build", "stackok.o", ".text")
 TEST_SECTION("build", "packet_start_ok.o", "xdp")


### PR DESCRIPTION
[Libbpf logic](https://github.com/libbpf/libbpf/blob/caa17bdcbfc58e68eaf4d017c058e6577606bf56/src/libbpf.c#L4390C1-L4393C2) is that if there are multiple programs then any programs in the .text section are subprograms to be skipped when enumerating programs.

So update the sample to follow the convention that the non-subprogram is in a section other than ".text". This also enables testing the verifier's ability to load programs that call subprograms in another section.) is that if there are multiple programs then any programs in the .text section are subprograms to be skipped when enumerating programs.

So the sample was updated to follow the convention that the non-subprogram is in a section other than ".text", allowing testing the ability to load programs that call subprograms in another section.  This PR updates the test accordingly and fixes a bug hit that prevented bpf2bpf calls across sections.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Updated handling of function relocations for improved processing of eBPF program calls.
  
- **Bug Fixes**
	- Simplified conditions for queuing function relocations, enhancing functionality.

- **Tests**
	- Modified existing test cases to align with updated eBPF verification requirements, including a change in section name for one of the tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->