### PR TITLE
Fix CMake nesting issues

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,9 +96,12 @@ endif ()
 
 include(cmake/SetupBoostHeaders.cmake)
 
+# Escape regex metacharacters in prevail_source_dir for use in list(FILTER ... REGEX ...)
+string(REGEX REPLACE "([][+.*()^$?|\\\\])" "\\\\\\1" prevail_source_dir_escaped "${prevail_source_dir}")
+
 file(GLOB_RECURSE prevail_LIB_SRC CONFIGURE_DEPENDS "${prevail_source_dir}/src/*.cpp")
-list(FILTER prevail_LIB_SRC EXCLUDE REGEX "${prevail_source_dir}/src/main/.*")
-list(FILTER prevail_LIB_SRC EXCLUDE REGEX "${prevail_source_dir}/src/test/.*")
+list(FILTER prevail_LIB_SRC EXCLUDE REGEX "${prevail_source_dir_escaped}/src/main/.*")
+list(FILTER prevail_LIB_SRC EXCLUDE REGEX "${prevail_source_dir_escaped}/src/test/.*")
 
 add_library(prevail ${prevail_LIB_SRC})
 # 1. Standard library include paths


### PR DESCRIPTION
Fixes: #986

This pull request updates the `CMakeLists.txt` file to consistently use a new variable, `prevail_source_dir`, instead of `CMAKE_SOURCE_DIR` for referencing the project's root directory. This change ensures that the build system works correctly when the project is included as a subdirectory or via `FetchContent`, avoiding issues where `CMAKE_SOURCE_DIR` points to the superproject rather than the prevail project's root.

Key changes grouped by theme:

**Build System Robustness:**

* Introduced the `prevail_source_dir` variable set to `PROJECT_SOURCE_DIR` and replaced all instances of `CMAKE_SOURCE_DIR` with `prevail_source_dir` to ensure correct path resolution when prevail is used as a dependency.

**Source and Include Path Updates:**

* Updated all source file references, include directories, and installation directives to use `prevail_source_dir` instead of `CMAKE_SOURCE_DIR`, ensuring correct file and directory paths throughout the build and install process. [[1]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL89-R123) [[2]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL129-R147) [[3]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL157-R165) [[4]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL180-R188) [[5]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL208-R220) [[6]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL259-R264) [[7]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL286-R291)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Standardized project-root handling across the build system to make path resolution consistent.
  * Updated build, install, and test orchestration so external components, headers, test assets, and packaging use the new consistent paths.
  * Preserved functional behavior; no runtime or public API changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->