### PR TITLE
Improve Linux helper support

### DIFF
--- a/src/asm_ostream.cpp
+++ b/src/asm_ostream.cpp
@@ -209,7 +209,6 @@ std::ostream& operator<<(std::ostream& os, const ArgSingle::Kind kind) {
 std::ostream& operator<<(std::ostream& os, const ArgPair::Kind kind) {
     switch (kind) {
     case ArgPair::Kind::PTR_TO_READABLE_MEM: return os << "mem";
-    case ArgPair::Kind::PTR_TO_READABLE_MEM_OR_NULL: return os << "mem?";
     case ArgPair::Kind::PTR_TO_WRITABLE_MEM: return os << "out";
     }
     assert(false);
@@ -222,7 +221,11 @@ std::ostream& operator<<(std::ostream& os, const ArgSingle arg) {
 }
 
 std::ostream& operator<<(std::ostream& os, const ArgPair arg) {
-    os << arg.kind << " " << arg.mem << "[" << arg.size;
+    os << arg.kind;
+    if (arg.or_null) {
+        os << "?";
+    }
+    os << " " << arg.mem << "[" << arg.size;
     if (arg.can_be_zero) {
         os << "?";
     }

--- a/src/asm_syntax.hpp
+++ b/src/asm_syntax.hpp
@@ -147,11 +147,11 @@ struct ArgSingle {
 struct ArgPair {
     enum class Kind {
         PTR_TO_READABLE_MEM,
-        PTR_TO_READABLE_MEM_OR_NULL,
         PTR_TO_WRITABLE_MEM,
     } kind{};
-    Reg mem;  ///< Pointer.
-    Reg size; ///< Size of space pointed to.
+    bool or_null{}; ///< true for PTR_TO_READABLE_MEM_OR_NULL and for PTR_TO_WRITABLE_MEM_OR_NULL
+    Reg mem;        ///< Pointer.
+    Reg size;       ///< Size of space pointed to.
     bool can_be_zero{};
     constexpr bool operator==(const ArgPair&) const = default;
 };

--- a/src/asm_unmarshal.cpp
+++ b/src/asm_unmarshal.cpp
@@ -473,8 +473,9 @@ struct Unmarshaller {
 
     static ArgPair::Kind toArgPairKind(const ebpf_argument_type_t t) {
         switch (t) {
-        case EBPF_ARGUMENT_TYPE_PTR_TO_READABLE_MEM_OR_NULL: return ArgPair::Kind::PTR_TO_READABLE_MEM_OR_NULL;
+        case EBPF_ARGUMENT_TYPE_PTR_TO_READABLE_MEM_OR_NULL:
         case EBPF_ARGUMENT_TYPE_PTR_TO_READABLE_MEM: return ArgPair::Kind::PTR_TO_READABLE_MEM;
+        case EBPF_ARGUMENT_TYPE_PTR_TO_WRITABLE_MEM_OR_NULL:
         case EBPF_ARGUMENT_TYPE_PTR_TO_WRITABLE_MEM: return ArgPair::Kind::PTR_TO_WRITABLE_MEM;
         default: break;
         }
@@ -523,6 +524,7 @@ struct Unmarshaller {
             }
             case EBPF_ARGUMENT_TYPE_PTR_TO_READABLE_MEM_OR_NULL:
             case EBPF_ARGUMENT_TYPE_PTR_TO_READABLE_MEM:
+            case EBPF_ARGUMENT_TYPE_PTR_TO_WRITABLE_MEM_OR_NULL:
             case EBPF_ARGUMENT_TYPE_PTR_TO_WRITABLE_MEM:
                 // Sanity check: This argument must be followed by EBPF_ARGUMENT_TYPE_CONST_SIZE or
                 // EBPF_ARGUMENT_TYPE_CONST_SIZE_OR_ZERO.
@@ -540,7 +542,9 @@ struct Unmarshaller {
                         proto.name);
                 }
                 const bool can_be_zero = (args[i + 1] == EBPF_ARGUMENT_TYPE_CONST_SIZE_OR_ZERO);
-                res.pairs.push_back({toArgPairKind(args[i]), Reg{gsl::narrow<uint8_t>(i)},
+                const bool or_null = args[i] == EBPF_ARGUMENT_TYPE_PTR_TO_READABLE_MEM_OR_NULL ||
+                                     args[i] == EBPF_ARGUMENT_TYPE_PTR_TO_WRITABLE_MEM_OR_NULL;
+                res.pairs.push_back({toArgPairKind(args[i]), or_null, Reg{gsl::narrow<uint8_t>(i)},
                                      Reg{gsl::narrow<uint8_t>(i + 1)}, can_be_zero});
                 i++;
                 break;

--- a/src/crab/ebpf_checker.cpp
+++ b/src/crab/ebpf_checker.cpp
@@ -63,9 +63,9 @@ using OnRequire = std::function<void(TypeToNumDomain&, const LinearConstraint&, 
 
 class EbpfChecker final {
   public:
-    explicit EbpfChecker(EbpfDomain& dom, const Assertion& assertion, const OnRequire& on_require_type,
-                         const OnRequire& on_require_value)
-        : assertion{assertion}, on_require_type{on_require_type}, on_require_value{on_require_value}, dom(dom) {}
+    explicit EbpfChecker(EbpfDomain& dom, Assertion assertion, OnRequire on_require_type, OnRequire on_require_value)
+        : assertion{std::move(assertion)}, on_require_type{std::move(on_require_type)},
+          on_require_value{std::move(on_require_value)}, dom(dom) {}
 
     void visit(const Assertion& assertion) { std::visit(*this, assertion); }
 

--- a/src/crab/ebpf_transformer.cpp
+++ b/src/crab/ebpf_transformer.cpp
@@ -757,7 +757,6 @@ void EbpfTransformer::operator()(const Call& call) {
     }
     for (ArgPair param : call.pairs) {
         switch (param.kind) {
-        case ArgPair::Kind::PTR_TO_READABLE_MEM_OR_NULL:
         case ArgPair::Kind::PTR_TO_READABLE_MEM:
             // Do nothing. No side effect allowed.
             break;

--- a/src/ebpf_base.h
+++ b/src/ebpf_base.h
@@ -26,6 +26,7 @@ typedef enum _ebpf_argument_type {
     EBPF_ARGUMENT_TYPE_PTR_TO_READABLE_MEM, // Memory must have been initialized.
     EBPF_ARGUMENT_TYPE_PTR_TO_READABLE_MEM_OR_NULL,
     EBPF_ARGUMENT_TYPE_PTR_TO_WRITABLE_MEM,
+    EBPF_ARGUMENT_TYPE_PTR_TO_WRITABLE_MEM_OR_NULL,
     EBPF_ARGUMENT_TYPE_UNSUPPORTED,
 } ebpf_argument_type_t;
 

--- a/src/helpers.hpp
+++ b/src/helpers.hpp
@@ -7,18 +7,20 @@
 namespace prevail {
 // A helper function's prototype is expressed by this struct.
 struct EbpfHelperPrototype {
-    const char* name;
+    const char* name{};
 
     // The return value is returned in register R0.
-    ebpf_return_type_t return_type;
+    ebpf_return_type_t return_type{};
 
     // Arguments are passed in registers R1 to R5.
-    ebpf_argument_type_t argument_type[5];
+    ebpf_argument_type_t argument_type[5]{};
 
     // Side effect: can this helper perform packet reallocation.
-    bool reallocate_packet;
+    bool reallocate_packet{};
 
     // If R1 holds a context, then this holds a pointer to the context descriptor.
-    const ebpf_context_descriptor_t* context_descriptor;
+    const ebpf_context_descriptor_t* context_descriptor{};
+
+    bool unsupported = false;
 };
 } // namespace prevail

--- a/src/linux/gpl/spec_type_descriptors.hpp
+++ b/src/linux/gpl/spec_type_descriptors.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include "ebpf_base.h"
 
 namespace prevail {
 constexpr int NMAPS = 64;


### PR DESCRIPTION
Add missing helper functions, support EBPF_ARGUMENT_TYPE_PTR_TO_WRITABLE_MEM_OR_NULL, and collect unsupported types as documented macros.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for nullable writable memory pointer arguments in eBPF helpers
  * Introduced unsupported helper identification and blocking

* **Bug Fixes & Improvements**
  * Enhanced validation of eBPF helper compatibility with stricter type checking
  * Improved context descriptor validation for helper function calls
  * Refined helper prototype specifications with expanded type definitions for better type safety

<!-- end of auto-generated comment: release notes by coderabbit.ai -->