### PR TITLE
Fix overflow in conversion from uvalue to svalue

### DIFF
--- a/src/crab/ebpf_domain.cpp
+++ b/src/crab/ebpf_domain.cpp
@@ -2334,11 +2334,9 @@ void ebpf_domain_t::shl(const Reg& dst_reg, int imm, const int finite_width) {
                 ub_n = ub_n << imm & uint_max;
             }
             m_inv.set(dst.uvalue, interval_t{lb_n, ub_n});
-            if (to_signed(ub_n) >= to_signed(lb_n)) {
-                m_inv.assign(dst.svalue, dst.uvalue);
-            } else {
-                havoc(dst.svalue);
-            }
+            m_inv.assign(dst.svalue, dst.uvalue);
+            overflow_signed(m_inv, dst.svalue, finite_width);
+            overflow_unsigned(m_inv, dst.uvalue, finite_width);
             return;
         }
     }
@@ -2461,11 +2459,9 @@ void ebpf_domain_t::ashr(const Reg& dst_reg, const linear_expression_t& right_sv
                 }
             }
             m_inv.set(dst.svalue, interval_t{lb_n, ub_n});
-            if (to_unsigned(ub_n) >= to_unsigned(lb_n)) {
-                m_inv.assign(dst.uvalue, dst.svalue);
-            } else {
-                havoc(dst.uvalue);
-            }
+            m_inv.assign(dst.uvalue, dst.svalue);
+            overflow_signed(m_inv, dst.svalue, finite_width);
+            overflow_unsigned(m_inv, dst.uvalue, finite_width);
             return;
         }
     }

--- a/src/crab/ebpf_domain.cpp
+++ b/src/crab/ebpf_domain.cpp
@@ -2374,7 +2374,8 @@ void ebpf_domain_t::lshr(const Reg& dst_reg, int imm, int finite_width) {
             }
         }
         m_inv.set(dst.uvalue, interval_t{lb_n, ub_n});
-        if (ub_n.narrow<int64_t>() >= lb_n.narrow<int64_t>()) {
+        if ((ub_n.fits<int64_t>() && lb_n.fits<int64_t>()) &&
+            ub_n.narrow<int64_t>() >= lb_n.narrow<int64_t>()) {
             // ? m_inv.set(dst.svalue, crab::interval_t{number_t{(int64_t)lb_n}, number_t{(int64_t)ub_n}});
             m_inv.assign(dst.svalue, dst.uvalue);
         } else {

--- a/src/crab/ebpf_domain.cpp
+++ b/src/crab/ebpf_domain.cpp
@@ -2374,13 +2374,9 @@ void ebpf_domain_t::lshr(const Reg& dst_reg, int imm, int finite_width) {
             }
         }
         m_inv.set(dst.uvalue, interval_t{lb_n, ub_n});
-        if ((ub_n.fits<int64_t>() && lb_n.fits<int64_t>()) &&
-            ub_n.narrow<int64_t>() >= lb_n.narrow<int64_t>()) {
-            // ? m_inv.set(dst.svalue, crab::interval_t{number_t{(int64_t)lb_n}, number_t{(int64_t)ub_n}});
-            m_inv.assign(dst.svalue, dst.uvalue);
-        } else {
-            havoc(dst.svalue);
-        }
+        m_inv.assign(dst.svalue, dst.uvalue);
+        overflow_signed(m_inv, dst.svalue, finite_width);
+        overflow_unsigned(m_inv, dst.uvalue, finite_width);
         return;
     }
     havoc(dst.svalue);

--- a/test-data/shift.yaml
+++ b/test-data/shift.yaml
@@ -1543,7 +1543,7 @@ messages:
   - "1:2: Code is unreachable after 1:2"
 
 ---
-test-case: check that left shift by 0 is idempotent - MAX_INT64
+test-case: check that left shift by 0 is idempotent - MAX_INT64 - via register
 
 pre:
   - r0.type=number

--- a/test-data/shift.yaml
+++ b/test-data/shift.yaml
@@ -1223,7 +1223,7 @@ messages:
   - "1:2: Code is unreachable after 1:2"
 
 ---
-test-case: check that unsigned right shift by 0 is idempotent - MIN_INT64 - via register
+test-case: check that unsigned right shift by 0 is idempotent - MAX_INT64 - via register
 
 pre:
   - r0.type=number

--- a/test-data/shift.yaml
+++ b/test-data/shift.yaml
@@ -1129,16 +1129,19 @@ code:
 
 post:
   - r0.type=number
+  - r0.svalue=-9223372036854775808
   - r0.uvalue=9223372036854775808
-  #  Note: The svalue gets havoced by the shift, so we can't check it.
   - r1.type=number
   - r1.svalue=-9223372036854775808
   - r1.uvalue=9223372036854775808
+  - r0.svalue=r1.svalue
   - r0.uvalue=r1.uvalue
+  - r2.svalue=1
   - r2.type=number
-  - r2.svalue=[0, 1]
-  - r2.uvalue=[0, 1]
-  - r2.svalue=r2.uvalue
+  - r2.uvalue=1
+
+messages:
+  - "1:2: Code is unreachable after 1:2"
 
 ---
 test-case: check that unsigned right shift by 0 is idempotent - valid svalue
@@ -1205,19 +1208,22 @@ code:
 
 post:
   - r0.type=number
+  - r0.svalue=-9223372036854775808
   - r0.uvalue=9223372036854775808
-  #  Note: The svalue gets havoced by the shift, so we can't check it.
   - r1.type=number
   - r1.svalue=-9223372036854775808
   - r1.uvalue=9223372036854775808
+  - r0.svalue=r1.svalue
   - r0.uvalue=r1.uvalue
+  - r2.svalue=1
   - r2.type=number
-  - r2.svalue=[0, 1]
-  - r2.uvalue=[0, 1]
-  - r2.svalue=r2.uvalue
+  - r2.uvalue=1
   - r3.type=number
   - r3.uvalue=0
   - r3.svalue=0
+
+messages:
+  - "1:2: Code is unreachable after 1:2"
 
 ---
 test-case: check that unsigned right shift by 0 is idempotent - valid svalue

--- a/test-data/shift.yaml
+++ b/test-data/shift.yaml
@@ -1106,7 +1106,7 @@ post:
   - r2.uvalue=32
 
 ---
-test-case: check that unsigned right shift by 0 is idempotent
+test-case: check that unsigned right shift by 0 is idempotent - svalue out of range
 
 pre:
   - r0.type=number
@@ -1137,3 +1137,40 @@ post:
   - r2.svalue=[0, 1]
   - r2.uvalue=[0, 1]
   - r2.svalue=r2.uvalue
+
+---
+test-case: check that unsigned right shift by 0 is idempotent - valid svalue
+
+pre:
+  - r0.type=number
+  - r0.svalue=9223372036854775807
+  - r0.uvalue=9223372036854775807
+  - r1.type=number
+  - r1.svalue=9223372036854775807
+  - r1.uvalue=9223372036854775807
+
+code:
+  <start>: |
+    r0 >>= 0
+    if r1 == r0 goto <one>
+    r2 = 0
+    exit
+  <one>: |
+    r2 = 1
+    exit
+
+post:
+  - r0.svalue=9223372036854775807
+  - r0.svalue=r1.svalue
+  - r0.type=number
+  - r0.uvalue=9223372036854775807
+  - r0.uvalue=r1.uvalue
+  - r1.svalue=9223372036854775807
+  - r1.type=number
+  - r1.uvalue=9223372036854775807
+  - r2.svalue=1
+  - r2.type=number
+  - r2.uvalue=1
+
+messages:
+  - "1:2: Code is unreachable after 1:2"

--- a/test-data/shift.yaml
+++ b/test-data/shift.yaml
@@ -1110,11 +1110,12 @@ test-case: check that unsigned right shift by 0 is idempotent - svalue out of ra
 
 pre:
   - r0.type=number
-  - r0.svalue=-8863041185711652825
-  - r0.uvalue=9583702887997898791
+  #  This is 0x8000000000000000, which is out of range for a signed 64-bit number.
+  - r0.svalue=-9223372036854775808
+  - r0.uvalue=9223372036854775808
   - r1.type=number
-  - r1.svalue=-8863041185711652825
-  - r1.uvalue=9583702887997898791
+  - r1.svalue=-9223372036854775808
+  - r1.uvalue=9223372036854775808
 
 code:
   <start>: |
@@ -1128,10 +1129,11 @@ code:
 
 post:
   - r0.type=number
-  - r0.uvalue=9583702887997898791
+  - r0.uvalue=9223372036854775808
+  #  Note: The svalue gets havoced by the shift, so we can't check it.
   - r1.type=number
-  - r1.svalue=-8863041185711652825
-  - r1.uvalue=9583702887997898791
+  - r1.svalue=-9223372036854775808
+  - r1.uvalue=9223372036854775808
   - r0.uvalue=r1.uvalue
   - r2.type=number
   - r2.svalue=[0, 1]
@@ -1143,6 +1145,7 @@ test-case: check that unsigned right shift by 0 is idempotent - valid svalue
 
 pre:
   - r0.type=number
+  #  This is 0x7fffffffffffffff, which is in range for a signed 64-bit number.
   - r0.svalue=9223372036854775807
   - r0.uvalue=9223372036854775807
   - r1.type=number

--- a/test-data/shift.yaml
+++ b/test-data/shift.yaml
@@ -1177,3 +1177,88 @@ post:
 
 messages:
   - "1:2: Code is unreachable after 1:2"
+
+---
+test-case: check that unsigned right shift by 0 is idempotent - svalue out of range - via register
+
+pre:
+  - r0.type=number
+  #  This is 0x8000000000000000, which is out of range for a signed 64-bit number.
+  - r0.svalue=-9223372036854775808
+  - r0.uvalue=9223372036854775808
+  - r1.type=number
+  - r1.svalue=-9223372036854775808
+  - r1.uvalue=9223372036854775808
+  - r3.type=number
+  - r3.uvalue=0
+  - r3.svalue=0
+
+code:
+  <start>: |
+    r0 >>= r3
+    if r1 == r0 goto <one>
+    r2 = 0
+    exit
+  <one>: |
+    r2 = 1
+    exit
+
+post:
+  - r0.type=number
+  - r0.uvalue=9223372036854775808
+  #  Note: The svalue gets havoced by the shift, so we can't check it.
+  - r1.type=number
+  - r1.svalue=-9223372036854775808
+  - r1.uvalue=9223372036854775808
+  - r0.uvalue=r1.uvalue
+  - r2.type=number
+  - r2.svalue=[0, 1]
+  - r2.uvalue=[0, 1]
+  - r2.svalue=r2.uvalue
+  - r3.type=number
+  - r3.uvalue=0
+  - r3.svalue=0
+
+---
+test-case: check that unsigned right shift by 0 is idempotent - valid svalue
+
+pre:
+  - r0.type=number
+  #  This is 0x7fffffffffffffff, which is in range for a signed 64-bit number.
+  - r0.svalue=9223372036854775807
+  - r0.uvalue=9223372036854775807
+  - r1.type=number
+  - r1.svalue=9223372036854775807
+  - r1.uvalue=9223372036854775807
+  - r3.type=number
+  - r3.uvalue=0
+  - r3.svalue=0
+
+code:
+  <start>: |
+    r0 >>= r3
+    if r1 == r0 goto <one>
+    r2 = 0
+    exit
+  <one>: |
+    r2 = 1
+    exit
+
+post:
+  - r0.svalue=9223372036854775807
+  - r0.svalue=r1.svalue
+  - r0.type=number
+  - r0.uvalue=9223372036854775807
+  - r0.uvalue=r1.uvalue
+  - r1.svalue=9223372036854775807
+  - r1.type=number
+  - r1.uvalue=9223372036854775807
+  - r2.svalue=1
+  - r2.type=number
+  - r2.uvalue=1
+  - r3.type=number
+  - r3.uvalue=0
+  - r3.svalue=0
+
+messages:
+  - "1:2: Code is unreachable after 1:2"

--- a/test-data/shift.yaml
+++ b/test-data/shift.yaml
@@ -1340,6 +1340,43 @@ messages:
   - "1:2: Code is unreachable after 1:2"
 
 ---
+test-case: check that signed right shift by 0 is idempotent - MAX_UINT64
+
+pre:
+  - r0.type=number
+  - r0.svalue=-1
+  - r0.uvalue=18446744073709551615
+  - r1.type=number
+  - r1.svalue=-1
+  - r1.uvalue=18446744073709551615
+
+code:
+  <start>: |
+    r0 s>>= 0
+    if r1 == r0 goto <one>
+    r2 = 0
+    exit
+  <one>: |
+    r2 = 1
+    exit
+
+post:
+  - r0.svalue=-1
+  - r0.svalue=r1.svalue
+  - r0.type=number
+  - r0.uvalue=18446744073709551615
+  - r0.uvalue=r1.uvalue
+  - r1.svalue=-1
+  - r1.type=number
+  - r1.uvalue=18446744073709551615
+  - r2.svalue=1
+  - r2.type=number
+  - r2.uvalue=1
+
+messages:
+  - "1:2: Code is unreachable after 1:2"
+
+---
 test-case: check that signed right shift by 0 is idempotent - MIN_INT64 - via register
 
 pre:
@@ -1415,6 +1452,49 @@ post:
   - r1.svalue=9223372036854775807
   - r1.type=number
   - r1.uvalue=9223372036854775807
+  - r2.svalue=1
+  - r2.type=number
+  - r2.uvalue=1
+  - r3.type=number
+  - r3.uvalue=0
+  - r3.svalue=0
+
+messages:
+  - "1:2: Code is unreachable after 1:2"
+
+---
+test-case: check that signed right shift by 0 is idempotent - MAX_UINT64 - via register
+
+pre:
+  - r0.type=number
+  - r0.svalue=-1
+  - r0.uvalue=18446744073709551615
+  - r1.type=number
+  - r1.svalue=-1
+  - r1.uvalue=18446744073709551615
+  - r3.type=number
+  - r3.uvalue=0
+  - r3.svalue=0
+
+code:
+  <start>: |
+    r0 s>>= r3
+    if r1 == r0 goto <one>
+    r2 = 0
+    exit
+  <one>: |
+    r2 = 1
+    exit
+
+post:
+  - r0.svalue=-1
+  - r0.svalue=r1.svalue
+  - r0.type=number
+  - r0.uvalue=18446744073709551615
+  - r0.uvalue=r1.uvalue
+  - r1.svalue=-1
+  - r1.type=number
+  - r1.uvalue=18446744073709551615
   - r2.svalue=1
   - r2.type=number
   - r2.uvalue=1

--- a/test-data/shift.yaml
+++ b/test-data/shift.yaml
@@ -1106,11 +1106,10 @@ post:
   - r2.uvalue=32
 
 ---
-test-case: check that unsigned right shift by 0 is idempotent - svalue out of range
+test-case: check that unsigned right shift by 0 is idempotent - MIN_INT64
 
 pre:
   - r0.type=number
-  #  This is 0x8000000000000000, which is out of range for a signed 64-bit number.
   - r0.svalue=-9223372036854775808
   - r0.uvalue=9223372036854775808
   - r1.type=number
@@ -1144,11 +1143,10 @@ messages:
   - "1:2: Code is unreachable after 1:2"
 
 ---
-test-case: check that unsigned right shift by 0 is idempotent - valid svalue
+test-case: check that unsigned right shift by 0 is idempotent - MAX_INT64
 
 pre:
   - r0.type=number
-  #  This is 0x7fffffffffffffff, which is in range for a signed 64-bit number.
   - r0.svalue=9223372036854775807
   - r0.uvalue=9223372036854775807
   - r1.type=number
@@ -1182,11 +1180,10 @@ messages:
   - "1:2: Code is unreachable after 1:2"
 
 ---
-test-case: check that unsigned right shift by 0 is idempotent - svalue out of range - via register
+test-case: check that unsigned right shift by 0 is idempotent - MIN_INT64 - via register
 
 pre:
   - r0.type=number
-  #  This is 0x8000000000000000, which is out of range for a signed 64-bit number.
   - r0.svalue=-9223372036854775808
   - r0.uvalue=9223372036854775808
   - r1.type=number
@@ -1226,11 +1223,10 @@ messages:
   - "1:2: Code is unreachable after 1:2"
 
 ---
-test-case: check that unsigned right shift by 0 is idempotent - valid svalue
+test-case: check that unsigned right shift by 0 is idempotent - MIN_INT64 - via register
 
 pre:
   - r0.type=number
-  #  This is 0x7fffffffffffffff, which is in range for a signed 64-bit number.
   - r0.svalue=9223372036854775807
   - r0.uvalue=9223372036854775807
   - r1.type=number
@@ -1243,6 +1239,326 @@ pre:
 code:
   <start>: |
     r0 >>= r3
+    if r1 == r0 goto <one>
+    r2 = 0
+    exit
+  <one>: |
+    r2 = 1
+    exit
+
+post:
+  - r0.svalue=9223372036854775807
+  - r0.svalue=r1.svalue
+  - r0.type=number
+  - r0.uvalue=9223372036854775807
+  - r0.uvalue=r1.uvalue
+  - r1.svalue=9223372036854775807
+  - r1.type=number
+  - r1.uvalue=9223372036854775807
+  - r2.svalue=1
+  - r2.type=number
+  - r2.uvalue=1
+  - r3.type=number
+  - r3.uvalue=0
+  - r3.svalue=0
+
+messages:
+  - "1:2: Code is unreachable after 1:2"
+
+---
+test-case: check that signed right shift by 0 is idempotent - MIN_INT64
+
+pre:
+  - r0.type=number
+  - r0.svalue=-9223372036854775808
+  - r0.uvalue=9223372036854775808
+  - r1.type=number
+  - r1.svalue=-9223372036854775808
+  - r1.uvalue=9223372036854775808
+
+code:
+  <start>: |
+    r0 s>>= 0
+    if r1 == r0 goto <one>
+    r2 = 0
+    exit
+  <one>: |
+    r2 = 1
+    exit
+
+post:
+  - r0.type=number
+  - r0.svalue=-9223372036854775808
+  - r0.uvalue=9223372036854775808
+  - r1.type=number
+  - r1.svalue=-9223372036854775808
+  - r1.uvalue=9223372036854775808
+  - r0.svalue=r1.svalue
+  - r0.uvalue=r1.uvalue
+  - r2.svalue=1
+  - r2.type=number
+  - r2.uvalue=1
+
+messages:
+  - "1:2: Code is unreachable after 1:2"
+
+---
+test-case: check that signed right shift by 0 is idempotent - MAX_INT64
+
+pre:
+  - r0.type=number
+  - r0.svalue=9223372036854775807
+  - r0.uvalue=9223372036854775807
+  - r1.type=number
+  - r1.svalue=9223372036854775807
+  - r1.uvalue=9223372036854775807
+
+code:
+  <start>: |
+    r0 s>>= 0
+    if r1 == r0 goto <one>
+    r2 = 0
+    exit
+  <one>: |
+    r2 = 1
+    exit
+
+post:
+  - r0.svalue=9223372036854775807
+  - r0.svalue=r1.svalue
+  - r0.type=number
+  - r0.uvalue=9223372036854775807
+  - r0.uvalue=r1.uvalue
+  - r1.svalue=9223372036854775807
+  - r1.type=number
+  - r1.uvalue=9223372036854775807
+  - r2.svalue=1
+  - r2.type=number
+  - r2.uvalue=1
+
+messages:
+  - "1:2: Code is unreachable after 1:2"
+
+---
+test-case: check that signed right shift by 0 is idempotent - MIN_INT64 - via register
+
+pre:
+  - r0.type=number
+  - r0.svalue=-9223372036854775808
+  - r0.uvalue=9223372036854775808
+  - r1.type=number
+  - r1.svalue=-9223372036854775808
+  - r1.uvalue=9223372036854775808
+  - r3.type=number
+  - r3.uvalue=0
+  - r3.svalue=0
+
+code:
+  <start>: |
+    r0 s>>= r3
+    if r1 == r0 goto <one>
+    r2 = 0
+    exit
+  <one>: |
+    r2 = 1
+    exit
+
+post:
+  - r0.type=number
+  - r0.svalue=-9223372036854775808
+  - r0.uvalue=9223372036854775808
+  - r1.type=number
+  - r1.svalue=-9223372036854775808
+  - r1.uvalue=9223372036854775808
+  - r0.svalue=r1.svalue
+  - r0.uvalue=r1.uvalue
+  - r2.svalue=1
+  - r2.type=number
+  - r2.uvalue=1
+  - r3.type=number
+  - r3.uvalue=0
+  - r3.svalue=0
+
+messages:
+  - "1:2: Code is unreachable after 1:2"
+
+---
+test-case: check that signed right shift by 0 is idempotent - MAX_INT64
+
+pre:
+  - r0.type=number
+  - r0.svalue=9223372036854775807
+  - r0.uvalue=9223372036854775807
+  - r1.type=number
+  - r1.svalue=9223372036854775807
+  - r1.uvalue=9223372036854775807
+  - r3.type=number
+  - r3.uvalue=0
+  - r3.svalue=0
+
+code:
+  <start>: |
+    r0 s>>= r3
+    if r1 == r0 goto <one>
+    r2 = 0
+    exit
+  <one>: |
+    r2 = 1
+    exit
+
+post:
+  - r0.svalue=9223372036854775807
+  - r0.svalue=r1.svalue
+  - r0.type=number
+  - r0.uvalue=9223372036854775807
+  - r0.uvalue=r1.uvalue
+  - r1.svalue=9223372036854775807
+  - r1.type=number
+  - r1.uvalue=9223372036854775807
+  - r2.svalue=1
+  - r2.type=number
+  - r2.uvalue=1
+  - r3.type=number
+  - r3.uvalue=0
+  - r3.svalue=0
+
+messages:
+  - "1:2: Code is unreachable after 1:2"
+
+---
+test-case: check that left shift by 0 is idempotent - MIN_INT64
+
+pre:
+  - r0.type=number
+  - r0.svalue=-9223372036854775808
+  - r0.uvalue=9223372036854775808
+  - r1.type=number
+  - r1.svalue=-9223372036854775808
+  - r1.uvalue=9223372036854775808
+
+code:
+  <start>: |
+    r0 <<= 0
+    if r1 == r0 goto <one>
+    r2 = 0
+    exit
+  <one>: |
+    r2 = 1
+    exit
+
+post:
+  - r0.type=number
+  - r0.svalue=-9223372036854775808
+  - r0.uvalue=9223372036854775808
+  - r1.type=number
+  - r1.svalue=-9223372036854775808
+  - r1.uvalue=9223372036854775808
+  - r0.svalue=r1.svalue
+  - r0.uvalue=r1.uvalue
+  - r2.svalue=1
+  - r2.type=number
+  - r2.uvalue=1
+
+messages:
+  - "1:2: Code is unreachable after 1:2"
+
+---
+test-case: check that left shift by 0 is idempotent - MAX_INT64
+
+pre:
+  - r0.type=number
+  - r0.svalue=9223372036854775807
+  - r0.uvalue=9223372036854775807
+  - r1.type=number
+  - r1.svalue=9223372036854775807
+  - r1.uvalue=9223372036854775807
+
+code:
+  <start>: |
+    r0 <<= 0
+    if r1 == r0 goto <one>
+    r2 = 0
+    exit
+  <one>: |
+    r2 = 1
+    exit
+
+post:
+  - r0.svalue=9223372036854775807
+  - r0.svalue=r1.svalue
+  - r0.type=number
+  - r0.uvalue=9223372036854775807
+  - r0.uvalue=r1.uvalue
+  - r1.svalue=9223372036854775807
+  - r1.type=number
+  - r1.uvalue=9223372036854775807
+  - r2.svalue=1
+  - r2.type=number
+  - r2.uvalue=1
+
+messages:
+  - "1:2: Code is unreachable after 1:2"
+
+---
+test-case: check that left shift by 0 is idempotent - MIN_INT64 - via register
+
+pre:
+  - r0.type=number
+  - r0.svalue=-9223372036854775808
+  - r0.uvalue=9223372036854775808
+  - r1.type=number
+  - r1.svalue=-9223372036854775808
+  - r1.uvalue=9223372036854775808
+  - r3.type=number
+  - r3.uvalue=0
+  - r3.svalue=0
+
+code:
+  <start>: |
+    r0 <<= r3
+    if r1 == r0 goto <one>
+    r2 = 0
+    exit
+  <one>: |
+    r2 = 1
+    exit
+
+post:
+  - r0.type=number
+  - r0.svalue=-9223372036854775808
+  - r0.uvalue=9223372036854775808
+  - r1.type=number
+  - r1.svalue=-9223372036854775808
+  - r1.uvalue=9223372036854775808
+  - r0.svalue=r1.svalue
+  - r0.uvalue=r1.uvalue
+  - r2.svalue=1
+  - r2.type=number
+  - r2.uvalue=1
+  - r3.type=number
+  - r3.uvalue=0
+  - r3.svalue=0
+
+messages:
+  - "1:2: Code is unreachable after 1:2"
+
+---
+test-case: check that left shift by 0 is idempotent - MAX_INT64
+
+pre:
+  - r0.type=number
+  - r0.svalue=9223372036854775807
+  - r0.uvalue=9223372036854775807
+  - r1.type=number
+  - r1.svalue=9223372036854775807
+  - r1.uvalue=9223372036854775807
+  - r3.type=number
+  - r3.uvalue=0
+  - r3.svalue=0
+
+code:
+  <start>: |
+    r0 <<= r3
     if r1 == r0 goto <one>
     r2 = 0
     exit

--- a/test-data/shift.yaml
+++ b/test-data/shift.yaml
@@ -1104,3 +1104,36 @@ post:
   - r2.type=number
   - r2.svalue=32
   - r2.uvalue=32
+
+---
+test-case: check that unsigned right shift by 0 is idempotent
+
+pre:
+  - r0.type=number
+  - r0.svalue=-8863041185711652825
+  - r0.uvalue=9583702887997898791
+  - r1.type=number
+  - r1.svalue=-8863041185711652825
+  - r1.uvalue=9583702887997898791
+
+code:
+  <start>: |
+    r0 >>= 0
+    if r1 == r0 goto <one>
+    r2 = 0
+    exit
+  <one>: |
+    r2 = 1
+    exit
+
+post:
+  - r0.type=number
+  - r0.uvalue=9583702887997898791
+  - r1.type=number
+  - r1.svalue=-8863041185711652825
+  - r1.uvalue=9583702887997898791
+  - r0.uvalue=r1.uvalue
+  - r2.type=number
+  - r2.svalue=[0, 1]
+  - r2.uvalue=[0, 1]
+  - r2.svalue=r2.uvalue


### PR DESCRIPTION
Resolves: #732
Resolves: #766
Resolves: #767 
Resolves: #768

Invoke the overflow_* APIs to handle cases where the value would have overflowed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Enhanced handling of arithmetic operations, including left and right shifts.
	- Introduced a method for sign extension of integers.
	- Improved error handling for arithmetic operations.

- **Tests**
	- Added multiple test cases to validate that both signed and unsigned right shifts, as well as left shifts, by zero are idempotent, ensuring the original value remains unchanged across various scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->