### PR TITLE
Fix duplicate CFG labels in function macro processing

### DIFF
--- a/src/ir/cfg_builder.cpp
+++ b/src/ir/cfg_builder.cpp
@@ -192,7 +192,7 @@ static void add_cfg_nodes(CfgBuilder& builder, const Label& caller_label, const 
                 if (!macro_labels.contains(next_macro_label)) {
                     macro_labels.insert(next_macro_label);
                 }
-                seen_labels.insert(macro_label);
+                seen_labels.insert(next_macro_label);
             }
         }
     }


### PR DESCRIPTION
## Summary

Fixes a bug where processing function macros incorrectly tracks which CFG nodes have been processed, causing duplicate labels to be created.

## Problem

In `add_cfg_nodes()`, the loop that walks successor nodes incorrectly inserted `macro_label` (the current node being processed) into `seen_labels` instead of `next_macro_label` (the successor being discovered). This caused:

1. Successors to be added to `macro_labels` for processing
2. But the wrong label marked as seen
3. When processing the successor later, its successors could be added again
4. This resulted in: `error : CRAB error : Label 424/1718 already exists`

## Fix

Change line 195 from:
```cpp
seen_labels.insert(macro_label);
```
to:
```cpp
seen_labels.insert(next_macro_label);
```

Fixes #990

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue in control flow graph processing during macro expansion that could result in incorrect code generation. The fix ensures proper traversal of successor labels, improving generated code correctness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->