### PR TITLE
Move building tests under option

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         configurations: [Debug, Release]
-        build_tests: [on, off]
+        build_tests: [true, false]
     runs-on: ubuntu-latest
     env:
       # Configuration type to build.  For documentation on how build matrices work, see
@@ -42,11 +42,11 @@ jobs:
           cmake --build build -j $(nproc)
 
       - name: Run unit tests
-        if: matrix.build_tests == 'on'
+        if: matrix.build_tests
         run: ./tests -d yes
 
       - name: Test for memory leaks
-        if: matrix.build_tests == 'on'
+        if: matrix.build_tests
         # Any memory leaks will cause the test to fail
         # This BPF program was chosen because it is the largest one in the repo
         run: valgrind --leak-check=full --errors-for-leak-kinds=all  --show-leak-kinds=all --error-exitcode=1 ./check ebpf-samples/cilium/bpf_xdp_snat_linux_v1.o 2/1
@@ -55,7 +55,7 @@ jobs:
     strategy:
       matrix:
         configurations: [Debug, Release]
-        build_tests: [on, off]
+        build_tests: [true, false]
     runs-on: windows-2022
     env:
       # Configuration type to build.  For documentation on how build matrices work, see
@@ -74,5 +74,5 @@ jobs:
           cmake --build build -j $(nproc) --config ${{env.BUILD_CONFIGURATION}}
 
       - name: Run unit tests
-        if: matrix.build_tests == 'on'
+        if: matrix.build_tests
         run: ./${{env.BUILD_CONFIGURATION}}/tests -d yes

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,7 @@ jobs:
     strategy:
       matrix:
         configurations: [Debug, Release]
+        build_tests: [on, off]
     runs-on: ubuntu-latest
     env:
       # Configuration type to build.  For documentation on how build matrices work, see
@@ -37,13 +38,15 @@ jobs:
       - name: Build
         run: |
           mkdir build
-          cmake -B build -DCMAKE_BUILD_TYPE=${{env.BUILD_CONFIGURATION}}
+          cmake -B build -DCMAKE_BUILD_TYPE=${{env.BUILD_CONFIGURATION}} -DVERIFIER_ENABLE_TESTS=${{matrix.build_tests}}
           cmake --build build -j $(nproc)
 
       - name: Run unit tests
+        if: matrix.build_tests == 'on'
         run: ./tests -d yes
 
       - name: Test for memory leaks
+        if: matrix.build_tests == 'on'
         # Any memory leaks will cause the test to fail
         # This BPF program was chosen because it is the largest one in the repo
         run: valgrind --leak-check=full --errors-for-leak-kinds=all  --show-leak-kinds=all --error-exitcode=1 ./check ebpf-samples/cilium/bpf_xdp_snat_linux_v1.o 2/1
@@ -52,6 +55,7 @@ jobs:
     strategy:
       matrix:
         configurations: [Debug, Release]
+        build_tests: [on, off]
     runs-on: windows-2022
     env:
       # Configuration type to build.  For documentation on how build matrices work, see
@@ -66,8 +70,9 @@ jobs:
       - name: Build
         run: |
           mkdir build
-          cmake -B build
+          cmake -B build -DVERIFIER_ENABLE_TESTS=${{matrix.build_tests}}
           cmake --build build -j $(nproc) --config ${{env.BUILD_CONFIGURATION}}
 
       - name: Run unit tests
+        if: matrix.build_tests == 'on'
         run: ./${{env.BUILD_CONFIGURATION}}/tests -d yes

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,8 @@ project(ebpf_verifier)
 
 include(FetchContent)
 
+option(VERIFIER_ENABLE_TESTS "Build tests" ON)
+
 FetchContent_Declare(GSL
         GIT_REPOSITORY "https://github.com/microsoft/GSL"
         GIT_TAG "v4.0.0"
@@ -13,12 +15,14 @@ FetchContent_Declare(GSL
 FetchContent_MakeAvailable(GSL)
 get_target_property(GSL_INCLUDE_DIRS Microsoft.GSL::GSL INTERFACE_INCLUDE_DIRECTORIES)
 
+if (VERIFIER_ENABLE_TESTS)
 FetchContent_Declare(Catch2
         GIT_REPOSITORY "https://github.com/catchorg/Catch2.git"
         GIT_TAG "v3.7.1"
         GIT_SHALLOW ON
 )
 FetchContent_MakeAvailable(Catch2)
+endif()
 
 if (IS_DIRECTORY "${PROJECT_SOURCE_DIR}/.git")
     # Install Git pre-commit hook
@@ -91,6 +95,7 @@ file(GLOB LIB_SRC
         "./src/linux/linux_platform.cpp"
 )
 
+if(VERIFIER_ENABLE_TESTS)
 file(GLOB ALL_TEST
         "./src/test/test_conformance.cpp"
         "./src/test/test_marshal.cpp"
@@ -99,6 +104,7 @@ file(GLOB ALL_TEST
         "./src/test/test_wto.cpp"
         "./src/test/test_yaml.cpp"
 )
+endif()
 
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" OR
         "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
@@ -115,13 +121,16 @@ endif ()
 
 add_library(ebpfverifier ${LIB_SRC})
 
+if(VERIFIER_ENABLE_TESTS)
 add_executable(check src/main/check.cpp src/main/linux_verifier.cpp)
 add_executable(tests ${ALL_TEST})
 add_executable(run_yaml src/main/run_yaml.cpp)
 add_executable(conformance_check src/test/conformance_check.cpp)
+endif()
 
 target_include_directories(ebpfverifier PRIVATE ${GSL_INCLUDE_DIRS})
 
+if(VERIFIER_ENABLE_TESTS)
 set_target_properties(check
         PROPERTIES
         RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/..")
@@ -139,6 +148,7 @@ set_target_properties(conformance_check
         RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/..")
 
 add_dependencies(tests conformance_check)
+endif()
 
 target_compile_options(ebpfverifier PRIVATE ${COMMON_FLAGS})
 target_compile_options(ebpfverifier PUBLIC "$<$<CONFIG:DEBUG>:${DEBUG_FLAGS}>")
@@ -146,7 +156,9 @@ target_compile_options(ebpfverifier PUBLIC "$<$<CONFIG:RELEASE>:${RELEASE_FLAGS}
 target_compile_options(ebpfverifier PUBLIC "$<$<CONFIG:SANITIZE>:${SANITIZE_FLAGS}>")
 
 add_subdirectory("external/bpf_conformance/external/elfio")
+if(VERIFIER_ENABLE_TESTS)
 add_subdirectory("external/bpf_conformance/src")
+endif()
 add_subdirectory("external/libbtf")
 
 # CMake derives a Visual Studio project GUID from the file path but can be overridden via a property
@@ -164,6 +176,7 @@ target_link_libraries(ebpfverifier PRIVATE libbtf)
 target_link_libraries(ebpfverifier PRIVATE Microsoft.GSL::GSL)
 target_compile_options(ebpfverifier PRIVATE ${COMMON_FLAGS})
 
+if(VERIFIER_ENABLE_TESTS)
 target_compile_options(check PRIVATE ${COMMON_FLAGS})
 target_compile_options(check PUBLIC "$<$<CONFIG:DEBUG>:${DEBUG_FLAGS}>")
 target_compile_options(check PUBLIC "$<$<CONFIG:RELEASE>:${RELEASE_FLAGS}>")
@@ -184,3 +197,4 @@ target_link_libraries(tests PRIVATE Catch2::Catch2WithMain)
 target_link_libraries(run_yaml PRIVATE ebpfverifier)
 
 target_link_libraries(conformance_check PRIVATE ebpfverifier)
+endif()


### PR DESCRIPTION
This pull request introduces several changes to the build configuration and the `CMakeLists.txt` to improve flexibility and control over test builds. The most important changes include adding a new build matrix option for tests, modifying the build workflow to conditionally run tests, and restructuring the `CMakeLists.txt` to enable or disable test builds based on a new option.

### Build Configuration Changes:

* [`.github/workflows/build.yml`](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R21): Added a new matrix option `build_tests` with values `on` and `off` to control whether tests are built and executed. Updated the build and test steps to conditionally include tests based on this matrix option. [[1]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R21) [[2]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L40-R49) [[3]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R58) [[4]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L69-R77)

### CMake Configuration Changes:

* [`CMakeLists.txt`](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR8-R9): Introduced a new `VERIFIER_ENABLE_TESTS` option to control the inclusion of test-related targets and dependencies.
* [`CMakeLists.txt`](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL16-L22): Moved the declaration and inclusion of `Catch2` and test source files under the new `VERIFIER_ENABLE_TESTS` option. This ensures that tests are only built when this option is enabled. [[1]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL16-L22) [[2]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL94-L102) [[3]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL118-L142) [[4]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR130-R171)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced conditional test execution based on the new `build_tests` configuration for both Ubuntu and Windows builds.
	- Added a new option to enable tests for the `ebpf_verifier` project, allowing users to include test builds.

- **Bug Fixes**
	- Improved configuration for the Catch2 testing framework to ensure proper fetching and linking of test executables.

- **Documentation**
	- Updated documentation to reflect the new test configuration options and their usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->