### PR TITLE
Update Catch2 to version 3.12.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -197,7 +197,7 @@ endif ()
 if (prevail_ENABLE_TESTS)
   FetchContent_Declare(Catch2
     GIT_REPOSITORY "https://github.com/catchorg/Catch2.git"
-    GIT_TAG "v3.11.0"
+    GIT_TAG "v3.12.0"
     GIT_SHALLOW ON
   )
   FetchContent_MakeAvailable(Catch2)


### PR DESCRIPTION
Release notes:
https://github.com/catchorg/Catch2/releases/tag/v3.12.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test framework dependency to the latest version for improved testing infrastructure.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->