### PR TITLE
Use T_UNINIT as lower bound for types

### DIFF
--- a/src/crab/type_encoding.hpp
+++ b/src/crab/type_encoding.hpp
@@ -40,7 +40,7 @@ enum type_encoding_t {
     T_SHARED = 0
 };
 
-constexpr type_encoding_t T_MIN = T_MAP_PROGRAMS;
+constexpr type_encoding_t T_MIN = T_UNINIT;
 constexpr type_encoding_t T_MAX = T_SHARED;
 
 std::vector<type_encoding_t> iterate_types(type_encoding_t lb, type_encoding_t ub);


### PR DESCRIPTION
Fix a crash when running on build/loop.o.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the minimum type encoding value to enhance type encoding operations.
  
- **Bug Fixes**
	- Reviewed logic surrounding type encoding usage for compatibility with the new minimum value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->