### PR TITLE
Bump Catch2 to 3.10.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,7 @@ get_target_property(GSL_INCLUDE_DIRS Microsoft.GSL::GSL INTERFACE_INCLUDE_DIRECT
 if (VERIFIER_ENABLE_TESTS)
     FetchContent_Declare(Catch2
             GIT_REPOSITORY "https://github.com/catchorg/Catch2.git"
-            GIT_TAG "v3.9.1"
+            GIT_TAG "v3.10.0"
             GIT_SHALLOW ON
     )
     FetchContent_MakeAvailable(Catch2)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Upgraded the testing framework to Catch2 v3.10.0 to incorporate the latest fixes and improvements in our test suite. This affects only the test environment and does not impact runtime behavior or public APIs, ensuring consistent application functionality.
* **Chores**
  * Routine dependency maintenance to keep development tooling current, improving developer experience and future compatibility without altering user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->