### PR TITLE
Do not transform when checking + check code reorg

### DIFF
--- a/src/asm_cfg.cpp
+++ b/src/asm_cfg.cpp
@@ -87,7 +87,7 @@ static void add_cfg_nodes(cfg_t& cfg, const label_t& caller_label, const label_t
         macro_labels.erase(macro_label);
 
         if (stack_frame_prefix == macro_label.stack_frame_prefix) {
-            throw std::runtime_error{stack_frame_prefix + ": illegal recursion"};
+            throw crab::InvalidControlFlow{stack_frame_prefix + ": illegal recursion"};
         }
 
         // Clone the macro block into a new block with the new stack frame prefix.
@@ -143,7 +143,7 @@ static void add_cfg_nodes(cfg_t& cfg, const label_t& caller_label, const label_t
         const label_t label(macro_label.from, macro_label.to, caller_label_str);
         if (const auto pins = std::get_if<CallLocal>(&cfg.at(label).cmd)) {
             if (stack_frame_depth >= MAX_CALL_STACK_FRAMES) {
-                throw std::runtime_error{"too many call stack frames"};
+                throw crab::InvalidControlFlow{"too many call stack frames"};
             }
             add_cfg_nodes(cfg, label, pins->target);
         }
@@ -163,7 +163,7 @@ static cfg_t instruction_seq_to_cfg(const InstructionSeq& insts, const bool must
     }
 
     if (insts.size() == 0) {
-        throw std::invalid_argument{"empty instruction sequence"};
+        throw crab::InvalidControlFlow{"empty instruction sequence"};
     } else {
         const auto& [label, inst, _0] = insts[0];
         cfg.get_node(cfg.entry_label()) >> cfg.get_node(label);
@@ -183,7 +183,7 @@ static cfg_t instruction_seq_to_cfg(const InstructionSeq& insts, const bool must
             fallthrough = std::get<0>(insts[i + 1]);
         } else {
             if (has_fall(inst) && must_have_exit) {
-                throw std::invalid_argument{"fallthrough in last instruction"};
+                throw crab::InvalidControlFlow{"fallthrough in last instruction"};
             }
         }
         if (const auto jmp = std::get_if<Jmp>(&inst)) {

--- a/src/asm_files.hpp
+++ b/src/asm_files.hpp
@@ -9,6 +9,11 @@
 #include "asm_syntax.hpp"
 #include "platform.hpp"
 
+class UnmarshalError final : public std::runtime_error {
+  public:
+    explicit UnmarshalError(const std::string& what) : std::runtime_error(what) {}
+};
+
 std::vector<raw_program> read_raw(std::string path, program_info info);
 std::vector<raw_program> read_elf(const std::string& path, const std::string& desired_section,
                                   const ebpf_verifier_options_t& options, const ebpf_platform_t* platform);

--- a/src/asm_unmarshal.cpp
+++ b/src/asm_unmarshal.cpp
@@ -696,7 +696,7 @@ struct Unmarshaller {
         }
     }
 
-    vector<LabeledInstruction> unmarshal(vector<ebpf_inst> const& insts, vector<btf_line_info_t> const& line_info) {
+    vector<LabeledInstruction> unmarshal(vector<ebpf_inst> const& insts) {
         vector<LabeledInstruction> prog;
         int exit_count = 0;
         if (insts.empty()) {
@@ -773,8 +773,8 @@ struct Unmarshaller {
 
             std::optional<btf_line_info_t> current_line_info = {};
 
-            if (pc < line_info.size()) {
-                current_line_info = line_info[pc];
+            if (pc < info.line_info.size()) {
+                current_line_info = info.line_info.at(pc);
             }
 
             prog.emplace_back(label_t(gsl::narrow<int>(pc)), new_ins, current_line_info);
@@ -796,7 +796,7 @@ struct Unmarshaller {
 std::variant<InstructionSeq, std::string> unmarshal(const raw_program& raw_prog, vector<vector<string>>& notes) {
     global_program_info = raw_prog.info;
     try {
-        return Unmarshaller{notes, raw_prog.info}.unmarshal(raw_prog.prog, raw_prog.line_info);
+        return Unmarshaller{notes, raw_prog.info}.unmarshal(raw_prog.prog);
     } catch (InvalidInstruction& arg) {
         std::ostringstream ss;
         ss << arg.pc << ": " << arg.what() << "\n";

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -43,9 +43,8 @@ struct ebpf_verifier_options_t {
 };
 
 struct ebpf_verifier_stats_t {
-    int total_unreachable;
-    int total_warnings;
-    int max_loop_count;
+    int total_warnings{};
+    int max_loop_count{};
 };
 
 extern thread_local ebpf_verifier_options_t thread_local_options;

--- a/src/crab/cfg.hpp
+++ b/src/crab/cfg.hpp
@@ -22,6 +22,11 @@
 
 namespace crab {
 
+class InvalidControlFlow final : public std::runtime_error {
+  public:
+    explicit InvalidControlFlow(const std::string& what) : std::runtime_error(what) {}
+};
+
 class cfg_t;
 
 // Node type for the CFG
@@ -322,7 +327,7 @@ class cfg_t final {
     [[nodiscard]]
     std::vector<label_t> sorted_labels() const {
         std::vector<label_t> labels = this->labels();
-        std::sort(labels.begin(), labels.end());
+        std::ranges::sort(labels);
         return labels;
     }
 
@@ -351,20 +356,6 @@ class cfg_t final {
         const auto rng = prev_nodes(b);
         return std::distance(rng.begin(), rng.end()) == 1;
     }
-
-    // mark reachable blocks from curId
-    template <class AnyCfg>
-    void mark_alive_blocks(label_t curId, AnyCfg& cfg_t, visited_t& visited) {
-        if (visited.contains(curId)) {
-            return;
-        }
-        visited.insert(curId);
-        for (const auto& child : cfg_t.next_nodes(curId)) {
-            mark_alive_blocks(child, cfg_t, visited);
-        }
-    }
-
-    void remove_unreachable_blocks();
 };
 
 class basic_block_t final {

--- a/src/crab/ebpf_checker.cpp
+++ b/src/crab/ebpf_checker.cpp
@@ -38,63 +38,50 @@ static bool check_require(const NumAbsDomain& inv, const linear_constraint_t& cs
     return false;
 }
 
+using OnRequire = std::function<void(NumAbsDomain&, const linear_constraint_t&, const std::string&)>;
+
 class ebpf_checker final {
   public:
-    explicit ebpf_checker(ebpf_domain_t& dom, const Assertion& assertion, const std::optional<label_t>& label = {})
-        : assertion{assertion}, label{label}, dom(dom), m_inv(dom.m_inv), stack(dom.stack), type_inv(dom.type_inv) {}
+    explicit ebpf_checker(ebpf_domain_t& dom, const Assertion& assertion, const OnRequire& on_require)
+        : assertion{assertion}, on_require{on_require}, dom(dom), m_inv(dom.m_inv), stack(dom.stack),
+          type_inv(dom.type_inv) {}
 
     void visit(const Assertion& assertion) { std::visit(*this, assertion); }
 
-    void operator()(const Addable&);
-    void operator()(const BoundedLoopCount&);
-    void operator()(const Comparable&);
-    void operator()(const FuncConstraint&);
-    void operator()(const ValidDivisor&);
-    void operator()(const TypeConstraint&);
-    void operator()(const ValidAccess&);
-    void operator()(const ValidCall&);
-    void operator()(const ValidMapKeyValue&);
-    void operator()(const ValidSize&);
-    void operator()(const ValidStore&);
-    void operator()(const ZeroCtxOffset&);
+    void operator()(const Addable&) const;
+    void operator()(const BoundedLoopCount&) const;
+    void operator()(const Comparable&) const;
+    void operator()(const FuncConstraint&) const;
+    void operator()(const ValidDivisor&) const;
+    void operator()(const TypeConstraint&) const;
+    void operator()(const ValidAccess&) const;
+    void operator()(const ValidCall&) const;
+    void operator()(const ValidMapKeyValue&) const;
+    void operator()(const ValidSize&) const;
+    void operator()(const ValidStore&) const;
+    void operator()(const ZeroCtxOffset&) const;
 
   private:
     std::string create_warning(const std::string& s) const { return s + " (" + to_string(assertion) + ")"; }
 
-    void require(NumAbsDomain& inv, const linear_constraint_t& cst, const std::string& msg) {
-        if (label && !check_require(inv, cst)) {
-            warnings.push_back(create_warning(msg));
-        }
-
-        if (thread_local_options.assume_assertions) {
-            // avoid redundant errors
-            inv += cst;
-        }
+    void require(NumAbsDomain& inv, const linear_constraint_t& cst, const std::string& msg) const {
+        on_require(inv, cst, create_warning(msg));
     }
 
-    void require(const std::string& msg) {
-        if (label) {
-            warnings.push_back(create_warning(msg));
-        }
-        if (thread_local_options.assume_assertions) {
-            m_inv.set_to_bottom();
-        }
-    }
+    void require(const std::string& msg) const { require(m_inv, linear_constraint_t::false_const(), msg); }
 
     // memory check / load / store
-    void check_access_stack(NumAbsDomain& inv, const linear_expression_t& lb, const linear_expression_t& ub);
-    void check_access_context(NumAbsDomain& inv, const linear_expression_t& lb, const linear_expression_t& ub);
+    void check_access_stack(NumAbsDomain& inv, const linear_expression_t& lb, const linear_expression_t& ub) const;
+    void check_access_context(NumAbsDomain& inv, const linear_expression_t& lb, const linear_expression_t& ub) const;
     void check_access_packet(NumAbsDomain& inv, const linear_expression_t& lb, const linear_expression_t& ub,
-                             std::optional<variable_t> packet_size);
+                             std::optional<variable_t> packet_size) const;
     void check_access_shared(NumAbsDomain& inv, const linear_expression_t& lb, const linear_expression_t& ub,
-                             variable_t shared_region_size);
+                             variable_t shared_region_size) const;
 
   public:
-    std::vector<std::string> warnings;
-
   private:
-    const Assertion& assertion;
-    const std::optional<label_t> label;
+    const Assertion assertion;
+    const OnRequire on_require;
 
     ebpf_domain_t& dom;
     // shorthands:
@@ -107,16 +94,28 @@ void ebpf_domain_assume(ebpf_domain_t& dom, const Assertion& assertion) {
     if (dom.is_bottom()) {
         return;
     }
-    ebpf_checker{dom, assertion}.visit(assertion);
+    ebpf_checker{dom, assertion,
+                 [](NumAbsDomain& inv, const linear_constraint_t& cst, const std::string&) {
+                     // avoid redundant errors
+                     inv += cst;
+                 }}
+        .visit(assertion);
 }
 
-std::vector<std::string> ebpf_domain_check(ebpf_domain_t& dom, const label_t& label, const Assertion& assertion) {
+std::vector<std::string> ebpf_domain_check(const ebpf_domain_t& dom, const Assertion& assertion) {
     if (dom.is_bottom()) {
         return {};
     }
-    ebpf_checker checker{dom, assertion, label};
+    ebpf_domain_t copy = dom;
+    std::vector<std::string> warnings;
+    ebpf_checker checker{copy, assertion,
+                         [&warnings](const NumAbsDomain& inv, const linear_constraint_t& cst, const std::string& msg) {
+                             if (!check_require(inv, cst)) {
+                                 warnings.push_back(msg);
+                             }
+                         }};
     checker.visit(assertion);
-    return std::move(checker.warnings);
+    return warnings;
 }
 
 static linear_constraint_t type_is_pointer(const reg_pack_t& r) {
@@ -136,7 +135,8 @@ static linear_constraint_t type_is_not_stack(const reg_pack_t& r) {
     return r.type != T_STACK;
 }
 
-void ebpf_checker::check_access_stack(NumAbsDomain& inv, const linear_expression_t& lb, const linear_expression_t& ub) {
+void ebpf_checker::check_access_stack(NumAbsDomain& inv, const linear_expression_t& lb,
+                                      const linear_expression_t& ub) const {
     using namespace crab::dsl_syntax;
     const variable_t r10_stack_offset = reg_pack(R10_STACK_POINTER).stack_offset;
     const auto interval = inv.eval_interval(r10_stack_offset);
@@ -149,7 +149,7 @@ void ebpf_checker::check_access_stack(NumAbsDomain& inv, const linear_expression
 }
 
 void ebpf_checker::check_access_context(NumAbsDomain& inv, const linear_expression_t& lb,
-                                        const linear_expression_t& ub) {
+                                        const linear_expression_t& ub) const {
     using namespace crab::dsl_syntax;
     require(inv, lb >= 0, "Lower bound must be at least 0");
     require(inv, ub <= global_program_info->type.context_descriptor->size,
@@ -158,7 +158,7 @@ void ebpf_checker::check_access_context(NumAbsDomain& inv, const linear_expressi
 }
 
 void ebpf_checker::check_access_packet(NumAbsDomain& inv, const linear_expression_t& lb, const linear_expression_t& ub,
-                                       const std::optional<variable_t> packet_size) {
+                                       const std::optional<variable_t> packet_size) const {
     using namespace crab::dsl_syntax;
     require(inv, lb >= variable_t::meta_offset(), "Lower bound must be at least meta_offset");
     if (packet_size) {
@@ -170,13 +170,13 @@ void ebpf_checker::check_access_packet(NumAbsDomain& inv, const linear_expressio
 }
 
 void ebpf_checker::check_access_shared(NumAbsDomain& inv, const linear_expression_t& lb, const linear_expression_t& ub,
-                                       const variable_t shared_region_size) {
+                                       const variable_t shared_region_size) const {
     using namespace crab::dsl_syntax;
     require(inv, lb >= 0, "Lower bound must be at least 0");
     require(inv, ub <= shared_region_size, std::string("Upper bound must be at most ") + shared_region_size.name());
 }
 
-void ebpf_checker::operator()(const Comparable& s) {
+void ebpf_checker::operator()(const Comparable& s) const {
     using namespace crab::dsl_syntax;
     if (type_inv.same_type(m_inv, s.r1, s.r2)) {
         // Same type. If both are numbers, that's okay. Otherwise:
@@ -197,13 +197,13 @@ void ebpf_checker::operator()(const Comparable& s) {
     };
 }
 
-void ebpf_checker::operator()(const Addable& s) {
+void ebpf_checker::operator()(const Addable& s) const {
     if (!type_inv.implies_type(m_inv, type_is_pointer(reg_pack(s.ptr)), type_is_number(s.num))) {
         require("Only numbers can be added to pointers");
     }
 }
 
-void ebpf_checker::operator()(const ValidDivisor& s) {
+void ebpf_checker::operator()(const ValidDivisor& s) const {
     using namespace crab::dsl_syntax;
     const auto reg = reg_pack(s.reg);
     if (!type_inv.implies_type(m_inv, type_is_pointer(reg), type_is_number(s.reg))) {
@@ -215,19 +215,19 @@ void ebpf_checker::operator()(const ValidDivisor& s) {
     }
 }
 
-void ebpf_checker::operator()(const ValidStore& s) {
+void ebpf_checker::operator()(const ValidStore& s) const {
     if (!type_inv.implies_type(m_inv, type_is_not_stack(reg_pack(s.mem)), type_is_number(s.val))) {
         require("Only numbers can be stored to externally-visible regions");
     }
 }
 
-void ebpf_checker::operator()(const TypeConstraint& s) {
+void ebpf_checker::operator()(const TypeConstraint& s) const {
     if (!type_inv.is_in_group(m_inv, s.reg, s.types)) {
         require("Invalid type");
     }
 }
 
-void ebpf_checker::operator()(const BoundedLoopCount& s) {
+void ebpf_checker::operator()(const BoundedLoopCount& s) const {
     // Enforces an upper bound on loop iterations by checking that the loop counter
     // does not exceed the specified limit
     using namespace crab::dsl_syntax;
@@ -235,7 +235,7 @@ void ebpf_checker::operator()(const BoundedLoopCount& s) {
     require(m_inv, counter <= s.limit, "Loop counter is too large");
 }
 
-void ebpf_checker::operator()(const FuncConstraint& s) {
+void ebpf_checker::operator()(const FuncConstraint& s) const {
     // Look up the helper function id.
     const reg_pack_t& reg = reg_pack(s.reg);
     const auto src_interval = m_inv.eval_interval(reg.svalue);
@@ -250,11 +250,7 @@ void ebpf_checker::operator()(const FuncConstraint& s) {
             const Call call = make_call(imm, *global_program_info->platform);
             for (const Assertion& sub_assertion : get_assertions(call, *global_program_info, {})) {
                 // TODO: create explicit sub assertions elsewhere
-                ebpf_checker sub_checker{dom, sub_assertion, label};
-                sub_checker.visit(sub_assertion);
-                for (const auto& warning : sub_checker.warnings) {
-                    warnings.push_back(warning);
-                }
+                ebpf_checker{dom, sub_assertion, on_require}.visit(sub_assertion);
             }
             return;
         }
@@ -262,13 +258,13 @@ void ebpf_checker::operator()(const FuncConstraint& s) {
     require("callx helper function id is not a valid singleton");
 }
 
-void ebpf_checker::operator()(const ValidSize& s) {
+void ebpf_checker::operator()(const ValidSize& s) const {
     using namespace crab::dsl_syntax;
     const auto r = reg_pack(s.reg);
     require(m_inv, s.can_be_zero ? r.svalue >= 0 : r.svalue > 0, "Invalid size");
 }
 
-void ebpf_checker::operator()(const ValidCall& s) {
+void ebpf_checker::operator()(const ValidCall& s) const {
     if (!s.stack_frame_prefix.empty()) {
         const EbpfHelperPrototype proto = global_program_info->platform->get_helper_prototype(s.func);
         if (proto.return_type == EBPF_RETURN_TYPE_INTEGER_OR_NO_RETURN_IF_SUCCEED) {
@@ -278,7 +274,7 @@ void ebpf_checker::operator()(const ValidCall& s) {
     }
 }
 
-void ebpf_checker::operator()(const ValidMapKeyValue& s) {
+void ebpf_checker::operator()(const ValidMapKeyValue& s) const {
     using namespace crab::dsl_syntax;
 
     const auto fd_type = dom.get_map_type(s.map_fd_reg);
@@ -360,7 +356,7 @@ static std::tuple<linear_expression_t, linear_expression_t> lb_ub_access_pair(co
     return {lb, ub};
 }
 
-void ebpf_checker::operator()(const ValidAccess& s) {
+void ebpf_checker::operator()(const ValidAccess& s) const {
     using namespace crab::dsl_syntax;
 
     const bool is_comparison_check = s.width == Value{Imm{0}};
@@ -435,7 +431,7 @@ void ebpf_checker::operator()(const ValidAccess& s) {
     });
 }
 
-void ebpf_checker::operator()(const ZeroCtxOffset& s) {
+void ebpf_checker::operator()(const ZeroCtxOffset& s) const {
     using namespace crab::dsl_syntax;
     const auto reg = reg_pack(s.reg);
     require(m_inv, reg.ctx_offset == 0, "Nonzero context offset");

--- a/src/crab/ebpf_domain.hpp
+++ b/src/crab/ebpf_domain.hpp
@@ -28,7 +28,7 @@ class ebpf_domain_t;
 
 void ebpf_domain_transform(ebpf_domain_t& inv, const Instruction& ins);
 void ebpf_domain_assume(ebpf_domain_t& dom, const Assertion& assertion);
-std::vector<std::string> ebpf_domain_check(ebpf_domain_t& dom, const label_t& label, const Assertion& assertion);
+std::vector<std::string> ebpf_domain_check(const ebpf_domain_t& dom, const Assertion& assertion);
 
 // TODO: make this an explicit instruction
 void ebpf_domain_initialize_loop_counter(ebpf_domain_t& dom, const label_t& label);

--- a/src/crab/ebpf_transformer.cpp
+++ b/src/crab/ebpf_transformer.cpp
@@ -141,7 +141,7 @@ void ebpf_domain_transform(ebpf_domain_t& inv, const Instruction& ins) {
         // Fail. raise an exception to stop the analysis.
         std::stringstream msg;
         msg << "Bug! pre-invariant:\n"
-            << inv.to_set() << "\n followed by instruction: " << ins << "\n"
+            << inv << "\n followed by instruction: " << ins << "\n"
             << "leads to bottom";
         throw std::logic_error(msg.str());
     }

--- a/src/crab/fwd_analyzer.cpp
+++ b/src/crab/fwd_analyzer.cpp
@@ -48,11 +48,9 @@ class member_component_visitor final {
 };
 
 class interleaved_fwd_fixpoint_iterator_t final {
-    using iterator = invariant_table_t::iterator;
-
     const cfg_t& _cfg;
     wto_t _wto;
-    invariant_table_t _pre, _post;
+    invariant_map_pair _inv;
 
     /// number of narrowing iterations. If the narrowing operator is
     /// indeed a narrowing operator this parameter is not
@@ -65,7 +63,7 @@ class interleaved_fwd_fixpoint_iterator_t final {
     bool _skip{true};
 
   private:
-    void set_pre(const label_t& label, const ebpf_domain_t& v) { _pre[label] = v; }
+    void set_pre(const label_t& label, const ebpf_domain_t& v) { _inv.pre[label] = v; }
 
     void transform_to_post(const label_t& label, ebpf_domain_t pre) {
         const GuardedInstruction& ins = _cfg.at(label);
@@ -78,7 +76,7 @@ class interleaved_fwd_fixpoint_iterator_t final {
         }
         ebpf_domain_transform(pre, ins.cmd);
 
-        _post[label] = std::move(pre);
+        _inv.post[label] = std::move(pre);
     }
 
     [[nodiscard]]
@@ -102,6 +100,9 @@ class interleaved_fwd_fixpoint_iterator_t final {
     }
 
     ebpf_domain_t join_all_prevs(const label_t& node) {
+        if (node == _cfg.entry_label()) {
+            return get_pre(node);
+        }
         ebpf_domain_t res = ebpf_domain_t::bottom();
         for (const label_t& prev : _cfg.prev_nodes(node)) {
             res |= get_post(prev);
@@ -112,24 +113,23 @@ class interleaved_fwd_fixpoint_iterator_t final {
   public:
     explicit interleaved_fwd_fixpoint_iterator_t(const cfg_t& cfg) : _cfg(cfg), _wto(cfg) {
         for (const auto& label : _cfg.labels()) {
-            _pre.emplace(label, ebpf_domain_t::bottom());
-            _post.emplace(label, ebpf_domain_t::bottom());
+            _inv.pre.emplace(label, ebpf_domain_t::bottom());
+            _inv.post.emplace(label, ebpf_domain_t::bottom());
         }
     }
 
-    ebpf_domain_t get_pre(const label_t& node) { return _pre.at(node); }
+    ebpf_domain_t get_pre(const label_t& node) { return _inv.pre.at(node); }
 
-    ebpf_domain_t get_post(const label_t& node) { return _post.at(node); }
+    ebpf_domain_t get_post(const label_t& node) { return _inv.post.at(node); }
 
     void operator()(const label_t& node);
 
     void operator()(const std::shared_ptr<wto_cycle_t>& cycle);
 
-    friend std::pair<invariant_table_t, invariant_table_t> run_forward_analyzer(const cfg_t& cfg,
-                                                                                ebpf_domain_t entry_inv);
+    friend invariant_map_pair run_forward_analyzer(const cfg_t& cfg, ebpf_domain_t entry_inv);
 };
 
-std::pair<invariant_table_t, invariant_table_t> run_forward_analyzer(const cfg_t& cfg, ebpf_domain_t entry_inv) {
+invariant_map_pair run_forward_analyzer(const cfg_t& cfg, ebpf_domain_t entry_inv) {
     // Go over the CFG in weak topological order (accounting for loops).
     interleaved_fwd_fixpoint_iterator_t analyzer(cfg);
     if (thread_local_options.cfg_opts.check_for_termination) {
@@ -144,7 +144,7 @@ std::pair<invariant_table_t, invariant_table_t> run_forward_analyzer(const cfg_t
     for (const auto& component : analyzer._wto) {
         std::visit(analyzer, component);
     }
-    return std::make_pair(analyzer._pre, analyzer._post);
+    return std::move(analyzer._inv);
 }
 
 void interleaved_fwd_fixpoint_iterator_t::operator()(const label_t& node) {
@@ -156,10 +156,10 @@ void interleaved_fwd_fixpoint_iterator_t::operator()(const label_t& node) {
         return;
     }
 
-    const ebpf_domain_t pre = node == _cfg.entry_label() ? get_pre(node) : join_all_prevs(node);
+    ebpf_domain_t pre = join_all_prevs(node);
 
     set_pre(node, pre);
-    transform_to_post(node, pre);
+    transform_to_post(node, std::move(pre));
 }
 
 void interleaved_fwd_fixpoint_iterator_t::operator()(const std::shared_ptr<wto_cycle_t>& cycle) {

--- a/src/crab/fwd_analyzer.hpp
+++ b/src/crab/fwd_analyzer.hpp
@@ -10,7 +10,10 @@
 namespace crab {
 
 using invariant_table_t = std::map<label_t, ebpf_domain_t>;
-
-std::pair<invariant_table_t, invariant_table_t> run_forward_analyzer(const cfg_t& cfg, ebpf_domain_t entry_inv);
+struct invariant_map_pair {
+    invariant_table_t pre;
+    invariant_table_t post;
+};
+invariant_map_pair run_forward_analyzer(const cfg_t& cfg, ebpf_domain_t entry_inv);
 
 } // namespace crab

--- a/src/crab_verifier.hpp
+++ b/src/crab_verifier.hpp
@@ -7,18 +7,21 @@
 #include "spec_type_descriptors.hpp"
 #include "string_constraints.hpp"
 
-bool run_ebpf_analysis(std::ostream& s, const cfg_t& cfg, const program_info& info,
-                       const ebpf_verifier_options_t& options, ebpf_verifier_stats_t* stats);
-
-bool ebpf_verify_program(std::ostream& os, const InstructionSeq& prog, const program_info& info,
-                         const ebpf_verifier_options_t& options, ebpf_verifier_stats_t* stats);
-
 using string_invariant_map = std::map<label_t, string_invariant>;
 
-std::tuple<string_invariant, bool> ebpf_analyze_program_for_test(std::ostream& os, const InstructionSeq& prog,
-                                                                 const string_invariant& entry_invariant,
-                                                                 const program_info& info,
-                                                                 const ebpf_verifier_options_t& options);
+struct analyze_params_t {
+    std::ostream* os{&std::cout};
+    const InstructionSeq* prog{};
+    // if exists, it will be moved from
+    std::unique_ptr<cfg_t> cfg{};
+    // invariants will be added to labels that appear as keys in out_invariants
+    const string_invariant* entry_invariant{};
+    string_invariant_map* out_invariants{};
+    const program_info* info{};
+    ebpf_verifier_options_t* options{};
+};
+
+ebpf_verifier_stats_t analyze_and_report(const analyze_params_t& params = {});
 
 int create_map_crab(const EbpfMapType& map_type, uint32_t key_size, uint32_t value_size, uint32_t max_entries,
                     ebpf_verifier_options_t options);

--- a/src/linux/linux_platform.cpp
+++ b/src/linux/linux_platform.cpp
@@ -3,17 +3,23 @@
 #include <stdexcept>
 #if __linux__
 #include <linux/bpf.h>
-#define PTYPE(name, descr, native_type, prefixes) {name, descr, native_type, prefixes}
-#define PTYPE_PRIVILEGED(name, descr, native_type, prefixes) {name, descr, native_type, prefixes, true}
+#define PTYPE(name, descr, native_type, prefixes) \
+    { name, descr, native_type, prefixes }
+#define PTYPE_PRIVILEGED(name, descr, native_type, prefixes) \
+    { name, descr, native_type, prefixes, true }
 #else
-#define PTYPE(name, descr, native_type, prefixes) {name, descr, 0, prefixes}
-#define PTYPE_PRIVILEGED(name, descr, native_type, prefixes) {name, descr, 0, prefixes, true}
+#define PTYPE(name, descr, native_type, prefixes) \
+    { name, descr, 0, prefixes }
+#define PTYPE_PRIVILEGED(name, descr, native_type, prefixes) \
+    { name, descr, 0, prefixes, true }
 #endif
 #include "crab_verifier.hpp"
 #include "helpers.hpp"
 #include "linux/gpl/spec_type_descriptors.hpp"
 #include "linux_platform.hpp"
 #include "platform.hpp"
+
+#include <asm_files.hpp>
 
 // Map definitions as they appear in an ELF file, so field width matters.
 struct bpf_load_map_def {
@@ -198,7 +204,7 @@ static int create_map_linux(const uint32_t map_type, const uint32_t key_size, co
     }
 
 #if __linux__
-    union bpf_attr attr{};
+    union bpf_attr attr {};
     memset(&attr, '\0', sizeof(attr));
     attr.map_type = map_type;
     attr.key_size = key_size;
@@ -237,7 +243,7 @@ EbpfMapDescriptor& get_map_descriptor_linux(const int map_fd) {
     // (key size, value size) from the execution context, but this is
     // not yet supported on Linux.
 
-    throw std::runtime_error(std::string("map_fd not found"));
+    throw UnmarshalError("map_fd not found");
 }
 
 const ebpf_platform_t g_ebpf_platform_linux = {get_program_type_linux,

--- a/src/main/check.cpp
+++ b/src/main/check.cpp
@@ -240,7 +240,7 @@ int main(int argc, char** argv) {
             std::cout << "Program terminates within " << verifier_stats.max_loop_count << " loop iterations\n";
         }
         std::cout << pass << "," << seconds << "," << resident_set_size_kb() << "\n";
-        return pass;
+        return !pass;
     } else if (domain == "linux") {
         // Pass the instruction sequence to the Linux kernel verifier.
         const auto [res, seconds] = bpf_verify_program(raw_prog.info.type, raw_prog.prog, &ebpf_verifier_options);

--- a/src/main/run_yaml.cpp
+++ b/src/main/run_yaml.cpp
@@ -41,7 +41,7 @@ int main(int argc, char** argv) {
             std::cout << "failed:\n";
             res = false;
             std::cout << "------\n";
-            print_failure(*maybe_failure, std::cout);
+            print_failure(*maybe_failure);
             std::cout << "------\n";
         } else {
             std::cout << "pass\n";

--- a/src/spec_type_descriptors.hpp
+++ b/src/spec_type_descriptors.hpp
@@ -48,18 +48,19 @@ struct EquivalenceKey {
     std::strong_ordering operator<=>(const EquivalenceKey&) const = default;
 };
 
-struct program_info {
-    const struct ebpf_platform_t* platform{};
-    std::vector<EbpfMapDescriptor> map_descriptors{};
-    EbpfProgramType type{};
-    std::map<EquivalenceKey, int> cache{};
-};
-
 struct btf_line_info_t {
     std::string file_name{};
     std::string source_line{};
     uint32_t line_number{};
     uint32_t column_number{};
+};
+
+struct program_info {
+    const struct ebpf_platform_t* platform{};
+    std::vector<EbpfMapDescriptor> map_descriptors{};
+    EbpfProgramType type{};
+    std::map<EquivalenceKey, int> cache{};
+    std::map<int, btf_line_info_t> line_info{};
 };
 
 struct raw_program {
@@ -69,7 +70,6 @@ struct raw_program {
     std::string function_name{};
     std::vector<ebpf_inst> prog{};
     program_info info{};
-    std::vector<btf_line_info_t> line_info{};
 };
 
 void print_map_descriptors(const std::vector<EbpfMapDescriptor>& descriptors, std::ostream& o);

--- a/src/test/ebpf_yaml.hpp
+++ b/src/test/ebpf_yaml.hpp
@@ -30,7 +30,7 @@ struct Failure {
     Diff<std::set<std::string>> messages;
 };
 
-void print_failure(const Failure& failure, std::ostream& out);
+void print_failure(const Failure& failure);
 
 std::optional<Failure> run_yaml_test_case(TestCase test_case, bool debug = false);
 

--- a/src/test/test_yaml.cpp
+++ b/src/test/test_yaml.cpp
@@ -13,7 +13,7 @@
             std::optional<Failure> failure = run_yaml_test_case(test_case); \
             if (failure) {                                                  \
                 std::cout << "test case: " << test_case.name << "\n";       \
-                print_failure(*failure, std::cout);                         \
+                print_failure(*failure);                                    \
             }                                                               \
             REQUIRE(!failure);                                              \
         });                                                                 \

--- a/test-data/jump.yaml
+++ b/test-data/jump.yaml
@@ -121,7 +121,7 @@ code:
 
 post: []
 messages:
-  - "0: Code is unreachable after 0"
+  - "0: Code becomes unreachable (assume r1 w== 13)"
 ---
 test-case: assume number w!= reg
 
@@ -204,9 +204,9 @@ post:
   - r0.svalue=1
   - r0.uvalue=1
 messages:
-  - "2:5: Code is unreachable after 2:5"
-  - "3:5: Code is unreachable after 3:5"
-  - "4:5: Code is unreachable after 4:5"
+  - "2:5: Code becomes unreachable (assume r1 s< -3)"
+  - "3:5: Code becomes unreachable (assume r1 s< -2)"
+  - "4:5: Code becomes unreachable (assume r1 s>= -1)"
 ---
 test-case: jump-32
 
@@ -238,9 +238,9 @@ post:
   - r0.svalue=1
   - r0.uvalue=1
 messages:
-  - "3:9: Code is unreachable after 3:9"
-  - "4:9: Code is unreachable after 4:9"
-  - "5:6: Code is unreachable after 5:6"
+  - "3:9: Code becomes unreachable (assume r1 w< 4)"
+  - "4:9: Code becomes unreachable (assume r1 w< 5)"
+  - "5:6: Code becomes unreachable (assume r1 w>= 6)"
 ---
 test-case: join stack
 
@@ -555,7 +555,7 @@ post:
   - r10.stack_offset=512
 
 messages:
-  - "7:9: Code is unreachable after 7:9"
+  - "7:9: Code becomes unreachable (assume r1 == r2)"
 ---
 test-case: lost implications in correlated branches
 
@@ -622,7 +622,7 @@ post:
   - r4.uvalue=18446744073709551594
 
 messages:
-  - "0:1: Code is unreachable after 0:1"
+  - "0:1: Code becomes unreachable (assume r4 w== 0)"
 ---
 test-case: unsigned comparison of negative number
 
@@ -645,7 +645,7 @@ post:
   - r1.uvalue=18446744073709551615
 
 messages:
-  - "0:1: Code is unreachable after 0:1"
+  - "0:1: Code becomes unreachable (assume r1 <= 0)"
 ---
 test-case: JMP32
 
@@ -668,7 +668,7 @@ post:
   - r1.uvalue=4294967294
 
 messages:
-  - "0:2: Code is unreachable after 0:2"
+  - "0:2: Code becomes unreachable (assume r1 ws> 0)"
 ---
 test-case: assume map_fd == map_fd
 
@@ -691,7 +691,7 @@ code:
 
 post: []
 messages:
-  - "0: Code is unreachable after 0"
+  - "0: Code becomes unreachable (assume r1 != r1)"
 ---
 test-case: assume map_fd1 != map_fd2
 
@@ -717,7 +717,7 @@ code:
 
 post: []
 messages:
-  - "0: Code is unreachable after 0"
+  - "0: Code becomes unreachable (assume r1 != r2)"
 ---
 test-case: assume map_fd1 < map_fd2
 
@@ -762,7 +762,7 @@ post:
   - r1.type=ctx
 
 messages:
-  - "0:2: Code is unreachable after 0:2"
+  - "0:2: Code becomes unreachable (assume r1 == 0)"
 ---
 test-case: JNE with imm 0 and pointer
 options: ["assume_assertions"]
@@ -781,8 +781,7 @@ code:
 post: []
 
 messages:
-  - "0:1: Code is unreachable after 0:1"
-  - "2: Code is unreachable after 2"
+  - "0:1: Code becomes unreachable (assume r1 == 0)"
   - "2: Invalid type (r0.type == number)"
 
 ---
@@ -803,7 +802,6 @@ code:
 post: []
 
 messages:
-  - "2: Code is unreachable after 2"
   - "2: Invalid type (r0.type == number)"
 
 ---
@@ -824,7 +822,6 @@ code:
 post: []
 
 messages:
-  - "2: Code is unreachable after 2"
   - "2: Invalid type (r0.type == number)"
 
 ---
@@ -852,7 +849,7 @@ post:
   - r1.uvalue=[0, +oo]
 
 messages:
-  - "0:2: Code is unreachable after 0:2"
+  - "0:2: Code becomes unreachable (assume r1 < 0)"
 
 ---
 test-case: JLE with imm 0 and pointer
@@ -879,7 +876,7 @@ post:
   - r1.uvalue=[1, +oo]
 
 messages:
-  - "0:2: Code is unreachable after 0:2"
+  - "0:2: Code becomes unreachable (assume r1 <= 0)"
 
 ---
 test-case: JGT with imm 0 and pointer
@@ -899,8 +896,7 @@ code:
 post: []
 
 messages:
-  - "0:1: Code is unreachable after 0:1"
-  - "2: Code is unreachable after 2"
+  - "0:1: Code becomes unreachable (assume r1 <= 0)"
   - "2: Invalid type (r0.type == number)"
 
 ---
@@ -921,8 +917,7 @@ code:
 post: []
 
 messages:
-  - "0:1: Code is unreachable after 0:1"
-  - "2: Code is unreachable after 2"
+  - "0:1: Code becomes unreachable (assume r1 < 0)"
   - "2: Invalid type (r0.type == number)"
 
 ---
@@ -943,7 +938,6 @@ code:
 post: []
 
 messages:
-  - "0: Code is unreachable after 0"
   - "0: Invalid type (r1.type == number)"
 
 ---
@@ -964,7 +958,6 @@ code:
 post: []
 
 messages:
-  - "0: Code is unreachable after 0"
   - "0: Invalid type (r1.type == number)"
 
 ---
@@ -985,7 +978,6 @@ code:
 post: []
 
 messages:
-  - "0: Code is unreachable after 0"
   - "0: Invalid type (r1.type == number)"
 
 ---
@@ -1006,7 +998,6 @@ code:
 post: []
 
 messages:
-  - "0: Code is unreachable after 0"
   - "0: Invalid type (r1.type == number)"
 
 ---
@@ -1027,7 +1018,6 @@ code:
 post: []
 
 messages:
-  - "0: Code is unreachable after 0"
   - "0: Invalid type (r1.type == number)"
 
 ---
@@ -1048,7 +1038,6 @@ code:
 post: []
 
 messages:
-  - "0: Code is unreachable after 0"
   - "0: Invalid type (r1.type == number)"
 
 ---
@@ -1069,7 +1058,6 @@ code:
 post: []
 
 messages:
-  - "0: Code is unreachable after 0"
   - "0: Invalid type (r1.type == number)"
 
 ---
@@ -1090,7 +1078,6 @@ code:
 post: []
 
 messages:
-  - "0: Code is unreachable after 0"
   - "0: Invalid type (r1.type == number)"
 
 ---
@@ -1111,7 +1098,6 @@ code:
 post: []
 
 messages:
-  - "0: Code is unreachable after 0"
   - "0: Invalid type (r1.type == number)"
 
 ---
@@ -1132,7 +1118,6 @@ code:
 post: []
 
 messages:
-  - "0: Code is unreachable after 0"
   - "0: Invalid type (r1.type == number)"
 
 ---
@@ -1153,7 +1138,6 @@ code:
 post: []
 
 messages:
-  - "0: Code is unreachable after 0"
   - "0: Invalid type (r1.type == number)"
 
 ---
@@ -1174,7 +1158,6 @@ code:
 post: []
 
 messages:
-  - "0: Code is unreachable after 0"
   - "0: Invalid type (r1.type == number)"
 
 ---
@@ -1195,7 +1178,6 @@ code:
 post: []
 
 messages:
-  - "0: Code is unreachable after 0"
   - "0: Invalid type (r1.type == number)"
 
 ---
@@ -1216,7 +1198,6 @@ code:
 post: []
 
 messages:
-  - "0: Code is unreachable after 0"
   - "0: Invalid type (r1.type == number)"
 
 ---
@@ -1237,7 +1218,6 @@ code:
 post: []
 
 messages:
-  - "0: Code is unreachable after 0"
   - "0: Invalid type (r1.type == number)"
 
 ---
@@ -1258,5 +1238,4 @@ code:
 post: []
 
 messages:
-  - "0: Code is unreachable after 0"
   - "0: Invalid type (r1.type == number)"

--- a/test-data/loop.yaml
+++ b/test-data/loop.yaml
@@ -282,7 +282,7 @@ code:
 post: []
 
 messages:
-  - "1:2: Code is unreachable after 1:2"
+  - "1:2: Code becomes unreachable (assume r0 >= 1)"
   - "0 (counter): Loop counter is too large (pc[0] < 100000)"
 ---
 test-case: simple infinite loop, less than or equal
@@ -299,7 +299,7 @@ code:
 post: []
 
 messages:
-  - "1:2: Code is unreachable after 1:2"
+  - "1:2: Code becomes unreachable (assume r0 > 1)"
   - "0 (counter): Loop counter is too large (pc[0] < 100000)"
 
 ---
@@ -317,7 +317,7 @@ code:
 post: []
 
 messages:
-  - "1:2: Code is unreachable after 1:2"
+  - "1:2: Code becomes unreachable (assume r0 != 0)"
   - "0 (counter): Loop counter is too large (pc[0] < 100000)"
 
 ---
@@ -335,7 +335,7 @@ code:
 post: []
 
 messages:
-  - "1:2: Code is unreachable after 1:2"
+  - "1:2: Code becomes unreachable (assume r0 <= 0)"
   - "0 (counter): Loop counter is too large (pc[0] < 100000)"
 
 ---
@@ -353,7 +353,7 @@ code:
 post: []
 
 messages:
-  - "1:2: Code is unreachable after 1:2"
+  - "1:2: Code becomes unreachable (assume r0 < 0)"
   - "0 (counter): Loop counter is too large (pc[0] < 100000)"
 ---
 test-case: infinite loop with multiple exits
@@ -369,8 +369,8 @@ code:
     exit
 post: []
 messages:
-  - "1:2: Code is unreachable after 1:2"
-  - "3:4: Code is unreachable after 3:4"
+  - "1:2: Code becomes unreachable (assume r0 <= 0)"
+  - "3:4: Code becomes unreachable (assume r0 >= 2)"
   - "0 (counter): Loop counter is too large (pc[0] < 100000)"
 
 ---
@@ -460,6 +460,6 @@ code:
 post: []
 
 messages:
-  - "1:3: Code is unreachable after 1:3"
+  - "1:3: Code becomes unreachable (assume r0 > 10)"
   - "2 (counter): Loop counter is too large (pc[2] < 100000)"
-  - "2:3: Code is unreachable after 2:3"
+  - "2:3: Code becomes unreachable (assume r0 <= 0)"

--- a/test-data/shift.yaml
+++ b/test-data/shift.yaml
@@ -1119,12 +1119,6 @@ pre:
 code:
   <start>: |
     r0 >>= 0
-    if r1 == r0 goto <one>
-    r2 = 0
-    exit
-  <one>: |
-    r2 = 1
-    exit
 
 post:
   - r0.type=number
@@ -1133,14 +1127,6 @@ post:
   - r1.type=number
   - r1.svalue=-9223372036854775808
   - r1.uvalue=9223372036854775808
-  - r0.svalue=r1.svalue
-  - r0.uvalue=r1.uvalue
-  - r2.svalue=1
-  - r2.type=number
-  - r2.uvalue=1
-
-messages:
-  - "1:2: Code is unreachable after 1:2"
 
 ---
 test-case: check that unsigned right shift by 0 is idempotent - MAX_INT64
@@ -1156,28 +1142,14 @@ pre:
 code:
   <start>: |
     r0 >>= 0
-    if r1 == r0 goto <one>
-    r2 = 0
-    exit
-  <one>: |
-    r2 = 1
-    exit
 
 post:
   - r0.svalue=9223372036854775807
-  - r0.svalue=r1.svalue
   - r0.type=number
   - r0.uvalue=9223372036854775807
-  - r0.uvalue=r1.uvalue
   - r1.svalue=9223372036854775807
   - r1.type=number
   - r1.uvalue=9223372036854775807
-  - r2.svalue=1
-  - r2.type=number
-  - r2.uvalue=1
-
-messages:
-  - "1:2: Code is unreachable after 1:2"
 
 ---
 test-case: check that unsigned right shift by 0 is idempotent - MIN_INT64 - via register
@@ -1196,12 +1168,6 @@ pre:
 code:
   <start>: |
     r0 >>= r3
-    if r1 == r0 goto <one>
-    r2 = 0
-    exit
-  <one>: |
-    r2 = 1
-    exit
 
 post:
   - r0.type=number
@@ -1210,17 +1176,9 @@ post:
   - r1.type=number
   - r1.svalue=-9223372036854775808
   - r1.uvalue=9223372036854775808
-  - r0.svalue=r1.svalue
-  - r0.uvalue=r1.uvalue
-  - r2.svalue=1
-  - r2.type=number
-  - r2.uvalue=1
   - r3.type=number
   - r3.uvalue=0
   - r3.svalue=0
-
-messages:
-  - "1:2: Code is unreachable after 1:2"
 
 ---
 test-case: check that unsigned right shift by 0 is idempotent - MAX_INT64 - via register
@@ -1239,31 +1197,17 @@ pre:
 code:
   <start>: |
     r0 >>= r3
-    if r1 == r0 goto <one>
-    r2 = 0
-    exit
-  <one>: |
-    r2 = 1
-    exit
 
 post:
   - r0.svalue=9223372036854775807
-  - r0.svalue=r1.svalue
   - r0.type=number
   - r0.uvalue=9223372036854775807
-  - r0.uvalue=r1.uvalue
   - r1.svalue=9223372036854775807
   - r1.type=number
   - r1.uvalue=9223372036854775807
-  - r2.svalue=1
-  - r2.type=number
-  - r2.uvalue=1
   - r3.type=number
   - r3.uvalue=0
   - r3.svalue=0
-
-messages:
-  - "1:2: Code is unreachable after 1:2"
 
 ---
 test-case: check that signed right shift by 0 is idempotent - MIN_INT64
@@ -1279,12 +1223,6 @@ pre:
 code:
   <start>: |
     r0 s>>= 0
-    if r1 == r0 goto <one>
-    r2 = 0
-    exit
-  <one>: |
-    r2 = 1
-    exit
 
 post:
   - r0.type=number
@@ -1293,14 +1231,6 @@ post:
   - r1.type=number
   - r1.svalue=-9223372036854775808
   - r1.uvalue=9223372036854775808
-  - r0.svalue=r1.svalue
-  - r0.uvalue=r1.uvalue
-  - r2.svalue=1
-  - r2.type=number
-  - r2.uvalue=1
-
-messages:
-  - "1:2: Code is unreachable after 1:2"
 
 ---
 test-case: check that signed right shift by 0 is idempotent - MAX_INT64
@@ -1316,28 +1246,14 @@ pre:
 code:
   <start>: |
     r0 s>>= 0
-    if r1 == r0 goto <one>
-    r2 = 0
-    exit
-  <one>: |
-    r2 = 1
-    exit
 
 post:
   - r0.svalue=9223372036854775807
-  - r0.svalue=r1.svalue
   - r0.type=number
   - r0.uvalue=9223372036854775807
-  - r0.uvalue=r1.uvalue
   - r1.svalue=9223372036854775807
   - r1.type=number
   - r1.uvalue=9223372036854775807
-  - r2.svalue=1
-  - r2.type=number
-  - r2.uvalue=1
-
-messages:
-  - "1:2: Code is unreachable after 1:2"
 
 ---
 test-case: check that signed right shift by 0 is idempotent - MAX_UINT64
@@ -1353,28 +1269,14 @@ pre:
 code:
   <start>: |
     r0 s>>= 0
-    if r1 == r0 goto <one>
-    r2 = 0
-    exit
-  <one>: |
-    r2 = 1
-    exit
 
 post:
   - r0.svalue=-1
-  - r0.svalue=r1.svalue
   - r0.type=number
   - r0.uvalue=18446744073709551615
-  - r0.uvalue=r1.uvalue
   - r1.svalue=-1
   - r1.type=number
   - r1.uvalue=18446744073709551615
-  - r2.svalue=1
-  - r2.type=number
-  - r2.uvalue=1
-
-messages:
-  - "1:2: Code is unreachable after 1:2"
 
 ---
 test-case: check that signed right shift by 0 is idempotent - MIN_INT64 - via register
@@ -1393,12 +1295,6 @@ pre:
 code:
   <start>: |
     r0 s>>= r3
-    if r1 == r0 goto <one>
-    r2 = 0
-    exit
-  <one>: |
-    r2 = 1
-    exit
 
 post:
   - r0.type=number
@@ -1407,17 +1303,9 @@ post:
   - r1.type=number
   - r1.svalue=-9223372036854775808
   - r1.uvalue=9223372036854775808
-  - r0.svalue=r1.svalue
-  - r0.uvalue=r1.uvalue
-  - r2.svalue=1
-  - r2.type=number
-  - r2.uvalue=1
   - r3.type=number
   - r3.uvalue=0
   - r3.svalue=0
-
-messages:
-  - "1:2: Code is unreachable after 1:2"
 
 ---
 test-case: check that signed right shift by 0 is idempotent - MAX_INT64
@@ -1436,31 +1324,17 @@ pre:
 code:
   <start>: |
     r0 s>>= r3
-    if r1 == r0 goto <one>
-    r2 = 0
-    exit
-  <one>: |
-    r2 = 1
-    exit
 
 post:
   - r0.svalue=9223372036854775807
-  - r0.svalue=r1.svalue
   - r0.type=number
   - r0.uvalue=9223372036854775807
-  - r0.uvalue=r1.uvalue
   - r1.svalue=9223372036854775807
   - r1.type=number
   - r1.uvalue=9223372036854775807
-  - r2.svalue=1
-  - r2.type=number
-  - r2.uvalue=1
   - r3.type=number
   - r3.uvalue=0
   - r3.svalue=0
-
-messages:
-  - "1:2: Code is unreachable after 1:2"
 
 ---
 test-case: check that signed right shift by 0 is idempotent - MAX_UINT64 - via register
@@ -1479,31 +1353,17 @@ pre:
 code:
   <start>: |
     r0 s>>= r3
-    if r1 == r0 goto <one>
-    r2 = 0
-    exit
-  <one>: |
-    r2 = 1
-    exit
 
 post:
   - r0.svalue=-1
-  - r0.svalue=r1.svalue
   - r0.type=number
   - r0.uvalue=18446744073709551615
-  - r0.uvalue=r1.uvalue
   - r1.svalue=-1
   - r1.type=number
   - r1.uvalue=18446744073709551615
-  - r2.svalue=1
-  - r2.type=number
-  - r2.uvalue=1
   - r3.type=number
   - r3.uvalue=0
   - r3.svalue=0
-
-messages:
-  - "1:2: Code is unreachable after 1:2"
 
 ---
 test-case: check that left shift by 0 is idempotent - MIN_INT64
@@ -1519,12 +1379,6 @@ pre:
 code:
   <start>: |
     r0 <<= 0
-    if r1 == r0 goto <one>
-    r2 = 0
-    exit
-  <one>: |
-    r2 = 1
-    exit
 
 post:
   - r0.type=number
@@ -1533,14 +1387,6 @@ post:
   - r1.type=number
   - r1.svalue=-9223372036854775808
   - r1.uvalue=9223372036854775808
-  - r0.svalue=r1.svalue
-  - r0.uvalue=r1.uvalue
-  - r2.svalue=1
-  - r2.type=number
-  - r2.uvalue=1
-
-messages:
-  - "1:2: Code is unreachable after 1:2"
 
 ---
 test-case: check that left shift by 0 is idempotent - MAX_INT64
@@ -1556,28 +1402,14 @@ pre:
 code:
   <start>: |
     r0 <<= 0
-    if r1 == r0 goto <one>
-    r2 = 0
-    exit
-  <one>: |
-    r2 = 1
-    exit
 
 post:
   - r0.svalue=9223372036854775807
-  - r0.svalue=r1.svalue
   - r0.type=number
   - r0.uvalue=9223372036854775807
-  - r0.uvalue=r1.uvalue
   - r1.svalue=9223372036854775807
   - r1.type=number
   - r1.uvalue=9223372036854775807
-  - r2.svalue=1
-  - r2.type=number
-  - r2.uvalue=1
-
-messages:
-  - "1:2: Code is unreachable after 1:2"
 
 ---
 test-case: check that left shift by 0 is idempotent - MIN_INT64 - via register
@@ -1596,12 +1428,6 @@ pre:
 code:
   <start>: |
     r0 <<= r3
-    if r1 == r0 goto <one>
-    r2 = 0
-    exit
-  <one>: |
-    r2 = 1
-    exit
 
 post:
   - r0.type=number
@@ -1610,17 +1436,9 @@ post:
   - r1.type=number
   - r1.svalue=-9223372036854775808
   - r1.uvalue=9223372036854775808
-  - r0.svalue=r1.svalue
-  - r0.uvalue=r1.uvalue
-  - r2.svalue=1
-  - r2.type=number
-  - r2.uvalue=1
   - r3.type=number
   - r3.uvalue=0
   - r3.svalue=0
-
-messages:
-  - "1:2: Code is unreachable after 1:2"
 
 ---
 test-case: check that left shift by 0 is idempotent - MAX_INT64 - via register
@@ -1639,28 +1457,14 @@ pre:
 code:
   <start>: |
     r0 <<= r3
-    if r1 == r0 goto <one>
-    r2 = 0
-    exit
-  <one>: |
-    r2 = 1
-    exit
 
 post:
   - r0.svalue=9223372036854775807
-  - r0.svalue=r1.svalue
   - r0.type=number
   - r0.uvalue=9223372036854775807
-  - r0.uvalue=r1.uvalue
   - r1.svalue=9223372036854775807
   - r1.type=number
   - r1.uvalue=9223372036854775807
-  - r2.svalue=1
-  - r2.type=number
-  - r2.uvalue=1
   - r3.type=number
   - r3.uvalue=0
   - r3.svalue=0
-
-messages:
-  - "1:2: Code is unreachable after 1:2"

--- a/test-data/unsigned.yaml
+++ b/test-data/unsigned.yaml
@@ -7,7 +7,7 @@ code:
   <start>: assume r1 < 0
 post: []
 messages:
-  - "0: Code is unreachable after 0"
+  - "0: Code becomes unreachable (assume r1 < 0)"
 ---
 test-case: "assume 0 w< 0 implies bottom"
 pre: ["r1.type=number", "r1.svalue=0", "r1.uvalue=0"]
@@ -15,7 +15,7 @@ code:
   <start>: assume w1 < 0
 post: []
 messages:
-  - "0: Code is unreachable after 0"
+  - "0: Code becomes unreachable (assume r1 w< 0)"
 ---
 test-case: "assume -1 < 0 implies bottom"
 pre: ["r1.type=number", "r1.svalue=-1", "r1.uvalue=18446744073709551615"]
@@ -23,7 +23,7 @@ code:
   <start>: assume r1 < 0
 post: []
 messages:
-  - "0: Code is unreachable after 0"
+  - "0: Code becomes unreachable (assume r1 < 0)"
 ---
 test-case: "assume -1 w< 0 implies bottom"
 pre: ["r1.type=number", "r1.svalue=-1", "r1.uvalue=18446744073709551615"]
@@ -31,7 +31,7 @@ code:
   <start>: assume w1 < 0
 post: []
 messages:
-  - "0: Code is unreachable after 0"
+  - "0: Code becomes unreachable (assume r1 w< 0)"
 ---
 test-case: "assume -1 < 1 implies bottom"
 pre: ["r1.type=number", "r1.svalue=-1", "r1.uvalue=18446744073709551615"]
@@ -39,7 +39,7 @@ code:
   <start>: assume r1 < 1
 post: []
 messages:
-  - "0: Code is unreachable after 0"
+  - "0: Code becomes unreachable (assume r1 < 1)"
 ---
 test-case: "assume -1 w< 1 implies bottom"
 pre: ["r1.type=number", "r1.svalue=-1", "r1.uvalue=18446744073709551615"]
@@ -47,7 +47,7 @@ code:
   <start>: assume w1 < 1
 post: []
 messages:
-  - "0: Code is unreachable after 0"
+  - "0: Code becomes unreachable (assume r1 w< 1)"
 ---
 test-case: "assume 1 < 0 implies bottom"
 pre: ["r1.type=number", "r1.svalue=1", "r1.uvalue=1"]
@@ -55,7 +55,7 @@ code:
   <start>: assume r1 < 0
 post: []
 messages:
-  - "0: Code is unreachable after 0"
+  - "0: Code becomes unreachable (assume r1 < 0)"
 ---
 test-case: "assume 1 w< 0 implies bottom"
 pre: ["r1.type=number", "r1.svalue=1", "r1.uvalue=1"]
@@ -63,7 +63,7 @@ code:
   <start>: assume w1 < 0
 post: []
 messages:
-  - "0: Code is unreachable after 0"
+  - "0: Code becomes unreachable (assume r1 w< 0)"
 ---
 test-case: "assume 1 < 1 implies bottom"
 pre: ["r1.type=number", "r1.svalue=1", "r1.uvalue=1"]
@@ -71,7 +71,7 @@ code:
   <start>: assume r1 < 1
 post: []
 messages:
-  - "0: Code is unreachable after 0"
+  - "0: Code becomes unreachable (assume r1 < 1)"
 ---
 test-case: "assume 1 w< 1 implies bottom"
 pre: ["r1.type=number", "r1.svalue=1", "r1.uvalue=1"]
@@ -79,7 +79,7 @@ code:
   <start>: assume w1 < 1
 post: []
 messages:
-  - "0: Code is unreachable after 0"
+  - "0: Code becomes unreachable (assume r1 w< 1)"
 ---
 test-case: "assume 2 < 1 implies bottom"
 pre: ["r1.type=number", "r1.svalue=2", "r1.uvalue=2"]
@@ -87,7 +87,7 @@ code:
   <start>: assume r1 < 1
 post: []
 messages:
-  - "0: Code is unreachable after 0"
+  - "0: Code becomes unreachable (assume r1 < 1)"
 ---
 test-case: "assume 2 w< 1 implies bottom"
 pre: ["r1.type=number", "r1.svalue=2", "r1.uvalue=2"]
@@ -95,7 +95,7 @@ code:
   <start>: assume w1 < 1
 post: []
 messages:
-  - "0: Code is unreachable after 0"
+  - "0: Code becomes unreachable (assume r1 w< 1)"
 ---
 test-case: "assume [0, 1] < 0 implies bottom"
 pre: ["r1.type=number", "r1.svalue=[0, 1]", "r1.uvalue=[0, 1]", "r1.svalue=r1.uvalue"]
@@ -103,7 +103,7 @@ code:
   <start>: assume r1 < 0
 post: []
 messages:
-  - "0: Code is unreachable after 0"
+  - "0: Code becomes unreachable (assume r1 < 0)"
 ---
 test-case: "assume [0, 1] w< 0 implies bottom"
 pre: ["r1.type=number", "r1.svalue=[0, 1]", "r1.uvalue=[0, 1]", "r1.svalue=r1.uvalue"]
@@ -111,7 +111,7 @@ code:
   <start>: assume w1 < 0
 post: []
 messages:
-  - "0: Code is unreachable after 0"
+  - "0: Code becomes unreachable (assume r1 w< 0)"
 ---
 test-case: "assume [2, 3] < 1 implies bottom"
 pre: ["r1.type=number", "r1.svalue=[2, 3]", "r1.uvalue=[2, 3]", "r1.svalue=r1.uvalue"]
@@ -119,7 +119,7 @@ code:
   <start>: assume r1 < 1
 post: []
 messages:
-  - "0: Code is unreachable after 0"
+  - "0: Code becomes unreachable (assume r1 < 1)"
 ---
 test-case: "assume [2, 3] w< 1 implies bottom"
 pre: ["r1.type=number", "r1.svalue=[2, 3]", "r1.uvalue=[2, 3]", "r1.svalue=r1.uvalue"]
@@ -127,7 +127,7 @@ code:
   <start>: assume w1 < 1
 post: []
 messages:
-  - "0: Code is unreachable after 0"
+  - "0: Code becomes unreachable (assume r1 w< 1)"
 ---
 test-case: "assume [-2, -1] < 0 implies bottom"
 pre: ["r1.type=number", "r1.svalue=[-2, -1]", "r1.uvalue=[18446744073709551614, 18446744073709551615]"]
@@ -135,7 +135,7 @@ code:
   <start>: assume r1 < 1
 post: []
 messages:
-  - "0: Code is unreachable after 0"
+  - "0: Code becomes unreachable (assume r1 < 1)"
 ---
 test-case: "assume [-2, -1] w< 0 implies bottom"
 pre: ["r1.type=number", "r1.svalue=[-2, -1]", "r1.uvalue=[18446744073709551614, 18446744073709551615]"]
@@ -143,7 +143,7 @@ code:
   <start>: assume w1 < 1
 post: []
 messages:
-  - "0: Code is unreachable after 0"
+  - "0: Code becomes unreachable (assume r1 w< 1)"
 ---
 test-case: "assume [-3, -2] < -3 implies bottom"
 pre: ["r1.type=number", "r1.svalue=[-3, -2]", "r1.uvalue=[18446744073709551613, 18446744073709551614]"]
@@ -151,7 +151,7 @@ code:
   <start>: assume r1 < -3
 post: []
 messages:
-  - "0: Code is unreachable after 0"
+  - "0: Code becomes unreachable (assume r1 < -3)"
 ---
 test-case: "assume [-3, -2] w< -3 implies bottom"
 pre: ["r1.type=number", "r1.svalue=[-3, -2]", "r1.uvalue=[18446744073709551613, 18446744073709551614]"]
@@ -159,7 +159,7 @@ code:
   <start>: assume w1 < -3
 post: []
 messages:
-  - "0: Code is unreachable after 0"
+  - "0: Code becomes unreachable (assume r1 w< -3)"
 ---
 test-case: "assume [-3, -2] < -4 implies bottom"
 pre: ["r1.type=number", "r1.svalue=[-3, -2]", "r1.uvalue=[18446744073709551613, 18446744073709551614]"]
@@ -167,7 +167,7 @@ code:
   <start>: assume r1 < -4
 post: []
 messages:
-  - "0: Code is unreachable after 0"
+  - "0: Code becomes unreachable (assume r1 < -4)"
 ---
 test-case: "assume [-3, -2] w< -4 implies bottom"
 pre: ["r1.type=number", "r1.svalue=[-3, -2]", "r1.uvalue=[18446744073709551613, 18446744073709551614]"]
@@ -175,7 +175,7 @@ code:
   <start>: assume w1 < -4
 post: []
 messages:
-  - "0: Code is unreachable after 0"
+  - "0: Code becomes unreachable (assume r1 w< -4)"
 ---
 test-case: "assume 1 < [0, 1] implies bottom"
 pre: ["r1.type=number", "r1.svalue=1", "r1.uvalue=1",
@@ -184,7 +184,7 @@ code:
   <start>: assume r1 < r2
 post: []
 messages:
-  - "0: Code is unreachable after 0"
+  - "0: Code becomes unreachable (assume r1 < r2)"
 ---
 test-case: "assume 1 w< [0, 1] implies bottom"
 pre: ["r1.type=number", "r1.svalue=1", "r1.uvalue=1",
@@ -193,7 +193,7 @@ code:
   <start>: assume w1 < r2
 post: []
 messages:
-  - "0: Code is unreachable after 0"
+  - "0: Code becomes unreachable (assume r1 w< r2)"
 ---
 test-case: "assume -1 < [0, 1] implies bottom"
 pre: ["r1.type=number", "r1.svalue=-1", "r1.uvalue=18446744073709551615",
@@ -202,7 +202,7 @@ code:
   <start>: assume r1 < r2
 post: []
 messages:
-  - "0: Code is unreachable after 0"
+  - "0: Code becomes unreachable (assume r1 < r2)"
 ---
 test-case: "assume -1 w< [0, 1] implies bottom"
 pre: ["r1.type=number", "r1.svalue=-1", "r1.uvalue=18446744073709551615",
@@ -211,7 +211,7 @@ code:
   <start>: assume w1 < r2
 post: []
 messages:
-  - "0: Code is unreachable after 0"
+  - "0: Code becomes unreachable (assume r1 w< r2)"
 ---
 test-case: "assume -1 < [1, 2] implies bottom"
 pre: ["r1.type=number", "r1.svalue=-1", "r1.uvalue=18446744073709551615",
@@ -220,7 +220,7 @@ code:
   <start>: assume r1 < r2
 post: []
 messages:
-  - "0: Code is unreachable after 0"
+  - "0: Code becomes unreachable (assume r1 < r2)"
 ---
 test-case: "assume -1 w< [1, 2] implies bottom"
 pre: ["r1.type=number", "r1.svalue=-1", "r1.uvalue=18446744073709551615",
@@ -229,7 +229,7 @@ code:
   <start>: assume w1 < r2
 post: []
 messages:
-  - "0: Code is unreachable after 0"
+  - "0: Code becomes unreachable (assume r1 w< r2)"
 ---
 test-case: "assume 2 < [0, 1] implies bottom"
 pre: ["r1.type=number", "r1.svalue=2", "r1.uvalue=2",
@@ -238,7 +238,7 @@ code:
   <start>: assume r1 < r2
 post: []
 messages:
-  - "0: Code is unreachable after 0"
+  - "0: Code becomes unreachable (assume r1 < r2)"
 ---
 test-case: "assume 2 w< [0, 1] implies bottom"
 pre: ["r1.type=number", "r1.svalue=2", "r1.uvalue=2",
@@ -247,7 +247,7 @@ code:
   <start>: assume w1 < r2
 post: []
 messages:
-  - "0: Code is unreachable after 0"
+  - "0: Code becomes unreachable (assume r1 w< r2)"
 ---
 test-case: "assume 1 < [0, 1] implies bottom"
 pre: ["r1.type=number", "r1.svalue=1", "r1.uvalue=1",
@@ -256,7 +256,7 @@ code:
   <start>: assume r1 < r2
 post: []
 messages:
-  - "0: Code is unreachable after 0"
+  - "0: Code becomes unreachable (assume r1 < r2)"
 ---
 test-case: "assume 1 w< [0, 1] implies bottom"
 pre: ["r1.type=number", "r1.svalue=1", "r1.uvalue=1",
@@ -265,7 +265,7 @@ code:
   <start>: assume w1 < r2
 post: []
 messages:
-  - "0: Code is unreachable after 0"
+  - "0: Code becomes unreachable (assume r1 w< r2)"
 ---
 test-case: "assume 2 < [0, 1] implies bottom"
 pre: ["r1.type=number", "r1.svalue=1", "r1.uvalue=1",
@@ -274,7 +274,7 @@ code:
   <start>: assume r1 < r2
 post: []
 messages:
-  - "0: Code is unreachable after 0"
+  - "0: Code becomes unreachable (assume r1 < r2)"
 ---
 test-case: "assume 2 w< [0, 1] implies bottom"
 pre: ["r1.type=number", "r1.svalue=1", "r1.uvalue=1",
@@ -283,7 +283,7 @@ code:
   <start>: assume w1 < r2
 post: []
 messages:
-  - "0: Code is unreachable after 0"
+  - "0: Code becomes unreachable (assume r1 w< r2)"
 ---
 test-case: "assume [2, 3] < [1, 2] implies bottom"
 pre: ["r1.type=number", "r1.svalue=[2, 3]", "r1.uvalue=[2, 3]", "r1.svalue=r1.uvalue",
@@ -292,7 +292,7 @@ code:
   <start>: assume r1 < r2
 post: []
 messages:
-  - "0: Code is unreachable after 0"
+  - "0: Code becomes unreachable (assume r1 < r2)"
 ---
 test-case: "assume [2, 3] w< [1, 2] implies bottom"
 pre: ["r1.type=number", "r1.svalue=[2, 3]", "r1.uvalue=[2, 3]", "r1.svalue=r1.uvalue",
@@ -301,7 +301,7 @@ code:
   <start>: assume w1 < r2
 post: []
 messages:
-  - "0: Code is unreachable after 0"
+  - "0: Code becomes unreachable (assume r1 w< r2)"
 ---
 test-case: "assume [-2, -1] < [0, 1] implies bottom"
 pre: ["r1.type=number", "r1.svalue=[-2, -1]", "r1.uvalue=[18446744073709551614, 18446744073709551615]",
@@ -310,7 +310,7 @@ code:
   <start>: assume r1 < r2
 post: []
 messages:
-  - "0: Code is unreachable after 0"
+  - "0: Code becomes unreachable (assume r1 < r2)"
 ---
 test-case: "assume [-2, -1] w< [0, 1] implies bottom"
 pre: ["r1.type=number", "r1.svalue=[-2, -1]", "r1.uvalue=[18446744073709551614, 18446744073709551615]",
@@ -319,7 +319,7 @@ code:
   <start>: assume w1 < r2
 post: []
 messages:
-  - "0: Code is unreachable after 0"
+  - "0: Code becomes unreachable (assume r1 w< r2)"
 ---
 test-case: "assume [-3, -2] < [-4, -3] implies bottom"
 pre: ["r1.type=number", "r1.svalue=[-3, -2]", "r1.uvalue=[18446744073709551613, 18446744073709551614]",
@@ -328,7 +328,7 @@ code:
   <start>: assume r1 < r2
 post: []
 messages:
-  - "0: Code is unreachable after 0"
+  - "0: Code becomes unreachable (assume r1 < r2)"
 ---
 test-case: "assume [-3, -2] w< [-4, -3] implies bottom"
 pre: ["r1.type=number", "r1.svalue=[-3, -2]", "r1.uvalue=[18446744073709551613, 18446744073709551614]",
@@ -337,7 +337,7 @@ code:
   <start>: assume w1 < r2
 post: []
 messages:
-  - "0: Code is unreachable after 0"
+  - "0: Code becomes unreachable (assume r1 w< r2)"
 ---
 test-case: "assume [-3, -2] < [-5, -4] implies bottom"
 pre: ["r1.type=number", "r1.svalue=[-3, -2]", "r1.uvalue=[18446744073709551613, 18446744073709551614]",
@@ -346,7 +346,7 @@ code:
   <start>: assume r1 < r2
 post: []
 messages:
-  - "0: Code is unreachable after 0"
+  - "0: Code becomes unreachable (assume r1 < r2)"
 ---
 test-case: "assume [-3, -2] w< [-5, -4] implies bottom"
 pre: ["r1.type=number", "r1.svalue=[-3, -2]", "r1.uvalue=[18446744073709551613, 18446744073709551614]",
@@ -355,7 +355,7 @@ code:
   <start>: assume w1 < r2
 post: []
 messages:
-  - "0: Code is unreachable after 0"
+  - "0: Code becomes unreachable (assume r1 w< r2)"
 ---
 test-case: "assume INT_MIN+1 < 0 implies bottom"
 pre: []
@@ -365,7 +365,7 @@ code:
     assume r1 < 0
 post: []
 messages:
-  - "1: Code is unreachable after 1"
+  - "1: Code becomes unreachable (assume r1 < 0)"
 ---
 test-case: "assume INT_MIN+1 w< 0 implies bottom"
 pre: []
@@ -375,7 +375,7 @@ code:
     assume w1 < 0
 post: []
 messages:
-  - "1: Code is unreachable after 1"
+  - "1: Code becomes unreachable (assume r1 w< 0)"
 ---
 test-case: "assume INT_MIN+1 w< 2 nop"
 pre: []
@@ -391,7 +391,7 @@ code:
   <start>: assume r1 < 0
 post: []
 messages:
-  - "0: Code is unreachable after 0"
+  - "0: Code becomes unreachable (assume r1 < 0)"
 ---
 test-case: "assume [INT32_MIN, -1] w< 0 implies bottom"
 pre: ["r1.type=number", "r1.svalue=[-2147483648, -1]", "r1.uvalue=[18446744071562067968, 18446744073709551615]"]
@@ -400,7 +400,7 @@ code:
     assume w1 < 0
 post: []
 messages:
-  - "0: Code is unreachable after 0"
+  - "0: Code becomes unreachable (assume r1 w< 0)"
 ---
 test-case: "assume something w< 0 implies bottom"
 pre: ["r1.type=number", "r1.svalue=-4294967298", "r1.uvalue=18446744069414584318"]
@@ -409,7 +409,7 @@ code:
     assume w1 < 0
 post: []
 messages:
-  - "0: Code is unreachable after 0"
+  - "0: Code becomes unreachable (assume r1 w< 0)"
 ---
 test-case: "assume INT_MIN+1 < 1 implies bottom"
 pre: []
@@ -419,7 +419,7 @@ code:
     assume r1 < 1
 post: []
 messages:
-  - "1: Code is unreachable after 1"
+  - "1: Code becomes unreachable (assume r1 < 1)"
 ---
 test-case: "assume INT32_MIN w< 1 implies bottom"
 pre: []
@@ -429,7 +429,7 @@ code:
     assume w1 < 1
 post: []
 messages:
-  - "1: Code is unreachable after 1"
+  - "1: Code becomes unreachable (assume r1 w< 1)"
 ---
 test-case: "assume INT_MIN+1 < INT_MIN+1 implies bottom"
 pre: []
@@ -440,7 +440,7 @@ code:
     assume r1 < r2
 post: []
 messages:
-  - "2: Code is unreachable after 2"
+  - "2: Code becomes unreachable (assume r1 < r2)"
 ---
 test-case: "assume INT32_MIN w< INT32_MIN implies bottom"
 pre: []
@@ -451,7 +451,7 @@ code:
     assume w1 < r2
 post: []
 messages:
-  - "2: Code is unreachable after 2"
+  - "2: Code becomes unreachable (assume r1 w< r2)"
 ---
 test-case: "assume INT_MIN+2 < INT_MIN+1 implies bottom"
 pre: []
@@ -462,7 +462,7 @@ code:
     assume r1 < r2
 post: []
 messages:
-  - "2: Code is unreachable after 2"
+  - "2: Code becomes unreachable (assume r1 < r2)"
 ---
 test-case: "assume -1 < INT_MIN+1 implies bottom"
 pre: []
@@ -473,7 +473,7 @@ code:
     assume r1 < r2
 post: []
 messages:
-  - "2: Code is unreachable after 2"
+  - "2: Code becomes unreachable (assume r1 < r2)"
 ---
 test-case: "assume -1 w< INT32_MIN implies bottom"
 pre: []
@@ -484,7 +484,7 @@ code:
     assume w1 < r2
 post: []
 messages:
-  - "2: Code is unreachable after 2"
+  - "2: Code becomes unreachable (assume r1 w< r2)"
 ---
 test-case: "assume INT32_MIN w< INT32_MAX implies bottom"
 pre: []
@@ -495,7 +495,7 @@ code:
     assume w1 < r2
 post: []
 messages:
-  - "2: Code is unreachable after 2"
+  - "2: Code becomes unreachable (assume r1 w< r2)"
 ---
 test-case: "assume [1, INT_MAX] < 1 implies bottom"
 pre: ["r1.type=number", "r1.svalue=[0, 9223372036854775806]", "r1.uvalue=[0, 9223372036854775806]", "r1.svalue=r1.uvalue"]
@@ -505,7 +505,7 @@ code:
     assume r1 < 1
 post: []
 messages:
-  - "1: Code is unreachable after 1"
+  - "1: Code becomes unreachable (assume r1 < 1)"
 ---
 test-case: "assume [1, INT32_MAX] w< 1 implies bottom"
 pre: ["r1.type=number", "r1.svalue=[1, 2147483647]", "r1.uvalue=[1, 2147483647]", "r1.svalue=r1.uvalue"]
@@ -514,7 +514,7 @@ code:
     assume w1 < 1
 post: []
 messages:
-  - "0: Code is unreachable after 0"
+  - "0: Code becomes unreachable (assume r1 w< 1)"
 ---
 test-case: "assume [INT_MAX-1, INT_MAX] < 1 implies bottom"
 pre: ["r1.type=number", "r1.svalue=[9223372036854775803, 9223372036854775804]", "r1.uvalue=[9223372036854775803, 9223372036854775804]", "r1.svalue=r1.uvalue"]
@@ -524,7 +524,7 @@ code:
     assume r1 < 1
 post: []
 messages:
-  - "1: Code is unreachable after 1"
+  - "1: Code becomes unreachable (assume r1 < 1)"
 ---
 test-case: "assume [INT32_MAX-1, INT32_MAX] < 1 implies bottom"
 pre: ["r1.type=number", "r1.svalue=[2147483646, 2147483647]", "r1.uvalue=[2147483646, 2147483647]", "r1.svalue=r1.uvalue"]
@@ -533,7 +533,7 @@ code:
     assume w1 < 1
 post: []
 messages:
-  - "0: Code is unreachable after 0"
+  - "0: Code becomes unreachable (assume r1 w< 1)"
 ---
 test-case: "assume [INT_MAX, INT_MAX+1] < 1 implies bottom"
 pre: ["r1.type=number", "r1.svalue=[9223372036854775803, 9223372036854775804]", "r1.uvalue=[9223372036854775803, 9223372036854775804]", "r1.svalue=r1.uvalue"]
@@ -543,7 +543,7 @@ code:
     assume r1 < 1
 post: []
 messages:
-  - "1: Code is unreachable after 1"
+  - "1: Code becomes unreachable (assume r1 < 1)"
 ---
 test-case: "assume 0 < 1 nop"
 pre: []
@@ -596,7 +596,7 @@ code:
     assume r1 > 1
 post: []
 messages:
-  - "0: Code is unreachable after 0"
+  - "0: Code becomes unreachable (assume r1 > 1)"
 ---
 test-case: "assume [0, 1] w> 1 implies bottom"
 pre: ["r1.type=number", "r1.svalue=[0, 1]", "r1.uvalue=[0, 1]", "r1.svalue=r1.uvalue"]
@@ -605,7 +605,7 @@ code:
     assume w1 > 1
 post: []
 messages:
-  - "0: Code is unreachable after 0"
+  - "0: Code becomes unreachable (assume r1 w> 1)"
 ---
 test-case: "assume [1, 2] > 1 narrows to 2"
 pre: ["r1.type=number", "r1.svalue=[1, 2]", "r1.uvalue=[1, 2]", "r1.svalue=r1.uvalue"]
@@ -685,7 +685,7 @@ code:
     assume r1 > r2
 post: []
 messages:
-  - "1: Code is unreachable after 1"
+  - "1: Code becomes unreachable (assume r1 > r2)"
 ---
 test-case: "assume [0, INT32_MAX] w> INT32_MAX implies bottom"
 pre: ["r1.type=number", "r1.svalue=[0, 2147483647]", "r1.uvalue=[0, 2147483647]", "r1.svalue=r1.uvalue"]
@@ -694,7 +694,7 @@ code:
     assume w1 > 2147483647
 post: []
 messages:
-  - "0: Code is unreachable after 0"
+  - "0: Code becomes unreachable (assume r1 w> 2147483647)"
 ---
 test-case: "assume [0, INT_MAX-4] >= INT_MAX-4 narrows to INT_MAX-4"
 pre: ["r1.type=number", "r1.svalue=[0, 9223372036854775803]", "r1.uvalue=[0, 9223372036854775803]", "r1.svalue=r1.uvalue"]
@@ -1085,7 +1085,7 @@ code:
   <start>: assume r1 != 11
 post: []
 messages:
-  - "0: Code is unreachable after 0"
+  - "0: Code becomes unreachable (assume r1 != 11)"
 ---
 test-case: "assume [0, 1] != 1 narrows to 0"
 pre: ["r1.type=number", "r1.svalue=[0, 1]", "r1.uvalue=[0, 1]"]
@@ -1111,7 +1111,7 @@ code:
   <start>: assume w1 != 11
 post: []
 messages:
-  - "0: Code is unreachable after 0"
+  - "0: Code becomes unreachable (assume r1 w!= 11)"
 ---
 test-case: "assume [3, 4] w< 2 implies bottom"
 pre: ["r1.type=number", "r1.svalue=[3, 4]", "r1.uvalue=[3, 4]"]
@@ -1119,7 +1119,7 @@ code:
   <start>: assume w1 < 2
 post: []
 messages:
-  - "0: Code is unreachable after 0"
+  - "0: Code becomes unreachable (assume r1 w< 2)"
 ---
 test-case: "assume [UINT32_MAX+1, UINT32_MAX+5] w< 2"
 pre: ["r1.type=number", "r1.uvalue=[4294967296, 4294967300]"]
@@ -1248,7 +1248,7 @@ code:
   <start>: assume w1 s> 0
 post: []
 messages:
-  - "0: Code is unreachable after 0"
+  - "0: Code becomes unreachable (assume r1 ws> 0)"
 ---
 test-case: signed 32-bit GT reg
 pre: ["r1.type=number", "r1.svalue=[-2, 2]", "r2.type=number", "r2.svalue=[-2, 2]"]


### PR DESCRIPTION
* Avoiding ebpf_transform on check should improve performance
* Unify verifier calls to a single function with options parameter, returs ebpf_verifier_stats_t 
--  Use unique_ptr for cfg_t input, since it is moved from
-- Out parameter for invariants that should be returned
* Add the assume commands that triggered unreachability
* More constness on ebpf_checker: should not mutate the invariant
* No reachability notes on assume-assert
* Use dedicated exceptions for input errors
* Remove line_info from raw_program

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced custom exception types for improved error handling in control flow and ELF file processing.
  - Added a new `analyze_params_t` structure to streamline eBPF analysis parameters.
  - Enhanced the `ebpf_checker` class to allow more modular requirement handling.
  - Added new test cases for various jump conditions, loops, and bitwise operations.

- **Bug Fixes**
  - Improved error reporting for map descriptor retrieval failures.

- **Tests**
  - Expanded test coverage with new cases for conditional jumps, loops, and bitwise operations.
  - Updated existing tests to clarify conditions leading to unreachable code and ensure accurate postconditions.

- **Documentation**
  - Improved clarity and organization of output messages in test cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->