### PR TITLE
Specialize GraphOps

### DIFF
--- a/src/crab/split_dbm.hpp
+++ b/src/crab/split_dbm.hpp
@@ -31,7 +31,6 @@
 #include "crab/variable.hpp"
 #include "crab_utils/adapt_sgraph.hpp"
 #include "crab_utils/debug.hpp"
-#include "crab_utils/graph_ops.hpp"
 #include "crab_utils/num_big.hpp"
 #include "crab_utils/num_safeint.hpp"
 #include "crab_utils/stats.hpp"
@@ -57,8 +56,6 @@ class SplitDBM final {
     using variable_vector_t = std::vector<variable_t>;
 
     using rev_map_t = std::vector<std::optional<variable_t>>;
-    using GrOps = GraphOps<graph_t>;
-    using edge_vector = GrOps::edge_vector;
     // < <x, y>, k> == x - y <= k.
     using diffcst_t = std::pair<std::pair<variable_t, variable_t>, Weight>;
     using vert_set_t = std::unordered_set<vert_id>;
@@ -129,7 +126,7 @@ class SplitDBM final {
     interval_t get_interval(variable_t x, int finite_width) const;
 
     // Restore potential after an edge addition
-    bool repair_potential(vert_id src, vert_id dest) { return GrOps::repair_potential(g, potential, src, dest); }
+    bool repair_potential(vert_id src, vert_id dest);
 
     void normalize();
 
@@ -304,7 +301,7 @@ class SplitDBM final {
     string_invariant to_set() const;
 
   public:
-    static void clear_thread_local_state() { GraphOps<AdaptGraph>::clear_thread_local_state(); }
+    static void clear_thread_local_state();
 }; // class SplitDBM
 
 } // namespace domains

--- a/src/crab_utils/heap.hpp
+++ b/src/crab_utils/heap.hpp
@@ -27,11 +27,10 @@ namespace crab {
 
 // A heap implementation with support for decrease/increase key.
 // @tparam Comp a predicate that compares two integers.
-template <std::predicate<int, int> Comparator>
 class Heap {
-    Comparator lt;
-    std::vector<int> heap;    // heap of ints
-    std::vector<int> indices; // int -> index in heap
+    std::function<bool(int, int)> lt; //
+    std::vector<int> heap;            // heap of ints
+    std::vector<int> indices;         // int -> index in heap
 
     // Index "traversal" functions
     static int left(const int i) { return i * 2 + 1; }
@@ -49,7 +48,8 @@ class Heap {
         indices[x] = i;
     }
 
-    void percolateDown(int i) {
+    void percolateDown() {
+        int i = 0;
         const int x = heap[i];
         const int size = heap.size();
         while (left(i) < size) {
@@ -74,7 +74,7 @@ class Heap {
     }
 
   public:
-    explicit Heap(const Comparator& c) : lt(c) {}
+    explicit Heap(const std::function<bool(int, int)>& lt) : lt{lt} {}
 
     [[nodiscard]]
     int size() const {
@@ -117,7 +117,7 @@ class Heap {
         indices[x] = -1;
         heap.pop_back();
         if (heap.size() > 1) {
-            percolateDown(0);
+            percolateDown();
         }
         return x;
     }

--- a/src/main/linux_verifier.cpp
+++ b/src/main/linux_verifier.cpp
@@ -2,10 +2,10 @@
 // SPDX-License-Identifier: MIT
 #if __linux__
 
+#include <cstring>
 #include <linux/bpf.h>
 #include <tuple>
 #include <unistd.h>
-#include <cstring>
 
 #include "config.hpp"
 #include "linux_verifier.hpp"


### PR DESCRIPTION
graph_ops.hpp is a large header with too many type parameters and implementation details, and is only needed for SplitDBM.

* Only include graph_ops.hpp from split_dbm.cpp
* Pass function to Heap, remove type parameter
* Use inline for thread_local static members
* Add WeightIndexable concept, preparing switch from template to a function (use operator() instead of operator[])
* Inline classes dedicated to operator overloading
* Add consts