### PR TITLE
Put stats collection under static variable

### DIFF
--- a/src/crab_utils/stats.cpp
+++ b/src/crab_utils/stats.cpp
@@ -94,7 +94,6 @@ void CrabStats::reset() {
     sw.clear();
 }
 
-void CrabStats::count(const std::string& name) { ++(*counters)[name]; }
 void CrabStats::count_max(const std::string& name, const unsigned v) {
     (*counters)[name] = std::max((*counters)[name], v);
 }
@@ -102,9 +101,6 @@ void CrabStats::count_max(const std::string& name, const unsigned v) {
 unsigned CrabStats::uset(const std::string& n, const unsigned v) { return (*counters)[n] = v; }
 unsigned CrabStats::get(const std::string& n) { return (*counters)[n]; }
 
-void CrabStats::start(const std::string& name) { (*sw)[name].start(); }
-void CrabStats::stop(const std::string& name) { (*sw)[name].stop(); }
-void CrabStats::resume(const std::string& name) { (*sw)[name].resume(); }
 
 /** Outputs all statistics to std output */
 void CrabStats::Print(std::ostream& OS) {

--- a/src/crab_utils/stats.hpp
+++ b/src/crab_utils/stats.hpp
@@ -33,7 +33,9 @@ inline std::ostream& operator<<(std::ostream& OS, const Stopwatch& sw) {
 }
 
 class CrabStats {
-    static const bool enabled = true;
+    /// Controls whether statistics collection is active.
+    /// When false, all statistics methods become no-ops for better performance.
+    static constexpr bool enabled = false;
     static thread_local lazy_allocator<std::map<std::string, unsigned>> counters;
     static thread_local lazy_allocator<std::map<std::string, Stopwatch>> sw;
 

--- a/src/crab_utils/stats.hpp
+++ b/src/crab_utils/stats.hpp
@@ -33,6 +33,7 @@ inline std::ostream& operator<<(std::ostream& OS, const Stopwatch& sw) {
 }
 
 class CrabStats {
+    static const bool enabled = true;
     static thread_local lazy_allocator<std::map<std::string, unsigned>> counters;
     static thread_local lazy_allocator<std::map<std::string, Stopwatch>> sw;
 
@@ -44,13 +45,29 @@ class CrabStats {
     /* counters */
     static unsigned get(const std::string& n);
     static unsigned uset(const std::string& n, unsigned v);
-    static void count(const std::string& name);
+    static void count(const std::string& name) {
+        if (enabled) {
+            ++(*counters)[name];
+        }
+    }
     static void count_max(const std::string& name, unsigned v);
 
     /* stop watch */
-    static void start(const std::string& name);
-    static void stop(const std::string& name);
-    static void resume(const std::string& name);
+    static void start(const std::string& name) {
+        if (enabled) {
+            (*sw)[name].start();
+        }
+    }
+    static void stop(const std::string& name) {
+        if (enabled) {
+            (*sw)[name].stop();
+        }
+    }
+    static void resume(const std::string& name) {
+        if (enabled) {
+            (*sw)[name].resume();
+        }
+    }
 
     /** Outputs all statistics to std output */
     static void Print(std::ostream& OS);

--- a/src/crab_utils/stats.hpp
+++ b/src/crab_utils/stats.hpp
@@ -48,7 +48,7 @@ class CrabStats {
     static unsigned get(const std::string& n);
     static unsigned uset(const std::string& n, unsigned v);
     static void count(const std::string& name) {
-        if (enabled) {
+        if constexpr (enabled) {
             ++(*counters)[name];
         }
     }
@@ -56,17 +56,17 @@ class CrabStats {
 
     /* stop watch */
     static void start(const std::string& name) {
-        if (enabled) {
+        if constexpr (enabled) {
             (*sw)[name].start();
         }
     }
     static void stop(const std::string& name) {
-        if (enabled) {
+        if constexpr (enabled) {
             (*sw)[name].stop();
         }
     }
     static void resume(const std::string& name) {
-        if (enabled) {
+        if constexpr (enabled) {
             (*sw)[name].resume();
         }
     }


### PR DESCRIPTION
This pull request includes changes to the `CrabStats` class to add an `enabled` flag and refactor several methods to check this flag before performing their operations. Additionally, some methods have been moved from the `.cpp` file to the `.hpp` file and made inline.

Enhancements to `CrabStats` class:

* Added a static constant `enabled` flag to the `CrabStats` class to control whether statistics are collected. (`src/crab_utils/stats.hpp`)
* Refactored the `count`, `start`, `stop`, and `resume` methods to check the `enabled` flag before executing their logic. These methods were also moved to the header file and made inline. (`src/crab_utils/stats.hpp`)

Code cleanup:

* Removed the `count`, `start`, `stop`, and `resume` method definitions from the `CrabStats` class implementation file. (`src/crab_utils/stats.cpp`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new static control variable to enable or disable statistics tracking at runtime.

- **Bug Fixes**
	- Removed unnecessary methods related to stopwatch management, streamlining the `CrabStats` functionality.

- **Refactor**
	- Updated method implementations to include conditional checks based on the new control variable, enhancing performance and usability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->