### PR TITLE
Bump yaml-cpp to v0.8.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -131,6 +131,7 @@ elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
 endif ()
 
 add_library(ebpfverifier ${LIB_SRC})
+target_compile_definitions(ebpfverifier PRIVATE YAML_CPP_STATIC_DEFINE)
 
 if (VERIFIER_ENABLE_TESTS)
     add_executable(check src/main/check.cpp src/main/linux_verifier.cpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,9 +66,6 @@ elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
     set(Boost_LIBRARY_DIRS ${CMAKE_BINARY_DIR}/packages/boost_filesystem-vc143/lib/native)
 
     if (VERIFIER_ENABLE_TESTS)
-        # MSVC's "std:c++20" option is the current standard that supports all the C++17
-        # features we use. However, cmake can't deal with that here, so we set it below.
-
         set(EXTERNAL_INSTALL_LOCATION ${CMAKE_BINARY_DIR}/packages/yaml-cpp)
         include(ExternalProject)
         ExternalProject_Add(yaml-cpp
@@ -79,6 +76,7 @@ elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
                 -DYAML_MSVC_SHARED_RT=ON
                 -DYAML_CPP_BUILD_TESTS=OFF
                 -DYAML_CPP_BUILD_TOOLS=OFF
+                -DCMAKE_POLICY_VERSION_MINIMUM=3.14
         )
         set(YAML_CPP_LIBRARIES ${EXTERNAL_INSTALL_LOCATION}/lib/yaml-cpp$<$<CONFIG:DEBUG>:d>.lib)
         set(YAML_CPP_INCLUDE_DIR ${EXTERNAL_INSTALL_LOCATION}/include/)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,7 +73,7 @@ elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
         include(ExternalProject)
         ExternalProject_Add(yaml-cpp
                 GIT_REPOSITORY https://github.com/jbeder/yaml-cpp.git
-                GIT_TAG "yaml-cpp-0.7.0"
+                GIT_TAG "0.8.0"
                 GIT_SHALLOW true
                 CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${EXTERNAL_INSTALL_LOCATION}
                 -DYAML_MSVC_SHARED_RT=ON


### PR DESCRIPTION
yaml-cpp release 0.8.0 is not yaml-cpp-0.8.0: https://github.com/jbeder/yaml-cpp/tags. The support for CMake3.4 does not play well with our configuration, so
* Use `-DCMAKE_POLICY_VERSION_MINIMUM=3.14`
* Statically link yaml-cpp: `target_compile_definitions(ebpfverifier PRIVATE YAML_CPP_STATIC_DEFINE)`

There's a pending PR regarding removal of CMake 3.4:
https://github.com/jbeder/yaml-cpp/pull/1351