### PR TITLE
Fail hard when a non-Assume instruction turns an invariant into bottom

### DIFF
--- a/src/crab_verifier.cpp
+++ b/src/crab_verifier.cpp
@@ -226,16 +226,21 @@ bool ebpf_verify_program(std::ostream& os, const InstructionSeq& prog, const pro
         prog_opt = prog;
     }
 
-    const checks_db report = get_ebpf_report(os, cfg, info, options, prog_opt);
-    if (options.print_failures) {
-        print_report(os, report, prog, options.print_line_info);
+    try {
+        const checks_db report = get_ebpf_report(os, cfg, info, options, prog_opt);
+        if (options.print_failures) {
+            print_report(os, report, prog, options.print_line_info);
+        }
+        if (stats) {
+            stats->total_unreachable = report.total_unreachable;
+            stats->total_warnings = report.total_warnings;
+            stats->max_loop_count = report.get_max_loop_count();
+        }
+        return report.total_warnings == 0;
+    } catch (std::logic_error& e) {
+        std::cerr << e.what();
+        return false;
     }
-    if (stats) {
-        stats->total_unreachable = report.total_unreachable;
-        stats->total_warnings = report.total_warnings;
-        stats->max_loop_count = report.get_max_loop_count();
-    }
-    return report.total_warnings == 0;
 }
 
 void ebpf_verifier_clear_thread_local_state() {


### PR DESCRIPTION
This makes #679 visible.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced error handling in the eBPF domain transformation process to prevent invalid state transitions.
	- Improved error reporting for verification failures, providing clearer feedback on logic errors.

- **Bug Fixes**
	- Restructured error handling in the verification process to ensure exceptions are managed appropriately.

- **Tests**
	- Updated test cases for legacy programs with improved organization and clarity.
	- Added new tests for specific failure scenarios related to eBPF program verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->