### PR TITLE
Fix two verifier soundness bugs found by pentest

### DIFF
--- a/src/crab/ebpf_transformer.cpp
+++ b/src/crab/ebpf_transformer.cpp
@@ -886,30 +886,43 @@ void EbpfTransformer::operator()(const Call& call) {
     constexpr Reg r0_reg{R0_RETURN_VALUE};
     const auto r0_pack = reg_pack(r0_reg);
     dom.state.values.havoc(r0_pack.stack_numeric_size);
-    if (call.is_map_lookup) {
-        // This is the only way to get a null pointer
-        if (maybe_fd_reg) {
-            if (const auto map_type = dom.get_map_type(*maybe_fd_reg)) {
-                if (thread_local_program_info->platform->get_map_type(*map_type).value_type == EbpfMapValueType::MAP) {
-                    if (const auto inner_map_fd = dom.get_map_inner_map_fd(*maybe_fd_reg)) {
-                        do_load_mapfd(r0_reg, to_signed(*inner_map_fd), true);
-                        goto out;
-                    }
-                } else {
-                    assign_valid_ptr(r0_reg, true);
-                    dom.state.values.assign(r0_pack.shared_offset, 0);
-                    dom.state.values.set(r0_pack.shared_region_size, dom.get_map_value_size(*maybe_fd_reg));
-                    dom.state.assign_type(r0_reg, T_SHARED);
-                    goto out;
-                }
-            }
-        }
-        // Fallthrough: map type unknown or map-in-map with unknown inner fd.
-        // Havoc shared_region_size so stale values from prior lookups don't persist.
+    // Set r0 as a nullable T_SHARED pointer at offset 0.
+    // If region_size is known, constrain it; otherwise havoc to prevent stale values.
+    auto assign_shared_map_value = [&](const std::optional<Interval>& region_size) {
         assign_valid_ptr(r0_reg, true);
         dom.state.values.assign(r0_pack.shared_offset, 0);
-        dom.state.values.havoc(r0_pack.shared_region_size);
+        if (region_size) {
+            dom.state.values.set(r0_pack.shared_region_size, *region_size);
+        } else {
+            dom.state.values.havoc(r0_pack.shared_region_size);
+        }
         dom.state.assign_type(r0_reg, T_SHARED);
+    };
+    auto resolve_map_lookup = [&] {
+        // Map lookup is the only way to get a null pointer.
+        if (!maybe_fd_reg) {
+            assign_shared_map_value(std::nullopt);
+            return;
+        }
+        const auto map_type = dom.get_map_type(*maybe_fd_reg);
+        if (!map_type) {
+            assign_shared_map_value(std::nullopt);
+            return;
+        }
+        if (thread_local_program_info->platform->get_map_type(*map_type).value_type == EbpfMapValueType::MAP) {
+            // Map-of-maps: r0 is an inner map fd if known, otherwise an opaque shared pointer.
+            if (const auto inner_map_fd = dom.get_map_inner_map_fd(*maybe_fd_reg)) {
+                do_load_mapfd(r0_reg, to_signed(*inner_map_fd), true);
+            } else {
+                assign_shared_map_value(std::nullopt);
+            }
+            return;
+        }
+        // Regular map: r0 is a shared pointer with known value size.
+        assign_shared_map_value(dom.get_map_value_size(*maybe_fd_reg));
+    };
+    if (call.is_map_lookup) {
+        resolve_map_lookup();
     } else if (call.return_ptr_type.has_value()) {
         assign_valid_ptr(r0_reg, call.return_nullable);
         dom.state.assign_type(r0_reg, *call.return_ptr_type);
@@ -919,7 +932,6 @@ void EbpfTransformer::operator()(const Call& call) {
         dom.state.assign_type(r0_reg, T_NUM);
         // dom.state.values.add_constraint(r0_pack.value < 0); for INTEGER_OR_NO_RETURN_IF_SUCCEED.
     }
-out:
     scratch_caller_saved_registers();
     if (call.reallocate_packet) {
         forget_packet_pointers();


### PR DESCRIPTION
## Summary

- **Stale `shared_region_size` after map_lookup fallthrough**: When the map type/fd is ambiguous (non-singleton interval), the fallthrough path in `Call` handling set `T_SHARED` without havocing `shared_region_size`, allowing a stale value from a prior lookup to persist. This permitted OOB reads on map values (e.g., offset 5000 on a 32-byte map value accepted). Fixed by adding `goto out` on success and `havoc(shared_region_size)` on the fallthrough.

- **Stale r1-r5 after BPF-to-BPF call return**: The `Exit` handler for subprogram returns restored callee-saved registers (r6-r9) and r10 but never scratched caller-saved registers (r1-r5). A caller could use stale pointer values in r1-r5 that the callee may have invalidated. Fixed by calling `scratch_caller_saved_registers()` in the `Exit` handler.

Both bugs were confirmed with crafted eBPF programs that the verifier accepted but shouldn't have (false accepts / soundness violations).

## Test plan

- [x] Full test suite passes (917 passed, 49 expected failures, 1 skipped, 0 actual failures)
- [x] Pentest reproducers now correctly rejected (exit code 1)
- [x] `bpf2bpf.o` sample programs still verify correctly (callee-saved r6-r9 preserved, only r1-r5 scratched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured caller-saved registers are always cleared after calls, improving register cleanup at function exit.
  * Refactored map-lookup handling to centralize result assignment, correctly handle missing/inner maps and unknown sizes, and prevent stale or invalid values from persisting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->