### PR TITLE
Log line info when dumping invariants

### DIFF
--- a/src/crab_verifier.cpp
+++ b/src/crab_verifier.cpp
@@ -134,7 +134,7 @@ static void print_report(std::ostream& os, const checks_db& db, const Instructio
 
 static checks_db get_analysis_report(std::ostream& s, cfg_t& cfg, const crab::invariant_table_t& pre_invariants,
                                      const crab::invariant_table_t& post_invariants,
-                                     const std::optional<InstructionSeq>& prog = std::nullopt) {
+                                     const std::optional<InstructionSeq> prog = std::nullopt) {
     // Analyze the control-flow graph.
     checks_db db = generate_report(cfg, pre_invariants, post_invariants);
     if (thread_local_options.print_invariants) {
@@ -162,7 +162,7 @@ static checks_db get_analysis_report(std::ostream& s, cfg_t& cfg, const crab::in
 
 static checks_db get_ebpf_report(std::ostream& s, cfg_t& cfg, program_info info,
                                  const ebpf_verifier_options_t* options,
-                                 const std::optional<InstructionSeq>& prog = std::nullopt) {
+                                 const std::optional<InstructionSeq> prog = std::nullopt) {
     global_program_info = std::move(info);
     crab::domains::clear_global_state();
     crab::variable_t::clear_thread_local_state();


### PR DESCRIPTION
This pull request introduces enhancements to the `crab_verifier.cpp` file, focusing on improving the reporting capabilities by incorporating optional program instruction sequences. The changes primarily add support for printing line information and ensure that the program's context is included in the analysis report when required.

Enhancements to reporting capabilities:

* [`src/crab_verifier.cpp`](diffhunk://#diff-e3c65b3e2779bdd7a17c56ff48fd12ba98fcfcd19ab41081150358a9bbcdf920L136-R154): Modified the `get_analysis_report` function to accept an optional `InstructionSeq` parameter and print line information if available.
* [`src/crab_verifier.cpp`](diffhunk://#diff-e3c65b3e2779bdd7a17c56ff48fd12ba98fcfcd19ab41081150358a9bbcdf920L150-R165): Updated the `get_ebpf_report` function to pass the optional `InstructionSeq` to the `get_analysis_report` function. [[1]](diffhunk://#diff-e3c65b3e2779bdd7a17c56ff48fd12ba98fcfcd19ab41081150358a9bbcdf920L150-R165) [[2]](diffhunk://#diff-e3c65b3e2779bdd7a17c56ff48fd12ba98fcfcd19ab41081150358a9bbcdf920L160-R175)
* [`src/crab_verifier.cpp`](diffhunk://#diff-e3c65b3e2779bdd7a17c56ff48fd12ba98fcfcd19ab41081150358a9bbcdf920L232-R252): Adjusted the `ebpf_verify_program` function to conditionally pass the `InstructionSeq` to `get_ebpf_report` based on the `print_failures` option.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced reporting capabilities in the verification process, allowing for optional line information to improve output clarity.
	- Updated report generation functions to process an optional instruction sequence, providing more detailed analysis results.

- **Bug Fixes**
	- Improved handling of line information in analysis reports to ensure accurate representation of source lines.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->