### PR TITLE
Fix ValidMapKeyValue diagnostic wording

### DIFF
--- a/src/printing.cpp
+++ b/src/printing.cpp
@@ -364,7 +364,7 @@ struct AssertionPrinterVisitor {
     }
 
     void operator()(ValidMapKeyValue const& a) {
-        _os << "within stack(" << a.access_reg << ":" << (a.key ? "key_size" : "value_size") << "(" << a.map_fd_reg
+        _os << "within(" << a.access_reg << ":" << (a.key ? "key_size" : "value_size") << "(" << a.map_fd_reg
             << "))";
     }
 


### PR DESCRIPTION
Closing for now per maintainer workflow: filing changes in the fork first. Tracking PR is in Alan-Jowett/ebpf-verifier and can be upstreamed later when requested.