### PR TITLE
Skip relocations to sections when parsing elf

### DIFF
--- a/src/asm_files.cpp
+++ b/src/asm_files.cpp
@@ -406,6 +406,13 @@ vector<raw_program> read_elf(std::istream& input_stream, const std::string& path
                     if (!reloc.get_entry(i, offset, index, type, addend)) {
                         continue;
                     }
+
+                    auto [symbol_value, symbol_type] = get_value(symbols, index);
+                    if (symbol_type == ELFIO::STT_SECTION) {
+                        // Skip relocations for sections.
+                        continue;
+                    }
+
                     if (offset < program_offset || offset >= program_offset + program_size) {
                         // Relocation is not for this program.
                         continue;


### PR DESCRIPTION
When programs contain a section that stores data, e.g., read-only data stored in the `.rodata` section, relocations to the data show up as relocation to the corresponding section, which results in an "Unresolved external symbol" error. We can skip when a relocation to a section is encountered to avoid such errors. This can be seen for the Cilium benchmark here: [bpf_host.o](https://github.com/a-hamza-r/ebpf-benchmarks/blob/main/cilium/bytecode/bpf_host.o)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced error handling and control flow for ELF file processing.
	- Improved relocation processing by skipping irrelevant symbols.
  
- **Bug Fixes**
	- Added runtime error checks for null map section data and invalid sizes.
	- Improved relocation value calculations to accommodate various map formats.

- **Refactor**
	- Updated function signature for better input handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->