### PR TITLE
Fix widening termination by removing constraint re-addition

### DIFF
--- a/src/crab/type_to_num.cpp
+++ b/src/crab/type_to_num.cpp
@@ -261,15 +261,9 @@ void TypeToNumDomain::havoc_register(const Reg& reg) {
 }
 
 TypeToNumDomain TypeToNumDomain::widen(const TypeToNumDomain& other) const {
-    auto extra_invariants = collect_type_dependent_constraints(other);
-
-    TypeToNumDomain res{types.widen(other.types), values.widen(other.values)};
-
-    // Now add in the extra invariants saved above.
-    for (const auto& [variable, interval] : extra_invariants) {
-        res.values.set(variable, interval);
-    }
-    return res;
+    // Unlike join, widen must NOT re-add type-dependent constraints:
+    // narrowing the widened result can defeat termination (see #960).
+    return TypeToNumDomain{types.widen(other.types), values.widen(other.values)};
 }
 
 TypeToNumDomain TypeToNumDomain::narrow(const TypeToNumDomain& other) const {


### PR DESCRIPTION
## Summary
- Fixes #960
- `TypeToNumDomain::widen` called `collect_type_dependent_constraints` and re-added intervals via `set()` after zone widening
- This triggered eager normalization (`close_after_widen`), which could produce bottom and cause infinite fixed-point iteration
- Fix: remove the constraint re-addition from `widen` — this logic belongs in `join` only, as it defeats widening's termination guarantee
- Note: the separate known issue of eager normalization in the zone domain constructor (`split_dbm.hpp:145`) is architectural and remains deferred

## Test plan
- [x] Issue's test case (`crossing_64_bit_signed_boundary_1`) now terminates (was infinite loop)
- [x] Full test suite passes (1244 passed, 279 expected failures, 0 unexpected)
- [ ] CI passes on all platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)