### PR TITLE
Fix SplitDBM unstable vertex detection and add widen closure test

### DIFF
--- a/src/crab/splitdbm/split_dbm.cpp
+++ b/src/crab/splitdbm/split_dbm.cpp
@@ -191,14 +191,16 @@ void SplitDBM::normalize() {
         return;
     }
 
-    struct UnstableWrap {
-        const VertSet& vs;
-        explicit UnstableWrap(const VertSet& s) : vs(s) {}
-        bool operator[](const VertId v) const { return vs.contains(v); }
+    // close_after_widen expects an is_stable predicate: returns true iff v is stable.
+    // Vertices in unstable_ are NOT stable, so we negate the membership test.
+    struct IsStable {
+        const VertSet& unstable;
+        explicit IsStable(const VertSet& s) : unstable(s) {}
+        bool operator[](const VertId v) const { return !unstable.contains(v); }
     };
 
     const auto p = pot_func(potential_);
-    apply_delta(close_after_widen(*scratch_, SubGraph(g_, 0), p, UnstableWrap(unstable_)));
+    apply_delta(close_after_widen(*scratch_, SubGraph(g_, 0), p, IsStable(unstable_)));
     apply_delta(close_after_assign(*scratch_, g_, p, 0));
 
     unstable_.clear();


### PR DESCRIPTION
## Summary
This PR fixes a critical bug in the SplitDBM unstable vertex detection logic and adds a comprehensive test case to verify the fix works correctly.

## Key Changes
- **Bug Fix**: Corrected the `UnstableWrap::operator[]` logic in `split_dbm.cpp` to properly identify unstable vertices by inverting the containment check (`!vs.contains(v)` instead of `vs.contains(v)`)
- **Test Addition**: Added a new test case `close_after_widen recovers transitive edge through unstable vertex` that validates the widen closure behavior
- **Include Addition**: Added missing `#include "crab/splitdbm/split_dbm.hpp"` to test file

## Implementation Details
The bug was in how unstable vertices were being identified during the widening operation. The `UnstableWrap` wrapper was incorrectly returning the opposite boolean value, causing vertices that should have been marked as unstable to be treated as stable and vice versa.

The new test case demonstrates the fix by:
1. Creating two graphs where the right graph has a looser edge (12 vs 10) on the transitive path 1→3
2. Verifying that after widening, the direct edge 1→3 is dropped (since 12 > 10)
3. Confirming that `close_after_widen` correctly recovers the transitive path 1→2→3 (5+5=10) through Dijkstra recovery from the unstable vertex 1
4. Validating that the recovered edge has the correct weight of 10

This ensures that the closure operation properly reconstructs transitive relationships that may have been lost during the widening process.

https://claude.ai/code/session_01XRADiTjoWyzfaoyhF2odaf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected stability handling during split DBM widening so transitive edges are recovered as expected.

* **Tests**
  * Added a test that verifies transitive edge recovery, preservation of intermediate edges and weights, and correct potentials after widening.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->