### PR TITLE
Restrict comparisons with pointers to legal operations

### DIFF
--- a/src/test/ebpf_yaml.cpp
+++ b/src/test/ebpf_yaml.cpp
@@ -192,6 +192,8 @@ static ebpf_verifier_options_t raw_options_to_options(const std::set<string>& ra
             options.big_endian = true;
         } else if (name == "!big_endian") {
             options.big_endian = false;
+        } else if (name == "assume_assertions"){
+            options.assume_assertions = true;
         } else {
             throw std::runtime_error("Unknown option: " + name);
         }

--- a/src/test/ebpf_yaml.cpp
+++ b/src/test/ebpf_yaml.cpp
@@ -195,7 +195,7 @@ static ebpf_verifier_options_t raw_options_to_options(const std::set<string>& ra
             options.big_endian = true;
         } else if (name == "!big_endian") {
             options.big_endian = false;
-        } else if (name == "assume_assertions"){
+        } else if (name == "assume_assertions") {
             options.assume_assertions = true;
         } else {
             throw std::runtime_error("Unknown option: " + name);

--- a/src/test/ebpf_yaml.cpp
+++ b/src/test/ebpf_yaml.cpp
@@ -179,6 +179,9 @@ static ebpf_verifier_options_t raw_options_to_options(const std::set<string>& ra
     // Default to the machine's native endianness.
     options.big_endian = (std::endian::native == std::endian::big);
 
+    // Default to not assuming assertions.
+    options.assume_assertions = false;
+
     for (const string& name : raw_options) {
         if (name == "!allow_division_by_zero") {
             options.allow_division_by_zero = false;

--- a/test-data/jump.yaml
+++ b/test-data/jump.yaml
@@ -998,12 +998,6 @@ messages:
   - "0: Code is unreachable after 0"
   - "0: Invalid type (r1.type == number)"
 
-
-
-
-
-
-
 ---
 test-case: JEQ32 with imm 0 and pointer
 options: ["assume_assertions"]

--- a/test-data/jump.yaml
+++ b/test-data/jump.yaml
@@ -715,3 +715,543 @@ post:
 
 messages:
   - "0: Invalid type (r1.type in {number, ctx, stack, packet, shared})"
+
+# # Test cases for special case of comparison of not a number against a number when immediate is 0
+---
+test-case: JEQ with imm 0 and pointer
+options: ["assume_assertions"]
+pre:
+  - "r1.type=ctx"
+  - "r1.svalue=[1, 2147418112]"
+  - "r1.ctx_offset=0"
+
+code:
+  <start>: |
+    if r1 == 0 goto <exit>
+    r0 = 1
+  <exit>: |
+    exit
+
+post:
+  - r0.svalue=1
+  - r0.type=number
+  - r0.uvalue=1
+  - r1.ctx_offset=0
+  - r1.svalue=[1, 2147418112]
+  - r1.type=ctx
+
+messages:
+  - "0:2: Code is unreachable after 0:2"
+---
+test-case: JNE with imm 0 and pointer
+options: ["assume_assertions"]
+pre:
+  - "r1.type=ctx"
+  - "r1.svalue=[1, 2147418112]"
+  - "r1.ctx_offset=0"
+
+code:
+  <start>: |
+    if r1 != 0 goto <exit>
+    r0 = 1
+  <exit>: |
+    exit
+
+post: []
+
+messages:
+  - "0:1: Code is unreachable after 0:1"
+  - "2: Code is unreachable after 2"
+  - "2: Invalid type (r0.type == number)"
+
+---
+test-case: JSET with imm 0 and pointer
+options: ["assume_assertions"]
+pre:
+  - "r1.type=ctx"
+  - "r1.svalue=[1, 2147418112]"
+  - "r1.ctx_offset=0"
+
+code:
+  <start>: |
+    if r1 &== 0 goto <exit>
+    r0 = 1
+  <exit>: |
+    exit
+
+post: []
+
+messages:
+  - "2: Code is unreachable after 2"
+  - "2: Invalid type (r0.type == number)"
+
+---
+test-case: JNSET with imm 0 and pointer
+options: ["assume_assertions"]
+pre:
+  - "r1.type=ctx"
+  - "r1.svalue=[1, 2147418112]"
+  - "r1.ctx_offset=0"
+
+code:
+  <start>: |
+    if r1 &!= 0 goto <exit>
+    r0 = 1
+  <exit>: |
+    exit
+
+post: []
+
+messages:
+  - "2: Code is unreachable after 2"
+  - "2: Invalid type (r0.type == number)"
+
+---
+test-case: JLT with imm 0 and pointer
+options: ["assume_assertions"]
+pre:
+  - "r1.type=ctx"
+  - "r1.svalue=[1, 2147418112]"
+  - "r1.ctx_offset=0"
+
+code:
+  <start>: |
+    if r1 < 0 goto <exit>
+    r0 = 1
+  <exit>: |
+    exit
+
+post:
+  - r0.svalue=1
+  - r0.type=number
+  - r0.uvalue=1
+  - r1.ctx_offset=0
+  - r1.svalue=[1, 2147418112]
+  - r1.type=ctx
+  - r1.uvalue=[0, +oo]
+
+messages:
+  - "0:2: Code is unreachable after 0:2"
+
+---
+test-case: JLE with imm 0 and pointer
+options: ["assume_assertions"]
+pre:
+  - "r1.type=ctx"
+  - "r1.svalue=[1, 2147418112]"
+  - "r1.ctx_offset=0"
+
+code:
+  <start>: |
+    if r1 <= 0 goto <exit>
+    r0 = 1
+  <exit>: |
+    exit
+
+post:
+  - r0.svalue=1
+  - r0.type=number
+  - r0.uvalue=1
+  - r1.ctx_offset=0
+  - r1.svalue=[1, 2147418112]
+  - r1.type=ctx
+  - r1.uvalue=[1, +oo]
+
+messages:
+  - "0:2: Code is unreachable after 0:2"
+
+---
+test-case: JGT with imm 0 and pointer
+options: ["assume_assertions"]
+pre:
+  - "r1.type=ctx"
+  - "r1.svalue=[1, 2147418112]"
+  - "r1.ctx_offset=0"
+
+code:
+  <start>: |
+    if r1 <= 0 goto <exit>
+    r0 = 1
+  <exit>: |
+    exit
+
+post:
+  - r0.svalue=1
+  - r0.type=number
+  - r0.uvalue=1
+  - r1.ctx_offset=0
+  - r1.svalue=[1, 2147418112]
+  - r1.type=ctx
+  - r1.uvalue=[1, +oo]
+
+messages:
+  - "0:2: Code is unreachable after 0:2"
+
+---
+test-case: JGE with imm 0 and pointer
+options: ["assume_assertions"]
+pre:
+  - "r1.type=ctx"
+  - "r1.svalue=[1, 2147418112]"
+  - "r1.ctx_offset=0"
+
+code:
+  <start>: |
+    if r1 <= 0 goto <exit>
+    r0 = 1
+  <exit>: |
+    exit
+
+post:
+  - r0.svalue=1
+  - r0.type=number
+  - r0.uvalue=1
+  - r1.ctx_offset=0
+  - r1.svalue=[1, 2147418112]
+  - r1.type=ctx
+  - r1.uvalue=[1, +oo]
+
+messages:
+  - "0:2: Code is unreachable after 0:2"
+
+---
+test-case: JSLT with imm 0 and pointer
+options: ["assume_assertions"]
+pre:
+  - "r1.type=ctx"
+  - "r1.svalue=[1, 2147418112]"
+  - "r1.ctx_offset=0"
+
+code:
+  <start>: |
+    if r1 s< 0 goto <exit>
+    r0 = 1
+  <exit>: |
+    exit
+
+post: []
+
+messages:
+  - "0: Code is unreachable after 0"
+  - "0: Invalid type (r1.type == number)"
+
+---
+test-case: JSLE with imm 0 and pointer
+options: ["assume_assertions"]
+pre:
+  - "r1.type=ctx"
+  - "r1.svalue=[1, 2147418112]"
+  - "r1.ctx_offset=0"
+
+code:
+  <start>: |
+    if r1 s<= 0 goto <exit>
+    r0 = 1
+  <exit>: |
+    exit
+
+post: []
+
+messages:
+  - "0: Code is unreachable after 0"
+  - "0: Invalid type (r1.type == number)"
+
+---
+test-case: JSGT with imm 0 and pointer
+options: ["assume_assertions"]
+pre:
+  - "r1.type=ctx"
+  - "r1.svalue=[1, 2147418112]"
+  - "r1.ctx_offset=0"
+
+code:
+  <start>: |
+    if r1 s<= 0 goto <exit>
+    r0 = 1
+  <exit>: |
+    exit
+
+post: []
+
+messages:
+  - "0: Code is unreachable after 0"
+  - "0: Invalid type (r1.type == number)"
+
+---
+test-case: JSGE with imm 0 and pointer
+options: ["assume_assertions"]
+pre:
+  - "r1.type=ctx"
+  - "r1.svalue=[1, 2147418112]"
+  - "r1.ctx_offset=0"
+
+code:
+  <start>: |
+    if r1 s<= 0 goto <exit>
+    r0 = 1
+  <exit>: |
+    exit
+
+post: []
+
+messages:
+  - "0: Code is unreachable after 0"
+  - "0: Invalid type (r1.type == number)"
+
+
+
+
+
+
+
+---
+test-case: JEQ32 with imm 0 and pointer
+options: ["assume_assertions"]
+pre:
+  - "r1.type=ctx"
+  - "r1.svalue=[1, 2147418112]"
+  - "r1.ctx_offset=0"
+
+code:
+  <start>: |
+    if w1 == 0 goto <exit>
+    r0 = 1
+  <exit>: |
+    exit
+
+post: []
+
+messages:
+  - "0: Code is unreachable after 0"
+  - "0: Invalid type (r1.type == number)"
+
+---
+test-case: JNE32 with imm 0 and pointer
+options: ["assume_assertions"]
+pre:
+  - "r1.type=ctx"
+  - "r1.svalue=[1, 2147418112]"
+  - "r1.ctx_offset=0"
+
+code:
+  <start>: |
+    if w1 != 0 goto <exit>
+    r0 = 1
+  <exit>: |
+    exit
+
+post: []
+
+messages:
+  - "0: Code is unreachable after 0"
+  - "0: Invalid type (r1.type == number)"
+
+---
+test-case: JSET32 with imm 0 and pointer
+options: ["assume_assertions"]
+pre:
+  - "r1.type=ctx"
+  - "r1.svalue=[1, 2147418112]"
+  - "r1.ctx_offset=0"
+
+code:
+  <start>: |
+    if w1 &== 0 goto <exit>
+    r0 = 1
+  <exit>: |
+    exit
+
+post: []
+
+messages:
+  - "0: Code is unreachable after 0"
+  - "0: Invalid type (r1.type == number)"
+
+---
+test-case: JNSET32 with imm 0 and pointer
+options: ["assume_assertions"]
+pre:
+  - "r1.type=ctx"
+  - "r1.svalue=[1, 2147418112]"
+  - "r1.ctx_offset=0"
+
+code:
+  <start>: |
+    if w1 &!= 0 goto <exit>
+    r0 = 1
+  <exit>: |
+    exit
+
+post: []
+
+messages:
+  - "0: Code is unreachable after 0"
+  - "0: Invalid type (r1.type == number)"
+
+---
+test-case: JLT32 with imm 0 and pointer
+options: ["assume_assertions"]
+pre:
+  - "r1.type=ctx"
+  - "r1.svalue=[1, 2147418112]"
+  - "r1.ctx_offset=0"
+
+code:
+  <start>: |
+    if w1 < 0 goto <exit>
+    r0 = 1
+  <exit>: |
+    exit
+
+post: []
+
+messages:
+  - "0: Code is unreachable after 0"
+  - "0: Invalid type (r1.type == number)"
+
+---
+test-case: JLE32 with imm 0 and pointer
+options: ["assume_assertions"]
+pre:
+  - "r1.type=ctx"
+  - "r1.svalue=[1, 2147418112]"
+  - "r1.ctx_offset=0"
+
+code:
+  <start>: |
+    if w1 <= 0 goto <exit>
+    r0 = 1
+  <exit>: |
+    exit
+
+post: []
+
+messages:
+  - "0: Code is unreachable after 0"
+  - "0: Invalid type (r1.type == number)"
+
+---
+test-case: JGT32 with imm 0 and pointer
+options: ["assume_assertions"]
+pre:
+  - "r1.type=ctx"
+  - "r1.svalue=[1, 2147418112]"
+  - "r1.ctx_offset=0"
+
+code:
+  <start>: |
+    if w1 <= 0 goto <exit>
+    r0 = 1
+  <exit>: |
+    exit
+
+post: []
+
+messages:
+  - "0: Code is unreachable after 0"
+  - "0: Invalid type (r1.type == number)"
+
+---
+test-case: JGE32 with imm 0 and pointer
+options: ["assume_assertions"]
+pre:
+  - "r1.type=ctx"
+  - "r1.svalue=[1, 2147418112]"
+  - "r1.ctx_offset=0"
+
+code:
+  <start>: |
+    if w1 <= 0 goto <exit>
+    r0 = 1
+  <exit>: |
+    exit
+
+post: []
+
+messages:
+  - "0: Code is unreachable after 0"
+  - "0: Invalid type (r1.type == number)"
+
+---
+test-case: JSLT32 with imm 0 and pointer
+options: ["assume_assertions"]
+pre:
+  - "r1.type=ctx"
+  - "r1.svalue=[1, 2147418112]"
+  - "r1.ctx_offset=0"
+
+code:
+  <start>: |
+    if w1 s< 0 goto <exit>
+    r0 = 1
+  <exit>: |
+    exit
+
+post: []
+
+messages:
+  - "0: Code is unreachable after 0"
+  - "0: Invalid type (r1.type == number)"
+
+---
+test-case: JSLE32 with imm 0 and pointer
+options: ["assume_assertions"]
+pre:
+  - "r1.type=ctx"
+  - "r1.svalue=[1, 2147418112]"
+  - "r1.ctx_offset=0"
+
+code:
+  <start>: |
+    if w1 s<= 0 goto <exit>
+    r0 = 1
+  <exit>: |
+    exit
+
+post: []
+
+messages:
+  - "0: Code is unreachable after 0"
+  - "0: Invalid type (r1.type == number)"
+
+---
+test-case: JSGT32 with imm 0 and pointer
+options: ["assume_assertions"]
+pre:
+  - "r1.type=ctx"
+  - "r1.svalue=[1, 2147418112]"
+  - "r1.ctx_offset=0"
+
+code:
+  <start>: |
+    if w1 s<= 0 goto <exit>
+    r0 = 1
+  <exit>: |
+    exit
+
+post: []
+
+messages:
+  - "0: Code is unreachable after 0"
+  - "0: Invalid type (r1.type == number)"
+
+---
+test-case: JSGE32 with imm 0 and pointer
+options: ["assume_assertions"]
+pre:
+  - "r1.type=ctx"
+  - "r1.svalue=[1, 2147418112]"
+  - "r1.ctx_offset=0"
+
+code:
+  <start>: |
+    if w1 s<= 0 goto <exit>
+    r0 = 1
+  <exit>: |
+    exit
+
+post: []
+
+messages:
+  - "0: Code is unreachable after 0"
+  - "0: Invalid type (r1.type == number)"


### PR DESCRIPTION
This pull request includes several key changes to the `src/assertions.cpp` and `src/test/ebpf_yaml.cpp` files, focusing on enhancing the handling of condition checks and adding new options for assertions. The most important changes are summarized below:

### Enhancements to Condition Handling:

* [`src/assertions.cpp`](diffhunk://#diff-6ce2751805a1c8beb6524a37731195a873e763cbeaf8110ba4f60645d65b6facR140-R164): Added a new `allow_pointers` flag to manage pointer comparisons based on the operation type and whether the operation is 64-bit. This ensures that only certain operations allow pointer comparisons.
* [`src/assertions.cpp`](diffhunk://#diff-6ce2751805a1c8beb6524a37731195a873e763cbeaf8110ba4f60645d65b6facL245-R271): Updated comments for better readability and clarity, particularly for binary operations.

### Addition of New Options:

* [`src/test/ebpf_yaml.cpp`](diffhunk://#diff-300a8b63871a012f56d32892465dccc29b139ffd1f01d0d0aaf3f2509e3a20e6R195-R196): Introduced the `assume_assertions` option to the `ebpf_verifier_options_t` structure, allowing the verifier to assume assertions during its operation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced pointer comparison handling in assertions to improve type safety.
	- Introduced a new option for handling assertion assumptions during verification.

- **Tests**
	- Added multiple test cases for conditional jumps and comparisons involving context types and immediate values, ensuring well-defined behavior in these scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->