### PR TITLE
ci: add apt-get update to CodeQL and coverage workflows

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -66,6 +66,7 @@ jobs:
       #    uses a compiled language
       - name: Install dependencies
         run: |
+          sudo apt-get update
           sudo apt install libboost-dev libboost-filesystem-dev libboost-program-options-dev libyaml-cpp-dev
 
       - run: |

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -23,6 +23,7 @@ jobs:
     steps:
       - name: Install dependencies
         run: |
+          sudo apt-get update
           sudo apt install libboost-dev libboost-filesystem-dev libboost-program-options-dev libyaml-cpp-dev lcov
           pip install gcovr
 


### PR DESCRIPTION
## Summary

- Add `sudo apt-get update` before `sudo apt install` in `codeql-analysis.yml` and `coverage.yml`
- The `build.yml` workflow already had this and was not affected

The CodeQL and coverage CI jobs have been failing because the GitHub Actions runner's pre-cached apt package index references Boost 1.83 `.deb` files (`1.83.0-2.1ubuntu3.1`) that have since been superseded on `security.ubuntu.com`, resulting in 404 errors during package download.

## Test plan

- [ ] CodeQL workflow passes on this PR
- [ ] Coverage workflow passes on this PR

🤖 This PR was created by Claude Code (claude.ai/code) running on behalf of Elazar.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD workflows by adding package list refresh steps in CodeQL analysis and coverage check workflows to ensure dependencies are properly updated during build processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->