### PR TITLE
Update CI workflow to ubuntu-latest

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -54,7 +54,7 @@ jobs:
 
   finish:
     needs: build_ubuntu
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Coveralls Finished
         uses: coverallsapp/github-action@master


### PR DESCRIPTION
Github is removing 20.04 in the near future,
and the standard example at https://github.com/coverallsapp/github-action uses ubuntu-latest

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated our quality assurance environment to the latest stable platform for improved compatibility and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->