### PR TITLE
Add expect failed test for loading BPF program with global variables

### DIFF
--- a/src/test/test_verify.cpp
+++ b/src/test/test_verify.cpp
@@ -426,6 +426,9 @@ TEST_SECTION("falco", "probe.o", "raw_tracepoint/signal_deliver")
 TEST_SECTION_REJECT_IF_STRICT("build", "mapoverflow.o", ".text")
 TEST_SECTION_REJECT_IF_STRICT("build", "mapunderflow.o", ".text")
 
+// Test uses global variables, which are not supported yet by the verifier.
+TEST_SECTION_FAIL("build", "global_variable.o", ".text")
+
 /*
  * These programs contain "call -1" instruction and cannot be verified:
 TEST_SECTION("raw_tracepoint/filler/sys_access_e")


### PR DESCRIPTION
Add test that is currently expected to fail for loading BPF programs with global non-const variables.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the subproject reference to a new commit, potentially including various improvements.
	- Added a new test case for verifying eBPF programs that utilize global variables, which are unsupported by the verifier.

- **Documentation**
	- Included comments listing eBPF programs that cannot be verified for better context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->