### PR TITLE
Handle invalid BTF map metadata

### DIFF
--- a/src/io/elf_map_parser.cpp
+++ b/src/io/elf_map_parser.cpp
@@ -286,8 +286,9 @@ ElfGlobalData extract_global_data(const parse_params_t& params, const ELFIO::elf
     if (has_btf_maps) {
         try {
             return parse_btf_section(params, reader);
-        } catch (const UnmarshalError&) {
-            // If BTF-defined maps can't be decoded, fall back to section-based map descriptors.
+        } catch (const UnmarshalError& e) {
+            // BTF-defined maps can't be decoded; fall back to section-based map descriptors.
+            std::cerr << "BTF map parsing failed, falling back to section-based maps: " << e.what() << std::endl;
         }
         return parse_map_sections(params, reader, symbols);
     }

--- a/src/io/elf_reader.cpp
+++ b/src/io/elf_reader.cpp
@@ -54,12 +54,7 @@ validate_and_get_lddw_pair(std::vector<EbpfInst>& instructions, size_t location,
 }
 
 bool is_map_section(const std::string& name) {
-    const std::string maps_prefix = "maps/";
-    const std::string dot_maps_prefix = ".maps/";
-    return name == "maps" || name == ".maps" ||
-           (name.length() > maps_prefix.length() && name.compare(0, maps_prefix.length(), maps_prefix) == 0) ||
-           (name.length() > dot_maps_prefix.length() &&
-            name.compare(0, dot_maps_prefix.length(), dot_maps_prefix) == 0);
+    return name == "maps" || name == ".maps" || name.starts_with("maps/") || name.starts_with(".maps/");
 }
 
 bool is_global_section(const std::string& name) {


### PR DESCRIPTION
Also: sections cannot be null except in OOM, and in this case ELFIOs behavior is already undefined.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * BTF-based map parsing now catches unmarshalling errors and falls back to section-based parsing instead of aborting.
  * Map-section detection expanded to recognize "maps", ".maps" and path variants (including subdirectories).
  * Added validation for map section pointers to ensure integrity when processing map data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->