### PR TITLE
Reserve the space for the _succs and _preds in AdaptGraph::growTo

### DIFF
--- a/src/crab_utils/adapt_sgraph.hpp
+++ b/src/crab_utils/adapt_sgraph.hpp
@@ -338,6 +338,8 @@ class AdaptGraph final {
     }
 
     void growTo(size_t v) {
+        _succs.reserve(v);
+        _preds.reserve(v);
         while (size() < v) {
             new_vertex();
         }


### PR DESCRIPTION
This pull request includes a minor change to the `AdaptGraph` class in the `src/crab_utils/adapt_sgraph.hpp` file. The change optimizes the `growTo` method by pre-allocating memory for successors and predecessors.

* [`src/crab_utils/adapt_sgraph.hpp`](diffhunk://#diff-4c63b3ea707b6f27ebed01536c576e716ccb123d50f5fa35deda1bc55f39426aR341-R342): Added calls to `_succs.reserve(v)` and `_preds.reserve(v)` in the `growTo` method to pre-allocate memory for successors and predecessors.