### PR TITLE
chore: fix readme instructions for generating dot file

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ A standard alternative to the --asm flag is `llvm-objdump -S FILE`.
 The cfg can be viewed using `dot` and the standard PDF viewer:
 ```
 sudo apt install graphviz
-./check ebpf-samples/cilium/bpf_lxc.o 2/1 --dot cfg.dot
+./check ebpf-samples/cilium/bpf_lxc.o 2/1 --dot cfg.dot --domain=stats
 dot -Tpdf cfg.dot > cfg.pdf
 ```
 


### PR DESCRIPTION
Fixing readme instructions for generating dot file 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Expanded installation instructions for Ubuntu, Windows, and MacOS, including specific dependencies.
	- Enhanced usage section with detailed command-line options and updated example command.
	- Updated testing instructions for the Linux verifier to indicate the need for `sudo`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->