### PR TITLE
Fix ebpf_base.h usability in C

### DIFF
--- a/src/ebpf_base.h
+++ b/src/ebpf_base.h
@@ -40,11 +40,11 @@ typedef struct _ebpf_context_descriptor {
 
 // Maximum number of nested function calls allowed in eBPF programs.
 // This limit helps prevent stack overflow and ensures predictable behavior.
-constexpr int MAX_CALL_STACK_FRAMES = 8;
+#define MAX_CALL_STACK_FRAMES 8
 
 // Stack space allocated for each subprogram (in bytes).
 // This ensures each function call has its own dedicated stack space.
-constexpr int EBPF_SUBPROGRAM_STACK_SIZE = 512;
+#define EBPF_SUBPROGRAM_STACK_SIZE 512
 
 // Total stack space usable with nested subprogram calls.
-constexpr int EBPF_TOTAL_STACK_SIZE = MAX_CALL_STACK_FRAMES * EBPF_SUBPROGRAM_STACK_SIZE;
+#define EBPF_TOTAL_STACK_SIZE (MAX_CALL_STACK_FRAMES * EBPF_SUBPROGRAM_STACK_SIZE)


### PR DESCRIPTION
ebpf_base.h says at the top:
> // This file contains type definitions that can be used in C or C++
> // that would typically be shared between the verifier and other
> // eBPF components.

However, PR #721 added some "constexpr int" lines at the end which
of course don't work with C files.  This PR corrects that by using
`#define` instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated constant declarations for improved compatibility and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->