### PR TITLE
docs: sync documentation with current code

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -52,7 +52,7 @@ Prevail verifies that eBPF programs:
                                  ▼
 ┌─────────────────────────────────────────────────────────────────┐
 │                    ELF Loader & Unmarshaller                    │
-│              (elf_loader.cpp, asm_unmarshal.cpp)                │
+│              (elf_loader.cpp, unmarshal.cpp)                    │
 └─────────────────────────────────────────────────────────────────┘
                                  │
                                  ▼

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -12,7 +12,7 @@ ELF Binary -> Unmarshal -> Build CFG -> Abstract Interpretation -> Result
 
 ### Stage 1: ELF Loading and Unmarshalling
 
-**Files**: `src/elf_loader.cpp`, `src/ir/asm_unmarshal.cpp`
+**Files**: `src/elf_loader.cpp`, `src/ir/unmarshal.cpp`
 
 1. **ELF Parsing**: Extract eBPF bytecode sections from ELF files
 2. **Instruction Decoding**: Convert raw bytes to structured instructions

--- a/docs/type-system.md
+++ b/docs/type-system.md
@@ -34,6 +34,10 @@ enum class Type {
     T_MAP,        // Map value pointer
     T_MAP_FD,     // Map file descriptor
     T_MAP_PROG,   // Map programs array
+    T_SOCKET,     // Socket structure pointer
+    T_BTF_ID,     // BTF-typed kernel object pointer
+    T_ALLOC_MEM,  // Helper-allocated memory pointer
+    T_FUNC,       // BPF function pointer (callback)
     T_TOP,        // Unknown type (any of the above)
     T_BOTTOM,     // Contradiction (unreachable)
 };
@@ -109,6 +113,12 @@ Each pointer type has associated numeric variables:
 | T_SHARED | shared_offset, shared_region_size |
 | T_MAP | map_value_size |
 | T_MAP_FD | map_fd |
+| T_SOCKET | socket_offset |
+| T_BTF_ID | btf_id_offset |
+| T_ALLOC_MEM | alloc_mem_offset, alloc_mem_size |
+| T_FUNC | *(none)* |
+
+> **Note:** `T_FUNC` intentionally has no associated offset or size variables. Function pointers (callback targets) are treated as opaque numeric values; see the empty mapping in `src/crab/type_to_num.hpp`.
 
 ### Register Pack
 
@@ -123,10 +133,14 @@ struct RegPack {
     Var stack_offset;        // For T_STACK
     Var packet_offset;       // For T_PACKET
     Var shared_offset;       // For T_SHARED
+    Var socket_offset;       // For T_SOCKET
+    Var btf_id_offset;       // For T_BTF_ID
+    Var alloc_mem_offset;    // For T_ALLOC_MEM
     
     // Size tracking
     Var shared_region_size;  // For T_SHARED
     Var stack_numeric_size;  // For T_STACK spills
+    Var alloc_mem_size;      // For T_ALLOC_MEM
     
     // Map-related
     Var map_fd;              // For T_MAP_FD

--- a/src/ir/syntax.hpp
+++ b/src/ir/syntax.hpp
@@ -85,7 +85,7 @@ struct Un {
 };
 
 /// This instruction is encoded similarly to LDDW.
-/// See comment in makeLddw() at asm_unmarshal.cpp
+/// See comment in makeLddw() at unmarshal.cpp
 struct LoadMapFd {
     Reg dst;
     int32_t mapfd{};


### PR DESCRIPTION
## Summary

Synchronizes documentation with the current codebase to fix several significant discrepancies.

## Changes

### File Path Corrections
- asm_unmarshal.cpp renamed to unmarshal.cpp

### Instruction Variant Updates
Added missing types to the documented Instruction variant:
- Undefined - For unknown/unimplemented instructions
- LoadPseudo - For LDDW pseudo forms (src=3,4,5,6)
- CallBtf - For CALL src=2 (helper by BTF ID)

### Type System Updates
Updated from 8 to 12 type encodings:
- Added T_SOCKET, T_BTF_ID, T_ALLOC_MEM, T_FUNC
- Fixed bitset size references (8 to 12)
- Fixed DSU sentinel count references (8 to 12)
- Added tracked variables for new pointer types
- Added RegPack fields for new types

### Code Comment Fix
- Fixed stale comment in src/ir/syntax.hpp referencing old filename

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated architecture and component references and expanded instruction/registry examples to reflect new variants and offsets.

* **Type System**
  * Extended type system with four new pointer-type categories (socket, BTF ID, allocated memory, function) and expanded tracking/offset/size bookkeeping to support them.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->