### PR TITLE
Prevent out of memory when parsing malformed sub-programs

### DIFF
--- a/src/asm_files.cpp
+++ b/src/asm_files.cpp
@@ -378,6 +378,12 @@ class program_reader_t {
                 const ELFIO::section& subprogram_section = *reader.sections[symbol_details.section_index];
 
                 if (const auto subprogram = find_subprogram(raw_programs, subprogram_section, symbol_details.name)) {
+                    // Don't permit recursive subprograms.
+                    if (subprogram == &prog) {
+                        throw UnmarshalError("Subprogram '" + symbol_details.name +
+                                             "' is the same as the calling program");
+                    }
+
                     // Make sure subprogram has already had any subprograms of its own appended.
                     std::string error = append_subprograms(*subprogram);
                     if (!error.empty()) {


### PR DESCRIPTION
If the subprogram being processed is the same as the current program, then the logic to copy the line-info entries performs an unbounded allocation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Implemented an enhanced error check to prevent recursive calls that could lead to infinite loops or system instability, ensuring that the application handles such cases more robustly without impacting valid functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->