### PR TITLE
Fix instype() CallBtf label and clarify CMPXCHG partial status

### DIFF
--- a/docs/feature-support-matrix.md
+++ b/docs/feature-support-matrix.md
@@ -63,7 +63,7 @@ Capability and configuration checks are described in `Notes / Evidence`; they do
 | Feature | Status | Notes / Evidence |
 |---|---|---|
 | Atomic add/or/and/xor (32/64) | Supported | `src/ir/unmarshal.cpp`: `getAtomicOp`, `makeMemOp`; `src/ir/cfg_builder.cpp`: `check_instruction_feature_support` |
-| Atomic xchg / cmpxchg (32/64) | Partial | `src/ir/unmarshal.cpp`: `getAtomicOp`; `src/crab/ebpf_transformer.cpp` atomic handling |
+| Atomic xchg / cmpxchg (32/64) | Partial | `src/ir/unmarshal.cpp`: `getAtomicOp`; `src/crab/ebpf_transformer.cpp` atomic handling; CMPXCHG uses havoc instead of modeling the comparison (see comment at `ebpf_transformer.cpp:748`) |
 
 ### Call Model and Helper Typing
 

--- a/src/ir/cfg_builder.cpp
+++ b/src/ir/cfg_builder.cpp
@@ -517,7 +517,7 @@ static std::string instype(Instruction ins) {
     } else if (std::holds_alternative<Callx>(ins)) {
         return "callx";
     } else if (std::holds_alternative<CallBtf>(ins)) {
-        return "call_mem";
+        return "call_btf";
     } else if (const auto pimm = std::get_if<Mem>(&ins)) {
         return pimm->is_load ? "load" : "store";
     } else if (std::holds_alternative<Atomic>(ins)) {


### PR DESCRIPTION
Minor feedback based on review of https://github.com/vbpf/prevail/pull/999

- Fix instype() mapping CallBtf to 'call_mem' instead of 'call_btf'
- Clarify atomic xchg/cmpxchg Partial status in feature-support-matrix.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated feature support matrix to clarify CMPXCHG operation behavior

* **Bug Fixes**
  * Corrected instruction type classification for improved statistical accuracy

<!-- end of auto-generated comment: release notes by coderabbit.ai -->