### PR TITLE
Allow prevail consumers to override MSVC settings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,9 @@ cmake_minimum_required(VERSION 3.24)
 if (POLICY CMP0167)
   cmake_policy(SET CMP0167 NEW)
 endif ()
-set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL")
+if (NOT DEFINED CMAKE_MSVC_RUNTIME_LIBRARY)
+  set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL")
+endif()
 
 project(prevail)
 


### PR DESCRIPTION
This pull request introduces a small improvement to the `CMakeLists.txt` build configuration. The change ensures that the `CMAKE_MSVC_RUNTIME_LIBRARY` variable is only set if it has not already been defined, which helps prevent unintended overrides of user or environment settings.

- Build configuration improvement:
  * Updated `CMakeLists.txt` to set `CMAKE_MSVC_RUNTIME_LIBRARY` only if it is not already defined, preventing accidental overrides.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build configuration to respect pre-existing runtime library settings, allowing custom user or toolchain configurations to be preserved instead of being overridden.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->