### PR TITLE
Set default CMAKE_MSVC_RUNTIME_LIBRARY values for FuzzerDebug

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,11 @@ if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" OR
     set(CMAKE_CXX_STANDARD_REQUIRED ON)
 elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
     list(APPEND CMAKE_CONFIGURATION_TYPES FuzzerDebug)
+    # Check if CMAKE_MSVC_RUNTIME_LIBRARY is set and set it to MultiThreadedDLL if not.
+    # This is required to make FuzzerDebug build with MSVC using MultiThreadedDLL runtime.
+    if (NOT CMAKE_MSVC_RUNTIME_LIBRARY)
+        set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>$<$<CONFIG:FuzzerDebug>:Debug>DLL")
+    endif ()
     list(REMOVE_DUPLICATES CMAKE_CONFIGURATION_TYPES)
     set(CMAKE_CONFIGURATION_TYPES "${CMAKE_CONFIGURATION_TYPES}" CACHE STRING
             "Add the configurations that we need"


### PR DESCRIPTION
This pull request includes a change to the `CMakeLists.txt` file to ensure proper configuration for building with MSVC using the MultiThreadedDLL runtime. The most important change involves checking and setting the `CMAKE_MSVC_RUNTIME_LIBRARY` if it is not already set.

Configuration improvements:

* [`CMakeLists.txt`](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR49-R53): Added a check to see if `CMAKE_MSVC_RUNTIME_LIBRARY` is set and, if not, set it to `MultiThreaded$<$<CONFIG:Debug>:Debug>$<$<CONFIG:FuzzerDebug>:Debug>DLL`. This ensures that the FuzzerDebug configuration builds correctly with MSVC using the MultiThreadedDLL runtime.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Improved build configuration for MSVC environments, ensuring smoother operation in specific debug builds. This update enhances compatibility and stability without altering overall project functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->