### PR TITLE
fix: include for yaml-cpp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,7 +68,7 @@ elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
             -DYAML_CPP_BUILD_TOOLS=OFF
     )
     set(YAML_CPP_LIBRARIES ${EXTERNAL_INSTALL_LOCATION}/lib/yaml-cpp$<$<CONFIG:DEBUG>:d>.lib)
-    set(YAML_CPP_INCLUDE_DIRS ${EXTERNAL_INSTALL_LOCATION}/include/)
+    set(YAML_CPP_INCLUDE_DIR ${EXTERNAL_INSTALL_LOCATION}/include/)
 endif ()
 
 include_directories(./external)
@@ -77,8 +77,11 @@ include_directories(./src)
 include_directories(./external/libbtf)
 include_directories(${GSL_INCLUDE_DIRS})
 include_directories(${Boost_INCLUDE_DIRS})
-include_directories(${YAML_CPP_INCLUDE_DIRS})
+include_directories(${YAML_CPP_INCLUDE_DIR})
+
+link_directories(${YAML_CPP_LIBRARY_DIR})
 link_directories(${Boost_LIBRARY_DIRS})
+
 
 file(GLOB LIB_SRC
         "./src/*.cpp"


### PR DESCRIPTION
There is a typo in YAML_CPP_INCLUDE_DIR variable.
The one defined by find_package() is singular.

Fixed to use the same name in all branches.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated configuration for handling external dependencies, specifically `yaml-cpp` and `Boost`.
	- Enhanced build process for MSVC compiler with new flags for `FuzzerDebug` configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->