### PR TITLE
Lazy init constant_limits with LazyAllocator

### DIFF
--- a/src/crab/ebpf_domain.hpp
+++ b/src/crab/ebpf_domain.hpp
@@ -68,6 +68,7 @@ class EbpfDomain final {
     EbpfDomain narrow(const EbpfDomain& other) const;
 
     static EbpfDomain calculate_constant_limits();
+    static void clear_thread_local_state();
     ExtendedNumber get_loop_count_upper_bound() const;
     Interval get_r0() const;
 

--- a/src/fwd_analyzer.cpp
+++ b/src/fwd_analyzer.cpp
@@ -1,8 +1,8 @@
 // Copyright (c) Prevail Verifier contributors.
 // SPDX-License-Identifier: Apache-2.0
+#include <ranges>
 #include <utility>
 #include <variant>
-#include <ranges>
 
 #include "cfg/cfg.hpp"
 #include "cfg/wto.hpp"
@@ -27,6 +27,7 @@ void ebpf_verifier_clear_thread_local_state() {
     thread_local_program_info.clear();
     clear_thread_local_state();
     SplitDBM::clear_thread_local_state();
+    EbpfDomain::clear_thread_local_state();
 }
 
 class InterleavedFwdFixpointIterator final {


### PR DESCRIPTION
Resolves: #972 

## Problem

The `constant_limits` static variable in `ebpf_domain.cpp` was initialized at static initialization time, before `thread_local_options` and `variable_registry` were properly set up. In release builds, this caused static initialization order issues where `EbpfDomain::calculate_constant_limits()` would capture uninitialized or default state from these thread-local variables, leading to incorrect constraint limits being cached and reused throughout the program's lifetime.

Additionally, even with lazy initialization, the cached limits could become stale when threads are reused with different configurations (e.g., in test suites where `thread_local_options` is reassigned between test cases), as the cache was never invalidated during thread-local state cleanup.

## Solution

1. **Lazy initialization**: Replace static initialization with `LazyAllocator<EbpfDomain, EbpfDomain::calculate_constant_limits>` to defer computation until first use, ensuring `thread_local_options` and `variable_registry` are populated before `calculate_constant_limits()` captures their state.

2. **Cache invalidation**: Add `EbpfDomain::clear_thread_local_state()` method that clears the `constant_limits` cache, and call it from `ebpf_verifier_clear_thread_local_state()` to prevent stale cached limits when threads are reused with different configurations.

3. **Soundness documentation**: Expand comment to explicitly document reentrancy safety (no recursion possible since `calculate_constant_limits` doesn't call `get_constant_limits()` or `widen(to_constants=true)`) and soundness of intersection-based clamping (only shrinks domain, preserving over-approximation).

## Changes

- Changed `constant_limits` from static initialization to `thread_local LazyAllocator`
- Added `get_constant_limits()` accessor function
- Added `EbpfDomain::clear_thread_local_state()` to invalidate the cache
- Updated `widen()` to use `get_constant_limits()` accessor
- Added comprehensive comment documenting soundness and safety

Widening clamping behavior remains identical; this only fixes the initialization timing and cache lifetime issues.

## Testing

Existing tests pass. The fix ensures correct behavior in release builds and when threads are reused across different verification contexts.



## Summary by CodeRabbit

* **Chores**
  * Optimized constant limits initialization through lazy-loading mechanism for improved performance and resource management.


<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Domain constants now initialize lazily to reduce startup cost and memory use.
  * Public control added to reset domain thread-local state for better lifecycle handling.

* **Bug Fixes**
  * Verifier teardown now clears domain-specific thread-local state too, preventing stale state across runs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->