### PR TITLE
Add support for WREG OPASSIGN WREG

### DIFF
--- a/src/asm_parse.cpp
+++ b/src/asm_parse.cpp
@@ -154,7 +154,7 @@ Instruction parse_instruction(const std::string& line, const std::map<std::strin
     if (regex_match(text, m, regex("callx " REG))) {
         return Callx{reg(m[1])};
     }
-    if (regex_match(text, m, regex(WREG OPASSIGN REG))) {
+    if (regex_match(text, m, regex(WREG OPASSIGN WREG))) {
         const std::string r = m[1];
         return Bin{.op = str_to_binop.at(m[2]), .dst = reg(r), .v = reg(m[3]), .is64 = is64_reg(r), .lddw = false};
     }


### PR DESCRIPTION
This pull request includes a change to the `parse_instruction` function in the `src/asm_parse.cpp` file to correct the parsing of a specific instruction format.

Parsing correction:

* [`src/asm_parse.cpp`](diffhunk://#diff-85a461493fc8f4611c8594f9721e78a2ee26ba02cedd57d11d876d98e33b9fecL157-R157): Modified the regular expression in the `parse_instruction` function to correctly match the `WREG OPASSIGN WREG` pattern instead of the incorrect `WREG OPASSIGN REG` pattern.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved parsing for assembly instructions involving wide registers, ensuring accurate matches for assignments between wide registers.
  
- **Bug Fixes**
	- Enhanced the regex pattern for better accuracy in instruction parsing without altering existing error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->