### PR TITLE
When including ebpf-verifier as a submodule, default to tests off

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,16 @@ project(ebpf_verifier)
 
 include(FetchContent)
 
-option(VERIFIER_ENABLE_TESTS "Build tests" ON)
+if (IS_DIRECTORY "${PROJECT_SOURCE_DIR}/.git")
+    # Install Git pre-commit hook
+    file(COPY scripts/pre-commit scripts/commit-msg
+            DESTINATION "${PROJECT_SOURCE_DIR}/.git/hooks")
+    option(VERIFIER_ENABLE_TESTS "Build tests" ON)
+else()
+    option(VERIFIER_ENABLE_TESTS "Build tests" OFF)
+endif ()
+
+message("Building tests: ${VERIFIER_ENABLE_TESTS}")
 
 FetchContent_Declare(GSL
         GIT_REPOSITORY "https://github.com/microsoft/GSL"
@@ -24,11 +33,6 @@ FetchContent_Declare(Catch2
 FetchContent_MakeAvailable(Catch2)
 endif()
 
-if (IS_DIRECTORY "${PROJECT_SOURCE_DIR}/.git")
-    # Install Git pre-commit hook
-    file(COPY scripts/pre-commit scripts/commit-msg
-            DESTINATION "${PROJECT_SOURCE_DIR}/.git/hooks")
-endif ()
 
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" OR
         "${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")


### PR DESCRIPTION
When using ebpf-verifier as a submodule, default to not building the tests collateral. This makes using this as a submodule simpler as it reduced the list of dependencies that need to be pre-installed. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Introduced conditional logic for enabling/disabling tests based on the presence of a `.git` directory.
	- Retained installation of Git pre-commit hooks within the new conditional structure.
	- Adjusted configuration for the Catch2 testing framework to align with the test enablement option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->