### PR TITLE
Add Program class, containing a cfg_t class

### DIFF
--- a/src/asm_syntax.hpp
+++ b/src/asm_syntax.hpp
@@ -353,12 +353,6 @@ struct BoundedLoopCount {
 using Assertion = std::variant<Comparable, Addable, ValidDivisor, ValidAccess, ValidStore, ValidSize, ValidMapKeyValue,
                                ValidCall, TypeConstraint, FuncConstraint, ZeroCtxOffset, BoundedLoopCount>;
 
-struct GuardedInstruction {
-    Instruction cmd;
-    std::vector<Assertion> preconditions;
-    bool operator==(const GuardedInstruction&) const = default;
-};
-
 std::ostream& operator<<(std::ostream& os, Instruction const& ins);
 std::string to_string(Instruction const& ins);
 

--- a/src/crab/array_domain.cpp
+++ b/src/crab/array_domain.cpp
@@ -793,11 +793,6 @@ std::optional<variable_t> array_domain_t::store_type(NumAbsDomain& inv, const li
     return {};
 }
 
-std::optional<variable_t> array_domain_t::store_type(NumAbsDomain& inv, const linear_expression_t& idx,
-                                                     const linear_expression_t& elem_size, const Reg& reg) {
-    return store_type(inv, idx, elem_size, variable_t::reg(data_kind_t::types, reg.v));
-}
-
 void array_domain_t::havoc(NumAbsDomain& inv, const data_kind_t kind, const linear_expression_t& idx,
                            const linear_expression_t& elem_size) {
     auto maybe_cell = split_and_find_var(*this, inv, kind, idx, elem_size);

--- a/src/crab/array_domain.hpp
+++ b/src/crab/array_domain.hpp
@@ -76,8 +76,6 @@ class array_domain_t final {
                                     const linear_expression_t& elem_size, const linear_expression_t& val);
     std::optional<variable_t> store_type(NumAbsDomain& inv, const linear_expression_t& idx,
                                          const linear_expression_t& elem_size, const linear_expression_t& val);
-    std::optional<variable_t> store_type(NumAbsDomain& inv, const linear_expression_t& idx,
-                                         const linear_expression_t& elem_size, const Reg& reg);
     void havoc(NumAbsDomain& inv, data_kind_t kind, const linear_expression_t& idx,
                const linear_expression_t& elem_size);
 

--- a/src/crab/ebpf_checker.cpp
+++ b/src/crab/ebpf_checker.cpp
@@ -15,6 +15,7 @@
 #include "crab_utils/num_safety.hpp"
 #include "dsl_syntax.hpp"
 #include "platform.hpp"
+#include "program.hpp"
 #include "string_constraints.hpp"
 
 using crab::domains::NumAbsDomain;

--- a/src/crab/fwd_analyzer.hpp
+++ b/src/crab/fwd_analyzer.hpp
@@ -4,8 +4,8 @@
 
 #include <map>
 
-#include "crab/cfg.hpp"
 #include "crab/ebpf_domain.hpp"
+#include "program.hpp"
 
 namespace crab {
 
@@ -15,6 +15,6 @@ struct invariant_map_pair {
 };
 using invariant_table_t = std::map<label_t, invariant_map_pair>;
 
-invariant_table_t run_forward_analyzer(const cfg_t& cfg, ebpf_domain_t entry_inv);
+invariant_table_t run_forward_analyzer(const Program& prog, ebpf_domain_t entry_inv);
 
 } // namespace crab

--- a/src/crab/type_domain.hpp
+++ b/src/crab/type_domain.hpp
@@ -12,6 +12,8 @@
 #include "crab/type_encoding.hpp"
 #include "crab/variable.hpp"
 
+#include "asm_syntax.hpp" // for Reg
+
 namespace crab {
 
 using domains::NumAbsDomain;

--- a/src/crab/wto.cpp
+++ b/src/crab/wto.cpp
@@ -4,13 +4,13 @@
 
 #include "wto.hpp"
 
-using crab::cfg_t;
-
 // This file contains an iterative implementation of the recursive algorithm in
 // Bourdoncle, "Efficient chaotic iteration strategies with widenings", 1993
 // http://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.38.3574
 // where _visit_stack is roughly equivalent to a stack trace in the recursive algorithm.
 // However, this scales much higher since it does not run out of stack memory.
+
+namespace crab {
 
 bool is_component_member(const label_t& label, const cycle_or_label& component) {
     if (const auto plabel = std::get_if<label_t>(&component)) {
@@ -308,3 +308,4 @@ const wto_nesting_t& wto_t::nesting(const label_t& label) const {
     }
     return _nesting.at(label);
 }
+} // namespace crab

--- a/src/crab/wto.hpp
+++ b/src/crab/wto.hpp
@@ -28,6 +28,9 @@
 #include <vector>
 
 #include "crab/cfg.hpp"
+#include "crab/label.hpp"
+
+namespace crab {
 
 // Bourdoncle, "Efficient chaotic iteration strategies with widenings", 1993
 // uses the notation w(c) to refer to the set of heads of the nested components
@@ -114,7 +117,7 @@ class wto_t final {
     friend class wto_builder_t;
 
   public:
-    explicit wto_t(const crab::cfg_t& cfg);
+    explicit wto_t(const cfg_t& cfg);
 
     [[nodiscard]]
     wto_partition_t::const_reverse_iterator begin() const {
@@ -144,3 +147,4 @@ class wto_t final {
         }
     }
 };
+} // namespace crab

--- a/src/crab/wto.hpp
+++ b/src/crab/wto.hpp
@@ -26,6 +26,7 @@
 #include <stack>
 #include <utility>
 #include <vector>
+#include <optional>
 
 #include "crab/cfg.hpp"
 #include "crab/label.hpp"

--- a/src/crab_utils/graph_ops.hpp
+++ b/src/crab_utils/graph_ops.hpp
@@ -502,6 +502,7 @@ class GraphOps {
     enum SMarkT { V_UNSTABLE = 0, V_STABLE = 1 };
     // Whether a vertex is in the current SCC/queue for Bellman-Ford.
     enum QMarkT { BF_NONE = 0, BF_SCC = 1, BF_QUEUED = 2 };
+
   private:
     // Scratch space needed by the graph algorithms.
     // Should really switch to some kind of arena allocator, rather
@@ -535,6 +536,7 @@ class GraphOps {
         ts = 0;
         ts_idx = 0;
     }
+
   private:
     static void grow_scratch(const size_t sz) {
         if (sz <= scratch_sz) {
@@ -975,6 +977,7 @@ class GraphOps {
             }
         }
     }
+
   public:
     template <class G>
     static bool repair_potential(const G& g, WeightVector& p, vert_id ii, vert_id jj) {
@@ -1047,6 +1050,7 @@ class GraphOps {
         }
         return delta;
     }
+
   private:
     // Compute the transitive closure of edges reachable from v, assuming
     // (1) the subgraph G \ {v} is closed, and
@@ -1101,6 +1105,7 @@ class GraphOps {
             vert_marks->at(*adj_head) = 0;
         }
     }
+
   public:
     static void close_over_edge(graph_t& g, vert_id ii, vert_id jj) {
         assert(ii != 0 && jj != 0);

--- a/src/crab_verifier.hpp
+++ b/src/crab_verifier.hpp
@@ -3,8 +3,8 @@
 #pragma once
 
 #include "config.hpp"
-#include "crab/cfg.hpp"
 #include "crab/fwd_analyzer.hpp"
+#include "program.hpp"
 #include "spec_type_descriptors.hpp"
 #include "string_constraints.hpp"
 
@@ -64,15 +64,15 @@ class Invariants final {
     crab::interval_t exit_value() const;
 
     int max_loop_count() const;
-    bool verified(const crab::cfg_t& cfg) const;
-    Report check_assertions(const crab::cfg_t& cfg) const;
+    bool verified(const Program& prog) const;
+    Report check_assertions(const Program& prog) const;
 
-    friend void print_invariants(std::ostream& os, const crab::cfg_t& cfg, bool simplify, const Invariants& invariants);
+    friend void print_invariants(std::ostream& os, const Program& prog, bool simplify, const Invariants& invariants);
 };
 
-Invariants analyze(const crab::cfg_t& cfg);
-Invariants analyze(const crab::cfg_t& cfg, const string_invariant& entry_invariant);
-inline bool verify(const crab::cfg_t& cfg) { return analyze(cfg).verified(cfg); }
+Invariants analyze(const Program& prog);
+Invariants analyze(const Program& prog, const string_invariant& entry_invariant);
+inline bool verify(const Program& prog) { return analyze(cfg).verified(cfg); }
 
 int create_map_crab(const EbpfMapType& map_type, uint32_t key_size, uint32_t value_size, uint32_t max_entries,
                     ebpf_verifier_options_t options);

--- a/src/crab_verifier.hpp
+++ b/src/crab_verifier.hpp
@@ -72,7 +72,7 @@ class Invariants final {
 
 Invariants analyze(const Program& prog);
 Invariants analyze(const Program& prog, const string_invariant& entry_invariant);
-inline bool verify(const Program& prog) { return analyze(cfg).verified(cfg); }
+inline bool verify(const Program& prog) { return analyze(prog).verified(prog); }
 
 int create_map_crab(const EbpfMapType& map_type, uint32_t key_size, uint32_t value_size, uint32_t max_entries,
                     ebpf_verifier_options_t options);

--- a/src/ebpf_verifier.hpp
+++ b/src/ebpf_verifier.hpp
@@ -5,6 +5,6 @@
 #include "asm_files.hpp"
 #include "asm_unmarshal.hpp"
 #include "config.hpp"
-#include "crab/cfg.hpp"
 #include "crab_verifier.hpp"
 #include "platform.hpp"
+#include "program.hpp"

--- a/src/program.hpp
+++ b/src/program.hpp
@@ -14,8 +14,10 @@
 class Program {
     friend struct cfg_builder_t;
 
-    std::map<label_t, GuardedInstruction> m_instructions{{label_t::entry, {.cmd = Undefined{}}},
-                                                         {label_t::exit, {.cmd = Undefined{}}}};
+    std::map<label_t, Instruction> m_instructions{{label_t::entry, Undefined{}}, {label_t::exit, Undefined{}}};
+
+    // This is a cache. The assertions can also be computed on the fly.
+    std::map<label_t, std::vector<Assertion>> m_assertions{{label_t::entry, {}}, {label_t::exit, {}}};
     crab::cfg_t m_cfg;
 
     // TODO: add program_info field
@@ -33,21 +35,21 @@ class Program {
         if (!m_instructions.contains(label)) {
             CRAB_ERROR("Label ", to_string(label), " not found in the CFG: ");
         }
-        return m_instructions.at(label).cmd;
+        return m_instructions.at(label);
     }
 
     Instruction& instruction_at(const label_t& label) {
         if (!m_instructions.contains(label)) {
             CRAB_ERROR("Label ", to_string(label), " not found in the CFG: ");
         }
-        return m_instructions.at(label).cmd;
+        return m_instructions.at(label);
     }
 
     std::vector<Assertion> assertions_at(const label_t& label) const {
         if (!m_instructions.contains(label)) {
             CRAB_ERROR("Label ", to_string(label), " not found in the CFG: ");
         }
-        return m_instructions.at(label).preconditions;
+        return m_assertions.at(label);
     }
 
     static Program from_sequence(const InstructionSeq& inst_seq, const program_info& info,

--- a/src/program.hpp
+++ b/src/program.hpp
@@ -46,7 +46,7 @@ class Program {
     }
 
     std::vector<Assertion> assertions_at(const label_t& label) const {
-        if (!m_instructions.contains(label)) {
+        if (!m_assertions.contains(label)) {
             CRAB_ERROR("Label ", to_string(label), " not found in the CFG: ");
         }
         return m_assertions.at(label);

--- a/src/program.hpp
+++ b/src/program.hpp
@@ -1,0 +1,71 @@
+// Copyright (c) Prevail Verifier contributors.
+// SPDX-License-Identifier: MIT
+#pragma once
+
+#include <map>
+#include <vector>
+
+#include "crab/cfg.hpp"
+#include "crab/label.hpp"
+#include "crab_utils/debug.hpp"
+
+#include "asm_syntax.hpp"
+
+class Program {
+    friend struct cfg_builder_t;
+
+    std::map<label_t, GuardedInstruction> m_instructions{{label_t::entry, {.cmd = Undefined{}}},
+                                                         {label_t::exit, {.cmd = Undefined{}}}};
+    crab::cfg_t m_cfg;
+
+    // TODO: add program_info field
+
+  public:
+    const crab::cfg_t& cfg() const { return m_cfg; }
+
+    //! return a view of the labels, including entry and exit
+    [[nodiscard]]
+    auto labels() const {
+        return m_cfg.labels();
+    }
+
+    const Instruction& instruction_at(const label_t& label) const {
+        if (!m_instructions.contains(label)) {
+            CRAB_ERROR("Label ", to_string(label), " not found in the CFG: ");
+        }
+        return m_instructions.at(label).cmd;
+    }
+
+    Instruction& instruction_at(const label_t& label) {
+        if (!m_instructions.contains(label)) {
+            CRAB_ERROR("Label ", to_string(label), " not found in the CFG: ");
+        }
+        return m_instructions.at(label).cmd;
+    }
+
+    std::vector<Assertion> assertions_at(const label_t& label) const {
+        if (!m_instructions.contains(label)) {
+            CRAB_ERROR("Label ", to_string(label), " not found in the CFG: ");
+        }
+        return m_instructions.at(label).preconditions;
+    }
+
+    static Program from_sequence(const InstructionSeq& inst_seq, const program_info& info,
+                                 const prepare_cfg_options& options);
+};
+
+class InvalidControlFlow final : public std::runtime_error {
+  public:
+    explicit InvalidControlFlow(const std::string& what) : std::runtime_error(what) {}
+};
+
+std::vector<Assertion> get_assertions(Instruction ins, const program_info& info, const std::optional<label_t>& label);
+
+std::vector<std::string> stats_headers();
+std::map<std::string, int> collect_stats(const Program& prog);
+
+using printfunc = std::function<void(std::ostream&, const label_t& label)>;
+void print_program(const Program& prog, std::ostream& os, bool simplify, const printfunc& prefunc,
+                   const printfunc& postfunc);
+void print_program(const Program& prog, std::ostream& os, bool simplify);
+void print_dot(const Program& prog, const std::string& outfile);

--- a/src/test/test_marshal.cpp
+++ b/src/test/test_marshal.cpp
@@ -226,9 +226,10 @@ static void compare_unmarshal_marshal(const ebpf_inst& ins, const ebpf_inst& exp
                                       const ebpf_platform_t& platform = g_ebpf_platform_linux) {
     program_info info{.platform = &platform, .type = platform.get_program_type("unspec", "unspec")};
     constexpr ebpf_inst exit{.opcode = INST_OP_EXIT};
-    InstructionSeq parsed = std::get<InstructionSeq>(unmarshal(raw_program{"", "", 0, "", {ins, exit, exit}, info}));
-    REQUIRE(parsed.size() == 3);
-    auto [_, single, _2] = parsed.front();
+    const InstructionSeq inst_seq =
+        std::get<InstructionSeq>(unmarshal(raw_program{"", "", 0, "", {ins, exit, exit}, info}));
+    REQUIRE(inst_seq.size() == 3);
+    auto [_, single, _2] = inst_seq.front();
     (void)_;  // unused
     (void)_2; // unused
     std::vector<ebpf_inst> marshaled = marshal(single, 0);
@@ -262,9 +263,10 @@ static void compare_unmarshal_marshal(const ebpf_inst& ins1, const ebpf_inst& in
     program_info info{.platform = &g_ebpf_platform_linux,
                       .type = g_ebpf_platform_linux.get_program_type("unspec", "unspec")};
     constexpr ebpf_inst exit{.opcode = INST_OP_EXIT};
-    auto parsed = std::get<InstructionSeq>(unmarshal(raw_program{"", "", 0, "", {ins1, ins2, exit, exit}, info}));
-    REQUIRE(parsed.size() == 3);
-    auto [_, single, _2] = parsed.front();
+    const InstructionSeq inst_seq =
+        std::get<InstructionSeq>(unmarshal(raw_program{"", "", 0, "", {ins1, ins2, exit, exit}, info}));
+    REQUIRE(inst_seq.size() == 3);
+    auto [_, single, _2] = inst_seq.front();
     (void)_;  // unused
     (void)_2; // unused
     std::vector<ebpf_inst> marshaled = marshal(single, 0);
@@ -280,9 +282,10 @@ static void compare_unmarshal_marshal(const ebpf_inst& ins1, const ebpf_inst& in
 static void compare_marshal_unmarshal(const Instruction& ins, bool double_cmd = false,
                                       const ebpf_platform_t& platform = g_ebpf_platform_linux) {
     program_info info{.platform = &platform, .type = platform.get_program_type("unspec", "unspec")};
-    InstructionSeq parsed = std::get<InstructionSeq>(unmarshal(raw_program{"", "", 0, "", marshal(ins, 0), info}));
-    REQUIRE(parsed.size() == 1);
-    auto [_, single, _2] = parsed.back();
+    const InstructionSeq inst_seq =
+        std::get<InstructionSeq>(unmarshal(raw_program{"", "", 0, "", marshal(ins, 0), info}));
+    REQUIRE(inst_seq.size() == 1);
+    auto [_, single, _2] = inst_seq.back();
     (void)_;  // unused
     (void)_2; // unused
     REQUIRE(single == ins);

--- a/src/test/test_verify.cpp
+++ b/src/test/test_verify.cpp
@@ -604,9 +604,9 @@ TEST_SECTION_LEGACY_FAIL("cilium", "bpf_lxc.o", "2/10")
 TEST_SECTION_FAIL("cilium", "bpf_lxc.o", "2/11")
 TEST_SECTION_FAIL("cilium", "bpf_lxc.o", "2/12")
 
-void test_analyze_thread(const Program* cfg, program_info* info, bool* res) {
+void test_analyze_thread(const Program* prog, program_info* info, bool* res) {
     thread_local_program_info.set(*info);
-    *res = verify(*cfg);
+    *res = verify(*prog);
 }
 
 // Test multithreading

--- a/src/test/test_verify.cpp
+++ b/src/test/test_verify.cpp
@@ -5,8 +5,6 @@
 
 #include "ebpf_verifier.hpp"
 
-using crab::cfg_t;
-
 #define FAIL_LOAD_ELF(dirname, filename, sectionname)                                                \
     TEST_CASE("Try loading nonexisting program: " dirname "/" filename, "[elf]") {                   \
         try {                                                                                        \
@@ -41,29 +39,29 @@ FAIL_UNMARSHAL("invalid", "invalid-lddw.o", ".text")
         REQUIRE(raw_progs.size() == 1);                                                                           \
         raw_program raw_prog = raw_progs.back();                                                                  \
         std::variant<InstructionSeq, std::string> prog_or_error = unmarshal(raw_prog);                            \
-        const auto prog = std::get_if<InstructionSeq>(&prog_or_error);                                            \
-        REQUIRE(prog != nullptr);                                                                                 \
-        cfg_t cfg = prepare_cfg(*prog, raw_prog.info, thread_local_options.cfg_opts);                             \
-        REQUIRE_THROWS_AS(analyze(cfg), UnmarshalError);                                                          \
+        const auto inst_seq = std::get_if<InstructionSeq>(&prog_or_error);                                        \
+        REQUIRE(inst_seq != nullptr);                                                                             \
+        Program prog = Program::from_sequence(*inst_seq, raw_prog.info, thread_local_options.cfg_opts);           \
+        REQUIRE_THROWS_AS(analyze(prog), UnmarshalError);                                                         \
     }
 
 FAIL_ANALYZE("build", "badmapptr.o", "test")
 
 // Verify a program in a section that may have multiple programs in it.
-#define VERIFY_PROGRAM(dirname, filename, section_name, program_name, _options, platform, should_pass, count) \
-    do {                                                                                                      \
-        thread_local_options = _options;                                                                      \
-        const auto raw_progs = read_elf("ebpf-samples/" dirname "/" filename, section_name, {}, platform);    \
-        REQUIRE(raw_progs.size() == count);                                                                   \
-        for (const auto& raw_prog : raw_progs) {                                                              \
-            if (count == 1 || raw_prog.function_name == program_name) {                                       \
-                const auto prog_or_error = unmarshal(raw_prog);                                               \
-                const auto prog = std::get_if<InstructionSeq>(&prog_or_error);                                \
-                REQUIRE(prog != nullptr);                                                                     \
-                const cfg_t cfg = prepare_cfg(*prog, raw_prog.info, thread_local_options.cfg_opts);           \
-                REQUIRE(verify(cfg) == should_pass);                                                          \
-            }                                                                                                 \
-        }                                                                                                     \
+#define VERIFY_PROGRAM(dirname, filename, section_name, program_name, _options, platform, should_pass, count)         \
+    do {                                                                                                              \
+        thread_local_options = _options;                                                                              \
+        const auto raw_progs = read_elf("ebpf-samples/" dirname "/" filename, section_name, {}, platform);            \
+        REQUIRE(raw_progs.size() == count);                                                                           \
+        for (const auto& raw_prog : raw_progs) {                                                                      \
+            if (count == 1 || raw_prog.function_name == program_name) {                                               \
+                const auto prog_or_error = unmarshal(raw_prog);                                                       \
+                const auto inst_seq = std::get_if<InstructionSeq>(&prog_or_error);                                    \
+                REQUIRE(inst_seq != nullptr);                                                                         \
+                const Program prog = Program::from_sequence(*inst_seq, raw_prog.info, thread_local_options.cfg_opts); \
+                REQUIRE(verify(prog) == should_pass);                                                                 \
+            }                                                                                                         \
+        }                                                                                                             \
     } while (0)
 
 // Verify a section with only one program in it.
@@ -606,7 +604,7 @@ TEST_SECTION_LEGACY_FAIL("cilium", "bpf_lxc.o", "2/10")
 TEST_SECTION_FAIL("cilium", "bpf_lxc.o", "2/11")
 TEST_SECTION_FAIL("cilium", "bpf_lxc.o", "2/12")
 
-void test_analyze_thread(const cfg_t* cfg, program_info* info, bool* res) {
+void test_analyze_thread(const Program* cfg, program_info* info, bool* res) {
     thread_local_program_info.set(*info);
     *res = verify(*cfg);
 }
@@ -617,21 +615,21 @@ TEST_CASE("multithreading", "[verify][multithreading]") {
     REQUIRE(raw_progs1.size() == 1);
     raw_program raw_prog1 = raw_progs1.back();
     auto prog_or_error1 = unmarshal(raw_prog1);
-    auto prog1 = std::get_if<InstructionSeq>(&prog_or_error1);
-    REQUIRE(prog1 != nullptr);
-    const cfg_t cfg1 = prepare_cfg(*prog1, raw_prog1.info, {});
+    auto inst_seq1 = std::get_if<InstructionSeq>(&prog_or_error1);
+    REQUIRE(inst_seq1 != nullptr);
+    const Program prog1 = Program::from_sequence(*inst_seq1, raw_prog1.info, {});
 
     auto raw_progs2 = read_elf("ebpf-samples/bpf_cilium_test/bpf_netdev.o", "2/2", {}, &g_ebpf_platform_linux);
     REQUIRE(raw_progs2.size() == 1);
     raw_program raw_prog2 = raw_progs2.back();
     auto prog_or_error2 = unmarshal(raw_prog2);
-    auto prog2 = std::get_if<InstructionSeq>(&prog_or_error2);
-    REQUIRE(prog2 != nullptr);
-    const cfg_t cfg2 = prepare_cfg(*prog2, raw_prog2.info, {});
+    auto inst_seq2 = std::get_if<InstructionSeq>(&prog_or_error2);
+    REQUIRE(inst_seq2 != nullptr);
+    const Program prog2 = Program::from_sequence(*inst_seq2, raw_prog2.info, {});
 
     bool res1, res2;
-    std::thread a(test_analyze_thread, &cfg1, &raw_prog1.info, &res1);
-    std::thread b(test_analyze_thread, &cfg2, &raw_prog2.info, &res2);
+    std::thread a(test_analyze_thread, &prog1, &raw_prog1.info, &res1);
+    std::thread b(test_analyze_thread, &prog2, &raw_prog2.info, &res2);
     a.join();
     b.join();
 

--- a/src/test/test_wto.cpp
+++ b/src/test/test_wto.cpp
@@ -6,11 +6,12 @@
 #include "crab/wto.hpp"
 
 using crab::label_t;
+using crab::wto_t;
 
 TEST_CASE("wto figure 1", "[wto]") {
     // Construct the example graph in figure 1 of Bourdoncle,
     // "Efficient chaotic iteration strategies with widenings", 1993.
-    const wto_t wto(crab::cfg_from_adjacency_list({{crab::label_t::entry, {label_t{1}}},
+    const wto_t wto(crab::cfg_from_adjacency_list({{label_t::entry, {label_t{1}}},
                                                    {label_t{1}, {label_t{2}}},
                                                    {label_t{2}, {label_t{3}}},
                                                    {label_t{3}, {label_t{4}}},
@@ -28,7 +29,7 @@ TEST_CASE("wto figure 1", "[wto]") {
 TEST_CASE("wto figure 2a", "[wto]") {
     // Construct the example graph in figure 2a of Bourdoncle,
     // "Efficient chaotic iteration strategies with widenings", 1993.
-    const wto_t wto(crab::cfg_from_adjacency_list({{crab::label_t::entry, {label_t{1}}},
+    const wto_t wto(crab::cfg_from_adjacency_list({{label_t::entry, {label_t{1}}},
                                                    {label_t{1}, {label_t{2}, label_t{4}}},
                                                    {label_t{2}, {label_t{3}}},
                                                    {label_t{3}, {label_t::exit}},
@@ -43,7 +44,7 @@ TEST_CASE("wto figure 2a", "[wto]") {
 TEST_CASE("wto figure 2b", "[wto]") {
     // Construct the example graph in figure 2b of Bourdoncle,
     // "Efficient chaotic iteration strategies with widenings", 1993.
-    const wto_t wto(crab::cfg_from_adjacency_list({{crab::label_t::entry, {label_t{1}}},
+    const wto_t wto(crab::cfg_from_adjacency_list({{label_t::entry, {label_t{1}}},
                                                    {label_t{1}, {label_t{2}, label_t{4}}},
                                                    {label_t{2}, {label_t{3}}},
                                                    {label_t{3}, {label_t{1}, label_t::exit}},


### PR DESCRIPTION
Extract code from cfg_t class so it only deals with control flow structure.
The new class Program holds cfg_t and mapping labels to instructions and from labels to assertions (a cache, essentially).

The class GuardedInstruction is removed, as it only clutters the code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a `Program` class for encapsulating control flow graphs and associated instructions.
	- Added methods for managing assertions and retrieving instructions within the `Program` class.
	- Enhanced `ebpf_checker` with new methods for validating eBPF assertions.

- **Bug Fixes**
	- Improved error handling in various functions related to instruction processing and verification.

- **Documentation**
	- Updated documentation to reflect changes in function signatures and class structures.

- **Refactor**
	- Transitioned from using `cfg_t` to `Program` across multiple components, streamlining the handling of instruction sequences.

- **Tests**
	- Updated test cases to utilize the new `Program` class, ensuring consistency and correctness in verification processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->