### PR TITLE
CXX settings shouldn't span lines as this causes wrongly generated vcxproj

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,17 +57,9 @@ if (MSVC)
     "Add the configurations that we need" FORCE)
 
   # Derive base debug flags and add sanitizer instrumentation
-  set(CMAKE_C_FLAGS_FUZZERDEBUG
-    "${CMAKE_C_FLAGS_DEBUG} /fsanitize=address /fsanitize=fuzzer "
-    "/fsanitize-coverage=inline-bool-flag /fsanitize-coverage=edge "
-    "/fsanitize-coverage=trace-cmp /fsanitize-coverage=trace-div "
-    "/ZH:SHA_256")
+  set(CMAKE_C_FLAGS_FUZZERDEBUG "${CMAKE_C_FLAGS_DEBUG} /fsanitize=address /fsanitize=fuzzer /fsanitize-coverage=inline-bool-flag /fsanitize-coverage=edge /fsanitize-coverage=trace-cmp /fsanitize-coverage=trace-div /ZH:SHA_256")
 
-  set(CMAKE_CXX_FLAGS_FUZZERDEBUG
-    "${CMAKE_CXX_FLAGS_DEBUG} /fsanitize=address /fsanitize=fuzzer "
-    "/fsanitize-coverage=inline-bool-flag /fsanitize-coverage=edge "
-    "/fsanitize-coverage=trace-cmp /fsanitize-coverage=trace-div "
-    "/ZH:SHA_256")
+  set(CMAKE_CXX_FLAGS_FUZZERDEBUG "${CMAKE_CXX_FLAGS_DEBUG} /fsanitize=address /fsanitize=fuzzer /fsanitize-coverage=inline-bool-flag /fsanitize-coverage=edge /fsanitize-coverage=trace-cmp /fsanitize-coverage=trace-div /ZH:SHA_256")
 
   # Propagate linker flags (same as Debug)
   set(CMAKE_EXE_LINKER_FLAGS_FUZZERDEBUG "${CMAKE_EXE_LINKER_FLAGS_DEBUG}")


### PR DESCRIPTION
When building with MSVC the CMake set command spanning multiple lines gets translated into a list of strings, not a single concatenated string. This breaks vcxproj generation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined build configuration for fuzzing debug builds by consolidating flag definitions, improving code organization without altering build behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->