### PR TITLE
Raise minimum cmake version to 3.16 to support MSVC_RUNTIME_LIBRARY 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 # Copyright (c) Prevail Verifier contributors.
 # SPDX-License-Identifier: MIT
-cmake_minimum_required(VERSION 3.14)
+# Set cmake version to 3.16 to use CMP0091 aka MSVC_RUNTIME_LIBRARY property.
+cmake_minimum_required(VERSION 3.16)
+
 project(ebpf_verifier)
 
 include(FetchContent)


### PR DESCRIPTION
This pull request includes an update to the `CMakeLists.txt` file to set the minimum required CMake version to 3.16. This change ensures compatibility with the MSVC_RUNTIME_LIBRARY property (CMP0091).

* [`CMakeLists.txt`](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL3-R5): Updated CMake version requirement from 3.14 to 3.16 to utilize the MSVC_RUNTIME_LIBRARY property.

This permits users of the library to select the version of the MSVC runtime to link against (i.e. permit linking against static version of the MSVC runtime).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the build configuration to require a newer toolchain version, improving handling of runtime libraries for Microsoft Visual C++ builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->