### PR TITLE
Handle upgrade from LCOV 1.15 to LCOV 2.0

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Build
         run: |
           mkdir build
-          cmake -B build -DCMAKE_BUILD_TYPE=${{env.BUILD_CONFIGURATION}} -DCMAKE_CXX_FLAGS="--coverage -fprofile-arcs -ftest-coverage -g"
+          cmake -B build -DCMAKE_BUILD_TYPE=${{env.BUILD_CONFIGURATION}} -DCMAKE_CXX_FLAGS="--coverage -fprofile-arcs -fprofile-update=atomic -ftest-coverage -g"
           cmake --build build -j $(nproc)
 
       - name: Run unit tests
@@ -43,7 +43,7 @@ jobs:
       - name: Generate code coverage report
         run: |
           mkdir coverage
-          lcov --capture --directory build --include '*/ebpf-verifier/src/*' --output-file coverage/lcov.info
+          lcov --ignore-errors --capture --directory build --include '*/ebpf-verifier/src/*' --output-file coverage/lcov.info
 
       - name: Coveralls Parallel
         uses: coverallsapp/github-action@master

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -39,6 +39,7 @@ jobs:
       - name: Run unit tests
         run: ./tests --abort --reporter compact
 
+      # Comment only change to test coverage report to coveralls
       - name: Generate code coverage report
         run: |
           mkdir coverage

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -34,7 +34,7 @@ jobs:
         run: |
           mkdir build
           cmake -B build -DCMAKE_BUILD_TYPE=${{env.BUILD_CONFIGURATION}} -DCMAKE_CXX_FLAGS="--coverage -fprofile-arcs -fprofile-update=atomic -ftest-coverage -g"
-          cmake --build build -j $(nproc)
+          cmake --build build -j $(nproc) --config ${{env.BUILD_CONFIGURATION}}
 
       - name: Run unit tests
         run: ./tests --abort --reporter compact
@@ -43,7 +43,7 @@ jobs:
       - name: Generate code coverage report
         run: |
           mkdir coverage
-          lcov --ignore-errors --capture --directory build --include '*/ebpf-verifier/src/*' --output-file coverage/lcov.info
+          lcov --ignore-errors all --capture --directory build --include '*/ebpf-verifier/src/*' --output-file coverage/lcov.info
 
       - name: Coveralls Parallel
         uses: coverallsapp/github-action@master


### PR DESCRIPTION
Ubuntu upgraded the lcov package from lcov 1.15 to lcov 2.0. This broke our CI pipeline. To address there are some changes required to the YAML pipeline.

Resolves: #827 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated GitHub Actions workflow for code coverage
	- Improved build configuration and coverage report generation
	- Enhanced robustness of coverage reporting process

<!-- end of auto-generated comment: release notes by coderabbit.ai -->