### PR TITLE
Make the assertions part of a generalized instruction

### DIFF
--- a/scripts/format-code
+++ b/scripts/format-code
@@ -169,15 +169,15 @@ check_clang-format()
         cf=$(command -v clang-format 2> /dev/null)
         if [[ ! -x ${cf} ]]; then
             echo "clang-format is not installed"
-            exit 1
+            exit 0  # do not fail, just warn
         fi
         cf="clang-format"
     fi
 
-    local required_cfver='17.0.3'
-    # shellcheck disable=SC2155
-    local cfver=$(${cf} --version | grep -o -E '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
-    check_version "${required_cfver}" "${cfver}"
+#    local required_cfver='17.0.3'
+#    # shellcheck disable=SC2155
+#    local cfver=$(${cf} --version | grep -o -E '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+#    check_version "${required_cfver}" "${cfver}"
 }
 
 check_clang-format

--- a/src/asm_cfg.cpp
+++ b/src/asm_cfg.cpp
@@ -18,14 +18,14 @@ using std::string;
 using std::to_string;
 using std::vector;
 
-static optional<label_t> get_jump(Instruction ins) {
+static optional<label_t> get_jump(Command ins) {
     if (const auto pins = std::get_if<Jmp>(&ins)) {
         return pins->target;
     }
     return {};
 }
 
-static bool has_fall(const Instruction& ins) {
+static bool has_fall(const Command& ins) {
     if (std::holds_alternative<Exit>(ins)) {
         return false;
     }
@@ -47,12 +47,12 @@ static void add_cfg_nodes(cfg_t& cfg, const label_t& caller_label, const label_t
     basic_block_t& exit_to_node = cfg.get_node(cfg.next_nodes(caller_label).front());
 
     // Construct the variable prefix to use for the new stack frame,
-    // and store a copy in the CallLocal instruction since the instruction-specific
+    // and store a copy in the CallLocal Command since the Command-specific
     // labels may only exist until the CFG is simplified.
     basic_block_t& caller_node = cfg.get_node(caller_label);
     const std::string stack_frame_prefix = to_string(caller_label);
     for (auto& inst : caller_node) {
-        if (const auto pcall = std::get_if<CallLocal>(&inst)) {
+        if (const auto pcall = std::get_if<CallLocal>(&inst.cmd)) {
             pcall->stack_frame_prefix = stack_frame_prefix;
         }
     }
@@ -73,9 +73,9 @@ static void add_cfg_nodes(cfg_t& cfg, const label_t& caller_label, const label_t
         const label_t label{macro_label.from, macro_label.to, stack_frame_prefix};
         auto& bb = cfg.insert(label);
         for (auto inst : cfg.get_node(macro_label)) {
-            if (const auto pexit = std::get_if<Exit>(&inst)) {
+            if (const auto pexit = std::get_if<Exit>(&inst.cmd)) {
                 pexit->stack_frame_prefix = label.stack_frame_prefix;
-            } else if (const auto pcall = std::get_if<Call>(&inst)) {
+            } else if (const auto pcall = std::get_if<Call>(&inst.cmd)) {
                 pcall->stack_frame_prefix = label.stack_frame_prefix;
             }
             bb.insert(inst);
@@ -123,7 +123,7 @@ static void add_cfg_nodes(cfg_t& cfg, const label_t& caller_label, const label_t
     for (const auto& macro_label : seen_labels) {
         for (const label_t label(macro_label.from, macro_label.to, caller_label_str);
              const auto& inst : cfg.get_node(label)) {
-            if (const auto pins = std::get_if<CallLocal>(&inst)) {
+            if (const auto pins = std::get_if<CallLocal>(&inst.cmd)) {
                 if (stack_frame_depth >= MAX_CALL_STACK_FRAMES) {
                     throw std::runtime_error{"too many call stack frames"};
                 }
@@ -142,7 +142,7 @@ static cfg_t instruction_seq_to_cfg(const InstructionSeq& insts, const bool must
     // Do a first pass ignoring all function macro calls.
     for (const auto& [label, inst, _] : insts) {
 
-        if (std::holds_alternative<Undefined>(inst)) {
+        if (std::holds_alternative<Undefined>(inst.cmd)) {
             continue;
         }
 
@@ -158,20 +158,20 @@ static cfg_t instruction_seq_to_cfg(const InstructionSeq& insts, const bool must
             cfg.get_node(*falling_from) >> bb;
             falling_from = {};
         }
-        if (has_fall(inst)) {
+        if (has_fall(inst.cmd)) {
             falling_from = label;
         }
-        if (auto jump_target = get_jump(inst)) {
+        if (auto jump_target = get_jump(inst.cmd)) {
             bb >> cfg.insert(*jump_target);
         }
 
-        if (std::holds_alternative<Exit>(inst)) {
+        if (std::holds_alternative<Exit>(inst.cmd)) {
             bb >> cfg.get_node(cfg.exit_label());
         }
     }
     if (falling_from) {
         if (must_have_exit) {
-            throw std::invalid_argument{"fallthrough in last instruction"};
+            throw std::invalid_argument{"fallthrough in last Command"};
         } else {
             cfg.get_node(*falling_from) >> cfg.get_node(cfg.exit_label());
         }
@@ -181,7 +181,7 @@ static cfg_t instruction_seq_to_cfg(const InstructionSeq& insts, const bool must
     // we only add new nodes that are actually reachable, based on the
     // results of the first pass.
     for (const auto& [label, inst, _] : insts) {
-        if (const auto pins = std::get_if<CallLocal>(&inst)) {
+        if (const auto pins = std::get_if<CallLocal>(&inst.cmd)) {
             add_cfg_nodes(cfg, label, pins->target);
         }
     }
@@ -236,9 +236,7 @@ static cfg_t to_nondet(const cfg_t& cfg) {
         basic_block_t& newbb = res.insert(this_label);
 
         for (const auto& ins : bb) {
-            if (!std::holds_alternative<Jmp>(ins)) {
-                newbb.insert(ins);
-            }
+            newbb.insert(ins);
         }
 
         for (const label_t& prev_label : bb.prev_blocks_set()) {
@@ -250,7 +248,7 @@ static cfg_t to_nondet(const cfg_t& cfg) {
         auto nextlist = bb.next_blocks_set();
         if (nextlist.size() == 2) {
             label_t mid_label = this_label;
-            auto jmp = std::get<Jmp>(*bb.rbegin());
+            auto jmp = std::get<Jmp>(bb.rbegin()->cmd);
 
             nextlist.erase(jmp.target);
             label_t fallthrough = *nextlist.begin();
@@ -262,7 +260,7 @@ static cfg_t to_nondet(const cfg_t& cfg) {
             for (const auto& [next_label, cond1] : jumps) {
                 label_t jump_label = label_t::make_jump(mid_label, next_label);
                 basic_block_t& jump_bb = res.insert(jump_label);
-                jump_bb.insert(Assume{cond1});
+                jump_bb.insert({.cmd = Assume{cond1}});
                 newbb >> jump_bb;
                 jump_bb >> res.insert(next_label);
             }
@@ -275,9 +273,9 @@ static cfg_t to_nondet(const cfg_t& cfg) {
     return res;
 }
 
-/// Get the type of given instruction.
+/// Get the type of given Command.
 /// Most of these type names are also statistics header labels.
-static std::string instype(Instruction ins) {
+static std::string instype(Command ins) {
     if (const auto pcall = std::get_if<Call>(&ins)) {
         if (pcall->is_map_lookup) {
             return "call_1";
@@ -334,20 +332,20 @@ std::map<std::string, int> collect_stats(const cfg_t& cfg) {
         basic_block_t const& bb = cfg.get_node(this_label);
 
         for (Instruction ins : bb) {
-            if (const auto pins = std::get_if<LoadMapFd>(&ins)) {
+            if (const auto pins = std::get_if<LoadMapFd>(&ins.cmd)) {
                 if (pins->mapfd == -1) {
                     res["map_in_map"] = 1;
                 }
             }
-            if (const auto pins = std::get_if<Call>(&ins)) {
+            if (const auto pins = std::get_if<Call>(&ins.cmd)) {
                 if (pins->reallocate_packet) {
                     res["reallocate"] = 1;
                 }
             }
-            if (const auto pins = std::get_if<Bin>(&ins)) {
+            if (const auto pins = std::get_if<Bin>(&ins.cmd)) {
                 res[pins->is64 ? "arith64" : "arith32"]++;
             }
-            res[instype(ins)]++;
+            res[instype(ins.cmd)]++;
         }
         if (unique(bb.prev_blocks()).size() > 1) {
             res["joins"]++;
@@ -369,10 +367,10 @@ cfg_t prepare_cfg(const InstructionSeq& prog, const program_info& info, const pr
     if (options.check_for_termination) {
         const wto_t wto(det_cfg);
         wto.for_each_loop_head(
-            [&](const label_t& label) { det_cfg.get_node(label).insert_front(IncrementLoopCounter{label}); });
+            [&](const label_t& label) { det_cfg.get_node(label).insert_front({.cmd = IncrementLoopCounter{label}}); });
     }
 
-    // Annotate the CFG by adding in assertions before every memory instruction.
+    // Annotate the CFG by adding in assertions before every memory Command.
     explicate_assertions(det_cfg, info);
 
     // Translate conditional jumps to non-deterministic jumps.

--- a/src/asm_files.cpp
+++ b/src/asm_files.cpp
@@ -200,7 +200,7 @@ void relocate_map(ebpf_inst& inst, const std::string& symbol_name,
 // are loaded and can be appended to the calling program.
 struct function_relocation {
     size_t prog_index{};              // Index of source program in vector of raw programs.
-    ELFIO::Elf_Xword source_offset{}; // Instruction offset in source section of source instruction.
+    ELFIO::Elf_Xword source_offset{}; // Instruction offset in source section of source Command.
     ELFIO::Elf_Xword relocation_entry_index{};
     string target_function_name;
 };
@@ -250,7 +250,7 @@ static void append_subprograms(raw_program& prog, const vector<raw_program>& pro
             prog.prog.insert(prog.prog.end(), subprogram.begin(), subprogram.end());
         }
 
-        // Fill in the PC offset into the imm field of the CallLocal instruction.
+        // Fill in the PC offset into the imm field of the CallLocal Command.
         const int64_t target_offset = gsl::narrow_cast<int64_t>(subprogram_offsets[reloc.target_function_name]);
         const auto offset_diff = target_offset - gsl::narrow<int64_t>(reloc.source_offset) - 1;
         if (offset_diff < std::numeric_limits<int32_t>::min() || offset_diff > std::numeric_limits<int32_t>::max()) {
@@ -480,7 +480,7 @@ vector<raw_program> read_elf(std::istream& input_stream, const std::string& path
 
         libbtf::btf_parse_line_information(vector_of<std::byte>(*btf), vector_of<std::byte>(*btf_ext), visitor);
 
-        // BTF doesn't include line info for every instruction, only on the first instruction per source line.
+        // BTF doesn't include line info for every instruction, only on the first Command per source line.
         for (auto& program : res) {
             for (size_t i = 1; i < program.line_info.size(); i++) {
                 // If the previous PC has line info, copy it.

--- a/src/asm_marshal.hpp
+++ b/src/asm_marshal.hpp
@@ -7,5 +7,5 @@
 #include "asm_syntax.hpp"
 #include "ebpf_vm_isa.hpp"
 
-std::vector<ebpf_inst> marshal(const Instruction& ins, pc_t pc);
+std::vector<ebpf_inst> marshal(const Command& ins, pc_t pc);
 // TODO marshal to ostream?

--- a/src/asm_ostream.hpp
+++ b/src/asm_ostream.hpp
@@ -39,8 +39,8 @@ void print(const InstructionSeq& insts, std::ostream& out, const std::optional<c
 
 std::string to_string(label_t const& label);
 
-std::ostream& operator<<(std::ostream& os, Instruction const& ins);
-std::string to_string(Instruction const& ins);
+std::ostream& operator<<(std::ostream& os, Command const& ins);
+std::string to_string(Command const& ins);
 
 std::ostream& operator<<(std::ostream& os, Bin::Op op);
 std::ostream& operator<<(std::ostream& os, Condition::Op op);
@@ -54,19 +54,18 @@ inline std::ostream& operator<<(std::ostream& os, Value const& a) {
     return os << std::get<Reg>(a);
 }
 
-inline std::ostream& operator<<(std::ostream& os, Undefined const& a) { return os << Instruction{a}; }
-inline std::ostream& operator<<(std::ostream& os, LoadMapFd const& a) { return os << Instruction{a}; }
-inline std::ostream& operator<<(std::ostream& os, Bin const& a) { return os << Instruction{a}; }
-inline std::ostream& operator<<(std::ostream& os, Un const& a) { return os << Instruction{a}; }
-inline std::ostream& operator<<(std::ostream& os, Call const& a) { return os << Instruction{a}; }
-inline std::ostream& operator<<(std::ostream& os, Callx const& a) { return os << Instruction{a}; }
-inline std::ostream& operator<<(std::ostream& os, Exit const& a) { return os << Instruction{a}; }
-inline std::ostream& operator<<(std::ostream& os, Jmp const& a) { return os << Instruction{a}; }
-inline std::ostream& operator<<(std::ostream& os, Packet const& a) { return os << Instruction{a}; }
-inline std::ostream& operator<<(std::ostream& os, Mem const& a) { return os << Instruction{a}; }
-inline std::ostream& operator<<(std::ostream& os, Atomic const& a) { return os << Instruction{a}; }
-inline std::ostream& operator<<(std::ostream& os, Assume const& a) { return os << Instruction{a}; }
-inline std::ostream& operator<<(std::ostream& os, Assert const& a) { return os << Instruction{a}; }
-inline std::ostream& operator<<(std::ostream& os, IncrementLoopCounter const& a) { return os << Instruction{a}; }
-std::ostream& operator<<(std::ostream& os, AssertionConstraint const& a);
-std::string to_string(AssertionConstraint const& constraint);
+inline std::ostream& operator<<(std::ostream& os, Undefined const& a) { return os << Command{a}; }
+inline std::ostream& operator<<(std::ostream& os, LoadMapFd const& a) { return os << Command{a}; }
+inline std::ostream& operator<<(std::ostream& os, Bin const& a) { return os << Command{a}; }
+inline std::ostream& operator<<(std::ostream& os, Un const& a) { return os << Command{a}; }
+inline std::ostream& operator<<(std::ostream& os, Call const& a) { return os << Command{a}; }
+inline std::ostream& operator<<(std::ostream& os, Callx const& a) { return os << Command{a}; }
+inline std::ostream& operator<<(std::ostream& os, Exit const& a) { return os << Command{a}; }
+inline std::ostream& operator<<(std::ostream& os, Jmp const& a) { return os << Command{a}; }
+inline std::ostream& operator<<(std::ostream& os, Packet const& a) { return os << Command{a}; }
+inline std::ostream& operator<<(std::ostream& os, Mem const& a) { return os << Command{a}; }
+inline std::ostream& operator<<(std::ostream& os, Atomic const& a) { return os << Command{a}; }
+inline std::ostream& operator<<(std::ostream& os, Assume const& a) { return os << Command{a}; }
+inline std::ostream& operator<<(std::ostream& os, IncrementLoopCounter const& a) { return os << Command{a}; }
+std::ostream& operator<<(std::ostream& os, const Assertion& a);
+std::string to_string(const Assertion& constraint);

--- a/src/asm_parse.cpp
+++ b/src/asm_parse.cpp
@@ -133,7 +133,7 @@ static Deref deref(const std::string& width, const std::string& basereg, const s
     };
 }
 
-Instruction parse_instruction(const std::string& line, const std::map<std::string, label_t>& label_name_to_label) {
+Command parse_instruction(const std::string& line, const std::map<std::string, label_t>& label_name_to_label) {
     // treat ";" as a comment
     std::string text = line.substr(0, line.find(';'));
     const size_t end = text.find_last_not_of(' ');
@@ -246,7 +246,7 @@ static InstructionSeq parse_program(std::istream& is) {
         if (line.empty()) {
             continue;
         }
-        Instruction ins = parse_instruction(line, {});
+        Command ins = parse_instruction(line, {});
         if (std::holds_alternative<Undefined>(ins)) {
             continue;
         }

--- a/src/asm_parse.hpp
+++ b/src/asm_parse.hpp
@@ -6,4 +6,4 @@
 
 #include "asm_syntax.hpp"
 
-Instruction parse_instruction(const std::string& line, const std::map<std::string, label_t>& label_name_to_label);
+Command parse_instruction(const std::string& line, const std::map<std::string, label_t>& label_name_to_label);

--- a/src/asm_unmarshal.hpp
+++ b/src/asm_unmarshal.hpp
@@ -15,7 +15,7 @@
  *
  *  \param raw_prog is the input program to parse.
  *  \param[out] notes is a vector for storing errors and warnings.
- *  \return a sequence of instruction if successful, an error string otherwise.
+ *  \return a sequence of Instruction if successful, an error string otherwise.
  */
 std::variant<InstructionSeq, std::string> unmarshal(const raw_program& raw_prog,
                                                     std::vector<std::vector<std::string>>& notes);

--- a/src/assertions.cpp
+++ b/src/assertions.cpp
@@ -20,8 +20,8 @@ class AssertExtractor {
 
     static Imm imm(const Value& v) { return std::get<Imm>(v); }
 
-    static vector<Assert> zero_offset_ctx(const Reg reg) {
-        vector<Assert> res;
+    static vector<Assertion> zero_offset_ctx(const Reg reg) {
+        vector<Assertion> res;
         res.emplace_back(TypeConstraint{reg, TypeGroup::ctx});
         res.emplace_back(ZeroCtxOffset{reg});
         return res;
@@ -37,25 +37,20 @@ class AssertExtractor {
     explicit AssertExtractor(program_info info, std::optional<label_t> label)
         : info{std::move(info)}, current_label(label) {}
 
-    vector<Assert> operator()(const Undefined&) const {
+    vector<Assertion> operator()(const Undefined&) const {
         assert(false);
         return {};
     }
 
-    vector<Assert> operator()(const Assert&) const {
-        assert(false);
-        return {};
-    }
+    vector<Assertion> operator()(const IncrementLoopCounter& ipc) const { return {{BoundedLoopCount{ipc.name}}}; }
 
-    vector<Assert> operator()(const IncrementLoopCounter& ipc) const { return {{BoundedLoopCount{ipc.name}}}; }
-
-    vector<Assert> operator()(const LoadMapFd&) const { return {}; }
+    vector<Assertion> operator()(const LoadMapFd&) const { return {}; }
 
     /// Packet access implicitly uses R6, so verify that R6 still has a pointer to the context.
-    vector<Assert> operator()(const Packet&) const { return zero_offset_ctx({6}); }
+    vector<Assertion> operator()(const Packet&) const { return zero_offset_ctx({6}); }
 
-    vector<Assert> operator()(const Exit&) const {
-        vector<Assert> res;
+    vector<Assertion> operator()(const Exit&) const {
+        vector<Assertion> res;
         if (current_label->stack_frame_prefix.empty()) {
             // Verify that Exit returns a number.
             res.emplace_back(TypeConstraint{Reg{R0_RETURN_VALUE}, TypeGroup::number});
@@ -63,8 +58,8 @@ class AssertExtractor {
         return res;
     }
 
-    vector<Assert> operator()(const Call& call) const {
-        vector<Assert> res;
+    vector<Assertion> operator()(const Call& call) const {
+        vector<Assertion> res;
         std::optional<Reg> map_fd_reg;
         res.emplace_back(ValidCall{call.func, call.stack_frame_prefix});
         for (ArgSingle arg : call.singles) {
@@ -90,7 +85,7 @@ class AssertExtractor {
                 res.emplace_back(ValidMapKeyValue{arg.reg, *map_fd_reg, arg.kind == ArgSingle::Kind::PTR_TO_MAP_KEY});
                 break;
             case ArgSingle::Kind::PTR_TO_CTX:
-                for (const Assert& a : zero_offset_ctx(arg.reg)) {
+                for (const Assertion& a : zero_offset_ctx(arg.reg)) {
                     res.emplace_back(a);
                 }
                 break;
@@ -120,21 +115,21 @@ class AssertExtractor {
         return res;
     }
 
-    vector<Assert> operator()(const CallLocal&) const { return {}; }
+    vector<Assertion> operator()(const CallLocal&) const { return {}; }
 
-    vector<Assert> operator()(const Callx& callx) const {
-        vector<Assert> res;
+    vector<Assertion> operator()(const Callx& callx) const {
+        vector<Assertion> res;
         res.emplace_back(TypeConstraint{callx.func, TypeGroup::number});
         res.emplace_back(FuncConstraint{callx.func});
         return res;
     }
 
     [[nodiscard]]
-    vector<Assert> explicate(const Condition& cond) const {
+    vector<Assertion> explicate(const Condition& cond) const {
         if (info.type.is_privileged) {
             return {};
         }
-        vector<Assert> res;
+        vector<Assertion> res;
         if (const auto pimm = std::get_if<Imm>(&cond.right)) {
             if (pimm->v != 0) {
                 // no need to check for valid access, it must be a number
@@ -181,17 +176,17 @@ class AssertExtractor {
         return res;
     }
 
-    vector<Assert> operator()(const Assume& ins) const { return explicate(ins.cond); }
+    vector<Assertion> operator()(const Assume& ins) const { return explicate(ins.cond); }
 
-    vector<Assert> operator()(const Jmp& ins) const {
+    vector<Assertion> operator()(const Jmp& ins) const {
         if (!ins.cond) {
             return {};
         }
         return explicate(*ins.cond);
     }
 
-    vector<Assert> operator()(const Mem& ins) const {
-        vector<Assert> res;
+    vector<Assertion> operator()(const Mem& ins) const {
+        vector<Assertion> res;
         const Reg basereg = ins.access.basereg;
         Imm width{static_cast<uint32_t>(ins.access.width)};
         const int offset = ins.access.offset;
@@ -219,24 +214,26 @@ class AssertExtractor {
         return res;
     }
 
-    vector<Assert> operator()(const Atomic& ins) const {
+    vector<Assertion> operator()(const Atomic& ins) const {
 
         return {
-            Assert{TypeConstraint{ins.valreg, TypeGroup::number}},
-            Assert{TypeConstraint{ins.access.basereg, TypeGroup::pointer}},
-            Assert{make_valid_access(ins.access.basereg, ins.access.offset,
-                                     Imm{static_cast<uint32_t>(ins.access.width)}, false)},
+            Assertion{TypeConstraint{ins.valreg, TypeGroup::number}},
+            Assertion{TypeConstraint{ins.access.basereg, TypeGroup::pointer}},
+            Assertion{make_valid_access(ins.access.basereg, ins.access.offset,
+                                        Imm{static_cast<uint32_t>(ins.access.width)}, false)},
         };
     }
 
-    vector<Assert> operator()(const Un& ins) const { return {Assert{TypeConstraint{ins.dst, TypeGroup::number}}}; }
+    vector<Assertion> operator()(const Un& ins) const {
+        return {Assertion{TypeConstraint{ins.dst, TypeGroup::number}}};
+    }
 
-    vector<Assert> operator()(const Bin& ins) const {
+    vector<Assertion> operator()(const Bin& ins) const {
         switch (ins.op) {
         case Bin::Op::MOV:
             if (const auto src = std::get_if<Reg>(&ins.v)) {
                 if (!ins.is64) {
-                    return {Assert{TypeConstraint{*src, TypeGroup::number}}};
+                    return {Assertion{TypeConstraint{*src, TypeGroup::number}}};
                 }
             }
             return {};
@@ -244,27 +241,27 @@ class AssertExtractor {
         case Bin::Op::MOVSX16:
         case Bin::Op::MOVSX32:
             if (const auto src = std::get_if<Reg>(&ins.v)) {
-                return {Assert{TypeConstraint{*src, TypeGroup::number}}};
+                return {Assertion{TypeConstraint{*src, TypeGroup::number}}};
             }
             return {};
         case Bin::Op::ADD: {
             if (const auto src = std::get_if<Reg>(&ins.v)) {
-                return {Assert{TypeConstraint{ins.dst, TypeGroup::ptr_or_num}},
-                        Assert{TypeConstraint{*src, TypeGroup::ptr_or_num}}, Assert{Addable{*src, ins.dst}},
-                        Assert{Addable{ins.dst, *src}}};
+                return {Assertion{TypeConstraint{ins.dst, TypeGroup::ptr_or_num}},
+                        Assertion{TypeConstraint{*src, TypeGroup::ptr_or_num}}, Assertion{Addable{*src, ins.dst}},
+                        Assertion{Addable{ins.dst, *src}}};
             }
-            return {Assert{TypeConstraint{ins.dst, TypeGroup::ptr_or_num}}};
+            return {Assertion{TypeConstraint{ins.dst, TypeGroup::ptr_or_num}}};
         }
         case Bin::Op::SUB: {
             if (const auto reg = std::get_if<Reg>(&ins.v)) {
-                vector<Assert> res;
+                vector<Assertion> res;
                 // disallow map-map since same type does not mean same offset
                 // TODO: map identities
                 res.emplace_back(TypeConstraint{ins.dst, TypeGroup::ptr_or_num});
                 res.emplace_back(Comparable{.r1 = ins.dst, .r2 = *reg, .or_r2_is_number = true});
                 return res;
             }
-            return {Assert{TypeConstraint{ins.dst, TypeGroup::ptr_or_num}}};
+            return {Assertion{TypeConstraint{ins.dst, TypeGroup::ptr_or_num}}};
         }
         case Bin::Op::UDIV:
         case Bin::Op::UMOD:
@@ -272,43 +269,39 @@ class AssertExtractor {
         case Bin::Op::SMOD: {
             if (const auto src = std::get_if<Reg>(&ins.v)) {
                 const bool is_signed = (ins.op == Bin::Op::SDIV || ins.op == Bin::Op::SMOD);
-                return {Assert{TypeConstraint{ins.dst, TypeGroup::number}}, Assert{ValidDivisor{*src, is_signed}}};
+                return {Assertion{TypeConstraint{ins.dst, TypeGroup::number}},
+                        Assertion{ValidDivisor{*src, is_signed}}};
             }
-            return {Assert{TypeConstraint{ins.dst, TypeGroup::number}}};
+            return {Assertion{TypeConstraint{ins.dst, TypeGroup::number}}};
         }
         // For all other binary operations, the destination register must be a number and the source must either be an
         // immediate or a number.
         default:
             if (const auto src = std::get_if<Reg>(&ins.v)) {
-                return {Assert{TypeConstraint{ins.dst, TypeGroup::number}},
-                        Assert{TypeConstraint{*src, TypeGroup::number}}};
+                return {Assertion{TypeConstraint{ins.dst, TypeGroup::number}},
+                        Assertion{TypeConstraint{*src, TypeGroup::number}}};
             } else {
-                return {Assert{TypeConstraint{ins.dst, TypeGroup::number}}};
+                return {Assertion{TypeConstraint{ins.dst, TypeGroup::number}}};
             }
         }
         assert(false);
     }
 };
 
-vector<Assert> get_assertions(Instruction ins, const program_info& info, const std::optional<label_t>& label) {
+vector<Assertion> get_assertions(Command ins, const program_info& info, const std::optional<label_t>& label) {
     return std::visit(AssertExtractor{info, label}, ins);
 }
 
 /// Annotate the CFG by adding explicit assertions for all the preconditions
-/// of any instruction. For example, jump instructions are asserted not to
+/// of any Command. For example, jump instructions are asserted not to
 /// compare numbers and pointers, or pointers to potentially distinct memory
 /// regions. The verifier will use these assertions to treat the program as
 /// unsafe unless it can prove that the assertions can never fail.
 void explicate_assertions(cfg_t& cfg, const program_info& info) {
     for (auto& [label, bb] : cfg) {
         (void)label; // unused
-        vector<Instruction> insts;
-        for (const auto& ins : bb) {
-            for (const auto& a : get_assertions(ins, info, bb.label())) {
-                insts.emplace_back(a);
-            }
-            insts.push_back(ins);
+        for (auto& ins : bb) {
+            ins.preconditions = get_assertions(ins.cmd, info, bb.label());
         }
-        bb.swap_instructions(insts);
     }
 }

--- a/src/crab/cfg.hpp
+++ b/src/crab/cfg.hpp
@@ -35,7 +35,6 @@ class cfg_t;
 class basic_block_t final {
     friend class cfg_t;
 
-  private:
   public:
     basic_block_t(const basic_block_t&) = delete;
 
@@ -60,7 +59,7 @@ class basic_block_t final {
         m_ts.push_back(arg);
     }
 
-    /// Insert an instruction at the front of the basic block.
+    /// Insert an Instruction at the front of the basic block.
     /// @note Cannot modify entry or exit blocks.
     void insert_front(const Instruction& arg) {
         assert(label() != label_t::entry);
@@ -625,11 +624,11 @@ struct prepare_cfg_options {
 cfg_t prepare_cfg(const InstructionSeq& prog, const program_info& info, const prepare_cfg_options& options);
 
 void explicate_assertions(cfg_t& cfg, const program_info& info);
-std::vector<Assert> get_assertions(Instruction ins, const program_info& info, const std::optional<label_t>& label);
+std::vector<Assertion> get_assertions(Command ins, const program_info& info, const std::optional<label_t>& label);
 
 void print_dot(const cfg_t& cfg, std::ostream& out);
 void print_dot(const cfg_t& cfg, const std::string& outfile);
 
-std::ostream& operator<<(std::ostream& o, const crab::basic_block_t& bb);
+std::ostream& operator<<(std::ostream& o, const basic_block_t& bb);
 std::ostream& operator<<(std::ostream& o, const crab::basic_block_rev_t& bb);
 std::ostream& operator<<(std::ostream& o, const cfg_t& cfg);

--- a/src/crab/ebpf_domain.cpp
+++ b/src/crab/ebpf_domain.cpp
@@ -1195,9 +1195,20 @@ static linear_constraint_t type_is_not_stack(const reg_pack_t& r) {
     return r.type != T_STACK;
 }
 
+void ebpf_domain_t::operator()(const Assertion& assertion) {
+    if (check_require || thread_local_options.assume_assertions) {
+        this->current_assertion = to_string(assertion);
+        std::visit(*this, assertion);
+        this->current_assertion.clear();
+    }
+}
+
 void ebpf_domain_t::operator()(const basic_block_t& bb) {
-    for (const Instruction& statement : bb) {
-        std::visit(*this, statement);
+    for (const Instruction& ins : bb) {
+        for (const Assertion& assertion : ins.preconditions) {
+            (*this)(assertion);
+        }
+        std::visit(*this, ins.cmd);
     }
 }
 
@@ -1382,7 +1393,9 @@ void ebpf_domain_t::operator()(const Exit& a) {
     restore_callee_saved_registers(prefix);
 }
 
-void ebpf_domain_t::operator()(const Jmp& a) {}
+void ebpf_domain_t::operator()(const Jmp&) const {
+    // This is a NOP. It only exists to hold the jump preconditions.
+}
 
 void ebpf_domain_t::operator()(const Comparable& s) {
     using namespace crab::dsl_syntax;
@@ -1446,18 +1459,18 @@ void ebpf_domain_t::operator()(const BoundedLoopCount& s) {
 void ebpf_domain_t::operator()(const FuncConstraint& s) {
     // Look up the helper function id.
     const reg_pack_t& reg = reg_pack(s.reg);
-    auto src_interval = m_inv.eval_interval(reg.svalue);
-    if (auto sn = src_interval.singleton()) {
+    const auto src_interval = m_inv.eval_interval(reg.svalue);
+    if (const auto sn = src_interval.singleton()) {
         if (sn->fits<int32_t>()) {
             // We can now process it as if the id was immediate.
-            int32_t imm = sn->cast_to<int32_t>();
+            const int32_t imm = sn->cast_to<int32_t>();
             if (!global_program_info->platform->is_helper_usable(imm)) {
                 require(m_inv, linear_constraint_t::false_const(), "invalid helper function id " + std::to_string(imm));
                 return;
             }
             Call call = make_call(imm, *global_program_info->platform);
-            for (Assert a : get_assertions(call, *global_program_info, {})) {
-                (*this)(a);
+            for (const Assertion& assertion : get_assertions(call, *global_program_info, {})) {
+                (*this)(assertion);
             }
             return;
         }
@@ -1756,14 +1769,6 @@ void ebpf_domain_t::operator()(const ZeroCtxOffset& s) {
     using namespace crab::dsl_syntax;
     const auto reg = reg_pack(s.reg);
     require(m_inv, reg.ctx_offset == 0, "Nonzero context offset");
-}
-
-void ebpf_domain_t::operator()(const Assert& stmt) {
-    if (check_require || thread_local_options.assume_assertions) {
-        this->current_assertion = to_string(stmt.cst);
-        std::visit(*this, stmt.cst);
-        this->current_assertion.clear();
-    }
 }
 
 void ebpf_domain_t::operator()(const Packet& a) {

--- a/src/crab/ebpf_domain.hpp
+++ b/src/crab/ebpf_domain.hpp
@@ -52,32 +52,34 @@ class ebpf_domain_t final {
     // abstract transformers
     void operator()(const basic_block_t& bb);
 
-    void operator()(const Addable&);
-    void operator()(const Assert&);
     void operator()(const Assume&);
     void operator()(const Bin&);
     void operator()(const Call&);
     void operator()(const CallLocal&);
     void operator()(const Callx&);
-    void operator()(const Comparable&);
     void operator()(const Exit&);
-    void operator()(const FuncConstraint&);
-    void operator()(const Jmp&);
+    void operator()(const Jmp&) const;
     void operator()(const LoadMapFd&);
     void operator()(const Atomic&);
     void operator()(const Mem&);
-    void operator()(const ValidDivisor&);
     void operator()(const Packet&);
-    void operator()(const TypeConstraint&);
     void operator()(const Un&);
     void operator()(const Undefined&);
+    void operator()(const IncrementLoopCounter&);
+
+    void operator()(const Assertion&);
+
+    void operator()(const Addable&);
+    void operator()(const Comparable&);
+    void operator()(const FuncConstraint&);
+    void operator()(const ValidDivisor&);
+    void operator()(const TypeConstraint&);
     void operator()(const ValidAccess&);
     void operator()(const ValidCall&);
     void operator()(const ValidMapKeyValue&);
     void operator()(const ValidSize&);
     void operator()(const ValidStore&);
     void operator()(const ZeroCtxOffset&);
-    void operator()(const IncrementLoopCounter&);
     void operator()(const BoundedLoopCount&);
 
     void initialize_loop_counter(const label_t& label);

--- a/src/crab/fwd_analyzer.cpp
+++ b/src/crab/fwd_analyzer.cpp
@@ -128,7 +128,7 @@ std::pair<invariant_table_t, invariant_table_t> run_forward_analyzer(const cfg_t
         // Initialize loop counters for potential loop headers.
         // This enables enforcement of upper bounds on loop iterations
         // during program verification.
-        // TODO: Consider making this an instruction instead of an explicit call.
+        // TODO: Consider making this a Command instead of an explicit call.
         analyzer._wto.for_each_loop_head([&](const label_t& label) { entry_inv.initialize_loop_counter(label); });
     }
     analyzer.set_pre(cfg.entry_label(), entry_inv);

--- a/src/crab/split_dbm.cpp
+++ b/src/crab/split_dbm.cpp
@@ -1206,7 +1206,8 @@ string_invariant SplitDBM::to_set() const {
 std::ostream& operator<<(std::ostream& o, const SplitDBM& dom) { return o << dom.to_set(); }
 
 bool SplitDBM::eval_expression_overflow(const linear_expression_t& e, Weight& out) const {
-    [[maybe_unused]] const bool overflow = convert_NtoW_overflow(e.constant_term(), out);
+    [[maybe_unused]]
+    const bool overflow = convert_NtoW_overflow(e.constant_term(), out);
     assert(!overflow);
     for (const auto& [variable, coefficient] : e.variable_terms()) {
         Weight coef;

--- a/src/crab/wto.cpp
+++ b/src/crab/wto.cpp
@@ -41,7 +41,7 @@ struct visit_args_t {
     std::weak_ptr<wto_cycle_t> containing_cycle;
 
     visit_args_t(const visit_task_type_t t, label_t v, wto_partition_t& p, std::weak_ptr<wto_cycle_t> cc)
-        : type(t), vertex(std::move(v)), partition(p), containing_cycle(std::move(cc)){};
+        : type(t), vertex(std::move(v)), partition(p), containing_cycle(std::move(cc)) {};
 };
 
 struct wto_vertex_data_t {

--- a/src/spec_type_descriptors.hpp
+++ b/src/spec_type_descriptors.hpp
@@ -67,7 +67,7 @@ struct btf_line_info_t {
 struct raw_program {
     std::string filename{};
     std::string section_name{};
-    uint32_t insn_off{}; // Byte offset in section of first instruction in this program.
+    uint32_t insn_off{}; // Byte offset in section of first Command in this program.
     std::string function_name{};
     std::vector<ebpf_inst> prog{};
     program_info info{};

--- a/src/test/ebpf_yaml.cpp
+++ b/src/test/ebpf_yaml.cpp
@@ -152,7 +152,7 @@ static InstructionSeq raw_cfg_to_instruction_seq(const vector<std::tuple<string,
     for (const auto& [label_name, raw_block] : raw_blocks) {
         for (const string& line : raw_block) {
             try {
-                const Instruction& ins = parse_instruction(line, label_name_to_label);
+                const Command& ins = parse_instruction(line, label_name_to_label);
                 if (std::holds_alternative<Undefined>(ins)) {
                     std::cout << "text:" << line << "; ins: " << ins << "\n";
                 }
@@ -182,7 +182,7 @@ static ebpf_verifier_options_t raw_options_to_options(const std::set<string>& ra
     // Default to not assuming assertions.
     options.assume_assertions = false;
 
-    // Permit test cases to not have an exit instruction.
+    // Permit test cases to not have an exit Command.
     options.cfg_opts.must_have_exit = false;
 
     for (const string& name : raw_options) {


### PR DESCRIPTION
Each instruction is a pair (`Command`, `vector<Assertion>`).

Jump instructions are retained in the nondeterministic graph, since they store the preconditions of the jump