### PR TITLE
Cache YAML test suite parsing to avoid redundant re-parsing

### DIFF
--- a/src/test/ebpf_yaml.cpp
+++ b/src/test/ebpf_yaml.cpp
@@ -581,7 +581,17 @@ void print_failure(const Failure& failure, std::ostream& os) {
 }
 
 void foreach_suite(const string& path, const std::function<void(const TestCase&)>& f) {
-    for (const TestCase& test_case : read_suite(path)) {
+    static std::map<string, vector<TestCase>> cache;
+    auto [it, inserted] = cache.try_emplace(path);
+    if (inserted) {
+        try {
+            it->second = read_suite(path);
+        } catch (...) {
+            cache.erase(it);
+            throw;
+        }
+    }
+    for (const TestCase& test_case : it->second) {
         f(test_case);
     }
 }


### PR DESCRIPTION
Catch2's DYNAMIC_SECTION re-executes the test body for each section, causing read_suite() to parse each YAML file N times. Cache results in a static map to parse each file only once. YAML tests are ~25x faster.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test-suite loading performance by adding per-path caching of parsed YAML suites, reducing repeated reads/parses on repeated runs.
  * Initialization error handling preserved: failures during first load still surface as before.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->