### PR TITLE
Add support for is_valid_before

### DIFF
--- a/src/crab_verifier.hpp
+++ b/src/crab_verifier.hpp
@@ -58,6 +58,7 @@ class Invariants final {
     Invariants(const Invariants& invariants) = default;
 
     bool is_valid_after(const label_t& label, const string_invariant& state) const;
+    bool is_valid_before(const label_t& label, const string_invariant& state) const;
 
     string_invariant invariant_at(const label_t& label) const;
 


### PR DESCRIPTION
The uBPF fuzzer needs a version of the API that checks against the pre-conditions at the label instead of the post conditions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new state validation mechanism that checks conditions prior to specified events, offering additional insights during verification.
  
- **Refactor**
  - Updated the existing state check process to ensure more robust validation by refining the evaluation logic for post-event conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->