### PR TITLE
Add failure slicing for verification errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,9 @@ Verbosity:
                               into a single basic block. Default: enabled
           --line-info         Print line information
           --print-btf-types   Print BTF types
+          --failure-slice     Print minimal failure diagnostic (causal trace)
+          --failure-slice-depth N
+                              Maximum backward traversal steps (default: 200)
   -v                          Print invariants and first failure
   -f                          Print first failure
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,7 @@ This documentation provides a comprehensive guide to understanding the Prevail e
 | [Control Flow Graph](cfg.md) | CFG construction and weak topological ordering |
 | [Memory Model](memory-model.md) | Stack, packet, context, and shared memory handling |
 | [Type System](type-system.md) | Type domains and type-guided verification |
+| [Failure Slicing](failure-slicing.md) | Minimal diagnostic slices for verification failures |
 | [Building](building.md) | Build instructions for all platforms |
 | [Testing](testing.md) | Test infrastructure and conformance testing |
 | [Glossary](glossary.md) | Terminology and definitions |

--- a/docs/failure-slicing.md
+++ b/docs/failure-slicing.md
@@ -1,0 +1,475 @@
+# Failure Slicing
+
+Failure slicing is a diagnostic feature that computes the minimal subset of a program
+that contributed to a verification failure. When verification fails, instead of showing
+the entire CFG with all invariants, failure slicing identifies only the instructions and
+state that are causally relevant to the error.
+
+## Motivation
+
+Large eBPF programs can have thousands of instructions, but a verification failure
+typically involves only a small fraction of them. Failure slicing helps developers and
+LLM-based tools focus on the relevant code path without being overwhelmed by unrelated
+instructions.
+
+## Quick Start
+
+```bash
+./bin/check program.o section --failure-slice
+```
+
+Output includes:
+- Error message and location
+- Relevant registers at the failure point
+- Slice size (number of causal instructions)
+- Control-flow summary (branch-path skeleton through the slice)
+- Filtered CFG showing only relevant invariants and instructions
+- Per-predecessor invariants at join points (when applicable)
+
+## Concepts
+
+### Backward Slicing
+
+Given a failure at label L involving registers R1, R2, …, the algorithm walks backward
+through the CFG to find all instructions that contributed to the values in those
+registers at that point. The walk tracks both **data dependencies** (which registers
+flow into which) and **control dependencies** (which branch conditions determine
+reachability of the failing instruction).
+
+For example, if verification fails because "R1 is not a valid pointer":
+
+1. The slice starts with R1 as relevant
+2. If R1 was defined by `r1 = r2 + 4`, then R2 becomes relevant
+3. If R2 was loaded from the stack `r2 = *(r10 - 8)`, then stack offset -8 becomes relevant
+4. If the failing label is guarded by `assume r4 == 0`, then R4 becomes relevant
+5. The algorithm continues until it reaches program entry or exhausts relevance
+
+### Two-Map Architecture: Visited vs Slice Labels
+
+The backward walk maintains two separate maps:
+
+- **`visited`**: Tracks *all* labels explored during traversal, used for deduplication.
+  A label that is merely traversed (e.g., a passthrough where r3 flows through unchanged)
+  appears in `visited` but not in the output.
+- **`slice_labels`**: Tracks only labels whose instructions actually *interact* with
+  relevant registers (read or write them). Only these labels appear in the output.
+
+This separation prevents "pass-through explosion" where the entire program would be
+included just because a register flows through many blocks without being read or written.
+
+### Per-Label Relevance
+
+Each label in the slice tracks which registers and stack offsets are relevant at that
+point. This enables filtered display of invariants — showing only the parts of the
+abstract state that matter for understanding the failure.
+
+### Instruction Dependencies
+
+During forward analysis, the verifier optionally records what each instruction reads
+and writes:
+
+- **Registers read/written**: e.g., `r1 = r2 + r3` reads R2, R3 and writes R1
+- **Registers clobbered**: e.g., a helper call clobbers R0–R5 without reading them
+- **Stack offsets read/written**: e.g., `*(r10 - 8) = r1` writes stack[-8]
+
+This information is computed once during verification and reused for slicing.
+
+## CLI Usage
+
+```bash
+# Basic usage — shows first failure with filtered output
+./bin/check program.o section --failure-slice
+
+# Control backward traversal depth (default: 200 worklist steps)
+./bin/check program.o section --failure-slice --failure-slice-depth 500
+
+# With simplified basic blocks (collapses sequential instructions)
+./bin/check program.o section --failure-slice --simplify
+
+# Combined with other options
+./bin/check program.o section --failure-slice --line-info
+```
+
+**Default behavior:**
+- Shows only the first failure (not all failures)
+- Disables simplification (shows each instruction separately)
+- Filters assertions to only show those involving relevant registers
+- Filters invariants to only show constraints involving relevant registers
+
+## Output Format
+
+```text
+=== Failure Slice 1 of 1 ===
+
+[ERROR] Upper bound must be at most packet_size (valid_access(r3.offset+32, width=8) for write)
+[LOCATION] 230
+[RELEVANT REGISTERS] r3, r4
+[SLICE SIZE] 14 program points
+
+[CONTROL FLOW] 209, 210, ..., {225:226 | 225:228 (assume r1 > r2)} -> 229 (if r4 != 0), 229:230 (assume r4 == 0), 230 FAIL
+
+[CAUSAL TRACE]
+Pre-invariant : [
+    r3.type=packet, r4.type=number,
+    packet_size=34,
+    r3.packet_offset=[22, 82], r4.svalue=[-22, 0],
+    ...]
+  from 209;
+209:
+  r3 = r1;
+  ...
+```
+
+### Output Sections
+
+| Section | Description |
+|---------|-------------|
+| `[ERROR]` | The verification error message and assertion |
+| `[LOCATION]` | The failing label (PC or edge label) |
+| `[RELEVANT REGISTERS]` | Registers/stack offsets at the failure point that the error depends on |
+| `[SLICE SIZE]` | Number of program points in the slice |
+| `[CONTROL FLOW]` | Compact branch-path skeleton: labels in order, with Assume/Jmp annotations |
+| `[CAUSAL TRACE]` | Filtered CFG with per-instruction invariants for slice labels only |
+
+## Algorithm Details
+
+### Step 1: Seed from Assertion
+
+Extract registers directly from the failed assertion type:
+- `ValidAccess{.reg = R1}` → seed = {R1}
+- `TypeConstraint{.reg = R3}` → seed = {R3}
+- Assertions with no register dependencies (e.g., `BoundedLoopCount`) produce an
+  empty seed; the algorithm enters **conservative mode**, including all reachable
+  labels to show the loop structure and control flow leading to the failure.
+
+### Step 2: Failing Instruction Reads
+
+The failing instruction itself always contributes. For example, the store
+`*(u64 *)(r3 + 32) = r8` reads R3 and R8 but writes to memory, not registers.
+Without special-casing, `instruction_contributes` would be false (no relevant
+register is *written*). The algorithm forces `instruction_contributes = true` at
+the failing label so that the instruction's read registers (R3, R8) enter the
+relevance set.
+
+### Step 3: Backward Traversal
+
+Using a worklist, walk `cfg.parents_of(label)` for each relevant label.
+
+**Transfer function** at each label:
+
+```text
+relevant_before = relevant_after
+    - remove regs_written     (not relevant before their definition)
+    - remove regs_clobbered   (killed without reading)
+    + add regs_read           IF instruction_contributes
+    - remove stack_written     (unless also in stack_read)
+    + add stack_read           IF instruction_contributes
+```
+
+An instruction **contributes** when:
+1. It writes to a relevant register or stack slot (data dependency), OR
+2. It is a control-flow instruction (`Jmp` or `Assume`) that reads a relevant register
+   (branch decisions that shape the path to the failure), OR
+3. It is the failing instruction itself (step 2), OR
+4. It is an immediate path guard (step 4 below).
+
+Only contributing instructions are added to `slice_labels`; non-contributing labels
+are still added to `visited` for traversal but are excluded from the output.
+
+### Step 4: Immediate Path Guards
+
+When the backward walk encounters an `Assume` instruction that is a **direct
+predecessor** of the failing label, it is treated as always-contributing. Assumes
+are path conditions that constrain which abstract states reach the failing point —
+they are causally relevant even if they don't write to data-relevant registers.
+
+For example, `assume r4 w== 0` at edge 229:230 guards the failing store at label
+230. The algorithm detects this by checking whether the current label is in
+`cfg.parents_of(failing_label)`. When it is, the Assume's read registers (R4) are
+added to the relevance set, which pulls in the upstream definition of R4.
+
+This is intentionally conservative: only the *immediate* guard of the failing label
+is treated specially. Other `Assume` and `Jmp` instructions are included only when
+they read registers that are already relevant (condition 2 above). Expanding to all
+control-flow instructions regardless of relevance would cause the slice to explode.
+
+### Step 5: Merge on Revisit
+
+If a label is visited multiple times (due to control-flow joins), the relevance
+sets are unioned. If no new registers or stack offsets are added, the label is
+skipped to avoid redundant work.
+
+### Step 6: Step Limit
+
+The worklist stops after `max_steps` items (default: 200, configurable via
+`--failure-slice-depth`). This prevents unbounded traversal on very large programs
+while still reaching relevant definitions that may be dozens of blocks upstream.
+
+### Step 7: Join-Point Expansion
+
+After the worklist completes, the algorithm scans all traversed labels for join
+points (labels with ≥2 CFG predecessors where at least one predecessor is already in
+the slice). All predecessors of such join points are added to the slice — even if
+the worklist never reached them — so the per-predecessor invariant display is
+complete. This post-processing step ensures converging paths are visible without
+requiring the worklist budget to be large enough to traverse all branches.
+
+## Join-Point Context
+
+When the backward walk crosses a join point (a label with ≥ 2 predecessors in the
+slice), the printer emits per-predecessor post-invariants. This directly surfaces
+the §4.11 "Lost Correlations" pattern from the
+[LLM Context Document](llm-context.md):
+
+```text
+229:
+  --- join point: per-predecessor state ---
+  from 227: [packet_size=62, r4.svalue=0]
+  from 228: [packet_size=34, r4.svalue=-22]
+  --- end join point ---
+```
+
+The merged state `packet_size=34, r4.svalue=[-22,0]` loses the correlation between
+the flag variable (R4) and the packet size. The per-predecessor display makes this
+loss explicit without requiring the reader to reconstruct it from the full CFG.
+
+## Control-Flow Summary
+
+The `[CONTROL FLOW]` section provides a compact branch-path skeleton through the
+slice. Each label is listed in sorted order with annotations for branch instructions:
+
+```text
+[CONTROL FLOW] 209, 210, ..., {225:226 (assume r1 <= r2) | 225:228 (assume r1 > r2)} -> 229 (if r4 != 0), 229:230 (assume r4 == 0), 230 FAIL
+```
+
+Labels are comma-separated. At join points (labels with ≥2 predecessors in the slice),
+converging predecessors are grouped as `{pred1 | pred2} -> join_label`.
+
+This tells the reader the high-level story: which branches were taken, where paths
+converge, and which assumptions hold — all in a single line.
+
+## Filtering Details
+
+### Assertion Filtering
+
+Only assertions involving relevant registers are shown. Uses
+`extract_assertion_registers()` to determine which registers an assertion depends on.
+
+### Invariant Filtering
+
+The `RelevantState::is_relevant_constraint()` method filters constraint strings:
+
+- **Simple constraints**: `r1.type=number` — shown if R1 is relevant
+- **Relational constraints**: `r1.svalue-r8.svalue<=100` — shown if R1 OR R8 is relevant
+- **Stack constraints**: `s[4088...4095].type=ctx` — shown if stack offset overlaps
+- **Global context**: `packet_size`, `meta_offset` — always shown
+
+**Design note:** Filtering is performed on serialized constraint strings at the output
+stream level rather than by querying the abstract domain directly. This is because:
+
+1. The abstract domain (`EbpfDomain`) is available in the invariant map, but its
+   serialization produces a flat list of constraint strings — there is no API to
+   enumerate "constraints involving register R1" without parsing the output.
+2. The abstract domain is a reduced product of multiple numeric domains (intervals,
+   congruences, linear constraints) — extracting "which registers does this constraint
+   touch" would require traversing each domain's internal representation.
+3. The constraint string format is stable (`rN.field`, `s[offset...offset]`) making
+   regex matching reliable without deep Crab knowledge.
+
+## Data Structures
+
+### InstructionDeps
+
+```cpp
+struct InstructionDeps {
+    std::set<Reg> regs_read;
+    std::set<Reg> regs_written;
+    std::set<Reg> regs_clobbered;    // Killed without reading (e.g., helper call)
+    std::set<int64_t> stack_read;    // Concrete stack offsets
+    std::set<int64_t> stack_written;
+};
+```
+
+### RelevantState
+
+```cpp
+struct RelevantState {
+    std::set<Reg> registers;
+    std::set<int64_t> stack_offsets;
+
+    // Check if a constraint string involves a relevant register
+    bool is_relevant_constraint(const std::string& constraint) const;
+};
+```
+
+### FailureSlice
+
+```cpp
+struct FailureSlice {
+    Label failing_label;
+    VerificationError error;
+    std::map<Label, RelevantState> relevance;  // Per-label relevant state
+
+    std::set<Label> impacted_labels() const;   // Keys of relevance map
+};
+```
+
+## API
+
+### Enabling Dependency Collection
+
+Set the flag before verification:
+
+```cpp
+ebpf_verifier_options_t options;
+options.verbosity_opts.collect_instruction_deps = true;
+```
+
+### Computing Slices
+
+After verification fails:
+
+```cpp
+AnalysisResult result = analyze(prog);
+if (result.failed) {
+    // max_steps: worklist step limit (default 200)
+    // max_slices: number of failures to process (0 = all, 1 = first only)
+    std::vector<FailureSlice> slices = result.compute_failure_slices(
+        prog, /*max_steps=*/200, /*max_slices=*/1);
+
+    for (const auto& slice : slices) {
+        // slice.failing_label  — where the error occurred
+        // slice.error          — the verification error
+        // slice.impacted_labels() — set of labels in the slice
+        // slice.relevance      — per-label relevant registers/stack
+    }
+}
+```
+
+### Printing Slices
+
+```cpp
+// simplify: collapse basic blocks (default false for slices)
+// compact: skip invariants entirely (default false)
+print_failure_slices(std::cout, prog, /*simplify=*/false, result, slices);
+```
+
+### Invariant Filtering
+
+Use the stream manipulator to filter invariant output:
+
+```cpp
+// Set filter — only show constraints involving these registers
+os << invariant_filter(&relevant_state) << domain;
+
+// Clear filter
+os << invariant_filter(nullptr) << domain;
+```
+
+## Examples
+
+### Simple Case: Null Pointer After Map Lookup
+
+```bash
+./bin/check ebpf-samples/build/nullmapref.o test --failure-slice
+```
+
+```text
+=== Failure Slice 1 of 1 ===
+
+[ERROR] Possible null access (valid_access(r0.offset, width=4) for write)
+[LOCATION] 7
+[RELEVANT REGISTERS] r0
+[SLICE SIZE] 6 program points
+[CONTROL FLOW] 0, 2, 3, 4, 6, 7 FAIL
+```
+
+The slice traces R0 from the failing store back through `bpf_map_lookup_elem` (which
+returns a nullable pointer) to the map setup instructions. The key invariant at the
+failure point is `r0.svalue=[0, 2147418112]` — the lower bound of 0 means NULL is
+possible.
+
+### Complex Case: Lost Correlations
+
+```bash
+./bin/check ebpf-samples/cilium/bpf_xdp_dsr_linux.o 2/20 --failure-slice
+```
+
+```text
+=== Failure Slice 1 of 1 ===
+
+[ERROR] Upper bound must be at most packet_size (valid_access(r3.offset+32, width=8) for write)
+[LOCATION] 230
+[RELEVANT REGISTERS] r3, r4
+[SLICE SIZE] 14 program points
+[CONTROL FLOW] 209, 210, ..., {225:226 | 225:228 (assume r1 > r2)} -> 229 (if r4 != 0), 229:230 (assume r4 == 0), 230 FAIL
+```
+
+From a 240-instruction program with 2003 lines of verbose output, the slice extracts
+14 instructions in 335 lines. The slice shows:
+- R3's definition chain (packet pointer + offset)
+- `225:228: assume r1 > r2` — the branch where the packet is too small
+- `228: r4 = -22` — the error code assigned on the short-packet path
+- `229:230: assume r4 w== 0` — the path guard that should prevent reaching the store
+- `230: *(u64 *)(r3 + 32) = r8` — the failing store
+
+The key diagnostic insight: the verifier loses the correlation between R4 (the error
+flag) and `packet_size` at the join point (block 229), so `assume r4 == 0` does not
+narrow `packet_size` — a §4.11 "Lost Correlations" pattern.
+
+## Performance
+
+Output size comparison across test cases:
+
+| Program | `-v` lines | `--failure-slice` lines | Slice instructions | Reduction |
+|---------|:----------:|:-----------------------:|:------------------:|:---------:|
+| nullmapref.o (10 instrs) | 39 | 132 | 6 | N/A |
+| packet_overflow.o (8 instrs) | 68 | 79 | 4 | N/A |
+| divzero.o (18 instrs) | 61 | 152 | 8 | N/A |
+| bpf_xdp_dsr_linux.o 2/20 (240 instrs) | 2,003 | 335 | 14 | **83%** |
+
+For small programs (e.g., nullmapref.o), the slice output can be *larger* than `-v`
+because of section headers and per-instruction filtered invariants — this is expected
+and not a regression. The real value is on large programs where the slice provides
+dramatic reduction while preserving all causally relevant information.
+
+## Limitations
+
+- **Counter-based errors** (e.g., "Loop counter is too large" from `--termination`)
+  have no register dependencies; the slicer uses conservative mode to include all
+  reachable labels, showing the loop structure and control flow but without
+  register-level causal filtering.
+- **Verification passes** (exit code 0) produce no failure slices — there is nothing
+  to slice.
+- **Control-flow inclusion is relevance-gated**: `Jmp` and `Assume` instructions are
+  included when they read registers that are already relevant. This means branches on
+  *unrelated* registers (that happen to be on the path) are excluded, keeping slices
+  small — but it may omit dominating branches several blocks away whose condition
+  registers are not in the relevance set.
+- **Invariant verbosity**: Filtered invariants still include all matching constraints
+  for relevant registers. For registers that participate in many relational constraints,
+  this can still produce substantial output.
+
+## Integration with LLM Context
+
+The [LLM Context Document](../docs/llm-context.md) provides patterns for interpreting
+verification failures. When using failure slices with an LLM:
+
+1. Run with `--failure-slice` to get minimal output
+2. The `[ERROR]` and `[RELEVANT REGISTERS]` sections identify the assertion and registers
+3. The `[CONTROL FLOW]` section shows the branch-path skeleton
+4. The `[CAUSAL TRACE]` shows filtered invariants at each contributing instruction
+5. Match the error message to patterns in Section 4 of the LLM context doc
+6. The fix typically involves the earliest instruction in the slice or a missing guard
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `src/result.hpp` | `FailureSlice`, `RelevantState`, `InstructionDeps`, `invariant_filter` |
+| `src/result.cpp` | `compute_failure_slices()`, `extract_instruction_deps()`, `extract_assertion_registers()`, `is_relevant_constraint()` |
+| `src/printing.cpp` | `print_failure_slices()`, `print_invariants_filtered()`, join-point context, control-flow summary |
+| `src/fwd_analyzer.cpp` | Hooks to populate deps during forward analysis |
+| `src/ir/parse.cpp` | Invariant filter integration in `operator<<(StringInvariant)` |
+| `src/config.hpp` | `collect_instruction_deps` flag |
+| `src/main/check.cpp` | `--failure-slice` and `--failure-slice-depth` CLI flags |

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -25,6 +25,12 @@ struct verbosity_options_t {
 
     /// Print the BTF types in JSON format.
     bool dump_btf_types_json = false;
+
+    /// Collect instruction dependencies for failure slice computation.
+    /// When true, the forward analysis annotates each instruction with
+    /// the registers and stack offsets it reads/writes, enabling efficient
+    /// backward slicing for failure diagnostics.
+    bool collect_instruction_deps = false;
 };
 
 struct ebpf_verifier_options_t {

--- a/src/crab/ebpf_domain.cpp
+++ b/src/crab/ebpf_domain.cpp
@@ -21,6 +21,19 @@ namespace prevail {
 
 StringInvariant EbpfDomain::to_set() const { return rcp.to_set() + stack.to_set(); }
 
+std::optional<int64_t> EbpfDomain::get_stack_offset(const Reg& reg) const {
+    // Only return an offset when the register is *definitely* a stack pointer,
+    // not just possibly one. This ensures we don't misclassify memory deps.
+    if (rcp.types.get_type(reg) != T_STACK) {
+        return std::nullopt;
+    }
+    const auto offset = rcp.values.eval_interval(reg_pack(reg).stack_offset);
+    if (const auto singleton = offset.singleton()) {
+        return singleton->cast_to<int64_t>();
+    }
+    return std::nullopt;
+}
+
 EbpfDomain EbpfDomain::top() {
     EbpfDomain abs;
     abs.set_to_top();

--- a/src/crab/ebpf_domain.hpp
+++ b/src/crab/ebpf_domain.hpp
@@ -82,6 +82,13 @@ class EbpfDomain final {
 
     StringInvariant to_set() const;
 
+    /// Check if a register may be a stack pointer and return its stack offset if known.
+    /// Used by failure slicing to detect stack accesses through derived pointers.
+    /// @return The concrete stack offset if the register is definitely a stack pointer with a known offset,
+    ///         std::nullopt otherwise.
+    [[nodiscard]]
+    std::optional<int64_t> get_stack_offset(const Reg& reg) const;
+
   private:
     // private generic domain functions
     void add_value_constraint(const LinearConstraint& cst);

--- a/src/ir/parse.cpp
+++ b/src/ir/parse.cpp
@@ -13,6 +13,7 @@
 #include "ir/parse.hpp"
 #include "ir/unmarshal.hpp"
 #include "platform.hpp"
+#include "result.hpp"
 #include "string_constraints.hpp"
 
 using std::regex;
@@ -482,12 +483,21 @@ std::ostream& operator<<(std::ostream& o, const StringInvariant& inv) {
     if (inv.is_bottom()) {
         return o << "_|_";
     }
+
+    // Check for invariant filter
+    const RelevantState* filter = get_invariant_filter(o);
+
     // Intervals
     bool first = true;
     o << "[";
     auto& set = inv.maybe_inv.value();
     std::string lastbase;
     for (const auto& item : set) {
+        // Skip items that don't involve relevant registers (if filter is set)
+        if (filter && !filter->is_relevant_constraint(item)) {
+            continue;
+        }
+
         if (first) {
             first = false;
         } else {

--- a/src/ir/syntax.hpp
+++ b/src/ir/syntax.hpp
@@ -28,6 +28,7 @@ struct Imm {
 struct Reg {
     uint8_t v{};
     constexpr bool operator==(const Reg&) const = default;
+    constexpr auto operator<=>(const Reg&) const = default;
 };
 
 using Value = std::variant<Imm, Reg>;

--- a/src/result.cpp
+++ b/src/result.cpp
@@ -1,14 +1,109 @@
 // Copyright (c) Prevail Verifier contributors.
 // SPDX-License-Identifier: MIT
+#include <algorithm>
 #include <map>
 #include <ranges>
+#include <regex>
 #include <sstream>
 
 #include "crab/ebpf_domain.hpp"
 #include "ir/program.hpp"
 #include "result.hpp"
+#include "spec/ebpf_base.h"
+#include "spec/vm_isa.hpp"
 
 namespace prevail {
+
+// Stream-local storage index for invariant filter
+static int invariant_filter_index() {
+    static const int index = std::ios_base::xalloc();
+    return index;
+}
+
+const RelevantState* get_invariant_filter(std::ostream& os) {
+    return static_cast<const RelevantState*>(os.pword(invariant_filter_index()));
+}
+
+std::ostream& operator<<(std::ostream& os, const invariant_filter& filter) {
+    os.pword(invariant_filter_index()) = const_cast<void*>(static_cast<const void*>(filter.state));
+    return os;
+}
+
+bool RelevantState::is_relevant_constraint(const std::string& constraint) const {
+    // Extract the register or stack reference from the constraint.
+    // Constraints look like: "r1.type=number", "r2.svalue=[0, 100]", "s[4088...4095].type=ctx"
+    // Relational constraints: "r1.svalue-r8.svalue<=-100", "r0.svalue=r3.svalue+2"
+    // Also handle: "packet_size=54", "meta_offset=[-4098, 0]"
+
+    // Track whether we matched any known pattern.  When at least one pattern
+    // fires but nothing is relevant we return false; the conservative
+    // `return true` at the end only applies to truly unparseable constraints.
+    bool parsed_any_pattern = false;
+
+    // Check for ANY register mentioned in the constraint (not just at start).
+    // This handles relational constraints like "r1.svalue-r8.svalue<=100".
+    static const std::regex reg_pattern(R"(r(\d+)\.)");
+    std::sregex_iterator it(constraint.begin(), constraint.end(), reg_pattern);
+    std::sregex_iterator end;
+
+    while (it != end) {
+        parsed_any_pattern = true;
+        const uint8_t reg_num = static_cast<uint8_t>(std::stoi((*it)[1].str()));
+        if (registers.contains(Reg{reg_num})) {
+            return true; // At least one relevant register is mentioned
+        }
+        ++it;
+    }
+
+    // Precompute absolute stack offsets once to avoid repeated conversion in loops
+    std::vector<int64_t> abs_stack_offsets;
+    abs_stack_offsets.reserve(stack_offsets.size());
+    for (const auto& rel_offset : stack_offsets) {
+        abs_stack_offsets.push_back(EBPF_TOTAL_STACK_SIZE + rel_offset);
+    }
+
+    // Check for stack range pattern: s[start...end]
+    static const std::regex stack_range_pattern(R"(s\[(\d+)\.\.\.(\d+)\])");
+    std::sregex_iterator stack_it(constraint.begin(), constraint.end(), stack_range_pattern);
+    while (stack_it != end) {
+        parsed_any_pattern = true;
+        const int64_t abs_start = std::stoll((*stack_it)[1].str());
+        const int64_t abs_end = std::stoll((*stack_it)[2].str());
+        for (const auto& abs_offset : abs_stack_offsets) {
+            if (abs_offset >= abs_start && abs_offset <= abs_end) {
+                return true; // Overlaps within the constraint range
+            }
+        }
+        ++stack_it;
+    }
+
+    // Check for single-offset stack pattern: s[offset]
+    static const std::regex stack_single_pattern(R"(s\[(\d+)\]\.)");
+    std::sregex_iterator single_it(constraint.begin(), constraint.end(), stack_single_pattern);
+    while (single_it != end) {
+        parsed_any_pattern = true;
+        const int64_t abs_pos = std::stoll((*single_it)[1].str());
+        for (const auto& abs_offset : abs_stack_offsets) {
+            if (abs_offset == abs_pos) {
+                return true;
+            }
+        }
+        ++single_it;
+    }
+
+    // Global constraints (packet_size, meta_offset) - always show for context
+    if (constraint.starts_with("packet_size") || constraint.starts_with("meta_offset")) {
+        return true;
+    }
+
+    // A known pattern was parsed but nothing matched — the constraint is irrelevant.
+    if (parsed_any_pattern) {
+        return false;
+    }
+
+    // If we can't parse it at all, show it (conservative)
+    return true;
+}
 
 bool AnalysisResult::is_valid_after(const Label& label, const StringInvariant& state) const {
     const EbpfDomain abstract_state =
@@ -93,6 +188,457 @@ std::map<Label, std::vector<std::string>> AnalysisResult::find_unreachable(const
         }
     }
     return unreachable;
+}
+
+/// Extract the registers and stack offsets read/written by an instruction.
+/// Used to populate InstructionDeps during forward analysis.
+InstructionDeps extract_instruction_deps(const Instruction& ins, const EbpfDomain& pre_state) {
+    InstructionDeps deps;
+
+    std::visit(
+        [&](const auto& v) {
+            using T = std::decay_t<decltype(v)>;
+
+            if constexpr (std::is_same_v<T, Bin>) {
+                // dst = dst op src (or dst = src for MOV/MOVSX)
+                deps.regs_written.insert(v.dst);
+                if (v.op != Bin::Op::MOV && v.op != Bin::Op::MOVSX8 && v.op != Bin::Op::MOVSX16 &&
+                    v.op != Bin::Op::MOVSX32) {
+                    // Non-move ops also read dst
+                    deps.regs_read.insert(v.dst);
+                }
+                if (const auto* reg = std::get_if<Reg>(&v.v)) {
+                    deps.regs_read.insert(*reg);
+                }
+            } else if constexpr (std::is_same_v<T, Un>) {
+                // dst = op(dst)
+                deps.regs_read.insert(v.dst);
+                deps.regs_written.insert(v.dst);
+            } else if constexpr (std::is_same_v<T, LoadMapFd> || std::is_same_v<T, LoadMapAddress>) {
+                deps.regs_written.insert(v.dst);
+            } else if constexpr (std::is_same_v<T, Mem>) {
+                deps.regs_read.insert(v.access.basereg);
+                if (v.is_load) {
+                    // Load: value = *(basereg + offset)
+                    if (const auto* dst_reg = std::get_if<Reg>(&v.value)) {
+                        deps.regs_written.insert(*dst_reg);
+                    }
+                    // Track stack read if base is a stack pointer (R10 or derived)
+                    if (v.access.basereg.v == R10_STACK_POINTER) {
+                        deps.stack_read.insert(v.access.offset);
+                    } else if (const auto stack_off = pre_state.get_stack_offset(v.access.basereg)) {
+                        // basereg is a stack pointer with known offset from R10
+                        // Compute the actual stack slot: stack_off is absolute (e.g., 4096),
+                        // convert to relative from R10: relative = offset + (stack_off - EBPF_TOTAL_STACK_SIZE)
+                        deps.stack_read.insert(v.access.offset + (*stack_off - EBPF_TOTAL_STACK_SIZE));
+                    }
+                } else {
+                    // Store: *(basereg + offset) = value
+                    if (const auto* src_reg = std::get_if<Reg>(&v.value)) {
+                        deps.regs_read.insert(*src_reg);
+                    }
+                    // Track stack write if base is a stack pointer (R10 or derived)
+                    if (v.access.basereg.v == R10_STACK_POINTER) {
+                        deps.stack_written.insert(v.access.offset);
+                    } else if (const auto stack_off = pre_state.get_stack_offset(v.access.basereg)) {
+                        deps.stack_written.insert(v.access.offset + (*stack_off - EBPF_TOTAL_STACK_SIZE));
+                    }
+                }
+            } else if constexpr (std::is_same_v<T, Atomic>) {
+                deps.regs_read.insert(v.access.basereg);
+                deps.regs_read.insert(v.valreg);
+                if (v.fetch) {
+                    deps.regs_written.insert(v.valreg);
+                }
+                // Track stack read/write if base is a stack pointer (R10 or derived)
+                if (v.access.basereg.v == R10_STACK_POINTER) {
+                    deps.stack_read.insert(v.access.offset);
+                    deps.stack_written.insert(v.access.offset);
+                } else if (const auto stack_off = pre_state.get_stack_offset(v.access.basereg)) {
+                    const auto adjusted_off = v.access.offset + (*stack_off - EBPF_TOTAL_STACK_SIZE);
+                    deps.stack_read.insert(adjusted_off);
+                    deps.stack_written.insert(adjusted_off);
+                }
+            } else if constexpr (std::is_same_v<T, Call>) {
+                // Calls read R1-R5 as arguments, write R0 as return value,
+                // and clobber R1-R5 (caller-saved registers are killed).
+                // Separate clobbers from writes so backward slicing can:
+                // - Stop propagation for post-call uses of R1-R5 (they're killed)
+                // - Still trace R1-R5 as read-deps when R0 is relevant-after (args affect return)
+                for (uint8_t i = 1; i <= 5; ++i) {
+                    deps.regs_read.insert(Reg{i});      // Arguments feed into return value
+                    deps.regs_clobbered.insert(Reg{i}); // Killed after call
+                }
+                deps.regs_written.insert(Reg{0}); // Return value
+            } else if constexpr (std::is_same_v<T, CallLocal>) {
+                // Local (macro-inlined) calls:
+                // - read R1-R5 as arguments
+                // - write R0 as return value
+                // - clobber R1-R5 (caller-saved)
+                // - adjust frame pointer R10 (save/restore callee-saved regs)
+                for (uint8_t i = 1; i <= 5; ++i) {
+                    deps.regs_read.insert(Reg{i});      // Arguments
+                    deps.regs_clobbered.insert(Reg{i}); // Killed after call
+                }
+                deps.regs_written.insert(Reg{0});  // Return value
+                deps.regs_read.insert(Reg{10});    // Frame pointer read
+                deps.regs_written.insert(Reg{10}); // Frame pointer adjusted
+            } else if constexpr (std::is_same_v<T, Callx>) {
+                // Indirect call: reads the function pointer and R1-R5,
+                // writes R0, and clobbers R1-R5.
+                deps.regs_read.insert(v.func);
+                for (uint8_t i = 1; i <= 5; ++i) {
+                    deps.regs_read.insert(Reg{i});      // Arguments
+                    deps.regs_clobbered.insert(Reg{i}); // Killed after call
+                }
+                deps.regs_written.insert(Reg{0});
+            } else if constexpr (std::is_same_v<T, Exit>) {
+                deps.regs_read.insert(Reg{0}); // Return value
+                if (!v.stack_frame_prefix.empty()) {
+                    // Subprogram return restores callee-saved registers and frame pointer.
+                    for (uint8_t i = R6; i <= R9; ++i) {
+                        deps.regs_written.insert(Reg{i});
+                    }
+                    deps.regs_written.insert(Reg{R10_STACK_POINTER});
+                }
+            } else if constexpr (std::is_same_v<T, Jmp>) {
+                if (v.cond) {
+                    deps.regs_read.insert(v.cond->left);
+                    if (const auto* reg = std::get_if<Reg>(&v.cond->right)) {
+                        deps.regs_read.insert(*reg);
+                    }
+                }
+            } else if constexpr (std::is_same_v<T, Assume>) {
+                deps.regs_read.insert(v.cond.left);
+                if (const auto* reg = std::get_if<Reg>(&v.cond.right)) {
+                    deps.regs_read.insert(*reg);
+                }
+            } else if constexpr (std::is_same_v<T, Packet>) {
+                if (v.regoffset) {
+                    deps.regs_read.insert(*v.regoffset);
+                }
+                deps.regs_written.insert(Reg{0}); // Result in R0
+                // Packet clobbers caller-saved registers R1-R5 without reading them
+                for (uint8_t i = 1; i <= 5; ++i) {
+                    deps.regs_clobbered.insert(Reg{i});
+                }
+            }
+            // Undefined and IncrementLoopCounter have no register deps
+        },
+        ins);
+
+    return deps;
+}
+
+/// Extract the registers referenced by an assertion.
+/// Used to seed backward slicing from the point of failure.
+std::set<Reg> extract_assertion_registers(const Assertion& assertion) {
+    return std::visit(
+        [](const auto& a) -> std::set<Reg> {
+            using T = std::decay_t<decltype(a)>;
+
+            if constexpr (std::is_same_v<T, Comparable>) {
+                return {a.r1, a.r2};
+            } else if constexpr (std::is_same_v<T, Addable>) {
+                return {a.ptr, a.num};
+            } else if constexpr (std::is_same_v<T, ValidDivisor>) {
+                return {a.reg};
+            } else if constexpr (std::is_same_v<T, ValidAccess>) {
+                std::set<Reg> regs{a.reg};
+                if (const auto* r = std::get_if<Reg>(&a.width)) {
+                    regs.insert(*r);
+                }
+                return regs;
+            } else if constexpr (std::is_same_v<T, ValidStore>) {
+                return {a.mem, a.val};
+            } else if constexpr (std::is_same_v<T, ValidSize>) {
+                return {a.reg};
+            } else if constexpr (std::is_same_v<T, ValidMapKeyValue>) {
+                return {a.access_reg, a.map_fd_reg};
+            } else if constexpr (std::is_same_v<T, ValidCall>) {
+                // ValidCall checks function validity, no direct register deps
+                return {};
+            } else if constexpr (std::is_same_v<T, TypeConstraint>) {
+                return {a.reg};
+            } else if constexpr (std::is_same_v<T, FuncConstraint>) {
+                return {a.reg};
+            } else if constexpr (std::is_same_v<T, ZeroCtxOffset>) {
+                return {a.reg};
+            } else if constexpr (std::is_same_v<T, BoundedLoopCount>) {
+                // Loop counter, not a register
+                return {};
+            }
+            return {};
+        },
+        assertion);
+}
+
+std::vector<FailureSlice> AnalysisResult::compute_failure_slices(const Program& prog, const SliceParams params) const {
+    const auto max_steps = params.max_steps;
+    const auto max_slices = params.max_slices;
+    std::vector<FailureSlice> slices;
+
+    // Find all labels with errors
+    for (const auto& [label, inv_pair] : invariants) {
+        if (inv_pair.pre.is_bottom()) {
+            continue; // Unreachable
+        }
+        if (!inv_pair.error) {
+            continue; // No error here
+        }
+
+        // Check if we've reached the max slices limit
+        if (max_slices > 0 && slices.size() >= max_slices) {
+            break;
+        }
+
+        FailureSlice slice{
+            .failing_label = label,
+            .error = *inv_pair.error,
+            .relevance = {},
+        };
+
+        // Seed relevant registers from the actual failing assertion.
+        // Forward analysis stops at the first failing assertion, which may not be
+        // assertions[0]. Replay the checks against the pre-state to identify
+        // the actual failing assertion and seed relevance from it.
+        RelevantState initial_relevance;
+        const auto& assertions = prog.assertions_at(label);
+        bool found_failing = false;
+        for (const auto& assertion : assertions) {
+            if (ebpf_domain_check(inv_pair.pre, assertion, label)) {
+                for (const auto& reg : extract_assertion_registers(assertion)) {
+                    initial_relevance.registers.insert(reg);
+                }
+                found_failing = true;
+                break;
+            }
+        }
+        // Fallback: if no failing assertion was identified (shouldn't happen),
+        // or if the failing assertion has no register deps, aggregate all assertions.
+        if (!found_failing || initial_relevance.registers.empty()) {
+            for (const auto& assertion : assertions) {
+                for (const auto& reg : extract_assertion_registers(assertion)) {
+                    initial_relevance.registers.insert(reg);
+                }
+            }
+        }
+
+        // Always include the failing label in the slice, even if no registers were extracted
+        // (e.g., ValidCall, BoundedLoopCount assertions have no register deps)
+
+        // `visited` tracks all explored labels for deduplication during backward traversal.
+        // `slice_labels` tracks only labels that interact with relevant registers (the output slice).
+        std::map<Label, RelevantState> visited;
+        std::set<Label> conservative_visited; // Dedup for empty-relevance labels in conservative mode
+        std::map<Label, RelevantState> slice_labels;
+
+        // Worklist: (label, relevant_state_after_this_label)
+        std::vector<std::pair<Label, RelevantState>> worklist;
+        worklist.emplace_back(label, initial_relevance);
+
+        // When the seed has no register/stack deps (e.g., BoundedLoopCount),
+        // perform a conservative backward walk so the slice still shows the
+        // loop structure and control flow leading to the failure.
+        const bool conservative_mode = initial_relevance.registers.empty() && initial_relevance.stack_offsets.empty();
+
+        size_t steps = 0;
+
+        // Hoist the parent lookup for the failing label outside the hot loop;
+        // it is invariant and parents_of() may return a temporary.
+        const auto parents_of_fail = prog.cfg().parents_of(label);
+
+        while (!worklist.empty() && steps < max_steps) {
+            auto [current_label, relevant_after] = worklist.back();
+            worklist.pop_back();
+
+            // Skip if nothing is relevant — unless we're in conservative mode
+            // (empty-seed assertions like BoundedLoopCount) or this is the failing label.
+            if (!conservative_mode && current_label != label && relevant_after.registers.empty() &&
+                relevant_after.stack_offsets.empty()) {
+                continue;
+            }
+
+            // Merge with existing relevance at this label (for deduplication)
+            auto& existing = visited[current_label];
+            const size_t prev_size = existing.registers.size() + existing.stack_offsets.size();
+            existing.registers.insert(relevant_after.registers.begin(), relevant_after.registers.end());
+            existing.stack_offsets.insert(relevant_after.stack_offsets.begin(), relevant_after.stack_offsets.end());
+            const size_t new_size = existing.registers.size() + existing.stack_offsets.size();
+
+            // If no new relevance was added, skip (already processed with same or broader relevance).
+            // In conservative mode with empty relevance, use a separate visited set for dedup.
+            if (new_size == prev_size) {
+                if (prev_size > 0) {
+                    continue;
+                }
+                // Empty relevance (conservative mode): skip if we already visited this label
+                if (!conservative_visited.insert(current_label).second) {
+                    continue;
+                }
+            }
+
+            // Compute what's relevant BEFORE this instruction using deps
+            RelevantState relevant_before;
+            const auto inv_it = invariants.find(current_label);
+            if (inv_it != invariants.end() && inv_it->second.deps) {
+                const auto& deps = *inv_it->second.deps;
+
+                // Start with what's relevant after
+                relevant_before = relevant_after;
+
+                // Remove registers that are written by this instruction
+                // (they weren't relevant before their definition)
+                for (const auto& reg : deps.regs_written) {
+                    relevant_before.registers.erase(reg);
+                }
+
+                // Remove registers that are clobbered (killed without reading).
+                // These stop propagation for post-instruction uses but don't add read-deps.
+                for (const auto& reg : deps.regs_clobbered) {
+                    relevant_before.registers.erase(reg);
+                }
+
+                // Determine if this instruction contributes to the slice.
+                // An instruction contributes when it writes to a relevant register/stack slot,
+                // or when it is a control-flow decision (Jmp/Assume) that reads relevant registers.
+                bool instruction_contributes = false;
+                for (const auto& reg : deps.regs_written) {
+                    if (relevant_after.registers.contains(reg)) {
+                        instruction_contributes = true;
+                        break;
+                    }
+                }
+                for (const auto& offset : deps.stack_written) {
+                    if (relevant_after.stack_offsets.contains(offset)) {
+                        instruction_contributes = true;
+                        break;
+                    }
+                }
+
+                // Control-flow instructions (Jmp/Assume) that read relevant registers
+                // contribute to the slice because they shape the path to the failure.
+                if (!instruction_contributes) {
+                    const auto& ins = prog.instruction_at(current_label);
+                    if (std::holds_alternative<Jmp>(ins) || std::holds_alternative<Assume>(ins)) {
+                        for (const auto& reg : deps.regs_read) {
+                            if (relevant_after.registers.contains(reg)) {
+                                instruction_contributes = true;
+                                break;
+                            }
+                        }
+                    }
+                }
+
+                // Immediate path guard: when the current label is a direct predecessor
+                // of the failing label and is an Assume instruction, its condition
+                // registers are causally relevant — they determine reachability.
+                if (std::holds_alternative<Assume>(prog.instruction_at(current_label))) {
+                    if (std::find(parents_of_fail.begin(), parents_of_fail.end(), current_label) !=
+                        parents_of_fail.end()) {
+                        instruction_contributes = true;
+                    }
+                }
+
+                // At the failing label, the assertion depends on registers the instruction
+                // reads (e.g., base pointer r3 in a store). Since stores write to memory
+                // not registers, instruction_contributes would be false without this.
+                if (current_label == label) {
+                    instruction_contributes = true;
+                }
+
+                // In conservative mode (empty seed, e.g., BoundedLoopCount), include all
+                // reachable labels so the slice shows the loop structure and control flow.
+                if (conservative_mode) {
+                    instruction_contributes = true;
+                }
+
+                if (instruction_contributes) {
+                    for (const auto& reg : deps.regs_read) {
+                        relevant_before.registers.insert(reg);
+                    }
+                    for (const auto& offset : deps.stack_read) {
+                        relevant_before.stack_offsets.insert(offset);
+                    }
+                }
+
+                // Remove stack locations that are written by this instruction,
+                // but preserve offsets that are also read (read-modify-write, e.g., Atomic).
+                // Done before storing to slice_labels for consistency with register handling
+                // (written registers are removed before storage at lines 476-478).
+                for (const auto& offset : deps.stack_written) {
+                    if (!deps.stack_read.contains(offset)) {
+                        relevant_before.stack_offsets.erase(offset);
+                    }
+                }
+
+                if (instruction_contributes) {
+                    // Only include contributing labels in the output slice.
+                    // Store relevant_before so pre-invariant filtering shows the
+                    // instruction's read-deps (the true upstream dependencies).
+                    slice_labels[current_label] = relevant_before;
+                }
+            } else {
+                // No deps available: conservatively treat this label as contributing
+                // and propagate all current relevance to predecessors.
+                relevant_before = relevant_after;
+                slice_labels[current_label] = relevant_before;
+            }
+
+            // Add predecessors to worklist
+            for (const auto& parent : prog.cfg().parents_of(current_label)) {
+                worklist.emplace_back(parent, relevant_before);
+            }
+
+            ++steps;
+        }
+
+        // Expand join points: for any traversed label that is a join point
+        // (≥2 predecessors) where at least one predecessor is already in the slice,
+        // add the join-point label itself and all predecessors that have invariants.
+        // This ensures the causal trace shows converging paths that cause precision loss.
+        // Note: predecessors may not be in `visited` if the worklist budget was exhausted
+        // before reaching them, so we check the invariant map directly.
+        std::map<Label, RelevantState> join_expansion;
+        for (const auto& [v_label, v_relevance] : visited) {
+            const auto& parents = prog.cfg().parents_of(v_label);
+            if (parents.size() < 2) {
+                continue;
+            }
+            // Check that at least one predecessor is in the slice (this join is relevant)
+            bool has_slice_parent = false;
+            for (const auto& parent : parents) {
+                if (slice_labels.contains(parent)) {
+                    has_slice_parent = true;
+                    break;
+                }
+            }
+            if (!has_slice_parent) {
+                continue;
+            }
+            // Include the join-point label itself so the printing code can display
+            // per-predecessor state at this join.
+            if (!slice_labels.contains(v_label)) {
+                join_expansion[v_label] = v_relevance;
+            }
+            // Include all predecessors so the join display is complete.
+            // Use visited relevance if available, otherwise use the join-point's relevance.
+            for (const auto& parent : parents) {
+                if (slice_labels.contains(parent) || join_expansion.contains(parent)) {
+                    continue;
+                }
+                const auto& rel = visited.contains(parent) ? visited.at(parent) : v_relevance;
+                join_expansion[parent] = rel;
+            }
+        }
+        slice_labels.insert(join_expansion.begin(), join_expansion.end());
+
+        // Build the slice from contributing labels only
+        slice.relevance = std::move(slice_labels);
+        slices.push_back(std::move(slice));
+    }
+
+    return slices;
 }
 
 } // namespace prevail

--- a/src/result.hpp
+++ b/src/result.hpp
@@ -2,8 +2,11 @@
 // SPDX-License-Identifier: MIT
 #pragma once
 
+#include <iosfwd>
 #include <map>
 #include <optional>
+#include <set>
+#include <vector>
 
 #include "crab/ebpf_domain.hpp"
 #include "ir/program.hpp"
@@ -27,10 +30,84 @@ struct ObservationCheckResult {
     std::string message;
 };
 
+/// Dependencies of an instruction: what registers and stack locations it reads/writes.
+/// Populated during forward analysis when collect_instruction_deps is enabled.
+struct InstructionDeps {
+    std::set<Reg> regs_read;
+    std::set<Reg> regs_written;
+    std::set<Reg> regs_clobbered;    // Registers killed/overwritten without reading (e.g., R1-R5 after call)
+    std::set<int64_t> stack_read;    // Concrete stack offsets when known
+    std::set<int64_t> stack_written; // Concrete stack offsets when known
+};
+
+/// Extract the registers and stack offsets read/written by an instruction.
+/// @param ins The instruction to analyze.
+/// @param pre_state The abstract state before the instruction (for resolving pointer values).
+/// @return The dependencies of the instruction.
+InstructionDeps extract_instruction_deps(const Instruction& ins, const EbpfDomain& pre_state);
+
+/// Extract the registers referenced by an assertion.
+/// Used to seed backward slicing from the point of failure.
+/// @param assertion The assertion to analyze.
+/// @return The set of registers the assertion depends on.
+std::set<Reg> extract_assertion_registers(const Assertion& assertion);
+
 struct InvariantMapPair {
     EbpfDomain pre;
     std::optional<VerificationError> error;
     EbpfDomain post;
+    std::optional<InstructionDeps> deps; // Populated when collect_instruction_deps is set
+};
+
+/// State that is relevant at a specific program point.
+/// Used to filter what parts of the invariant to display.
+struct RelevantState {
+    std::set<Reg> registers;
+    std::set<int64_t> stack_offsets; // Relative stack offsets (e.g., Mem.access.offset values like -8)
+
+    /// Check if a constraint string (e.g., "r1.type=number") involves a relevant register.
+    [[nodiscard]]
+    bool is_relevant_constraint(const std::string& constraint) const;
+};
+
+/// Stream manipulator to filter invariant output to only relevant registers.
+/// Usage: os << invariant_filter(&relevant_state) << domain;
+/// To clear: os << invariant_filter(nullptr) << domain;
+struct invariant_filter {
+    const RelevantState* state;
+    explicit invariant_filter(const RelevantState* s) : state(s) {}
+};
+
+/// Get the current invariant filter from a stream (nullptr if none).
+const RelevantState* get_invariant_filter(std::ostream& os);
+
+/// Set the invariant filter on a stream.
+std::ostream& operator<<(std::ostream& os, const invariant_filter& filter);
+
+/// A minimal diagnostic slice of a verification failure.
+/// Contains labels that contributed to the failure, with per-label
+/// tracking of which registers/stack locations are relevant.
+struct FailureSlice {
+    /// The label where this failure occurred.
+    Label failing_label;
+
+    /// The error at this failure point.
+    VerificationError error;
+
+    /// Per-label relevant state. Keys are the impacted labels.
+    /// At each label, indicates which registers and stack offsets
+    /// should be displayed in the invariant.
+    std::map<Label, RelevantState> relevance;
+
+    /// Convenience: get all impacted labels.
+    [[nodiscard]]
+    std::set<Label> impacted_labels() const {
+        std::set<Label> result;
+        for (const auto& [label, _] : relevance) {
+            result.insert(label);
+        }
+        return result;
+    }
 };
 
 struct AnalysisResult {
@@ -61,10 +138,39 @@ struct AnalysisResult {
 
     [[nodiscard]]
     std::map<Label, std::vector<std::string>> find_unreachable(const Program& prog) const;
+
+    /// Parameters for compute_failure_slices to avoid swapping size_t arguments.
+    struct SliceParams {
+        size_t max_steps = 200; ///< Maximum worklist items to process per failure.
+        size_t max_slices = 0;  ///< Maximum number of slices to compute (0 = all).
+    };
+
+    /// Compute failure slices for verification errors.
+    /// Returns one slice per failure, each containing the set of impacted labels.
+    [[nodiscard]]
+    std::vector<FailureSlice> compute_failure_slices(const Program& prog, SliceParams params) const;
+
+    [[nodiscard]]
+    std::vector<FailureSlice> compute_failure_slices(const Program& prog) const {
+        return compute_failure_slices(prog, SliceParams{});
+    }
 };
 
 void print_error(std::ostream& os, const VerificationError& error);
 void print_invariants(std::ostream& os, const Program& prog, bool simplify, const AnalysisResult& result);
 void print_unreachable(std::ostream& os, const Program& prog, const AnalysisResult& result);
+
+/// Print invariants filtered to only show labels in the given set.
+/// Used to print a failure slice in context.
+/// @param compact If true, skip invariant output and only show instructions.
+/// @param relevance If provided, only show assertions involving relevant registers.
+void print_invariants_filtered(std::ostream& os, const Program& prog, bool simplify, const AnalysisResult& result,
+                               const std::set<Label>& filter, bool compact = false,
+                               const std::map<Label, RelevantState>* relevance = nullptr);
+
+/// Print all failure slices in a structured diagnostic format.
+/// @param compact If true, skip detailed invariants for smaller output.
+void print_failure_slices(std::ostream& os, const Program& prog, bool simplify, const AnalysisResult& result,
+                          const std::vector<FailureSlice>& slices, bool compact = false);
 
 } // namespace prevail

--- a/src/test/test_failure_slice.cpp
+++ b/src/test/test_failure_slice.cpp
@@ -1,0 +1,285 @@
+// Copyright (c) Prevail Verifier contributors.
+// SPDX-License-Identifier: MIT
+
+#include <catch2/catch_all.hpp>
+#include <filesystem>
+#include <sstream>
+
+#include "ebpf_verifier.hpp"
+#include "linux/gpl/spec_type_descriptors.hpp"
+
+using namespace prevail;
+
+// Helper to check if a test sample file exists
+static bool sample_exists(const std::string& filename) { return std::filesystem::exists(filename); }
+
+// Helper to load a program, run analysis with deps collection, and compute slices
+static std::vector<FailureSlice> get_failure_slices(const std::string& filename, const std::string& section) {
+    ebpf_verifier_options_t options{};
+    options.verbosity_opts.collect_instruction_deps = true;
+
+    auto raw_progs = read_elf(filename, section, "", options, &g_ebpf_platform_linux);
+    REQUIRE(raw_progs.size() == 1);
+
+    const RawProgram& raw_prog = raw_progs.back();
+    auto prog_or_error = unmarshal(raw_prog, options);
+    auto inst_seq = std::get_if<InstructionSeq>(&prog_or_error);
+    REQUIRE(inst_seq != nullptr);
+
+    const Program prog = Program::from_sequence(*inst_seq, raw_prog.info, options);
+    auto result = analyze(prog);
+
+    return result.compute_failure_slices(prog);
+}
+
+// Test that extract_instruction_deps correctly identifies register reads/writes
+TEST_CASE("extract_instruction_deps for Bin instruction", "[failure_slice][deps]") {
+    // r1 = r1 + r2 should read r1, r2 and write r1
+    Bin bin_add{Bin::Op::ADD, Reg{1}, Reg{2}, true, false};
+    Instruction ins = bin_add;
+    EbpfDomain dom = EbpfDomain::top();
+
+    auto deps = extract_instruction_deps(ins, dom);
+
+    REQUIRE(deps.regs_written.contains(Reg{1}));
+    REQUIRE(deps.regs_read.contains(Reg{1})); // ADD also reads dst
+    REQUIRE(deps.regs_read.contains(Reg{2}));
+}
+
+TEST_CASE("extract_instruction_deps for MOV instruction", "[failure_slice][deps]") {
+    // r1 = r2 should read r2 and write r1 (but not read r1)
+    Bin bin_mov{Bin::Op::MOV, Reg{1}, Reg{2}, true, false};
+    Instruction ins = bin_mov;
+    EbpfDomain dom = EbpfDomain::top();
+
+    auto deps = extract_instruction_deps(ins, dom);
+
+    REQUIRE(deps.regs_written.contains(Reg{1}));
+    REQUIRE_FALSE(deps.regs_read.contains(Reg{1})); // MOV doesn't read dst
+    REQUIRE(deps.regs_read.contains(Reg{2}));
+}
+
+TEST_CASE("extract_instruction_deps for Mem load", "[failure_slice][deps]") {
+    // r1 = *(r10 - 8) should read r10, write r1, and read stack[-8]
+    Mem mem_load{Deref{8, Reg{10}, -8}, Reg{1}, true};
+    Instruction ins = mem_load;
+    EbpfDomain dom = EbpfDomain::top();
+
+    auto deps = extract_instruction_deps(ins, dom);
+
+    REQUIRE(deps.regs_written.contains(Reg{1}));
+    REQUIRE(deps.regs_read.contains(Reg{10}));
+    REQUIRE(deps.stack_read.contains(-8));
+}
+
+TEST_CASE("extract_instruction_deps for Mem store", "[failure_slice][deps]") {
+    // *(r10 - 8) = r1 should read r10, r1 and write stack[-8]
+    Mem mem_store{Deref{8, Reg{10}, -8}, Reg{1}, false};
+    Instruction ins = mem_store;
+    EbpfDomain dom = EbpfDomain::top();
+
+    auto deps = extract_instruction_deps(ins, dom);
+
+    REQUIRE(deps.regs_read.contains(Reg{10}));
+    REQUIRE(deps.regs_read.contains(Reg{1}));
+    REQUIRE(deps.stack_written.contains(-8));
+}
+
+// Test that extract_assertion_registers correctly identifies assertion dependencies
+TEST_CASE("extract_assertion_registers for ValidAccess", "[failure_slice][deps]") {
+    ValidAccess va{0, Reg{1}, 0, Imm{8}, false, AccessType::read};
+    Assertion assertion = va;
+
+    auto regs = extract_assertion_registers(assertion);
+
+    REQUIRE(regs.contains(Reg{1}));
+}
+
+TEST_CASE("extract_assertion_registers for Comparable", "[failure_slice][deps]") {
+    Comparable comp{Reg{1}, Reg{2}, false};
+    Assertion assertion = comp;
+
+    auto regs = extract_assertion_registers(assertion);
+
+    REQUIRE(regs.contains(Reg{1}));
+    REQUIRE(regs.contains(Reg{2}));
+}
+
+TEST_CASE("extract_assertion_registers for ValidDivisor", "[failure_slice][deps]") {
+    ValidDivisor vd{Reg{3}, false};
+    Assertion assertion = vd;
+
+    auto regs = extract_assertion_registers(assertion);
+
+    REQUIRE(regs.contains(Reg{3}));
+}
+
+TEST_CASE("extract_assertion_registers for BoundedLoopCount", "[failure_slice][deps]") {
+    BoundedLoopCount blc{Label{0}};
+    Assertion assertion = blc;
+
+    auto regs = extract_assertion_registers(assertion);
+
+    REQUIRE(regs.empty());
+}
+
+// Integration tests using real failing programs
+TEST_CASE("failure slice for badmapptr.o", "[failure_slice][integration]") {
+    const std::string sample = "ebpf-samples/build/badmapptr.o";
+    if (!sample_exists(sample)) {
+        SKIP("Sample file not found: " << sample);
+    }
+    auto slices = get_failure_slices(sample, "test");
+
+    REQUIRE(slices.size() == 1);
+    REQUIRE(slices[0].relevance.size() == 2); // Labels 2 and 4
+    REQUIRE(slices[0].relevance.contains(slices[0].failing_label));
+
+    // The failure is about r1 type (map_fd is not in {number, ctx, stack, packet, shared})
+    auto& failing_relevance = slices[0].relevance.at(slices[0].failing_label);
+    REQUIRE(failing_relevance.registers.size() == 1);
+    REQUIRE(failing_relevance.registers.contains(Reg{1}));
+}
+
+TEST_CASE("failure slice for exposeptr.o", "[failure_slice][integration]") {
+    const std::string sample = "ebpf-samples/build/exposeptr.o";
+    if (!sample_exists(sample)) {
+        SKIP("Sample file not found: " << sample);
+    }
+    auto slices = get_failure_slices(sample, ".text");
+
+    REQUIRE(slices.size() == 1);
+    REQUIRE(slices[0].relevance.size() > 0);
+
+    // The failure involves map update with registers r1, r3
+    auto& failing_relevance = slices[0].relevance.at(slices[0].failing_label);
+    // At minimum r3 should be relevant (the value being stored)
+    REQUIRE(failing_relevance.registers.size() > 0);
+}
+
+TEST_CASE("failure slice for nullmapref.o", "[failure_slice][integration]") {
+    const std::string sample = "ebpf-samples/build/nullmapref.o";
+    if (!sample_exists(sample)) {
+        SKIP("Sample file not found: " << sample);
+    }
+    auto slices = get_failure_slices(sample, "test");
+
+    REQUIRE(slices.size() >= 1);
+    // Slice should have at least the failing label
+    REQUIRE(slices[0].relevance.size() >= 1);
+}
+
+// Test print_failure_slices produces output
+TEST_CASE("print_failure_slices produces structured output", "[failure_slice][print]") {
+    const std::string sample = "ebpf-samples/build/badmapptr.o";
+    if (!sample_exists(sample)) {
+        SKIP("Sample file not found: " << sample);
+    }
+    ebpf_verifier_options_t options{};
+    options.verbosity_opts.collect_instruction_deps = true;
+
+    auto raw_progs = read_elf(sample, "test", "", options, &g_ebpf_platform_linux);
+    REQUIRE(raw_progs.size() == 1);
+
+    const RawProgram& raw_prog = raw_progs.back();
+    auto prog_or_error = unmarshal(raw_prog, options);
+    auto inst_seq = std::get_if<InstructionSeq>(&prog_or_error);
+    REQUIRE(inst_seq != nullptr);
+
+    const Program prog = Program::from_sequence(*inst_seq, raw_prog.info, options);
+    auto result = analyze(prog);
+    auto slices = result.compute_failure_slices(prog);
+
+    std::stringstream output;
+    print_failure_slices(output, prog, false, result, slices);
+
+    std::string output_str = output.str();
+
+    // Check expected sections are present
+    REQUIRE(output_str.find("[ERROR]") != std::string::npos);
+    REQUIRE(output_str.find("[LOCATION]") != std::string::npos);
+    REQUIRE(output_str.find("[RELEVANT REGISTERS]") != std::string::npos);
+    REQUIRE(output_str.find("[SLICE SIZE]") != std::string::npos);
+    REQUIRE(output_str.find("[CAUSAL TRACE]") != std::string::npos);
+}
+
+// Test that passing programs produce no slices
+TEST_CASE("passing program produces no failure slices", "[failure_slice][integration]") {
+    const std::string sample = "ebpf-samples/build/stackok.o";
+    if (!sample_exists(sample)) {
+        SKIP("Sample file not found: " << sample);
+    }
+    ebpf_verifier_options_t options{};
+    options.verbosity_opts.collect_instruction_deps = true;
+
+    auto raw_progs = read_elf(sample, ".text", "", options, &g_ebpf_platform_linux);
+    REQUIRE(raw_progs.size() == 1);
+
+    const RawProgram& raw_prog = raw_progs.back();
+    auto prog_or_error = unmarshal(raw_prog, options);
+    auto inst_seq = std::get_if<InstructionSeq>(&prog_or_error);
+    REQUIRE(inst_seq != nullptr);
+
+    const Program prog = Program::from_sequence(*inst_seq, raw_prog.info, options);
+    auto result = analyze(prog);
+
+    REQUIRE_FALSE(result.failed);
+
+    auto slices = result.compute_failure_slices(prog);
+    REQUIRE(slices.empty());
+}
+
+// Test that Assume control-dependency logic includes guard condition registers.
+// When an Assume is a direct predecessor of the failing label, its condition
+// registers should appear as relevant in the slice.
+TEST_CASE("assume guard registers become relevant in slice", "[failure_slice][integration]") {
+    const std::string sample = "ebpf-samples/build/dependent_read.o";
+    if (!sample_exists(sample)) {
+        SKIP("Sample file not found: " << sample);
+    }
+    auto slices = get_failure_slices(sample, "xdp");
+
+    REQUIRE(slices.size() >= 1);
+    const auto& slice = slices[0];
+    REQUIRE(slice.relevance.size() > 0);
+
+    // Check that at least one Assume label is in the slice
+    // (the guard condition that determines reachability of the failing label)
+    ebpf_verifier_options_t options{};
+    options.verbosity_opts.collect_instruction_deps = true;
+    auto raw_progs = read_elf(sample, "xdp", "", options, &g_ebpf_platform_linux);
+    REQUIRE(raw_progs.size() == 1);
+    auto prog_or_error = unmarshal(raw_progs.back(), options);
+    auto inst_seq = std::get_if<InstructionSeq>(&prog_or_error);
+    REQUIRE(inst_seq != nullptr);
+    const Program prog = Program::from_sequence(*inst_seq, raw_progs.back().info, options);
+
+    bool found_assume_in_slice = false;
+    for (const auto& [label, relevance] : slice.relevance) {
+        if (std::holds_alternative<Assume>(prog.instruction_at(label))) {
+            found_assume_in_slice = true;
+            // The Assume's condition registers should be in the relevance set
+            REQUIRE(relevance.registers.size() > 0);
+            break;
+        }
+    }
+    REQUIRE(found_assume_in_slice);
+}
+
+TEST_CASE("empty seed assertion still includes failing label", "[failure_slice][integration]") {
+    const std::string sample = "ebpf-samples/build/bounded_loop.o";
+    if (!sample_exists(sample)) {
+        SKIP("Sample file not found: " << sample);
+    }
+    auto slices = get_failure_slices(sample, "test");
+    if (slices.empty()) {
+        // bounded_loop may pass verification depending on build; skip if so
+        SKIP("Program passed verification (no failure slices)");
+    }
+
+    // The slice should still contain the failing label even with no register deps
+    for (const auto& slice : slices) {
+        auto labels = slice.impacted_labels();
+        REQUIRE(labels.contains(slice.failing_label));
+    }
+}


### PR DESCRIPTION
Implement backward slicing from verification failure points to produce minimal diagnostic output. The slicer traces register, stack dependencies, and control flow dependencies backward through the CFG to identify which instructions contributed to each failure.

Key features:
- Seed backward traversal from assertion registers at failure points
- Track register reads/writes and stack dependencies per instruction
- Filter invariant display to only relevant registers and constraints
- Show per-predecessor state at join points to expose precision loss
- Conservative mode for assertions with no register deps (e.g., BoundedLoopCount)
- Convergence groups in control flow summary: {pred1 | pred2} -> join
- --failure-slice CLI flag for the check tool
- Integration tests for failure slicing behavior

Resolves: #995

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Failure Slicing: emit compact causal diagnostics for verification failures, showing relevant registers/stack offsets, join-point-aware control‑flow summaries, and configurable traversal depth/compact output.

* **Documentation**
  * Added a Failure Slicing guide and updated CLI usage to document --failure-slice and --failure-slice-depth.

* **Tests**
  * New test suite validating dependency extraction, slicing logic, and formatted failure output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->