### PR TITLE
Cleanup wto parts in fwd_analyzer

### DIFF
--- a/src/crab/wto.hpp
+++ b/src/crab/wto.hpp
@@ -92,6 +92,9 @@ class wto_cycle_t final {
     }
 };
 
+// Check if node is a member of the wto component.
+bool is_component_member(const label_t& label, const cycle_or_label& component);
+
 class wto_t final {
     // Top level components, in reverse order.
     wto_partition_t _components;
@@ -102,10 +105,10 @@ class wto_t final {
     // Table mapping label to the list of heads of cycles containing the label.
     // This is an on-demand cache, since for most vertices the nesting is never
     // looked at so we only create a wto_nesting_t for cases we actually need it.
-    std::map<label_t, wto_nesting_t> _nesting;
+    mutable std::map<label_t, wto_nesting_t> _nesting;
 
-    std::vector<label_t> collect_heads(const label_t& label);
-    std::optional<label_t> head(const label_t& label);
+    std::vector<label_t> collect_heads(const label_t& label) const;
+    std::optional<label_t> head(const label_t& label) const;
 
     wto_t() = default;
     friend class wto_builder_t;
@@ -124,7 +127,7 @@ class wto_t final {
     }
 
     friend std::ostream& operator<<(std::ostream& o, const wto_t& wto);
-    const wto_nesting_t& nesting(const label_t& label);
+    const wto_nesting_t& nesting(const label_t& label) const;
 
     /**
      * Visit the heads of all loops in the WTO.


### PR DESCRIPTION
* Make nesting field in wto_t mutable (cache)
* Move component member check to wto.cpp and simplify
* Make extrapolate and refine functions file-static instead of class-static


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new function, `is_component_member`, for checking membership in components.
- **Improvements**
	- Enhanced const-correctness for several methods in the `wto_t` class, allowing for safer use in const contexts.
	- Simplified control flow in the forward analyzer by removing the visitor pattern and improving modularity.
- **Bug Fixes**
	- Updated method signatures to reflect const-correctness, ensuring methods do not modify object state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->