### PR TITLE
Fix stack access with bpf2bpf calls

### DIFF
--- a/src/asm_cfg.cpp
+++ b/src/asm_cfg.cpp
@@ -119,7 +119,6 @@ static void add_cfg_nodes(cfg_t& cfg, const label_t& caller_label, const label_t
     // Finally, recurse to replace any nested function macros.
     string caller_label_str = to_string(caller_label);
     long stack_frame_depth = std::ranges::count(caller_label_str, STACK_FRAME_DELIMITER) + 2;
-    constexpr int MAX_CALL_STACK_FRAMES = 8;
     for (auto& macro_label : seen_labels) {
         for (const label_t label(macro_label.from, macro_label.to, caller_label_str);
              const auto& inst : cfg.get_node(label)) {

--- a/src/asm_files.cpp
+++ b/src/asm_files.cpp
@@ -21,6 +21,7 @@ using std::string;
 using std::vector;
 
 template <typename T>
+    requires std::is_trivially_copyable_v<T>
 static vector<T> vector_of(const char* data, const ELFIO::Elf_Xword size) {
     if (size % sizeof(T) != 0 || size > std::numeric_limits<uint32_t>::max() || !data) {
         throw std::runtime_error("Invalid argument to vector_of");
@@ -29,6 +30,7 @@ static vector<T> vector_of(const char* data, const ELFIO::Elf_Xword size) {
 }
 
 template <typename T>
+    requires std::is_trivially_copyable_v<T>
 static vector<T> vector_of(const ELFIO::section& sec) {
     return vector_of<T>(sec.get_data(), sec.get_size());
 }

--- a/src/asm_syntax.hpp
+++ b/src/asm_syntax.hpp
@@ -59,7 +59,7 @@ struct label_t {
         if (stack_frame_prefix.empty()) {
             return 1;
         }
-        return 2 + std::count(stack_frame_prefix.begin(), stack_frame_prefix.end(), STACK_FRAME_DELIMITER);
+        return 2 + std::ranges::count(stack_frame_prefix, STACK_FRAME_DELIMITER);
     }
 
     friend std::ostream& operator<<(std::ostream& os, const label_t& label) {

--- a/src/asm_syntax.hpp
+++ b/src/asm_syntax.hpp
@@ -53,8 +53,9 @@ struct label_t {
 
     [[nodiscard]]
     int call_stack_depth() const {
-        // The call stack depth is the number of "/" separated components in the label,
-        // which is one more than the number of "/" separated components in the prefix.
+        // The call stack depth is the number of '/' separated components in the label,
+        // which is one more than the number of '/' separated components in the prefix,
+        // hence two more than the number of '/' in the prefix, if any.
         if (stack_frame_prefix.empty()) {
             return 1;
         }

--- a/src/asm_syntax.hpp
+++ b/src/asm_syntax.hpp
@@ -51,6 +51,16 @@ struct label_t {
         return to != -1;
     }
 
+    [[nodiscard]]
+    int call_stack_depth() const {
+        // The call stack depth is the number of "/" separated components in the label,
+        // which is one more than the number of "/" separated components in the prefix.
+        if (stack_frame_prefix.empty()) {
+            return 1;
+        }
+        return 2 + std::count(stack_frame_prefix.begin(), stack_frame_prefix.end(), STACK_FRAME_DELIMITER);
+    }
+
     friend std::ostream& operator<<(std::ostream& os, const label_t& label) {
         if (label == entry) {
             return os << "entry";
@@ -337,6 +347,7 @@ enum class AccessType {
 };
 
 struct ValidAccess {
+    int call_stack_depth{};
     Reg reg;
     int32_t offset{};
     Value width{Imm{0}};

--- a/src/asm_unmarshal.cpp
+++ b/src/asm_unmarshal.cpp
@@ -338,7 +338,7 @@ struct Unmarshaller {
             const uint8_t basereg = isLoad ? inst.src : inst.dst;
 
             if (basereg == R10_STACK_POINTER &&
-                (inst.offset + opcode_to_width(inst.opcode) > 0 || inst.offset < -EBPF_STACK_SIZE)) {
+                (inst.offset + opcode_to_width(inst.opcode) > 0 || inst.offset < -EBPF_TOTAL_STACK_SIZE)) {
                 note("Stack access out of bounds");
             }
             auto res = Mem{

--- a/src/assertions.cpp
+++ b/src/assertions.cpp
@@ -27,10 +27,10 @@ class AssertExtractor {
         return res;
     }
 
-    ValidAccess make_valid_access(Reg reg, int32_t offset = {}, Value width = Imm{0}, bool or_null = {},
-                                  AccessType access_type = {}) const {
-        int depth = current_label.has_value() ? current_label.value().call_stack_depth() : 1;
-        return ValidAccess{ depth, reg, offset, width, or_null, access_type};
+    ValidAccess make_valid_access(const Reg reg, const int32_t offset = {}, const Value& width = Imm{0},
+                                  const bool or_null = {}, const AccessType access_type = {}) const {
+        const int depth = current_label.has_value() ? current_label.value().call_stack_depth() : 1;
+        return ValidAccess{depth, reg, offset, width, or_null, access_type};
     }
 
   public:
@@ -207,8 +207,8 @@ class AssertExtractor {
             }
         } else {
             res.emplace_back(TypeConstraint{basereg, TypeGroup::pointer});
-            res.emplace_back(make_valid_access(basereg, offset, width, false,
-                                               ins.is_load ? AccessType::read : AccessType::write));
+            res.emplace_back(
+                make_valid_access(basereg, offset, width, false, ins.is_load ? AccessType::read : AccessType::write));
             if (!info.type.is_privileged && !ins.is_load) {
                 if (const auto preg = std::get_if<Reg>(&ins.value)) {
                     if (width.v != 8) {

--- a/src/assertions.cpp
+++ b/src/assertions.cpp
@@ -193,7 +193,8 @@ class AssertExtractor {
         Imm width{static_cast<uint32_t>(ins.access.width)};
         const int offset = ins.access.offset;
         if (basereg.v == R10_STACK_POINTER) {
-            if (offset < -EBPF_STACK_SIZE || offset + static_cast<int>(width.v) > 0) {
+            // We know we are accessing the stack.
+            if (offset < -EBPF_TOTAL_STACK_SIZE || offset + static_cast<int>(width.v) > 0) {
                 // This assertion will fail
                 res.emplace_back(
                     ValidAccess{basereg, offset, width, false, ins.is_load ? AccessType::read : AccessType::write});

--- a/src/assertions.cpp
+++ b/src/assertions.cpp
@@ -194,7 +194,7 @@ class AssertExtractor {
         const int offset = ins.access.offset;
         if (basereg.v == R10_STACK_POINTER) {
             // We know we are accessing the stack.
-            if (offset < -EBPF_TOTAL_STACK_SIZE || offset + static_cast<int>(width.v) > 0) {
+            if (offset < -EBPF_SUBPROGRAM_STACK_SIZE || offset + static_cast<int>(width.v) > 0) {
                 // This assertion will fail
                 res.emplace_back(
                     ValidAccess{basereg, offset, width, false, ins.is_load ? AccessType::read : AccessType::write});

--- a/src/crab/array_domain.cpp
+++ b/src/crab/array_domain.cpp
@@ -816,7 +816,7 @@ void array_domain_t::havoc(NumAbsDomain& inv, const data_kind_t kind, const line
 void array_domain_t::store_numbers(const NumAbsDomain& inv, const variable_t _idx, const variable_t _width) {
 
     // TODO: this should be an user parameter.
-    const number_t max_num_elems = EBPF_STACK_SIZE;
+    const number_t max_num_elems = EBPF_TOTAL_STACK_SIZE;
 
     if (is_bottom()) {
         return;

--- a/src/crab/bitset_domain.cpp
+++ b/src/crab/bitset_domain.cpp
@@ -6,23 +6,23 @@
 std::ostream& operator<<(std::ostream& o, const bitset_domain_t& b) {
     o << "Numbers -> {";
     bool first = true;
-    for (int i = -EBPF_STACK_SIZE; i < 0; i++) {
-        if (b.non_numerical_bytes[EBPF_STACK_SIZE + i]) {
+    for (int i = -EBPF_TOTAL_STACK_SIZE; i < 0; i++) {
+        if (b.non_numerical_bytes[EBPF_TOTAL_STACK_SIZE + i]) {
             continue;
         }
         if (!first) {
             o << ", ";
         }
         first = false;
-        o << "[" << EBPF_STACK_SIZE + i;
+        o << "[" << EBPF_TOTAL_STACK_SIZE + i;
         int j = i + 1;
         for (; j < 0; j++) {
-            if (b.non_numerical_bytes[EBPF_STACK_SIZE + j]) {
+            if (b.non_numerical_bytes[EBPF_TOTAL_STACK_SIZE + j]) {
                 break;
             }
         }
         if (j > i + 1) {
-            o << "..." << EBPF_STACK_SIZE + j - 1;
+            o << "..." << EBPF_TOTAL_STACK_SIZE + j - 1;
         }
         o << "]";
         i = j;
@@ -40,19 +40,19 @@ string_invariant bitset_domain_t::to_set() const {
     }
 
     std::set<std::string> result;
-    for (int i = -EBPF_STACK_SIZE; i < 0; i++) {
-        if (non_numerical_bytes[EBPF_STACK_SIZE + i]) {
+    for (int i = -EBPF_TOTAL_STACK_SIZE; i < 0; i++) {
+        if (non_numerical_bytes[EBPF_TOTAL_STACK_SIZE + i]) {
             continue;
         }
-        std::string value = "s[" + std::to_string(EBPF_STACK_SIZE + i);
+        std::string value = "s[" + std::to_string(EBPF_TOTAL_STACK_SIZE + i);
         int j = i + 1;
         for (; j < 0; j++) {
-            if (non_numerical_bytes[EBPF_STACK_SIZE + j]) {
+            if (non_numerical_bytes[EBPF_TOTAL_STACK_SIZE + j]) {
                 break;
             }
         }
         if (j > i + 1) {
-            value += "..." + std::to_string(EBPF_STACK_SIZE + j - 1);
+            value += "..." + std::to_string(EBPF_TOTAL_STACK_SIZE + j - 1);
         }
         value += "].type=number";
         result.insert(value);

--- a/src/crab/bitset_domain.hpp
+++ b/src/crab/bitset_domain.hpp
@@ -109,7 +109,7 @@ class bitset_domain_t final {
     bool all_num(int32_t lb, int32_t ub) const {
         assert(lb < ub);
         lb = std::max(lb, 0);
-        ub = std::min(ub, (int32_t)EBPF_TOTAL_STACK_SIZE);
+        ub = std::min(ub, (int)EBPF_TOTAL_STACK_SIZE);
         if (lb < 0 || ub > (int)non_numerical_bytes.size()) {
             return false;
         }

--- a/src/crab/bitset_domain.hpp
+++ b/src/crab/bitset_domain.hpp
@@ -4,7 +4,7 @@
 #include <bitset>
 #include <cassert>
 
-#include "ebpf_base.h" // for EBPF_TOTAL_STACK_SIZE
+#include "ebpf_base.h" // for EBPF_TOTAL_STACK_SIZE constant
 #include "string_constraints.hpp"
 
 class bitset_domain_t final {
@@ -109,7 +109,7 @@ class bitset_domain_t final {
     bool all_num(int32_t lb, int32_t ub) const {
         assert(lb < ub);
         lb = std::max(lb, 0);
-        ub = std::min(ub, EBPF_TOTAL_STACK_SIZE);
+        ub = std::min(ub, (int32_t)EBPF_TOTAL_STACK_SIZE);
         if (lb < 0 || ub > (int)non_numerical_bytes.size()) {
             return false;
         }

--- a/src/crab/bitset_domain.hpp
+++ b/src/crab/bitset_domain.hpp
@@ -4,12 +4,12 @@
 #include <bitset>
 #include <cassert>
 
-#include "spec_type_descriptors.hpp" // for EBPF_STACK_SIZE
+#include "ebpf_base.h" // for EBPF_TOTAL_STACK_SIZE
 #include "string_constraints.hpp"
 
 class bitset_domain_t final {
   private:
-    using bits_t = std::bitset<EBPF_STACK_SIZE>;
+    using bits_t = std::bitset<EBPF_TOTAL_STACK_SIZE>;
     bits_t non_numerical_bytes;
 
   public:
@@ -64,7 +64,7 @@ class bitset_domain_t final {
 
     [[nodiscard]]
     std::pair<bool, bool> uniformity(size_t lb, int width) const {
-        width = std::min(width, (int)(EBPF_STACK_SIZE - lb));
+        width = std::min(width, (int)(EBPF_TOTAL_STACK_SIZE - lb));
         bool only_num = true;
         bool only_non_num = true;
         for (int j = 0; j < width; j++) {
@@ -82,21 +82,21 @@ class bitset_domain_t final {
     [[nodiscard]]
     int all_num_width(size_t lb) const {
         size_t ub = lb;
-        while ((ub < EBPF_STACK_SIZE) && !non_numerical_bytes[ub]) {
+        while ((ub < EBPF_TOTAL_STACK_SIZE) && !non_numerical_bytes[ub]) {
             ub++;
         }
         return (int)(ub - lb);
     }
 
     void reset(size_t lb, int n) {
-        n = std::min(n, (int)(EBPF_STACK_SIZE - lb));
+        n = std::min(n, (int)(EBPF_TOTAL_STACK_SIZE - lb));
         for (int i = 0; i < n; i++) {
             non_numerical_bytes.reset(lb + i);
         }
     }
 
     void havoc(size_t lb, int width) {
-        width = std::min(width, (int)(EBPF_STACK_SIZE - lb));
+        width = std::min(width, (int)(EBPF_TOTAL_STACK_SIZE - lb));
         for (int i = 0; i < width; i++) {
             non_numerical_bytes.set(lb + i);
         }
@@ -109,7 +109,7 @@ class bitset_domain_t final {
     bool all_num(int32_t lb, int32_t ub) const {
         assert(lb < ub);
         lb = std::max(lb, 0);
-        ub = std::min(ub, EBPF_STACK_SIZE);
+        ub = std::min(ub, EBPF_TOTAL_STACK_SIZE);
         if (lb < 0 || ub > (int)non_numerical_bytes.size()) {
             return false;
         }

--- a/src/crab/ebpf_domain.cpp
+++ b/src/crab/ebpf_domain.cpp
@@ -941,15 +941,15 @@ void ebpf_domain_t::havoc_subprogram_stack(const std::string& prefix) {
     // Calculate the call stack depth being returned from.  Since we're returning
     // *to* the given prefix, the current call stack is 2 + the number of
     // '/' separators because we need to account for the current frame and the root frame.
-    int call_stack_depth = 2 + std::count(prefix.begin(), prefix.end(), STACK_FRAME_DELIMITER);
+    const int call_stack_depth = 2 + std::ranges::count(prefix, STACK_FRAME_DELIMITER);
 
-    variable_t r10_stack_offset = reg_pack(R10_STACK_POINTER).stack_offset;
-    auto intv = m_inv.eval_interval(r10_stack_offset);
+    const variable_t r10_stack_offset = reg_pack(R10_STACK_POINTER).stack_offset;
+    const auto intv = m_inv.eval_interval(r10_stack_offset);
     if (!intv.is_singleton()) {
         return;
     }
-    int64_t stack_offset = intv.singleton()->cast_to<int64_t>();
-    int32_t stack_start = stack_offset - EBPF_SUBPROGRAM_STACK_SIZE * call_stack_depth;
+    const int64_t stack_offset = intv.singleton()->cast_to<int64_t>();
+    const int32_t stack_start = stack_offset - EBPF_SUBPROGRAM_STACK_SIZE * call_stack_depth;
     for (const data_kind_t kind : iterate_kinds()) {
         stack.havoc(m_inv, kind, stack_start, EBPF_SUBPROGRAM_STACK_SIZE);
     }
@@ -1201,13 +1201,13 @@ void ebpf_domain_t::operator()(const basic_block_t& bb) {
     }
 }
 
-void ebpf_domain_t::check_access_stack(NumAbsDomain& inv, const linear_expression_t& lb,
-                                       const linear_expression_t& ub, int call_stack_depth) const {
+void ebpf_domain_t::check_access_stack(NumAbsDomain& inv, const linear_expression_t& lb, const linear_expression_t& ub,
+                                       const int call_stack_depth) const {
     using namespace crab::dsl_syntax;
-    variable_t r10_stack_offset = reg_pack(R10_STACK_POINTER).stack_offset;
-    auto interval = inv.eval_interval(r10_stack_offset);
+    const variable_t r10_stack_offset = reg_pack(R10_STACK_POINTER).stack_offset;
+    const auto interval = inv.eval_interval(r10_stack_offset);
     if (interval.is_singleton()) {
-        int64_t stack_offset = interval.singleton()->cast_to<int64_t>();
+        const int64_t stack_offset = interval.singleton()->cast_to<int64_t>();
         require(inv, lb >= stack_offset - EBPF_SUBPROGRAM_STACK_SIZE * call_stack_depth,
                 "Lower bound must be at least r10.stack_offset - EBPF_SUBPROGRAM_STACK_SIZE * call_stack_depth");
     }
@@ -2054,7 +2054,7 @@ void ebpf_domain_t::do_mem_store(const Mem& b, Type val_type, SValue val_svalue,
     int width = b.access.width;
     const number_t offset{b.access.offset};
     if (b.access.basereg.v == R10_STACK_POINTER) {
-        auto r10_stack_offset = reg_pack(b.access.basereg).stack_offset;
+        const auto r10_stack_offset = reg_pack(b.access.basereg).stack_offset;
         const auto r10_interval = m_inv.eval_interval(r10_stack_offset);
         if (r10_interval.is_singleton()) {
             const int32_t stack_offset = r10_interval.singleton()->cast_to<int32_t>();

--- a/src/crab/ebpf_domain.cpp
+++ b/src/crab/ebpf_domain.cpp
@@ -819,7 +819,7 @@ ebpf_domain_t ebpf_domain_t::calculate_constant_limits() {
         inv += r.svalue >= std::numeric_limits<int32_t>::min();
         inv += r.uvalue <= std::numeric_limits<uint32_t>::max();
         inv += r.uvalue >= 0;
-        inv += r.stack_offset <= EBPF_STACK_SIZE;
+        inv += r.stack_offset <= EBPF_TOTAL_STACK_SIZE;
         inv += r.stack_offset >= 0;
         inv += r.shared_offset <= r.shared_region_size;
         inv += r.shared_offset >= 0;
@@ -1199,7 +1199,7 @@ void ebpf_domain_t::check_access_stack(NumAbsDomain& inv, const linear_expressio
                                        const linear_expression_t& ub) const {
     using namespace crab::dsl_syntax;
     require(inv, lb >= 0, "Lower bound must be at least 0");
-    require(inv, ub <= EBPF_STACK_SIZE, "Upper bound must be at most EBPF_STACK_SIZE");
+    require(inv, ub <= EBPF_TOTAL_STACK_SIZE, "Upper bound must be at most EBPF_TOTAL_STACK_SIZE");
 }
 
 void ebpf_domain_t::check_access_context(NumAbsDomain& inv, const linear_expression_t& lb,
@@ -2911,9 +2911,9 @@ ebpf_domain_t ebpf_domain_t::setup_entry(const bool init_r1) {
     ebpf_domain_t inv;
     const auto r10 = reg_pack(R10_STACK_POINTER);
     constexpr Reg r10_reg{R10_STACK_POINTER};
-    inv += EBPF_STACK_SIZE <= r10.svalue;
+    inv += EBPF_TOTAL_STACK_SIZE <= r10.svalue;
     inv += r10.svalue <= PTR_MAX;
-    inv.assign(r10.stack_offset, EBPF_STACK_SIZE);
+    inv.assign(r10.stack_offset, EBPF_TOTAL_STACK_SIZE);
     // stack_numeric_size would be 0, but TOP has the same result
     // so no need to assign it.
     inv.type_inv.assign_type(inv.m_inv, r10_reg, T_STACK);

--- a/src/crab/ebpf_domain.cpp
+++ b/src/crab/ebpf_domain.cpp
@@ -2056,10 +2056,11 @@ void ebpf_domain_t::do_mem_store(const Mem& b, Type val_type, SValue val_svalue,
     if (b.access.basereg.v == R10_STACK_POINTER) {
         auto r10_stack_offset = reg_pack(b.access.basereg).stack_offset;
         const auto r10_interval = m_inv.eval_interval(r10_stack_offset);
-        assert(r10_interval.is_singleton());
-        const int32_t stack_offset = r10_interval.singleton()->cast_to<int32_t>();
-        const number_t base_addr{stack_offset};
-        do_store_stack(m_inv, width, base_addr + offset, val_type, val_svalue, val_uvalue, val_reg);
+        if (r10_interval.is_singleton()) {
+            const int32_t stack_offset = r10_interval.singleton()->cast_to<int32_t>();
+            const number_t base_addr{stack_offset};
+            do_store_stack(m_inv, width, base_addr + offset, val_type, val_svalue, val_uvalue, val_reg);
+        }
         return;
     }
     m_inv = type_inv.join_over_types(m_inv, b.access.basereg, [&](NumAbsDomain& inv, const type_encoding_t type) {

--- a/src/crab/ebpf_domain.cpp
+++ b/src/crab/ebpf_domain.cpp
@@ -940,8 +940,8 @@ void ebpf_domain_t::restore_callee_saved_registers(const std::string& prefix) {
 void ebpf_domain_t::havoc_subprogram_stack(const std::string& prefix) {
     // Calculate the call stack depth being returned from.  Since we're returning
     // *to* the given prefix, the current call stack is 1 + the number of
-    // '/'-separated labels in the prefix.
-    int call_stack_depth = 2 + std::count(prefix.begin(), prefix.end(), '/');
+    // '/'-separated labels in the prefix, hence 2 plus the number of separators in the prefix.
+    int call_stack_depth = 2 + std::count(prefix.begin(), prefix.end(), STACK_FRAME_DELIMITER);
 
     variable_t r10_stack_offset = reg_pack(R10_STACK_POINTER).stack_offset;
     auto intv = m_inv.eval_interval(r10_stack_offset);

--- a/src/crab/ebpf_domain.cpp
+++ b/src/crab/ebpf_domain.cpp
@@ -1198,7 +1198,10 @@ void ebpf_domain_t::operator()(const basic_block_t& bb) {
 void ebpf_domain_t::check_access_stack(NumAbsDomain& inv, const linear_expression_t& lb,
                                        const linear_expression_t& ub) const {
     using namespace crab::dsl_syntax;
-    require(inv, lb >= 0, "Lower bound must be at least 0");
+    variable_t r10_stack_offset = reg_pack(R10_STACK_POINTER).stack_offset;
+    int64_t stack_offset = m_inv.eval_interval(r10_stack_offset).singleton()->cast_to<int64_t>();
+    require(inv, lb >= stack_offset - EBPF_SUBPROGRAM_STACK_SIZE,
+            "Lower bound must be at least r10.stack_offset - EBPF_SUBPROGRAM_STACK_SIZE");
     require(inv, ub <= EBPF_TOTAL_STACK_SIZE, "Upper bound must be at most EBPF_TOTAL_STACK_SIZE");
 }
 

--- a/src/crab/ebpf_domain.cpp
+++ b/src/crab/ebpf_domain.cpp
@@ -939,8 +939,8 @@ void ebpf_domain_t::restore_callee_saved_registers(const std::string& prefix) {
 
 void ebpf_domain_t::havoc_subprogram_stack(const std::string& prefix) {
     // Calculate the call stack depth being returned from.  Since we're returning
-    // *to* the given prefix, the current call stack is 1 + the number of
-    // '/'-separated labels in the prefix, hence 2 plus the number of separators in the prefix.
+    // *to* the given prefix, the current call stack is 2 + the number of
+    // '/' separators because we need to account for the current frame and the root frame.
     int call_stack_depth = 2 + std::count(prefix.begin(), prefix.end(), STACK_FRAME_DELIMITER);
 
     variable_t r10_stack_offset = reg_pack(R10_STACK_POINTER).stack_offset;

--- a/src/crab/ebpf_domain.hpp
+++ b/src/crab/ebpf_domain.hpp
@@ -149,6 +149,7 @@ class ebpf_domain_t final {
     void scratch_caller_saved_registers();
     void save_callee_saved_registers(const std::string& prefix);
     void restore_callee_saved_registers(const std::string& prefix);
+    void havoc_subprogram_stack(const std::string& prefix);
     [[nodiscard]]
     std::optional<uint32_t> get_map_type(const Reg& map_fd_reg) const;
     [[nodiscard]]
@@ -167,7 +168,7 @@ class ebpf_domain_t final {
     void require(domains::NumAbsDomain& inv, const linear_constraint_t& cst, const std::string& s) const;
 
     // memory check / load / store
-    void check_access_stack(NumAbsDomain& inv, const linear_expression_t& lb, const linear_expression_t& ub) const;
+    void check_access_stack(NumAbsDomain& inv, const linear_expression_t& lb, const linear_expression_t& ub, int call_stack_depth) const;
     void check_access_context(NumAbsDomain& inv, const linear_expression_t& lb, const linear_expression_t& ub) const;
     void check_access_packet(NumAbsDomain& inv, const linear_expression_t& lb, const linear_expression_t& ub,
                              std::optional<variable_t> packet_size) const;

--- a/src/ebpf_base.h
+++ b/src/ebpf_base.h
@@ -37,3 +37,11 @@ typedef struct _ebpf_context_descriptor {
     int end;  // Offset into ctx struct of pointer to end of data.
     int meta; // Offset into ctx struct of pointer to metadata.
 } ebpf_context_descriptor_t;
+
+constexpr int MAX_CALL_STACK_FRAMES = 8;
+
+// Stack space per subprogram.
+constexpr int EBPF_SUBPROGRAM_STACK_SIZE = 512;
+
+// Total stack space usable with nested subprogram calls.
+constexpr int EBPF_TOTAL_STACK_SIZE (MAX_CALL_STACK_FRAMES * EBPF_SUBPROGRAM_STACK_SIZE);

--- a/src/ebpf_base.h
+++ b/src/ebpf_base.h
@@ -38,10 +38,13 @@ typedef struct _ebpf_context_descriptor {
     int meta; // Offset into ctx struct of pointer to metadata.
 } ebpf_context_descriptor_t;
 
+// Maximum number of nested function calls allowed in eBPF programs.
+// This limit helps prevent stack overflow and ensures predictable behavior.
 constexpr int MAX_CALL_STACK_FRAMES = 8;
 
-// Stack space per subprogram.
+// Stack space allocated for each subprogram (in bytes).
+// This ensures each function call has its own dedicated stack space.
 constexpr int EBPF_SUBPROGRAM_STACK_SIZE = 512;
 
 // Total stack space usable with nested subprogram calls.
-constexpr int EBPF_TOTAL_STACK_SIZE (MAX_CALL_STACK_FRAMES * EBPF_SUBPROGRAM_STACK_SIZE);
+constexpr int EBPF_TOTAL_STACK_SIZE = MAX_CALL_STACK_FRAMES * EBPF_SUBPROGRAM_STACK_SIZE;

--- a/src/spec_type_descriptors.hpp
+++ b/src/spec_type_descriptors.hpp
@@ -12,6 +12,9 @@
 
 constexpr int EBPF_STACK_SIZE = 512;
 
+// Stack space when subprograms are used.
+constexpr int EBPF_SUBPROGRAM_STACK_SIZE = 256;
+
 enum class EbpfMapValueType { ANY, MAP, PROGRAM };
 
 struct EbpfMapType {

--- a/src/spec_type_descriptors.hpp
+++ b/src/spec_type_descriptors.hpp
@@ -10,11 +10,6 @@
 
 #include "crab_utils/lazy_allocator.hpp"
 
-constexpr int EBPF_STACK_SIZE = 512;
-
-// Stack space when subprograms are used.
-constexpr int EBPF_SUBPROGRAM_STACK_SIZE = 256;
-
 enum class EbpfMapValueType { ANY, MAP, PROGRAM };
 
 struct EbpfMapType {

--- a/src/test/conformance_check.cpp
+++ b/src/test/conformance_check.cpp
@@ -21,8 +21,8 @@
  * @param[in] input String containing hex bytes.
  * @return Vector of bytes.
  */
-std::vector<uint8_t> base16_decode(const std::string& input) {
-    std::vector<uint8_t> output;
+std::vector<std::byte> base16_decode(const std::string& input) {
+    std::vector<std::byte> output;
     std::stringstream ss(input);
     std::string value;
     while (std::getline(ss, value, ' ')) {
@@ -30,7 +30,7 @@ std::vector<uint8_t> base16_decode(const std::string& input) {
             continue;
         }
         try {
-            output.push_back(std::stoi(value, nullptr, 16));
+            output.push_back(static_cast<std::byte>(std::stoi(value, nullptr, 16)));
         } catch (std::invalid_argument&) {
             std::cerr << "base16_decode failed to decode " << value << "\n";
         } catch (std::out_of_range&) {

--- a/src/test/ebpf_yaml.cpp
+++ b/src/test/ebpf_yaml.cpp
@@ -269,6 +269,7 @@ std::optional<Failure> run_yaml_test_case(TestCase test_case, bool debug) {
 }
 
 template <typename T>
+    requires std::is_trivially_copyable_v<T>
 static vector<T> vector_of(const std::vector<std::byte>& bytes) {
     auto data = bytes.data();
     const auto size = bytes.size();
@@ -284,8 +285,10 @@ void add_stack_variable(std::set<std::string>& more, int& offset, const std::vec
     constexpr size_t size = sizeof(TS);
     static_assert(sizeof(TU) == size);
     const auto src = memory_bytes.data() + offset + memory_bytes.size() - EBPF_TOTAL_STACK_SIZE;
-    const TS svalue{*reinterpret_cast<const TS*>(src)};
-    const TU uvalue{*reinterpret_cast<const TU*>(src)};
+    TS svalue;
+    std::memcpy(&svalue, src, size);
+    TU uvalue;
+    std::memcpy(&uvalue, src, size);
     const auto range = "s[" + std::to_string(offset) + "..." + std::to_string(offset + size - 1) + "]";
     more.insert(range + ".svalue=" + std::to_string(svalue));
     more.insert(range + ".uvalue=" + std::to_string(uvalue));

--- a/src/test/ebpf_yaml.hpp
+++ b/src/test/ebpf_yaml.hpp
@@ -39,7 +39,7 @@ struct ConformanceTestResult {
     crab::interval_t r0_value = crab::interval_t::top();
 };
 
-ConformanceTestResult run_conformance_test_case(const std::vector<uint8_t>& memory_bytes,
-                                                const std::vector<uint8_t>& program_bytes, bool debug);
+ConformanceTestResult run_conformance_test_case(const std::vector<std::byte>& memory_bytes,
+                                                const std::vector<std::byte>& program_bytes, bool debug);
 
 bool run_yaml(const std::string& path);

--- a/test-data/atomic.yaml
+++ b/test-data/atomic.yaml
@@ -264,6 +264,7 @@ test-case: atomic 32-bit ADD stack
 
 pre: ["r1.type=number", "r1.svalue=2", "r1.uvalue=2",
       "r2.type=stack", "r2.stack_offset=0", "r2.svalue=[1, 2147418112]", "r2.uvalue=[1, 2147418112]", "r2.svalue=r2.uvalue",
+      "r10.type=stack", "r10.stack_offset=512",
       "s[4...7].type=number", "s[4...7].svalue=1", "s[4...7].uvalue=1"]
 
 code:
@@ -272,12 +273,14 @@ code:
 
 post: ["r1.type=number", "r1.svalue=2", "r1.uvalue=2",
        "r2.type=stack", "r2.stack_offset=0", "r2.svalue=[1, 2147418112]", "r2.uvalue=[1, 2147418112]", "r2.svalue=r2.uvalue",
+       "r10.type=stack", "r10.stack_offset=512",
        "s[4...7].type=number", "s[4...7].svalue=3", "s[4...7].uvalue=3"]
 ---
 test-case: atomic 32-bit ADD and fetch stack
 
 pre: ["r1.type=number", "r1.svalue=2", "r1.uvalue=2",
       "r2.type=stack", "r2.stack_offset=0", "r2.svalue=[1, 2147418112]", "r2.uvalue=[1, 2147418112]", "r2.svalue=r2.uvalue",
+      "r10.type=stack", "r10.stack_offset=512",
       "s[4...7].type=number", "s[4...7].svalue=1", "s[4...7].uvalue=1"]
 
 code:
@@ -286,12 +289,14 @@ code:
 
 post: ["r1.type=number", "r1.svalue=1", "r1.uvalue=1",
        "r2.type=stack", "r2.stack_offset=0", "r2.svalue=[1, 2147418112]", "r2.uvalue=[1, 2147418112]", "r2.svalue=r2.uvalue",
+       "r10.type=stack", "r10.stack_offset=512",
        "s[4...7].type=number", "s[4...7].svalue=3", "s[4...7].uvalue=3"]
 ---
 test-case: atomic 64-bit ADD stack
 
 pre: ["r1.type=number", "r1.svalue=2", "r1.uvalue=2",
       "r2.type=stack", "r2.stack_offset=0", "r2.svalue=[1, 2147418112]", "r2.uvalue=[1, 2147418112]", "r2.svalue=r2.uvalue",
+      "r10.type=stack", "r10.stack_offset=512",
       "s[4...11].type=number", "s[4...11].svalue=1", "s[4...11].uvalue=1"]
 
 code:
@@ -300,12 +305,14 @@ code:
 
 post: ["r1.type=number", "r1.svalue=2", "r1.uvalue=2",
        "r2.type=stack", "r2.stack_offset=0", "r2.svalue=[1, 2147418112]", "r2.uvalue=[1, 2147418112]", "r2.svalue=r2.uvalue",
+       "r10.type=stack", "r10.stack_offset=512",
        "s[4...11].type=number", "s[4...11].svalue=3", "s[4...11].uvalue=3"]
 ---
 test-case: atomic 64-bit ADD and fetch stack
 
 pre: ["r1.type=number", "r1.svalue=2", "r1.uvalue=2",
       "r2.type=stack", "r2.stack_offset=0", "r2.svalue=[1, 2147418112]", "r2.uvalue=[1, 2147418112]", "r2.svalue=r2.uvalue",
+      "r10.type=stack", "r10.stack_offset=512",
       "s[4...11].type=number", "s[4...11].svalue=1", "s[4...11].uvalue=1"]
 
 code:
@@ -314,12 +321,14 @@ code:
 
 post: ["r1.type=number", "r1.svalue=1", "r1.uvalue=1",
        "r2.type=stack", "r2.stack_offset=0", "r2.svalue=[1, 2147418112]", "r2.uvalue=[1, 2147418112]", "r2.svalue=r2.uvalue",
+       "r10.type=stack", "r10.stack_offset=512",
        "s[4...11].type=number", "s[4...11].svalue=3", "s[4...11].uvalue=3"]
 ---
 test-case: atomic 32-bit AND stack
 
 pre: ["r1.type=number", "r1.svalue=3", "r1.uvalue=3",
       "r2.type=stack", "r2.stack_offset=0", "r2.svalue=[1, 2147418112]", "r2.uvalue=[1, 2147418112]", "r2.svalue=r2.uvalue",
+      "r10.type=stack", "r10.stack_offset=512",
       "s[4...7].type=number", "s[4...7].svalue=5", "s[4...7].uvalue=5"]
 
 code:
@@ -328,12 +337,14 @@ code:
 
 post: ["r1.type=number", "r1.svalue=3", "r1.uvalue=3",
        "r2.type=stack", "r2.stack_offset=0", "r2.svalue=[1, 2147418112]", "r2.uvalue=[1, 2147418112]", "r2.svalue=r2.uvalue",
+       "r10.type=stack", "r10.stack_offset=512",
        "s[4...7].type=number", "s[4...7].svalue=1", "s[4...7].uvalue=1"]
 ---
 test-case: atomic 32-bit AND and fetch stack
 
 pre: ["r1.type=number", "r1.svalue=3", "r1.uvalue=3",
       "r2.type=stack", "r2.stack_offset=0", "r2.svalue=[1, 2147418112]", "r2.uvalue=[1, 2147418112]", "r2.svalue=r2.uvalue",
+      "r10.type=stack", "r10.stack_offset=512",
       "s[4...7].type=number", "s[4...7].svalue=5", "s[4...7].uvalue=5"]
 
 code:
@@ -342,12 +353,14 @@ code:
 
 post: ["r1.type=number", "r1.svalue=5", "r1.uvalue=5",
        "r2.type=stack", "r2.stack_offset=0", "r2.svalue=[1, 2147418112]", "r2.uvalue=[1, 2147418112]", "r2.svalue=r2.uvalue",
+       "r10.type=stack", "r10.stack_offset=512",
        "s[4...7].type=number", "s[4...7].svalue=1", "s[4...7].uvalue=1"]
 ---
 test-case: atomic 64-bit AND stack
 
 pre: ["r1.type=number", "r1.svalue=3", "r1.uvalue=3",
       "r2.type=stack", "r2.stack_offset=0", "r2.svalue=[1, 2147418112]", "r2.uvalue=[1, 2147418112]", "r2.svalue=r2.uvalue",
+      "r10.type=stack", "r10.stack_offset=512",
       "s[4...11].type=number", "s[4...11].svalue=5", "s[4...11].uvalue=5"]
 
 code:
@@ -356,12 +369,14 @@ code:
 
 post: ["r1.type=number", "r1.svalue=3", "r1.uvalue=3",
        "r2.type=stack", "r2.stack_offset=0", "r2.svalue=[1, 2147418112]", "r2.uvalue=[1, 2147418112]", "r2.svalue=r2.uvalue",
+       "r10.type=stack", "r10.stack_offset=512",
        "s[4...11].type=number", "s[4...11].svalue=1", "s[4...11].uvalue=1"]
 ---
 test-case: atomic 64-bit AND and fetch stack
 
 pre: ["r1.type=number", "r1.svalue=3", "r1.uvalue=3",
       "r2.type=stack", "r2.stack_offset=0", "r2.svalue=[1, 2147418112]", "r2.uvalue=[1, 2147418112]", "r2.svalue=r2.uvalue",
+      "r10.type=stack", "r10.stack_offset=512",
       "s[4...11].type=number", "s[4...11].svalue=5", "s[4...11].uvalue=5"]
 
 code:
@@ -370,12 +385,14 @@ code:
 
 post: ["r1.type=number", "r1.svalue=5", "r1.uvalue=5",
        "r2.type=stack", "r2.stack_offset=0", "r2.svalue=[1, 2147418112]", "r2.uvalue=[1, 2147418112]", "r2.svalue=r2.uvalue",
+       "r10.type=stack", "r10.stack_offset=512",
        "s[4...11].type=number", "s[4...11].svalue=1", "s[4...11].uvalue=1"]
 ---
 test-case: atomic 32-bit OR stack
 
 pre: ["r1.type=number", "r1.svalue=3", "r1.uvalue=3",
       "r2.type=stack", "r2.stack_offset=0", "r2.svalue=[1, 2147418112]", "r2.uvalue=[1, 2147418112]", "r2.svalue=r2.uvalue",
+      "r10.type=stack", "r10.stack_offset=512",
       "s[4...7].type=number", "s[4...7].svalue=5", "s[4...7].uvalue=5"]
 
 code:
@@ -384,12 +401,14 @@ code:
 
 post: ["r1.type=number", "r1.svalue=3", "r1.uvalue=3",
        "r2.type=stack", "r2.stack_offset=0", "r2.svalue=[1, 2147418112]", "r2.uvalue=[1, 2147418112]", "r2.svalue=r2.uvalue",
+       "r10.type=stack", "r10.stack_offset=512",
        "s[4...7].type=number", "s[4...7].svalue=7", "s[4...7].uvalue=7"]
 ---
 test-case: atomic 32-bit OR and fetch stack
 
 pre: ["r1.type=number", "r1.svalue=3", "r1.uvalue=3",
       "r2.type=stack", "r2.stack_offset=0", "r2.svalue=[1, 2147418112]", "r2.uvalue=[1, 2147418112]", "r2.svalue=r2.uvalue",
+      "r10.type=stack", "r10.stack_offset=512",
       "s[4...7].type=number", "s[4...7].svalue=5", "s[4...7].uvalue=5"]
 
 code:
@@ -398,12 +417,14 @@ code:
 
 post: ["r1.type=number", "r1.svalue=5", "r1.uvalue=5",
        "r2.type=stack", "r2.stack_offset=0", "r2.svalue=[1, 2147418112]", "r2.uvalue=[1, 2147418112]", "r2.svalue=r2.uvalue",
+       "r10.type=stack", "r10.stack_offset=512",
        "s[4...7].type=number", "s[4...7].svalue=7", "s[4...7].uvalue=7"]
 ---
 test-case: atomic 64-bit OR stack
 
 pre: ["r1.type=number", "r1.svalue=3", "r1.uvalue=3",
       "r2.type=stack", "r2.stack_offset=0", "r2.svalue=[1, 2147418112]", "r2.uvalue=[1, 2147418112]", "r2.svalue=r2.uvalue",
+      "r10.type=stack", "r10.stack_offset=512",
       "s[4...11].type=number", "s[4...11].svalue=5", "s[4...11].uvalue=5"]
 
 code:
@@ -412,12 +433,14 @@ code:
 
 post: ["r1.type=number", "r1.svalue=3", "r1.uvalue=3",
        "r2.type=stack", "r2.stack_offset=0", "r2.svalue=[1, 2147418112]", "r2.uvalue=[1, 2147418112]", "r2.svalue=r2.uvalue",
+       "r10.type=stack", "r10.stack_offset=512",
        "s[4...11].type=number", "s[4...11].svalue=7", "s[4...11].uvalue=7"]
 ---
 test-case: atomic 64-bit OR and fetch stack
 
 pre: ["r1.type=number", "r1.svalue=3", "r1.uvalue=3",
       "r2.type=stack", "r2.stack_offset=0", "r2.svalue=[1, 2147418112]", "r2.uvalue=[1, 2147418112]", "r2.svalue=r2.uvalue",
+      "r10.type=stack", "r10.stack_offset=512",
       "s[4...11].type=number", "s[4...11].svalue=5", "s[4...11].uvalue=5"]
 
 code:
@@ -426,12 +449,14 @@ code:
 
 post: ["r1.type=number", "r1.svalue=5", "r1.uvalue=5",
        "r2.type=stack", "r2.stack_offset=0", "r2.svalue=[1, 2147418112]", "r2.uvalue=[1, 2147418112]", "r2.svalue=r2.uvalue",
+       "r10.type=stack", "r10.stack_offset=512",
        "s[4...11].type=number", "s[4...11].svalue=7", "s[4...11].uvalue=7"]
 ---
 test-case: atomic 32-bit XOR stack
 
 pre: ["r1.type=number", "r1.svalue=3", "r1.uvalue=3",
       "r2.type=stack", "r2.stack_offset=0", "r2.svalue=[1, 2147418112]", "r2.uvalue=[1, 2147418112]", "r2.svalue=r2.uvalue",
+      "r10.type=stack", "r10.stack_offset=512",
       "s[4...7].type=number", "s[4...7].svalue=5", "s[4...7].uvalue=5"]
 
 code:
@@ -440,12 +465,14 @@ code:
 
 post: ["r1.type=number", "r1.svalue=3", "r1.uvalue=3",
        "r2.type=stack", "r2.stack_offset=0", "r2.svalue=[1, 2147418112]", "r2.uvalue=[1, 2147418112]", "r2.svalue=r2.uvalue",
+       "r10.type=stack", "r10.stack_offset=512",
        "s[4...7].type=number", "s[4...7].svalue=6", "s[4...7].uvalue=6"]
 ---
 test-case: atomic 32-bit XOR and fetch stack
 
 pre: ["r1.type=number", "r1.svalue=3", "r1.uvalue=3",
       "r2.type=stack", "r2.stack_offset=0", "r2.svalue=[1, 2147418112]", "r2.uvalue=[1, 2147418112]", "r2.svalue=r2.uvalue",
+      "r10.type=stack", "r10.stack_offset=512",
       "s[4...7].type=number", "s[4...7].svalue=5", "s[4...7].uvalue=5"]
 
 code:
@@ -454,12 +481,14 @@ code:
 
 post: ["r1.type=number", "r1.svalue=5", "r1.uvalue=5",
        "r2.type=stack", "r2.stack_offset=0", "r2.svalue=[1, 2147418112]", "r2.uvalue=[1, 2147418112]", "r2.svalue=r2.uvalue",
+       "r10.type=stack", "r10.stack_offset=512",
        "s[4...7].type=number", "s[4...7].svalue=6", "s[4...7].uvalue=6"]
 ---
 test-case: atomic 64-bit XOR stack
 
 pre: ["r1.type=number", "r1.svalue=3", "r1.uvalue=3",
       "r2.type=stack", "r2.stack_offset=0", "r2.svalue=[1, 2147418112]", "r2.uvalue=[1, 2147418112]", "r2.svalue=r2.uvalue",
+      "r10.type=stack", "r10.stack_offset=512",
       "s[4...11].type=number", "s[4...11].svalue=5", "s[4...11].uvalue=5"]
 
 code:
@@ -468,12 +497,14 @@ code:
 
 post: ["r1.type=number", "r1.svalue=3", "r1.uvalue=3",
        "r2.type=stack", "r2.stack_offset=0", "r2.svalue=[1, 2147418112]", "r2.uvalue=[1, 2147418112]", "r2.svalue=r2.uvalue",
+       "r10.type=stack", "r10.stack_offset=512",
        "s[4...11].type=number", "s[4...11].svalue=6", "s[4...11].uvalue=6"]
 ---
 test-case: atomic 64-bit XOR and fetch stack
 
 pre: ["r1.type=number", "r1.svalue=3", "r1.uvalue=3",
       "r2.type=stack", "r2.stack_offset=0", "r2.svalue=[1, 2147418112]", "r2.uvalue=[1, 2147418112]", "r2.svalue=r2.uvalue",
+      "r10.type=stack", "r10.stack_offset=512",
       "s[4...11].type=number", "s[4...11].svalue=5", "s[4...11].uvalue=5"]
 
 code:
@@ -482,12 +513,14 @@ code:
 
 post: ["r1.type=number", "r1.svalue=5", "r1.uvalue=5",
        "r2.type=stack", "r2.stack_offset=0", "r2.svalue=[1, 2147418112]", "r2.uvalue=[1, 2147418112]", "r2.svalue=r2.uvalue",
+       "r10.type=stack", "r10.stack_offset=512",
        "s[4...11].type=number", "s[4...11].svalue=6", "s[4...11].uvalue=6"]
 ---
 test-case: atomic 32-bit XCHG stack
 
 pre: ["r1.type=number", "r1.svalue=2", "r1.uvalue=2",
       "r2.type=stack", "r2.stack_offset=0", "r2.svalue=[1, 2147418112]", "r2.uvalue=[1, 2147418112]", "r2.svalue=r2.uvalue",
+      "r10.type=stack", "r10.stack_offset=512",
       "s[4...7].type=number", "s[4...7].svalue=5", "s[4...7].uvalue=5"]
 
 code:
@@ -496,12 +529,14 @@ code:
 
 post: ["r1.type=number", "r1.svalue=5", "r1.uvalue=5",
        "r2.type=stack", "r2.stack_offset=0", "r2.svalue=[1, 2147418112]", "r2.uvalue=[1, 2147418112]", "r2.svalue=r2.uvalue",
+       "r10.type=stack", "r10.stack_offset=512",
        "s[4...7].type=number", "s[4...7].svalue=2", "s[4...7].uvalue=2"]
 ---
 test-case: atomic 64-bit XCHG stack
 
 pre: ["r1.type=number", "r1.svalue=2", "r1.uvalue=2",
       "r2.type=stack", "r2.stack_offset=0", "r2.svalue=[1, 2147418112]", "r2.uvalue=[1, 2147418112]", "r2.svalue=r2.uvalue",
+      "r10.type=stack", "r10.stack_offset=512",
       "s[4...11].type=number", "s[4...11].svalue=5", "s[4...11].uvalue=5"]
 
 code:
@@ -510,6 +545,7 @@ code:
 
 post: ["r1.type=number", "r1.svalue=5", "r1.uvalue=5",
        "r2.type=stack", "r2.stack_offset=0", "r2.svalue=[1, 2147418112]", "r2.uvalue=[1, 2147418112]", "r2.svalue=r2.uvalue",
+       "r10.type=stack", "r10.stack_offset=512",
        "s[4...11].type=number", "s[4...11].svalue=2", "s[4...11].uvalue=2"]
 ---
 test-case: atomic 32-bit CMPXCHG stack
@@ -517,6 +553,7 @@ test-case: atomic 32-bit CMPXCHG stack
 pre: ["r0.type=number", "r0.svalue=1", "r0.uvalue=1",
       "r1.type=number", "r1.svalue=2", "r1.uvalue=2",
       "r2.type=stack", "r2.stack_offset=0", "r2.svalue=[1, 2147418112]", "r2.uvalue=[1, 2147418112]", "r2.svalue=r2.uvalue",
+      "r10.type=stack", "r10.stack_offset=512",
       "s[4...7].type=number", "s[4...7].svalue=1", "s[4...7].uvalue=1"]
 
 code:
@@ -526,6 +563,7 @@ code:
 post: ["r0.type=number", "r0.svalue=1", "r0.uvalue=1",
        "r1.type=number", "r1.svalue=2", "r1.uvalue=2",
        "r2.type=stack", "r2.stack_offset=0", "r2.svalue=[1, 2147418112]", "r2.uvalue=[1, 2147418112]", "r2.svalue=r2.uvalue",
+       "r10.type=stack", "r10.stack_offset=512",
        "s[4...7].type=number"]
 ---
 test-case: atomic 64-bit CMPXCHG stack
@@ -533,6 +571,7 @@ test-case: atomic 64-bit CMPXCHG stack
 pre: ["r0.type=number", "r0.svalue=1", "r0.uvalue=1",
       "r1.type=number", "r1.svalue=2", "r1.uvalue=2",
       "r2.type=stack", "r2.stack_offset=0", "r2.svalue=[1, 2147418112]", "r2.uvalue=[1, 2147418112]", "r2.svalue=r2.uvalue",
+      "r10.type=stack", "r10.stack_offset=512",
       "s[4...11].type=number", "s[4...11].svalue=1", "s[4...11].uvalue=1"]
 
 code:
@@ -542,6 +581,7 @@ code:
 post: ["r0.type=number", "r0.svalue=1", "r0.uvalue=1",
        "r1.type=number", "r1.svalue=2", "r1.uvalue=2",
        "r2.type=stack", "r2.stack_offset=0", "r2.svalue=[1, 2147418112]", "r2.uvalue=[1, 2147418112]", "r2.svalue=r2.uvalue",
+       "r10.type=stack", "r10.stack_offset=512",
        "s[4...11].type=number"]
 ---
 test-case: atomic 32-bit ADD to non-pointer space

--- a/test-data/call.yaml
+++ b/test-data/call.yaml
@@ -294,6 +294,7 @@ pre: ["r1.type=map_fd", "r1.map_fd=1",
       "r2.type=stack", "r2.stack_offset=504",
       "r3.type=number", "r3.svalue=8", "r3.uvalue=8",
       "r4.type=number",
+      "r10.type=stack", "r10.stack_offset=512",
       "s[504...511].type=number"]
 
 code:
@@ -302,6 +303,8 @@ code:
 
 post:
   - r0.type=number
+  - r10.type=stack
+  - r10.stack_offset=512
   - s[504...511].type=number
 ---
 test-case: bpf_ringbuf_output with non-numeric stack value
@@ -309,7 +312,8 @@ test-case: bpf_ringbuf_output with non-numeric stack value
 pre: ["r1.type=map_fd", "r1.map_fd=1",
       "r2.type=stack", "r2.stack_offset=504",
       "r3.type=number", "r3.svalue=8", "r3.uvalue=8",
-      "r4.type=number"]
+      "r4.type=number",
+      "r10.type=stack", "r10.stack_offset=512"]
 
 code:
   <start>: |
@@ -317,6 +321,8 @@ code:
 
 post:
   - r0.type=number
+  - r10.type=stack
+  - r10.stack_offset=512
 
 messages:
   - "0: Stack content is not numeric (valid_access(r2.offset, width=r3) for read)"
@@ -345,7 +351,8 @@ test-case: bpf_get_stack
 pre: ["r1.type=ctx", "r1.ctx_offset=0",
       "r2.type=stack", "r2.stack_offset=504",
       "r3.type=number", "r3.svalue=8", "r3.uvalue=8",
-      "r4.type=number"]
+      "r4.type=number",
+      "r10.type=stack", "r10.stack_offset=512"]
 
 code:
   <start>: |
@@ -354,6 +361,8 @@ code:
 post:
   - r0.type=number
   - s[504...511].type=number
+  - r10.type=stack
+  - r10.stack_offset=512
 ---
 test-case: bpf_get_stack overwriting ctx
 
@@ -389,7 +398,8 @@ post:
 test-case: bpf_trace_printk with negative size buffer
 
 pre: ["r1.type=stack", "r1.stack_offset=504",
-      "r2.type=number", "r2.svalue=-13", "r2.uvalue=18446744073709551603"]
+      "r2.type=number", "r2.svalue=-13", "r2.uvalue=18446744073709551603",
+      "r10.type=stack", "r10.stack_offset=512"]
 
 code:
   <start>: |
@@ -397,6 +407,8 @@ code:
 
 post:
   - r0.type=number
+  - r10.type=stack
+  - r10.stack_offset=512
 
 messages:
   - "0: Invalid size (r2.value > 0)"

--- a/test-data/calllocal.yaml
+++ b/test-data/calllocal.yaml
@@ -3,15 +3,15 @@
 ---
 test-case: call local with stack
 
-pre: ["r10.type=stack", "r10.stack_offset=512",
-      "s[511...511].type=number", "s[511...511].svalue=2", "s[511...511].uvalue=2"]
+pre: ["r10.type=stack", "r10.stack_offset=1024",
+      "s[1023...1023].type=number", "s[1023...1023].svalue=2", "s[1023...1023].uvalue=2"]
 
 code:
   <start>: |
     call <sub>
     exit
   <sub>: |
-    *(u8 *)(r10 - 1) = 1 ; this should not change s[511...511]
+    *(u8 *)(r10 - 1) = 1 ; this should not change s[1023...1023]
     r0 = *(u8 *)(r10 - 1)
     exit
 
@@ -20,10 +20,10 @@ post:
   - r0.svalue=1
   - r0.uvalue=1
   - r10.type=stack
-  - r10.stack_offset=512
-  - s[511].type=number
-  - s[511].svalue=2
-  - s[511].uvalue=2
+  - r10.stack_offset=1024
+  - s[1023].type=number
+  - s[1023].svalue=2
+  - s[1023].uvalue=2
 ---
 test-case: call local
 

--- a/test-data/calllocal.yaml
+++ b/test-data/calllocal.yaml
@@ -1,6 +1,30 @@
 # Copyright (c) Prevail Verifier contributors.
 # SPDX-License-Identifier: MIT
 ---
+test-case: call local with stack
+
+pre: ["r10.type=stack", "r10.stack_offset=512",
+      "s[511...511].type=number", "s[511...511].svalue=2", "s[511...511].uvalue=2"]
+
+code:
+  <start>: |
+    call <sub>
+    exit
+  <sub>: |
+    *(u8 *)(r10 - 1) = 1 ; this should not change s[511...511]
+    r0 = *(u8 *)(r10 - 1)
+    exit
+
+post:
+  - r0.type=number
+  - r0.svalue=1
+  - r0.uvalue=1
+  - r10.type=stack
+  - r10.stack_offset=512
+  - s[511].type=number
+  - s[511].svalue=2
+  - s[511].uvalue=2
+---
 test-case: call local
 
 pre: []

--- a/test-data/calllocal.yaml
+++ b/test-data/calllocal.yaml
@@ -1,41 +1,6 @@
 # Copyright (c) Prevail Verifier contributors.
 # SPDX-License-Identifier: MIT
 ---
-test-case: call local with stack
-
-pre: ["r10.type=stack", "r10.stack_offset=1536",
-      "s[1535...1535].type=number", "s[1535...1535].svalue=1", "s[1535...1535].uvalue=1"]
-
-code:
-  <start>: |
-    call <sub1>
-    r1 = *(u8 *)(r10 - 1)
-    r0 += r1              ; r0 = 1 + 2 + 3 = 6
-    exit
-  <sub1>: |
-    *(u8 *)(r10 - 1) = 2  ; this should not change the caller's stack
-    call <sub2>
-    r1 = *(u8 *)(r10 - 1)
-    r0 += r1              ; r0 = 2 + 3 = 5
-    exit
-  <sub2>: |
-    *(u8 *)(r10 - 1) = 3  ; this should not change the caller's stack
-    r0 = *(u8 *)(r10 - 1)
-    exit
-
-post:
-  - r0.type=number
-  - r0.svalue=6
-  - r0.uvalue=6
-  - r1.type=number
-  - r1.svalue=1
-  - r1.uvalue=1
-  - r10.type=stack
-  - r10.stack_offset=1536
-  - s[1535].type=number
-  - s[1535].svalue=1
-  - s[1535].uvalue=1
----
 test-case: call local
 
 pre: []
@@ -369,3 +334,38 @@ post: []
 
 messages:
   - "0/2: illegal recursion"
+---
+test-case: call local with stack
+
+pre: ["r10.type=stack", "r10.stack_offset=1536",
+      "s[1535...1535].type=number", "s[1535...1535].svalue=1", "s[1535...1535].uvalue=1"]
+
+code:
+  <start>: |
+    call <sub1>
+    r1 = *(u8 *)(r10 - 1)
+    r0 += r1              ; r0 = 1 + 2 + 3 = 6
+    exit
+  <sub1>: |
+    *(u8 *)(r10 - 1) = 2  ; this should not change the caller's stack
+    call <sub2>
+    r1 = *(u8 *)(r10 - 1)
+    r0 += r1              ; r0 = 2 + 3 = 5
+    exit
+  <sub2>: |
+    *(u8 *)(r10 - 1) = 3  ; this should not change the caller's stack
+    r0 = *(u8 *)(r10 - 1)
+    exit
+
+post:
+  - r0.type=number
+  - r0.svalue=6
+  - r0.uvalue=6
+  - r1.type=number
+  - r1.svalue=1
+  - r1.uvalue=1
+  - r10.type=stack
+  - r10.stack_offset=1536
+  - s[1535].type=number
+  - s[1535].svalue=1
+  - s[1535].uvalue=1

--- a/test-data/calllocal.yaml
+++ b/test-data/calllocal.yaml
@@ -347,14 +347,14 @@ code:
     r0 += r1              ; r0 = 1 + 2 + 3 = 6
     exit
   <sub1>: |
-    *(u8 *)(r10 - 1) = 2  ; this should not change the caller's stack
+    *(u8 *)(r10 - 513) = 2
     call <sub2>
-    r1 = *(u8 *)(r10 - 1)
+    r1 = *(u8 *)(r10 - 513)
     r0 += r1              ; r0 = 2 + 3 = 5
     exit
   <sub2>: |
-    *(u8 *)(r10 - 1) = 3  ; this should not change the caller's stack
-    r0 = *(u8 *)(r10 - 1)
+    *(u8 *)(r10 - 1025) = 3
+    r0 = *(u8 *)(r10 - 1025)
     exit
 
 post:

--- a/test-data/calllocal.yaml
+++ b/test-data/calllocal.yaml
@@ -3,27 +3,38 @@
 ---
 test-case: call local with stack
 
-pre: ["r10.type=stack", "r10.stack_offset=1024",
-      "s[1023...1023].type=number", "s[1023...1023].svalue=2", "s[1023...1023].uvalue=2"]
+pre: ["r10.type=stack", "r10.stack_offset=1536",
+      "s[1535...1535].type=number", "s[1535...1535].svalue=1", "s[1535...1535].uvalue=1"]
 
 code:
   <start>: |
-    call <sub>
+    call <sub1>
+    r1 = *(u8 *)(r10 - 1)
+    r0 += r1              ; r0 = 1 + 2 + 3 = 6
     exit
-  <sub>: |
-    *(u8 *)(r10 - 1) = 1 ; this should not change s[1023...1023]
+  <sub1>: |
+    *(u8 *)(r10 - 1) = 2  ; this should not change the caller's stack
+    call <sub2>
+    r1 = *(u8 *)(r10 - 1)
+    r0 += r1              ; r0 = 2 + 3 = 5
+    exit
+  <sub2>: |
+    *(u8 *)(r10 - 1) = 3  ; this should not change the caller's stack
     r0 = *(u8 *)(r10 - 1)
     exit
 
 post:
   - r0.type=number
-  - r0.svalue=1
-  - r0.uvalue=1
+  - r0.svalue=6
+  - r0.uvalue=6
+  - r1.type=number
+  - r1.svalue=1
+  - r1.uvalue=1
   - r10.type=stack
-  - r10.stack_offset=1024
-  - s[1023].type=number
-  - s[1023].svalue=2
-  - s[1023].uvalue=2
+  - r10.stack_offset=1536
+  - s[1535].type=number
+  - s[1535].svalue=1
+  - s[1535].uvalue=1
 ---
 test-case: call local
 

--- a/test-data/callx.yaml
+++ b/test-data/callx.yaml
@@ -220,6 +220,7 @@ pre: ["r1.type=map_fd", "r1.map_fd=1",
       "r3.type=stack", "r3.stack_offset=496",
       "r4.type=number",
       "r8.type=number", "r8.svalue=2", "r8.uvalue=2",
+      "r10.type=stack", "r10.stack_offset=512",
       "s[496...511].type=number"]
 
 code:
@@ -232,6 +233,8 @@ post:
   - r8.type=number
   - r8.svalue=2
   - r8.uvalue=2
+  - r10.type=stack
+  - r10.stack_offset=512
 
 ---
 test-case: callx bpf_map_update_elem with shared value
@@ -401,6 +404,7 @@ pre: ["r1.type=map_fd", "r1.map_fd=1",
       "r3.type=number", "r3.svalue=8", "r3.uvalue=8",
       "r4.type=number",
       "r8.type=number", "r8.svalue=130", "r8.uvalue=130",
+      "r10.type=stack", "r10.stack_offset=512",
       "s[504...511].type=number"]
 
 code:
@@ -412,6 +416,8 @@ post:
   - r8.type=number
   - r8.svalue=130
   - r8.uvalue=130
+  - r10.type=stack
+  - r10.stack_offset=512
   - s[504...511].type=number
 ---
 test-case: callx bpf_ringbuf_output with non-numeric stack value
@@ -420,7 +426,8 @@ pre: ["r1.type=map_fd", "r1.map_fd=1",
       "r2.type=stack", "r2.stack_offset=504",
       "r3.type=number", "r3.svalue=8", "r3.uvalue=8",
       "r4.type=number",
-      "r8.type=number", "r8.svalue=130", "r8.uvalue=130"]
+      "r8.type=number", "r8.svalue=130", "r8.uvalue=130",
+      "r10.type=stack", "r10.stack_offset=512"]
 
 code:
   <start>: |
@@ -431,6 +438,8 @@ post:
   - r8.type=number
   - r8.svalue=130
   - r8.uvalue=130
+  - r10.type=stack
+  - r10.stack_offset=512
 
 messages:
   - "0: Stack content is not numeric (valid_access(r2.offset, width=r3) for read)"

--- a/test-data/jump.yaml
+++ b/test-data/jump.yaml
@@ -493,6 +493,7 @@ pre: ["r0.type=number",
       "r7.type=stack", "r7.stack_offset=0",
       "r8.type=packet", "r8.packet_offset=4",
       "r9.type=packet", "r9.packet_offset=0",
+      "r10.type=stack", "r10.stack_offset=512",
       "meta_offset=0"]
 
 code:
@@ -532,6 +533,8 @@ post:
   - r8.packet_offset=4
   - r9.type=packet
   - r9.packet_offset=0
+  - r10.type=stack
+  - r10.stack_offset=512
 
 messages:
   - "7:9: Code is unreachable after 7:9"

--- a/test-data/stack.yaml
+++ b/test-data/stack.yaml
@@ -594,4 +594,4 @@ post:
   - s[511].uvalue=0
 
 messages:
-  - "0: Lower bound must be at least r10.stack_offset - EBPF_SUBPROGRAM_STACK_SIZE (valid_access(r10.offset-513, width=1) for write)"
+  - "0: Lower bound must be at least r10.stack_offset - EBPF_SUBPROGRAM_STACK_SIZE * call_stack_depth (valid_access(r10.offset-513, width=1) for write)"

--- a/test-data/stack.yaml
+++ b/test-data/stack.yaml
@@ -572,3 +572,26 @@ post:
   - r10.stack_offset=512
   - r10.type=stack
   - s[498...511].type=number
+---
+test-case: invalid stack access
+
+pre: ["r10.type=stack", "r10.stack_offset=1024"]
+
+code:
+  <start>: |
+    *(u8 *)(r10 - 513) = 0 ; write out of range
+    r0 = 0
+    exit
+
+post:
+  - r0.type=number
+  - r0.svalue=0
+  - r0.uvalue=0
+  - r10.type=stack
+  - r10.stack_offset=1024
+  - s[511].type=number
+  - s[511].svalue=0
+  - s[511].uvalue=0
+
+messages:
+  - "0: Lower bound must be at least r10.stack_offset - EBPF_SUBPROGRAM_STACK_SIZE (valid_access(r10.offset-513, width=1) for write)"

--- a/test-data/subtract.yaml
+++ b/test-data/subtract.yaml
@@ -101,7 +101,8 @@ test-case: allow subtraction of equal dual-typed pointers
 
 pre: ["r2.type=[-2, -1]", "r2.packet_offset=4", "r2.stack_offset=4",
       "r3.type=[-2, -1]", "r3.packet_offset=8", "r3.stack_offset=8",
-      "r2.type=r3.type", "meta_offset=-4", "packet_size=[16,32]"]
+      "r2.type=r3.type", "meta_offset=-4", "packet_size=[16,32]",
+      "r10.type=stack", "r10.stack_offset=512"]
 
 code:
   <start>: |
@@ -114,6 +115,8 @@ post:
   - r3.type=number
   - r3.svalue=4
   - r3.uvalue=4
+  - r10.type=stack
+  - r10.stack_offset=512
   - meta_offset=-4
   - packet_size=[16, 32]
 
@@ -137,8 +140,9 @@ post:
 ---
 test-case: disallow subtraction of pointer from invalid pointer to a singleton region
 
-pre: ["r1.type=stack", "r1.stack_offset=[500, 580]",
-      "r2.type=stack", "r2.stack_offset=[140, 230]"]
+pre: ["r1.type=stack", "r1.stack_offset=[4040, 4130]",
+      "r2.type=stack", "r2.stack_offset=[140, 230]",
+      "r10.type=stack", "r10.stack_offset=4096"]
 
 code:
   <start>: |
@@ -146,10 +150,12 @@ code:
 
 post:
   - r1.type=number
-  - r1.svalue=[270, 440]
-  - r1.uvalue=[270, 440]
+  - r1.svalue=[3810, 3990]
+  - r1.uvalue=[3810, 3990]
   - r1.svalue=r1.uvalue
   - r2.type=stack
   - r2.stack_offset=[140, 230]
+  - r10.type=stack
+  - r10.stack_offset=4096
 messages:
-  - "0: Upper bound must be at most EBPF_STACK_SIZE (r2.type == number or r1.type == r2.type in {ctx, stack, packet})"
+  - "0: Upper bound must be at most EBPF_TOTAL_STACK_SIZE (r2.type == number or r1.type == r2.type in {ctx, stack, packet})"


### PR DESCRIPTION
This change allows 512 bytes of stack space _per call level_, rather than reusing the same 512 bytes of stack space for all call levels.  This allows local variables to work correctly.

Any stack space used by a subprogram is havoced when returning from a function call.

Rather than hard coding EBPF_TOTAL_STACK_SIZE everywhere, places that actually generate warnings use r10.stack_offset.  This was to avoid having to change all the YAML tests now, and then again in the future if we change (say) the max stack depth.  So YAML tests that assumed 512 (stack depth = 1) still do and still work as is.

Added a test case in stack.yaml that verifies that a program cannot use stack space reserved for a subprogram to be called.

Fixes #720 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced new constants for stack size management, enhancing control over stack usage in eBPF subprograms.
  - Added a new method for subprogram stack management and improved stack access validation.
  - Expanded test coverage with new test cases for atomic operations, stack manipulation, and BPF map interactions.
  - Enhanced memory handling with type-safe operations using `std::byte`.

- **Bug Fixes**
  - Improved handling of stack size limits and access checks to prevent out-of-bounds errors.

- **Documentation**
  - Updated comments and documentation to reflect changes in stack size constants and their implications.

- **Refactor**
  - Enhanced logic for control flow graph management, particularly in function macro processing.
  - Streamlined the creation of `ValidAccess` instances for better maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->