### PR TITLE
Update notest for Windows to install VS Clang

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,11 @@ cmake --build build
   
 #### Dependencies
 * Install [git](https://git-scm.com/download/win)
-* Install [Visual Studio Build Tools 2022](https://aka.ms/vs/17/release/vs_buildtools.exe) and choose the "C++ build tools" workload (Visual Studio Build Tools 2022 has support for CMake Version 3.25).
+* Install [Visual Studio Build Tools 2022](https://aka.ms/vs/17/release/vs_buildtools.exe) and:
+  * Choose the "C++ build tools" workload (Visual Studio Build Tools 2022 has support for CMake Version 3.25)
+  * Under Individual Components, select:
+    * "C++ Clang Compiler"
+    * "MSBuild support for LLVM"
 * Install [nuget.exe](https://www.nuget.org/downloads)
 
 #### Make on Windows (which uses a multi-configuration generator)


### PR DESCRIPTION
This pull request includes an update to the `README.md` file to clarify the installation instructions for dependencies.

* Updated the instructions for installing Visual Studio Build Tools 2022 to include the "C++ Clang Compiler" and "MSBuild support for LLVM" under Individual Components. (`README.md`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Updated Windows installation instructions to specify required components for Visual Studio Build Tools 2022.
	- Enhanced Docker section for clarity, emphasizing the need for elevated permissions when running the verifier in a privileged container.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->