### PR TITLE
Safety parity: propagate alloc_mem_size and decompose kfunc flags

### DIFF
--- a/docs/parity/README.md
+++ b/docs/parity/README.md
@@ -48,9 +48,11 @@ Out of scope:
 
 Many gaps are coupled. The most important dependency chains:
 
-1. **Pointer type classes** → helper families, lifetime tracking, kfuncs
-2. **BTF semantic integration** → kfuncs, BTF-ID pointer typing, object-type reasoning
-3. **Lifetime tracking** → socket helpers, ringbuf reserve/submit, kptr exchange
-4. **Callback verification** → `bpf_loop`, `for_each_map_elem`, timer callbacks
-5. **Program-type/context fidelity** → correct helper availability per attach point
-6. **Map identity propagation** → map-in-map chains, inner map descriptor reasoning
+1. **Lifetime tracking** → socket helpers, ringbuf ownership, kptr exchange, dynptr lifecycle, kfunc acquire/release
+2. **Pointer type classes** → helper families, lifetime tracking, kfuncs
+3. **BTF semantic integration** → kfuncs, BTF-ID pointer typing, map-value field validation
+4. **Callback body analysis** → `bpf_loop`, `for_each_map_elem`, timer callbacks, user ringbuf
+5. **Dynptr type representation** → dynptr helpers, dynptr ringbuf, user ringbuf
+6. **Program-type/context fidelity** → correct helper availability per attach point
+7. **Map identity propagation** → map-in-map chains, inner map descriptor reasoning
+8. **ISA extensions** → `may_goto` (open-coded iterators), `addr_space_cast` (arena)

--- a/docs/parity/btf-semantics.md
+++ b/docs/parity/btf-semantics.md
@@ -10,7 +10,21 @@ BTF section parsing and CO-RE relocations are implemented. What is missing is
 - [x] **kfunc argument type checking** — verify arguments against resolved kfunc prototypes (table-driven subset).
 - [x] **kfunc availability gating** — apply prototype-level availability checks (program type and privileged-only constraints) before analysis.
 - [ ] **kfunc return type propagation** — propagate BTF-typed return values into the register state. Current subset supports integer and map-value-or-null style return contracts only.
-- [ ] **kfunc flags** — handle kfunc behavioral flags (e.g., `KF_ACQUIRE`, `KF_RELEASE`, `KF_TRUSTED_ARGS`, `KF_SLEEPABLE`, `KF_DESTRUCTIVE`). Flagged entries are conservatively rejected today.
+- [ ] **kfunc flags** — per-flag handling for kfunc behavioral flags. Flags accepted today (type-level safety covered by existing checks):
+  - `KF_ACQUIRE` — type propagation works; release obligation not enforced (same gap as ringbuf, tracked in [lifetime.md](lifetime.md))
+  - `KF_DESTRUCTIVE` — privilege-level gate only
+  - `KF_TRUSTED_ARGS` — arguments type-checked via normal assertion path
+  - `KF_SLEEPABLE` — context constraint, not a memory-safety property
+
+  Flags rejected (require unimplemented infrastructure):
+  - `KF_RELEASE` — requires acquire/release state machine (see [lifetime.md](lifetime.md))
+
+  Flags not yet in the `KfuncFlags` enum (Linux defines but Prevail does not):
+  - `KF_RET_NULL` — forces null check on return value (safety-critical)
+  - `KF_RCU` / `KF_RCU_PROTECTED` — RCU pointer trust and critical-section enforcement (safety-critical)
+  - `KF_ITER_NEW` / `KF_ITER_NEXT` / `KF_ITER_DESTROY` — iterator lifecycle tracking (safety-critical)
+  - `KF_DEPRECATED` — load-time warning (informational)
+  - `KF_IMPLICIT_ARGS` — hidden argument injection (ABI)
 
 ## BTF-ID pointer typing
 

--- a/docs/parity/call-model.md
+++ b/docs/parity/call-model.md
@@ -2,9 +2,9 @@
 
 ## Callback verification
 
-- [x] **`PTR_TO_FUNC` argument type** — helper signatures now carry `PTR_TO_FUNC`, and verifier checks enforce `func`-typed callback registers.
-- [x] **Callback target validity** — helper calls with `PTR_TO_FUNC` now require singleton code-address targets that resolve to valid top-level instruction labels.
-- [ ] **Callback body analysis** — verify the callback subprogram body against the callback contract (expected argument types, return type, side-effect constraints). Basic shape validation is present: callback targets must have a reachable exit.
+- [x] **`PTR_TO_FUNC` argument type** — helper signatures carry `PTR_TO_FUNC`; verifier enforces `T_FUNC` type on the register.
+- [x] **Callback target validity** — helper calls with `PTR_TO_FUNC` require a singleton code-address register that resolves to a valid top-level instruction label (not a jump target, not Entry/Exit) with a reachable exit.
+- [ ] **Callback body analysis** — the callback subprogram body is not verified. Only structural checks are performed (valid label, reachable exit). No checking of callback argument types, return type, or side-effect constraints. The callback's code is present in the CFG but not analyzed under a callback-specific contract.
 - [ ] **Callback frame semantics** — model the callback's stack frame and register state as a nested verification context.
 
 ## Tail calls

--- a/docs/parity/helper-families.md
+++ b/docs/parity/helper-families.md
@@ -1,45 +1,52 @@
 # Helper Function Families
 
-Groups of helpers that are blocked by shared missing capabilities.
+Groups of helpers organized by their blocking dependencies.
 Items here represent *families*, not individual helper IDs. A family is checked off
-when all its members are semantically functional.
+when all its members are semantically functional (type-checked, ownership-tracked where required).
+
+## Fully functional
+
+- [x] **Scalar parse helpers** — `strtol` (105), `strtoul` (106). `PTR_TO_LONG` verified as writable 8-byte stack pointer.
+- [x] **MTU check** — `check_mtu` (163). `PTR_TO_INT` verified as writable 4-byte stack pointer.
+- [x] **Helpers beyond 0–211 in Linux 6.18** — all helper IDs present in Linux 6.18 beyond 211 have prototype coverage in the verifier tables.
+
+## Memory-safe but missing ownership tracking
+
+These helpers are type-checked and bounds-checked. The remaining gap is resource lifecycle
+enforcement, tracked in [lifetime.md](lifetime.md).
+
+- [ ] **Ringbuf reserve/submit/discard** — `ringbuf_reserve` (131), `ringbuf_submit` (132), `ringbuf_discard` (133). Type propagation works: `ringbuf_reserve` returns `T_ALLOC_MEM` (nullable) with offset=0 and size from the allocation size argument. Access through the returned pointer is bounds-checked. `ringbuf_submit`/`ringbuf_discard` enforce `T_ALLOC_MEM` argument type. **Missing**: ownership tracking — the verifier does not enforce that exactly one of submit/discard is called on every path, so programs that leak a reservation or use-after-free are accepted.
 
 ## Blocked by pointer type classes
 
-- [ ] **Socket lookup family** — `sk_lookup_tcp` (84), `sk_lookup_udp` (85), `skc_lookup_tcp` (99), `sk_fullsock` (95), `tcp_sock` (96), `get_listener_sock` (98). Requires socket pointer return/argument types + reference tracking.
-- [ ] **Socket casting family** — `skc_to_tcp6_sock` (136), `skc_to_tcp_sock` (137), `skc_to_tcp_timewait_sock` (138), `skc_to_tcp_request_sock` (139), `skc_to_udp6_sock` (140), `sock_from_file` (162), `skc_to_mptcp_sock` (196). Requires `PTR_TO_BTF_ID` return types.
-- [ ] **BTF object helpers** — `get_current_task_btf` (158), `task_pt_regs` (175), `per_cpu_ptr` (153), `this_cpu_ptr` (154). Requires `PTR_TO_BTF_ID` and `PTR_TO_PERCPU_BTF_ID`.
+- [ ] **Socket lookup family** — `sk_lookup_tcp` (84), `sk_lookup_udp` (85), `skc_lookup_tcp` (99), `sk_fullsock` (95), `tcp_sock` (96), `get_listener_sock` (98). Type propagation to `T_SOCKET` works; blocked on `PTR_TO_SOCK_COMMON` argument subtyping + reference tracking.
+- [ ] **Socket casting family** — `skc_to_tcp6_sock` (136), `skc_to_tcp_sock` (137), `skc_to_tcp_timewait_sock` (138), `skc_to_tcp_request_sock` (139), `skc_to_udp6_sock` (140), `sock_from_file` (162), `skc_to_mptcp_sock` (196). Requires BTF-ID-level socket subtype discrimination in return types.
+- [ ] **BTF object helpers** — `get_current_task_btf` (158), `task_pt_regs` (175), `per_cpu_ptr` (153), `this_cpu_ptr` (154). Requires `PTR_TO_BTF_ID` subtype compatibility and `PTR_TO_PERCPU_BTF_ID`.
 - [ ] **Storage helpers** — task/inode/cgroup/sk storage `get`/`delete` families. Requires `PTR_TO_BTF_ID` argument class.
+- [ ] **String helpers** — `snprintf` (165), `strncmp` (182). Requires `PTR_TO_CONST_STR`: proof that pointer targets a null-terminated string in a read-only map value at a constant offset.
 
-## Blocked by callback verification
+## Blocked by callback body analysis
 
-- [ ] **`bpf_loop`** (181) — requires `PTR_TO_FUNC` + callback body analysis.
-- [ ] **`bpf_for_each_map_elem`** (164) — requires `PTR_TO_FUNC` + callback body analysis.
-- [ ] **`bpf_find_vma`** (180) — requires `PTR_TO_FUNC` + `PTR_TO_BTF_ID` + callback body analysis.
+- [ ] **`bpf_loop`** (181) — `PTR_TO_FUNC` argument type is checked (singleton code address, reachable exit), but the callback body is not verified against its contract (expected argument types, return type, side-effect constraints).
+- [ ] **`bpf_for_each_map_elem`** (164) — same: target validation only, no body analysis.
+- [ ] **`bpf_find_vma`** (180) — same, plus requires `PTR_TO_BTF_ID` for the VMA argument.
 
 ## Blocked by lifetime/ownership tracking
 
-- [ ] **Ringbuf reserve/submit/discard** — `ringbuf_reserve` (131), `ringbuf_submit` (132), `ringbuf_discard` (133). Requires `PTR_TO_ALLOC_MEM` types + ownership tracking.
 - [ ] **kptr exchange** — `kptr_xchg` (194). Requires `PTR_TO_BTF_ID` + ownership transfer semantics.
 - [ ] **Socket release** — `sk_release` (86). Requires `PTR_TO_BTF_ID_SOCK_COMMON` + reference release tracking.
 
 ## Blocked by map-value embedded object types
 
-- [ ] **Spin lock** — `spin_lock` (93), `spin_unlock` (94). Requires `PTR_TO_SPIN_LOCK` + lock-region tracking.
-- [ ] **Timer** — `timer_init` (169), `timer_set_callback` (170), `timer_start` (171), `timer_cancel` (172). Requires `PTR_TO_TIMER` + `PTR_TO_FUNC`.
+- [ ] **Spin lock** — `spin_lock` (93), `spin_unlock` (94). Requires `PTR_TO_SPIN_LOCK` (BTF field offset validation) + lock-region tracking.
+- [ ] **Timer** — `timer_init` (169), `timer_set_callback` (170), `timer_start` (171), `timer_cancel` (172). Requires `PTR_TO_TIMER` (BTF field offset validation) + `PTR_TO_FUNC` callback body analysis.
 
-## Dynptr family
+## Blocked by dynptr type representation
 
-- [ ] **Dynptr core** — `dynptr_from_mem` (197), `dynptr_read` (201), `dynptr_write` (202), `dynptr_data` (203). Requires dynptr type representation + slice semantics.
-- [ ] **Dynptr ringbuf** — `ringbuf_reserve_dynptr` (198), `ringbuf_submit_dynptr` (199), `ringbuf_discard_dynptr` (200). Requires dynptr + ownership tracking.
-- [ ] **User ringbuf** — `user_ringbuf_drain` (209). Requires callback + dynptr support.
+- [ ] **Dynptr core** — `dynptr_from_mem` (197), `dynptr_read` (201), `dynptr_write` (202), `dynptr_data` (203). Requires dynptr stack-slot tracking with typestate (initialized/uninitialized) and slice semantics.
+- [ ] **Dynptr ringbuf** — `ringbuf_reserve_dynptr` (198), `ringbuf_submit_dynptr` (199), `ringbuf_discard_dynptr` (200). Requires dynptr + mandatory release tracking.
+- [ ] **User ringbuf** — `user_ringbuf_drain` (209). Requires callback body analysis + dynptr support (callback receives `PTR_TO_DYNPTR`).
 
-## String/scalar output helpers
+## Blocked by BPF exception support
 
-- [ ] **String helpers** — `snprintf` (165), `strncmp` (182). Requires `PTR_TO_CONST_STR`.
-- [ ] **Scalar parse helpers** — `strtol` (105), `strtoul` (106). Requires `PTR_TO_LONG`.
-- [ ] **MTU check** — `check_mtu` (163). Requires `PTR_TO_INT`.
-
-## Helpers beyond table range
-
-- [x] **Helpers beyond 0-211 in Linux 6.18** — all helper IDs present in Linux 6.18 beyond 211 have prototype coverage in the verifier tables.
+- [ ] **`bpf_throw`** — kfunc for BPF exceptions (Linux 6.7+). Requires exception frame modeling. Not defined in the kfunc table.

--- a/docs/parity/isa.md
+++ b/docs/parity/isa.md
@@ -1,9 +1,14 @@
 # ISA Instruction Forms
 
-Instruction forms that are decoded but not semantically handled.
+## Completed
 
-## Missing
+All instruction forms from the base BPF ISA (RFC 9669) are decoded and semantically handled:
 
 - [x] `CALL src=2` — helper call by BTF ID (kfunc). Decoded as `CallBtf`, resolved via table to typed call contracts; unknown/unsupported BTF IDs are rejected.
 - [x] `LDDW src=3` — variable address pseudo. Decoded as `LoadPseudo`, lowered to a 64-bit scalar immediate during CFG construction.
 - [x] `LDDW src=4` — code address pseudo. Decoded as `LoadPseudo` and propagated as `func` type for callback helper arguments.
+
+## Missing post-RFC extensions
+
+- [ ] **`may_goto`** (Linux 6.9+) — open-coded iterator loop bound instruction. Not decoded; programs using it are rejected at load time.
+- [ ] **`addr_space_cast`** (Linux 6.9+) — address space cast for arena pointers. Not decoded; required for `BPF_MAP_TYPE_ARENA` semantics beyond map-type recognition.

--- a/docs/parity/lifetime.md
+++ b/docs/parity/lifetime.md
@@ -1,7 +1,16 @@
 # Object Lifetime and Ownership Tracking
 
 The Linux verifier tracks owned references that must be released before program exit.
-Prevail has no reference tracking. This blocks multiple helper families.
+Prevail has no reference lifecycle tracking. The type system *can represent* pointer kinds
+involved in ownership (e.g., `T_ALLOC_MEM`, `T_SOCKET`, `T_BTF_ID`), and type-level safety
+is in parity: pointer types are correctly propagated, bounds-checked, and prevented from
+leaking to externally-visible memory. What is missing is the lifecycle enforcement layer:
+acquire/release obligations are not tracked, so programs that leak resources or use them
+after release are accepted.
+
+This is an intentional phasing decision. Memory safety and data-leakage prevention are
+enforced at the type level today. Resource lifecycle tracking is the next layer, to be
+implemented behind a feature flag.
 
 ## Reference tracking infrastructure
 
@@ -10,10 +19,11 @@ Prevail has no reference tracking. This blocks multiple helper families.
 
 ## Specific ownership protocols
 
-- [ ] **Socket references** — `sk_lookup_tcp`/`sk_lookup_udp`/`skc_lookup_tcp` acquire; `sk_release` releases. All paths must release before exit.
-- [ ] **Ringbuf reserve/submit/discard** — `ringbuf_reserve` acquires an alloc-mem reference; exactly one of `ringbuf_submit` or `ringbuf_discard` must consume it.
+- [ ] **Socket references** — `sk_lookup_tcp`/`sk_lookup_udp`/`skc_lookup_tcp` acquire; `sk_release` releases. All paths must release before exit. Type propagation to `T_SOCKET` works today; lifecycle enforcement does not.
+- [ ] **Ringbuf reserve/submit/discard** — `ringbuf_reserve` acquires an alloc-mem reference; exactly one of `ringbuf_submit` or `ringbuf_discard` must consume it. Type checking and bounds checking work today (`T_ALLOC_MEM` propagation, allocation size tracking, argument enforcement); ownership tracking does not.
+- [ ] **kfunc acquire/release** — kfuncs with `KF_ACQUIRE` are accepted (type propagation works); `KF_RELEASE` kfuncs are rejected (require the state machine). Once the state machine exists, both sides can be wired in.
 - [ ] **kptr exchange** — `kptr_xchg` swaps a BTF-ID pointer into a map value and returns the old one. The returned pointer is an owned reference if non-null.
-- [ ] **Dynptr lifecycle** — `dynptr_from_mem` and ringbuf dynptr helpers establish dynptr ownership; associated resources must be released.
+- [ ] **Dynptr lifecycle** — `dynptr_from_mem` and ringbuf dynptr helpers establish dynptr ownership; associated resources must be released. Requires dynptr type representation first.
 
 ## Map-value embedded object ownership
 

--- a/docs/parity/map-types.md
+++ b/docs/parity/map-types.md
@@ -32,3 +32,4 @@ They should be unconditionally available.
 - [ ] **Map-in-map identity propagation** — after `map_lookup_elem` on an outer map, the inner map descriptor (type, key/value size) should be available for subsequent helper calls. Currently, inner map identity is lost across control flow.
 - [ ] **External map FD reasoning** — when map metadata is unavailable (externally provided FDs), the verifier cannot reason about map properties. Needs a model for unknown-but-constrained map descriptors.
 - [x] **Tail-call map constraints in subprograms** — tail calls in subprograms are accepted; `map_fd_programs` argument typing remains enforced for `bpf_tail_call`.
+- [ ] **Arena map semantics** — `BPF_MAP_TYPE_ARENA` is in the map-type table, but arena-specific verification (user-mappable memory, `addr_space_cast` instruction) is not implemented.

--- a/docs/parity/pointer-type-classes.md
+++ b/docs/parity/pointer-type-classes.md
@@ -1,6 +1,6 @@
 # Pointer and Return Type Classes in Helper ABI
 
-The helper prototype table covers helpers 0–211, but many signatures use argument or return
+The helper prototype table covers helpers 0–211, but some signatures use argument or return
 type classes that are not yet modeled in verifier call semantics. Until the type system can represent
 these pointer kinds and propagate them through checks/transformers, the affected helpers remain unavailable.
 
@@ -9,24 +9,41 @@ and integration into helper argument/return checking.
 
 ## Return type classes
 
-- [ ] `PTR_TO_SOCK_COMMON_OR_NULL` — returned by `sk_lookup_tcp`, `sk_lookup_udp`, `skc_lookup_tcp`
-- [ ] `PTR_TO_SOCKET_OR_NULL` — returned by `sk_fullsock`
-- [ ] `PTR_TO_TCP_SOCKET_OR_NULL` — returned by `tcp_sock`, `get_listener_sock`
-- [ ] `PTR_TO_ALLOC_MEM_OR_NULL` — returned by `ringbuf_reserve`
-- [ ] `PTR_TO_BTF_ID_OR_NULL` — returned by `sock_from_file`, `skc_to_*` helpers, `kptr_xchg`
-- [ ] `PTR_TO_BTF_ID` (non-nullable) — returned by `get_current_task_btf`, `task_pt_regs`
+### Implemented
+
+Return types that are classified and propagated into register state:
+
+- [x] `EBPF_RETURN_TYPE_INTEGER` / `INTEGER_OR_NO_RETURN_IF_SUCCEED` — scalar return
+- [x] `PTR_TO_MAP_VALUE_OR_NULL` — returned by map lookup helpers; propagated as nullable map-value pointer
+- [x] `PTR_TO_SOCK_COMMON_OR_NULL` / `PTR_TO_SOCKET_OR_NULL` / `PTR_TO_TCP_SOCKET_OR_NULL` — all mapped to `T_SOCKET` (nullable). Type-system representation works; lifecycle tracking does not (see [lifetime.md](lifetime.md)).
+- [x] `PTR_TO_ALLOC_MEM_OR_NULL` — mapped to `T_ALLOC_MEM` (nullable). Type propagation works; ownership tracking does not (see [lifetime.md](lifetime.md)).
+- [x] `PTR_TO_BTF_ID_OR_NULL` / `PTR_TO_MEM_OR_BTF_ID_OR_NULL` — mapped to `T_BTF_ID` (nullable)
+- [x] `PTR_TO_BTF_ID` / `PTR_TO_MEM_OR_BTF_ID` (non-nullable) — mapped to `T_BTF_ID`
+
+### Not implemented
+
+- [ ] `EBPF_RETURN_TYPE_UNSUPPORTED` — catch-all for return types with no verifier model. Helpers using this are rejected.
 
 ## Argument type classes
 
-- [ ] `PTR_TO_BTF_ID` — used by task/inode/cgroup/socket storage helpers, `copy_from_user_task`, `ima_file_hash`, `cgrp_storage_*`, `find_vma`
-- [ ] `PTR_TO_SOCK_COMMON` — used by `sk_fullsock`, `tcp_sock`, `get_listener_sock`
-- [ ] `PTR_TO_BTF_ID_SOCK_COMMON` — used by `sk_release`, `tcp_check_syncookie`, socket casting helpers
-- [ ] `PTR_TO_SPIN_LOCK` — used by `spin_lock`, `spin_unlock`
-- [ ] `PTR_TO_TIMER` — used by `timer_init`, `timer_set_callback`, `timer_start`, `timer_cancel`
-- [x] `PTR_TO_FUNC` — used by `for_each_map_elem`, `loop`, `find_vma`, `timer_set_callback`
-- [ ] `PTR_TO_PERCPU_BTF_ID` — used by `per_cpu_ptr`, `this_cpu_ptr`
-- [ ] `PTR_TO_ALLOC_MEM` — used by `ringbuf_submit`, `ringbuf_discard`
-- [ ] `CONST_ALLOC_SIZE_OR_ZERO` — used by `ringbuf_reserve`
-- [ ] `PTR_TO_CONST_STR` — used by `snprintf`, `strncmp`
-- [ ] `PTR_TO_LONG` — used by `strtol`, `strtoul`, `kallsyms_lookup_name`
-- [ ] `PTR_TO_INT` — used by `check_mtu`
+### Implemented
+
+- [x] `PTR_TO_MAP_VALUE` / `PTR_TO_MAP_VALUE_OR_NULL` — map value pointers with offset/size tracking
+- [x] `PTR_TO_CTX` — program context pointer
+- [x] `PTR_TO_STACK` / `PTR_TO_STACK_OR_NULL` — stack pointers with bounds checking
+- [x] `PTR_TO_FUNC` — callback function pointer; validated as singleton code address targeting a label with reachable exit
+- [x] `PTR_TO_ALLOC_MEM` — used by `ringbuf_submit`, `ringbuf_discard`; enforces `T_ALLOC_MEM` type
+- [x] `CONST_ALLOC_SIZE_OR_ZERO` — used by `ringbuf_reserve`; enforces numeric type
+- [x] `PTR_TO_LONG` — used by `strtol`, `strtoul`; verified as writable 8-byte stack pointer
+- [x] `PTR_TO_INT` — used by `check_mtu`; verified as writable 4-byte stack pointer
+- [x] `PTR_TO_SOCKET` — enforces `T_SOCKET` type
+- [x] `PTR_TO_BTF_ID` — enforces `T_BTF_ID` type (argument-side check only; no BTF type-ID compatibility checking)
+
+### Not implemented
+
+- [ ] `PTR_TO_SOCK_COMMON` — used by `sk_fullsock`, `tcp_sock`, `get_listener_sock`. Currently accepted as generic socket but lacks the socket-subtype distinction.
+- [ ] `PTR_TO_BTF_ID_SOCK_COMMON` — used by `sk_release`, `tcp_check_syncookie`, socket casting helpers. Requires BTF-ID-level socket type discrimination.
+- [ ] `PTR_TO_SPIN_LOCK` — used by `spin_lock`, `spin_unlock`. Requires map-value field offset validation via BTF.
+- [ ] `PTR_TO_TIMER` — used by `timer_init`, `timer_set_callback`, `timer_start`, `timer_cancel`. Requires map-value field offset validation via BTF.
+- [ ] `PTR_TO_PERCPU_BTF_ID` — used by `per_cpu_ptr`, `this_cpu_ptr`. Requires per-CPU pointer semantics.
+- [ ] `PTR_TO_CONST_STR` — used by `snprintf`, `strncmp`. Requires proof that pointer targets a null-terminated string in a read-only map value at a constant offset.

--- a/src/ir/syntax.hpp
+++ b/src/ir/syntax.hpp
@@ -207,6 +207,7 @@ struct Call {
     bool reallocate_packet{};
     std::optional<TypeEncoding> return_ptr_type{}; ///< Non-integer return pointer type, if any.
     bool return_nullable{};                        ///< Whether the return pointer may be null.
+    std::optional<Reg> alloc_size_reg{};           ///< Register holding allocation size (for T_ALLOC_MEM returns).
     std::vector<ArgSingle> singles;
     std::vector<ArgPair> pairs;
     std::string stack_frame_prefix; ///< Variable prefix at point of call.

--- a/src/ir/unmarshal.cpp
+++ b/src/ir/unmarshal.cpp
@@ -551,6 +551,7 @@ struct Unmarshaller {
                 break;
             case EBPF_ARGUMENT_TYPE_CONST_ALLOC_SIZE_OR_ZERO:
                 res.singles.push_back({ArgSingle::Kind::CONST_SIZE_OR_ZERO, false, Reg{gsl::narrow<uint8_t>(i)}});
+                res.alloc_size_reg = Reg{gsl::narrow<uint8_t>(i)};
                 break;
             case EBPF_ARGUMENT_TYPE_PTR_TO_LONG:
                 res.singles.push_back({ArgSingle::Kind::PTR_TO_WRITABLE_LONG, false, Reg{gsl::narrow<uint8_t>(i)}});


### PR DESCRIPTION
- ringbuf_reserve now propagates allocation size into alloc_mem_offset=0 and alloc_mem_size from the size argument register, enabling proper bounds checking on allocated memory (was havoc'd to unknown).
- Kfunc flag handling decomposed: accept acquire, destructive, trusted_args, sleepable (type-level safety covered); reject release (requires unimplemented lifecycle state machine).
- Parity docs updated: accurate implemented/unimplemented tracking for pointer type classes, helper families, kfunc flags, and lifetime gaps. Resource-tracking gaps clearly documented as intentionally deferred.