### PR TITLE
Prevail mcp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,6 +100,8 @@ string(REGEX REPLACE "([][+.*()^$?|\\\\])" "\\\\\\1" prevail_source_dir_escaped 
 
 file(GLOB_RECURSE prevail_LIB_SRC CONFIGURE_DEPENDS "${prevail_source_dir}/src/*.cpp")
 list(FILTER prevail_LIB_SRC EXCLUDE REGEX "${prevail_source_dir_escaped}/src/main\\.cpp$")
+list(FILTER prevail_LIB_SRC EXCLUDE REGEX "${prevail_source_dir_escaped}/src/prevail_mcp\\.cpp$")
+list(FILTER prevail_LIB_SRC EXCLUDE REGEX "${prevail_source_dir_escaped}/src/mcp/.*")
 list(FILTER prevail_LIB_SRC EXCLUDE REGEX "${prevail_source_dir_escaped}/src/test/.*")
 
 add_library(prevail ${prevail_LIB_SRC})
@@ -193,6 +195,37 @@ else ()
     RUNTIME_OUTPUT_DIRECTORY "${prevail_binary_dir}")
 endif ()
 
+# MCP server
+option(prevail_ENABLE_MCP "Build MCP server" OFF)
+if (prevail_ENABLE_MCP)
+  FetchContent_Declare(nlohmann_json
+    GIT_REPOSITORY "https://github.com/nlohmann/json.git"
+    GIT_TAG "v3.12.0"
+    GIT_SHALLOW ON
+  )
+  FetchContent_MakeAvailable(nlohmann_json)
+
+  file(GLOB prevail_MCP_SRC CONFIGURE_DEPENDS "${prevail_source_dir}/src/mcp/*.cpp")
+  add_library(prevail_mcp_lib STATIC ${prevail_MCP_SRC})
+  target_link_libraries(prevail_mcp_lib PUBLIC prevail nlohmann_json::nlohmann_json)
+  target_include_directories(prevail_mcp_lib PUBLIC
+    "${prevail_source_dir}/src"
+  )
+
+  add_executable(prevail_mcp "${prevail_source_dir}/src/prevail_mcp.cpp")
+  target_link_libraries(prevail_mcp PRIVATE prevail_mcp_lib ${CMAKE_DL_LIBS})
+  if (CMAKE_CONFIGURATION_TYPES)
+    set_target_properties(prevail_mcp PROPERTIES
+      RUNTIME_OUTPUT_DIRECTORY_DEBUG "${prevail_binary_dir}"
+      RUNTIME_OUTPUT_DIRECTORY_RELEASE "${prevail_binary_dir}"
+      RUNTIME_OUTPUT_DIRECTORY_RELWITHDEBINFO "${prevail_binary_dir}"
+    )
+  else ()
+    set_target_properties(prevail_mcp PROPERTIES
+      RUNTIME_OUTPUT_DIRECTORY "${prevail_binary_dir}")
+  endif ()
+endif ()
+
 # Tests
 if (prevail_ENABLE_TESTS)
   FetchContent_Declare(Catch2
@@ -218,6 +251,11 @@ if (prevail_ENABLE_TESTS)
   target_link_libraries(run_yaml PRIVATE prevail ebpf_yaml_lib)
 
   target_link_libraries(tests PRIVATE prevail ebpf_yaml_lib bpf_conformance_core Catch2::Catch2WithMain Threads::Threads yaml-cpp::yaml-cpp)
+
+  if (prevail_ENABLE_MCP)
+    target_link_libraries(tests PRIVATE prevail_mcp_lib)
+    target_compile_definitions(tests PRIVATE PREVAIL_HAS_MCP)
+  endif ()
 
   if (CMAKE_CONFIGURATION_TYPES)
     set_target_properties(tests run_yaml PROPERTIES
@@ -249,6 +287,7 @@ install(TARGETS prevail libbtf GSL
 install(DIRECTORY "${prevail_source_dir}/src/"
   DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/prevail"
   FILES_MATCHING PATTERN "*.hpp" PATTERN "*.h"
+  PATTERN "mcp/*" EXCLUDE
   PATTERN "test/*" EXCLUDE
 )
 

--- a/README.md
+++ b/README.md
@@ -99,6 +99,12 @@ $ bin/prevail ebpf-samples/cilium/bpf_lxc.o 2/1
 PASS: 2/1
 ```
 
+### MCP Server
+
+An MCP server (`prevail_mcp`) exposes the verifier's analysis as structured JSON
+tools for LLM agents. Build with `cmake --build build --target prevail_mcp`.
+See [src/mcp/README.md](src/mcp/README.md) for details.
+
 <details><summary>Usage</summary>
 
 ```text

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,7 @@ This documentation provides a comprehensive guide to understanding the Prevail e
 | [Memory Model](memory-model.md) | Stack, packet, context, and shared memory handling |
 | [Type System](type-system.md) | Type domains and type-guided verification |
 | [Failure Slicing](failure-slicing.md) | Minimal diagnostic slices for verification failures |
+| [MCP Server](../src/mcp/README.md) | Structured verification queries for LLM agents |
 | [Building](building.md) | Build instructions for all platforms |
 | [Testing](testing.md) | Test infrastructure and conformance testing |
 | [Glossary](glossary.md) | Terminology and definitions |
@@ -94,6 +95,8 @@ Prevail verifies that eBPF programs:
 ```text
 src/
 ├── main.cpp        # CLI entry point
+├── mcp/            # MCP server (structured verification queries for LLM agents)
+├── prevail_mcp.cpp # MCP server entry point
 ├── ir/             # Intermediate representation
 │   ├── syntax.hpp  # Instruction definitions
 │   └── cfg_builder.cpp
@@ -127,7 +130,18 @@ src/
 
 When verification fails, you can use an LLM to help diagnose the issue.
 
-**Quick start** (with GitHub Copilot CLI):
+**Using the MCP server** (recommended — structured data, no text parsing):
+
+Build and start `prevail_mcp` (see [MCP Server](../src/mcp/README.md)):
+
+```bash
+cmake --build build --target prevail_mcp
+# Add to your MCP client (Copilot CLI: /mcp add, VS Code: .vscode/mcp.json)
+```
+
+Then ask your LLM: *"Use get_slice to diagnose the verification failure in program.o"*
+
+**Using prevail with verbose output** (text-based):
 
 ```text
 Using docs/llm-context.md, run ./bin/prevail <your-program.o> <section> -v and diagnose the failure.
@@ -138,7 +152,15 @@ Using docs/llm-context.md, run ./bin/prevail <your-program.o> <section> -v and d
 2. Copy the contents of `docs/llm-context.md` into your LLM conversation
 3. Paste the verification error and ask for diagnosis
 
-See [llm-context.md](llm-context.md) for the context document and [test-data/llm-context-tests.md](../test-data/llm-context-tests.md) for validated test cases.
+**Using prevail with failure slicing** (most concise text output):
+
+```bash
+./bin/prevail program.o section --failure-slice
+```
+
+See [llm-context.md](llm-context.md) for the diagnostic reference,
+[test-data/llm-context-tests.md](../test-data/llm-context-tests.md) for validated test cases,
+and [MCP Server](../src/mcp/README.md) for the structured query tools.
 
 ### Contributing New Failure Patterns
 

--- a/docs/llm-context.md
+++ b/docs/llm-context.md
@@ -490,6 +490,20 @@ Typical fixes:
 
 When analyzing failures, you may need more context. Here's how to request it:
 
+### MCP Server (Recommended for LLM Agents)
+
+If the `prevail_mcp` MCP server is available, use it for structured queries instead
+of parsing text output. The MCP server exposes the same analysis data as `prevail -v`
+and `prevail --failure-slice` through JSON tool calls:
+
+- **`get_slice`** — Backward slice with register relevance (replaces manual `-v` parsing)
+- **`get_invariant`** — Query pre/post state at specific PCs
+- **`get_instruction`** — Full detail for specific instructions
+- **`check_constraint`** — Test hypotheses about the verifier's state
+- **`get_source_mapping`** — Map between C source lines and BPF instructions
+
+See [src/mcp/README.md](../src/mcp/README.md) for the full tool reference.
+
 ### Verbose Output
 
 Run with `-v` flag for verbose output showing invariants at each step:
@@ -504,6 +518,14 @@ Request the full disassembly to see surrounding instructions:
 
 ```bash
 ./bin/prevail <elf-file> <section> --asm <disasm-file>
+```
+
+### Failure Slicing
+
+Run with `--failure-slice` for a minimal diagnostic showing only causal instructions:
+
+```bash
+./bin/prevail <elf-file> <section> --failure-slice
 ```
 
 ### Specific Invariant

--- a/src/analysis_engine.cpp
+++ b/src/analysis_engine.cpp
@@ -1,0 +1,284 @@
+// Copyright (c) Prevail Verifier contributors.
+// SPDX-License-Identifier: MIT
+
+#include "analysis_engine.hpp"
+
+#include <filesystem>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+
+namespace prevail {
+
+AnalysisEngine::AnalysisEngine(PlatformOps* ops) : ops_(ops) {
+    // Initialize options from platform defaults.
+    auto defaults = ops_->default_options();
+    current_opts_.check_termination = defaults.cfg_opts.check_for_termination;
+    current_opts_.allow_division_by_zero = defaults.allow_division_by_zero;
+    current_opts_.strict = defaults.strict;
+}
+
+bool AnalysisEngine::session_matches(const std::string& elf_path, const std::string& section,
+                                     const std::string& program, const std::string& type) const {
+    if (!session_) {
+        return false;
+    }
+    if (session_->elf_path != elf_path || session_->section != section || session_->program_name != program ||
+        session_type_ != type) {
+        return false;
+    }
+    // Re-analyze if the file has been modified since last analysis.
+    try {
+        return std::filesystem::last_write_time(elf_path) == session_->file_mtime;
+    } catch (const std::filesystem::filesystem_error&) {
+        return false; // File no longer accessible — force re-analysis.
+    }
+}
+
+std::vector<ProgramEntry> AnalysisEngine::list_programs(const std::string& elf_path) {
+    return ops_->list_programs(elf_path);
+}
+
+const AnalysisSession& AnalysisEngine::analyze(const std::string& elf_path, const std::string& section,
+                                               const std::string& program, const std::string& type,
+                                               std::optional<bool> check_termination,
+                                               std::optional<bool> allow_division_by_zero,
+                                               std::optional<bool> strict) {
+    // Build options from platform defaults, applying any explicit overrides.
+    // Options do not persist across calls — omitted options revert to defaults.
+    const auto defaults = ops_->default_options();
+    VerificationOptions new_opts{
+        defaults.cfg_opts.check_for_termination,
+        defaults.allow_division_by_zero,
+        defaults.strict,
+    };
+    if (check_termination.has_value()) {
+        new_opts.check_termination = *check_termination;
+    }
+    if (allow_division_by_zero.has_value()) {
+        new_opts.allow_division_by_zero = *allow_division_by_zero;
+    }
+    if (strict.has_value()) {
+        new_opts.strict = *strict;
+    }
+
+    // If options changed, invalidate the current session.
+    if (new_opts != current_opts_) {
+        session_.reset();
+        current_opts_ = new_opts;
+    }
+
+    // Reuse the current session if it matches.
+    if (session_matches(elf_path, section, program, type)) {
+        return *session_;
+    }
+
+    // Different program — discard old session and run fresh analysis.
+    session_.reset();
+
+    ops_->prepare_tls(type);
+
+    // Determine target program using the new ElfObject API.
+    std::string target_section = section;
+    std::string target_program = program;
+    if (target_section.empty() && target_program.empty()) {
+        auto entries = list_programs(elf_path);
+        for (const auto& entry : entries) {
+            if (entry.section != ".text") {
+                target_section = entry.section;
+                target_program = entry.function;
+                break;
+            }
+        }
+        if (target_section.empty() && !entries.empty()) {
+            target_section = entries.front().section;
+            target_program = entries.front().function;
+        }
+    }
+
+    auto tls_guard = std::make_unique<prevail::ThreadLocalGuard>();
+
+    prevail::ebpf_verifier_options_t options = ops_->default_options();
+    options.cfg_opts.check_for_termination = current_opts_.check_termination;
+    options.allow_division_by_zero = current_opts_.allow_division_by_zero;
+    options.strict = current_opts_.strict;
+    options.verbosity_opts.print_failures = true;
+    options.verbosity_opts.print_line_info = true;
+    options.verbosity_opts.collect_instruction_deps = true;
+
+    prevail::ElfObject elf(elf_path, options, ops_->platform());
+    const auto& raw_progs = elf.get_programs(target_section, target_program);
+
+    if (raw_progs.empty()) {
+        throw std::runtime_error("Program not found: " + target_program + " in " + elf_path);
+    }
+    const auto& found = raw_progs.front();
+
+    std::vector<std::vector<std::string>> notes;
+    auto prog_or_error = prevail::unmarshal(found, notes, options);
+    if (auto* err = std::get_if<std::string>(&prog_or_error)) {
+        throw std::runtime_error("Unmarshal error: " + *err);
+    }
+    auto& inst_seq = std::get<prevail::InstructionSeq>(prog_or_error);
+
+    prevail::Program prog = prevail::Program::from_sequence(inst_seq, found.info, options);
+    prevail::AnalysisResult result = prevail::analyze(prog);
+
+    // Build session with serialized invariants (while TLS is alive).
+    AnalysisSession session;
+    session.elf_path = elf_path;
+    session.section = found.section_name;
+    session.program_name = found.function_name;
+    session.inst_seq = std::move(inst_seq);
+    session.program = std::move(prog);
+    session.failed = result.failed;
+    session.max_loop_count = result.max_loop_count;
+    session.exit_value = result.exit_value;
+    session.file_mtime = std::filesystem::last_write_time(elf_path);
+
+    for (const auto& [label, inv_pair] : result.invariants) {
+        AnalysisSession::SerializedInvariant si;
+        si.pre_is_bottom = inv_pair.pre.is_bottom();
+        try {
+            if (!si.pre_is_bottom) {
+                si.pre = inv_pair.pre.to_set();
+            }
+            if (!inv_pair.post.is_bottom()) {
+                si.post = inv_pair.post.to_set();
+            }
+        } catch (const std::exception& e) {
+            std::cerr << "prevail: warning: failed to serialize invariant at label " << label.from << ": "
+                      << e.what() << std::endl;
+        }
+        if (inv_pair.error.has_value()) {
+            si.error_message = inv_pair.error->what();
+            si.error_label = inv_pair.error->where;
+        }
+        session.invariants.emplace(label, std::move(si));
+    }
+
+    // Build source maps from BTF line info.
+    int pc = 0;
+    for (const auto& [label, inst, line_info] : session.inst_seq) {
+        if (line_info.has_value()) {
+            session.pc_to_source[pc] = *line_info;
+            auto src_key = std::make_pair(line_info->file_name, static_cast<int>(line_info->line_number));
+            session.source_to_pcs[src_key].push_back(pc);
+        }
+        pc += prevail::size(inst);
+    }
+
+    // Build PC → Label lookup.
+    for (const auto& [label, inv] : session.invariants) {
+        session.pc_to_labels[label.from].push_back(label);
+    }
+
+    // Keep live state for check_constraint and slicing.
+    session.live_result = std::move(result);
+    session.tls_guard = std::move(tls_guard);
+
+    session_ = std::move(session);
+    session_type_ = type;
+    return *session_;
+}
+
+// ─── Live session operations ───────────────────────────────────────────────────
+
+prevail::ObservationCheckResult
+AnalysisEngine::check_constraint(const std::string& elf_path, const std::string& section, const std::string& program,
+                                 const std::string& type, const prevail::Label& label, prevail::InvariantPoint point,
+                                 const prevail::StringInvariant& observation, const std::string& mode_str) {
+    // analyze() ensures the session is live.
+    analyze(elf_path, section, program, type);
+
+    if (mode_str == "proven") {
+        auto it = session_->live_result->invariants.find(label);
+        if (it == session_->live_result->invariants.end()) {
+            return {.ok = false, .message = "No invariant available for label"};
+        }
+        const auto& abstract_state = (point == prevail::InvariantPoint::post) ? it->second.post : it->second.pre;
+        if (abstract_state.is_bottom()) {
+            return {.ok = false, .message = "Invariant at label is bottom (unreachable)"};
+        }
+
+        const auto observed_state = observation.is_bottom()
+                                        ? prevail::EbpfDomain::bottom()
+                                        : prevail::EbpfDomain::from_constraints(
+                                              observation.value(), prevail::thread_local_options.setup_constraints);
+        if (observed_state.is_bottom()) {
+            return {.ok = false, .message = "Observation constraints are unsatisfiable"};
+        }
+
+        if (abstract_state <= observed_state) {
+            return {.ok = true, .message = ""};
+        }
+        return {.ok = false,
+                .message = "Invariant does not prove the constraint (A ⊑ C is false). "
+                           "The verifier's state includes possibilities outside the observation."};
+    }
+
+    prevail::ObservationCheckMode mode;
+    if (mode_str == "entailed") {
+        mode = prevail::ObservationCheckMode::entailed;
+    } else if (mode_str == "consistent") {
+        mode = prevail::ObservationCheckMode::consistent;
+    } else {
+        return {.ok = false, .message = "Unknown mode: " + mode_str};
+    }
+    return session_->live_result->check_observation_at_label(label, point, observation, mode);
+}
+
+prevail::StringInvariant AnalysisEngine::get_live_invariant(const prevail::Label& label,
+                                                            prevail::InvariantPoint point) const {
+    if (!session_ || !session_->live_result) {
+        return prevail::StringInvariant::bottom();
+    }
+    auto it = session_->live_result->invariants.find(label);
+    if (it == session_->live_result->invariants.end()) {
+        return prevail::StringInvariant::bottom();
+    }
+    const auto& abstract_state = (point == prevail::InvariantPoint::post) ? it->second.post : it->second.pre;
+    if (abstract_state.is_bottom()) {
+        return prevail::StringInvariant::bottom();
+    }
+    return abstract_state.to_set();
+}
+
+std::vector<prevail::FailureSlice>
+AnalysisEngine::compute_failure_slices(const std::string& elf_path, const std::string& section,
+                                       const std::string& program, const std::string& type,
+                                       const prevail::Program& prog, size_t max_slices, size_t max_steps) {
+    analyze(elf_path, section, program, type);
+
+    prevail::AnalysisResult::SliceParams params;
+    params.max_slices = max_slices;
+    params.max_steps = max_steps;
+    return session_->live_result->compute_failure_slices(prog, params);
+}
+
+prevail::FailureSlice AnalysisEngine::compute_slice_from_label(const std::string& elf_path, const std::string& section,
+                                                               const std::string& program, const std::string& type,
+                                                               const prevail::Program& prog,
+                                                               const prevail::Label& label,
+                                                               const prevail::RelevantState& seed, size_t max_steps) {
+    analyze(elf_path, section, program, type);
+
+    prevail::RelevantState effective_seed = seed;
+    if (effective_seed.registers.empty() && effective_seed.stack_offsets.empty()) {
+        for (const auto& a : prog.assertions_at(label)) {
+            for (const auto& reg : prevail::extract_assertion_registers(a)) {
+                effective_seed.registers.insert(reg);
+            }
+        }
+        if (effective_seed.registers.empty()) {
+            auto deps = prevail::extract_instruction_deps(prog.instruction_at(label), prevail::EbpfDomain::top());
+            for (const auto& reg : deps.regs_read) {
+                effective_seed.registers.insert(reg);
+            }
+        }
+    }
+
+    return session_->live_result->compute_slice_from_label(prog, label, effective_seed, max_steps);
+}
+
+} // namespace prevail

--- a/src/analysis_engine.cpp
+++ b/src/analysis_engine.cpp
@@ -10,21 +10,25 @@
 
 namespace prevail {
 
-AnalysisEngine::AnalysisEngine(PlatformOps* ops) : ops_(ops) {
-    // Initialize options from platform defaults.
-    auto defaults = ops_->default_options();
-    current_opts_.check_termination = defaults.cfg_opts.check_for_termination;
-    current_opts_.allow_division_by_zero = defaults.allow_division_by_zero;
-    current_opts_.strict = defaults.strict;
+AnalysisEngine::AnalysisEngine(PlatformOps* ops) : ops_(ops) {}
+
+bool AnalysisEngine::analysis_options_equal(const prevail::ebpf_verifier_options_t& a,
+                                             const prevail::ebpf_verifier_options_t& b) {
+    return a.cfg_opts.check_for_termination == b.cfg_opts.check_for_termination &&
+           a.allow_division_by_zero == b.allow_division_by_zero && a.strict == b.strict;
 }
 
 bool AnalysisEngine::session_matches(const std::string& elf_path, const std::string& section,
-                                     const std::string& program, const std::string& type) const {
+                                     const std::string& program, const std::string& type,
+                                     const prevail::ebpf_verifier_options_t& options) const {
     if (!session_) {
         return false;
     }
     if (session_->elf_path != elf_path || session_->section != section || session_->program_name != program ||
         session_type_ != type) {
+        return false;
+    }
+    if (!analysis_options_equal(session_->options, options)) {
         return false;
     }
     // Re-analyze if the file has been modified since last analysis.
@@ -35,45 +39,32 @@ bool AnalysisEngine::session_matches(const std::string& elf_path, const std::str
     }
 }
 
+const prevail::ebpf_verifier_options_t& AnalysisEngine::session_options() const {
+    if (session_) {
+        return session_->options;
+    }
+    // No session — return platform defaults. Cache to avoid returning a dangling reference.
+    static thread_local prevail::ebpf_verifier_options_t defaults;
+    defaults = ops_->default_options();
+    return defaults;
+}
+
 std::vector<ProgramEntry> AnalysisEngine::list_programs(const std::string& elf_path) {
     return ops_->list_programs(elf_path);
 }
 
 const AnalysisSession& AnalysisEngine::analyze(const std::string& elf_path, const std::string& section,
                                                const std::string& program, const std::string& type,
-                                               std::optional<bool> check_termination,
-                                               std::optional<bool> allow_division_by_zero,
-                                               std::optional<bool> strict) {
-    // Build options from platform defaults, applying any explicit overrides.
-    // Options do not persist across calls — omitted options revert to defaults.
-    const auto defaults = ops_->default_options();
-    VerificationOptions new_opts{
-        defaults.cfg_opts.check_for_termination,
-        defaults.allow_division_by_zero,
-        defaults.strict,
-    };
-    if (check_termination.has_value()) {
-        new_opts.check_termination = *check_termination;
-    }
-    if (allow_division_by_zero.has_value()) {
-        new_opts.allow_division_by_zero = *allow_division_by_zero;
-    }
-    if (strict.has_value()) {
-        new_opts.strict = *strict;
-    }
-
-    // If options changed, invalidate the current session.
-    if (new_opts != current_opts_) {
-        session_.reset();
-        current_opts_ = new_opts;
-    }
+                                               const prevail::ebpf_verifier_options_t* options) {
+    // Use caller-provided options or platform defaults.
+    prevail::ebpf_verifier_options_t effective_options = options ? *options : ops_->default_options();
 
     // Reuse the current session if it matches.
-    if (session_matches(elf_path, section, program, type)) {
+    if (session_matches(elf_path, section, program, type, effective_options)) {
         return *session_;
     }
 
-    // Different program — discard old session and run fresh analysis.
+    // Different program or options — discard old session and run fresh analysis.
     session_.reset();
 
     ops_->prepare_tls(type);
@@ -98,15 +89,7 @@ const AnalysisSession& AnalysisEngine::analyze(const std::string& elf_path, cons
 
     auto tls_guard = std::make_unique<prevail::ThreadLocalGuard>();
 
-    prevail::ebpf_verifier_options_t options = ops_->default_options();
-    options.cfg_opts.check_for_termination = current_opts_.check_termination;
-    options.allow_division_by_zero = current_opts_.allow_division_by_zero;
-    options.strict = current_opts_.strict;
-    options.verbosity_opts.print_failures = true;
-    options.verbosity_opts.print_line_info = true;
-    options.verbosity_opts.collect_instruction_deps = true;
-
-    prevail::ElfObject elf(elf_path, options, ops_->platform());
+    prevail::ElfObject elf(elf_path, effective_options, ops_->platform());
     const auto& raw_progs = elf.get_programs(target_section, target_program);
 
     if (raw_progs.empty()) {
@@ -115,13 +98,13 @@ const AnalysisSession& AnalysisEngine::analyze(const std::string& elf_path, cons
     const auto& found = raw_progs.front();
 
     std::vector<std::vector<std::string>> notes;
-    auto prog_or_error = prevail::unmarshal(found, notes, options);
+    auto prog_or_error = prevail::unmarshal(found, notes, effective_options);
     if (auto* err = std::get_if<std::string>(&prog_or_error)) {
         throw std::runtime_error("Unmarshal error: " + *err);
     }
     auto& inst_seq = std::get<prevail::InstructionSeq>(prog_or_error);
 
-    prevail::Program prog = prevail::Program::from_sequence(inst_seq, found.info, options);
+    prevail::Program prog = prevail::Program::from_sequence(inst_seq, found.info, effective_options);
     prevail::AnalysisResult result = prevail::analyze(prog);
 
     // Build session with serialized invariants (while TLS is alive).
@@ -129,6 +112,7 @@ const AnalysisSession& AnalysisEngine::analyze(const std::string& elf_path, cons
     session.elf_path = elf_path;
     session.section = found.section_name;
     session.program_name = found.function_name;
+    session.options = effective_options;
     session.inst_seq = std::move(inst_seq);
     session.program = std::move(prog);
     session.failed = result.failed;

--- a/src/analysis_engine.hpp
+++ b/src/analysis_engine.hpp
@@ -1,0 +1,162 @@
+// Copyright (c) Prevail Verifier contributors.
+// SPDX-License-Identifier: MIT
+#pragma once
+
+/// @file Analysis engine: runs the PREVAIL pipeline and holds a single live session.
+
+#include "platform_ops.hpp"
+
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable : 4267) // Conversion from 'size_t' to 'int'.
+#endif
+
+#include "cfg/cfg.hpp"
+#include "result.hpp"
+#include "string_constraints.hpp"
+
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
+
+#include <filesystem>
+#include <map>
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace prevail {
+
+/// Verification options that affect analysis results.
+/// Defaults come from the platform (PlatformOps::default_options()).
+struct VerificationOptions {
+    bool check_termination;
+    bool allow_division_by_zero;
+    bool strict;
+
+    bool operator==(const VerificationOptions& other) const {
+        return check_termination == other.check_termination &&
+               allow_division_by_zero == other.allow_division_by_zero && strict == other.strict;
+    }
+    bool operator!=(const VerificationOptions& other) const { return !(*this == other); }
+};
+
+/// Holds all outputs from a single verification run.
+/// The session is always "live" — it retains both pre-serialized invariants
+/// (for callers that iterate or display them) and the live AnalysisResult with
+/// EbpfDomain objects (for check_constraint and backward slicing).
+/// Only one session exists at a time; analyzing a different program discards it.
+struct AnalysisSession {
+    std::string elf_path;
+    std::string section;
+    std::string program_name;
+
+    // The instruction sequence (labels + instructions + btf_line_info).
+    prevail::InstructionSeq inst_seq;
+
+    // The CFG program (for instruction_at, assertions_at, cfg navigation).
+    prevail::Program program;
+
+    // Overall result metadata.
+    bool failed = false;
+    int max_loop_count = 0;
+    prevail::Interval exit_value = prevail::Interval::top();
+
+    /// Pre-serialized invariant data per label (serialized while TLS is alive).
+    struct SerializedInvariant {
+        prevail::StringInvariant pre;
+        prevail::StringInvariant post;
+        std::optional<std::string> error_message;  // VerificationError::what().
+        std::optional<prevail::Label> error_label; // VerificationError::where.
+        bool pre_is_bottom = false;
+    };
+    std::map<prevail::Label, SerializedInvariant> invariants;
+
+    // Derived: PC → source line info (built from BTF in InstructionSeq).
+    std::map<int, prevail::btf_line_info_t> pc_to_source;
+
+    // Derived: (file, line) → list of PCs.
+    std::map<std::pair<std::string, int>, std::vector<int>> source_to_pcs;
+
+    // Derived: PC → labels in the invariant map that have this PC as .from.
+    std::map<int, std::vector<prevail::Label>> pc_to_labels;
+
+    // Live state: TLS guard keeps variable_registry alive for EbpfDomain ops.
+    // live_result must be declared BEFORE tls_guard so it is destroyed FIRST
+    // (C++ destroys members in reverse declaration order), ensuring EbpfDomain
+    // objects are cleaned up while the thread-local state is still valid.
+    std::optional<prevail::AnalysisResult> live_result;
+    std::unique_ptr<prevail::ThreadLocalGuard> tls_guard;
+
+    // File modification time at analysis time (for staleness detection).
+    std::filesystem::file_time_type file_mtime;
+};
+
+/// Runs the PREVAIL pipeline and holds a single live session.
+/// Re-analyzes when a different program or different options are requested.
+class AnalysisEngine {
+  public:
+    explicit AnalysisEngine(PlatformOps* ops);
+
+    /// Run analysis on the given ELF file (or return the current session if it
+    /// matches). Keeps TLS alive so check_constraint and slicing work without
+    /// re-analyzing. Option overrides are applied per-call against platform
+    /// defaults; omitted options revert to defaults (they do not persist from
+    /// previous calls).
+    /// @param type  Optional program type name override (e.g. "xdp", "bind").
+    /// @throws std::runtime_error on ELF parse, unmarshal, or analysis failure.
+    const AnalysisSession& analyze(const std::string& elf_path, const std::string& section = "",
+                                   const std::string& program = "", const std::string& type = "",
+                                   std::optional<bool> check_termination = std::nullopt,
+                                   std::optional<bool> allow_division_by_zero = std::nullopt,
+                                   std::optional<bool> strict = std::nullopt);
+
+    /// Check constraints against the live AnalysisResult (re-analyzes if needed).
+    /// @param mode_str  "consistent", "entailed", or "proven".
+    prevail::ObservationCheckResult check_constraint(const std::string& elf_path, const std::string& section,
+                                                     const std::string& program, const std::string& type,
+                                                     const prevail::Label& label, prevail::InvariantPoint point,
+                                                     const prevail::StringInvariant& observation,
+                                                     const std::string& mode_str);
+
+    /// Get the invariant at a label from the live session (calls to_set() on demand).
+    /// @returns StringInvariant::bottom() if no session, label not found, or state is bottom.
+    prevail::StringInvariant get_live_invariant(const prevail::Label& label, prevail::InvariantPoint point) const;
+
+    /// Compute failure slices from the live session (re-analyzes if needed).
+    std::vector<prevail::FailureSlice> compute_failure_slices(const std::string& elf_path, const std::string& section,
+                                                              const std::string& program, const std::string& type,
+                                                              const prevail::Program& prog, size_t max_slices = 1,
+                                                              size_t max_steps = 200);
+
+    /// Compute a backward slice from an arbitrary label (re-analyzes if needed).
+    prevail::FailureSlice compute_slice_from_label(const std::string& elf_path, const std::string& section,
+                                                   const std::string& program, const std::string& type,
+                                                   const prevail::Program& prog, const prevail::Label& label,
+                                                   const prevail::RelevantState& seed = {}, size_t max_steps = 200);
+
+    /// List all programs in an ELF file.
+    std::vector<ProgramEntry> list_programs(const std::string& elf_path);
+
+    /// Get the current verification options.
+    const VerificationOptions& options() const { return current_opts_; }
+
+    /// Get the platform pointer.
+    const prevail::ebpf_platform_t* platform() const { return ops_->platform(); }
+
+    /// Get the platform ops.
+    PlatformOps* ops() const { return ops_; }
+
+  private:
+    /// Check if the current session matches the requested program and options.
+    bool session_matches(const std::string& elf_path, const std::string& section, const std::string& program,
+                         const std::string& type) const;
+
+    PlatformOps* ops_;
+    std::optional<AnalysisSession> session_;
+    std::string session_type_;          // Program type override used for the current session.
+    VerificationOptions current_opts_;  // Current verification options (applied to session_).
+};
+
+} // namespace prevail

--- a/src/analysis_engine.hpp
+++ b/src/analysis_engine.hpp
@@ -28,20 +28,6 @@
 
 namespace prevail {
 
-/// Verification options that affect analysis results.
-/// Defaults come from the platform (PlatformOps::default_options()).
-struct VerificationOptions {
-    bool check_termination;
-    bool allow_division_by_zero;
-    bool strict;
-
-    bool operator==(const VerificationOptions& other) const {
-        return check_termination == other.check_termination &&
-               allow_division_by_zero == other.allow_division_by_zero && strict == other.strict;
-    }
-    bool operator!=(const VerificationOptions& other) const { return !(*this == other); }
-};
-
 /// Holds all outputs from a single verification run.
 /// The session is always "live" — it retains both pre-serialized invariants
 /// (for callers that iterate or display them) and the live AnalysisResult with
@@ -51,6 +37,9 @@ struct AnalysisSession {
     std::string elf_path;
     std::string section;
     std::string program_name;
+
+    // The verifier options used for this session.
+    prevail::ebpf_verifier_options_t options;
 
     // The instruction sequence (labels + instructions + btf_line_info).
     prevail::InstructionSeq inst_seq;
@@ -101,16 +90,19 @@ class AnalysisEngine {
 
     /// Run analysis on the given ELF file (or return the current session if it
     /// matches). Keeps TLS alive so check_constraint and slicing work without
-    /// re-analyzing. Option overrides are applied per-call against platform
-    /// defaults; omitted options revert to defaults (they do not persist from
-    /// previous calls).
-    /// @param type  Optional program type name override (e.g. "xdp", "bind").
+    /// re-analyzing.
+    ///
+    /// @param options  Verifier options. When null, uses platform defaults.
+    ///                 Only the fields that affect analysis results
+    ///                 (check_for_termination, allow_division_by_zero, strict)
+    ///                 are compared for cache invalidation; verbosity and other
+    ///                 flags are passed through to the verifier without affecting
+    ///                 session caching.
+    /// @param type     Optional program type name override (e.g. "xdp", "bind").
     /// @throws std::runtime_error on ELF parse, unmarshal, or analysis failure.
     const AnalysisSession& analyze(const std::string& elf_path, const std::string& section = "",
                                    const std::string& program = "", const std::string& type = "",
-                                   std::optional<bool> check_termination = std::nullopt,
-                                   std::optional<bool> allow_division_by_zero = std::nullopt,
-                                   std::optional<bool> strict = std::nullopt);
+                                   const prevail::ebpf_verifier_options_t* options = nullptr);
 
     /// Check constraints against the live AnalysisResult (re-analyzes if needed).
     /// @param mode_str  "consistent", "entailed", or "proven".
@@ -139,8 +131,9 @@ class AnalysisEngine {
     /// List all programs in an ELF file.
     std::vector<ProgramEntry> list_programs(const std::string& elf_path);
 
-    /// Get the current verification options.
-    const VerificationOptions& options() const { return current_opts_; }
+    /// Get the verifier options used for the current session.
+    /// Returns platform defaults if no session exists.
+    const prevail::ebpf_verifier_options_t& session_options() const;
 
     /// Get the platform pointer.
     const prevail::ebpf_platform_t* platform() const { return ops_->platform(); }
@@ -151,12 +144,15 @@ class AnalysisEngine {
   private:
     /// Check if the current session matches the requested program and options.
     bool session_matches(const std::string& elf_path, const std::string& section, const std::string& program,
-                         const std::string& type) const;
+                         const std::string& type, const prevail::ebpf_verifier_options_t& options) const;
+
+    /// Check if two option sets produce the same analysis results.
+    static bool analysis_options_equal(const prevail::ebpf_verifier_options_t& a,
+                                       const prevail::ebpf_verifier_options_t& b);
 
     PlatformOps* ops_;
     std::optional<AnalysisSession> session_;
     std::string session_type_;          // Program type override used for the current session.
-    VerificationOptions current_opts_;  // Current verification options (applied to session_).
 };
 
 } // namespace prevail

--- a/src/mcp/README.md
+++ b/src/mcp/README.md
@@ -1,0 +1,129 @@
+# prevail_mcp — PREVAIL Verifier MCP Server
+
+An [MCP (Model Context Protocol)](https://modelcontextprotocol.io/) server that exposes
+PREVAIL's eBPF verification analysis as structured, queryable tools for LLM agents.
+
+Instead of parsing verbose text output from `check`, LLM agents can query invariants,
+errors, control flow, source mappings, and constraint hypotheses through structured JSON
+tool calls.
+
+## Building
+
+The MCP server is built alongside the `check` executable:
+
+```bash
+cmake -B build -DCMAKE_BUILD_TYPE=Release
+cmake --build build --target prevail_mcp
+```
+
+Output: `bin/prevail_mcp`
+
+To disable the MCP server build:
+
+```bash
+cmake -B build -Dprevail_ENABLE_MCP=OFF
+```
+
+## Usage
+
+The server communicates via JSON-RPC 2.0 over stdio. Two framing modes are
+supported, auto-detected from the first byte of input:
+- **Newline-delimited JSON (NDJSON)** — used by GitHub Copilot CLI
+- **Content-Length framing** — used by VS Code and spec-compliant clients
+
+The server is designed to be launched by an MCP client such as GitHub Copilot CLI or VS Code.
+
+### GitHub Copilot CLI
+
+```
+/mcp add
+```
+
+Set **Command** to the path to `prevail_mcp` (e.g. `bin/prevail_mcp`).
+
+### VS Code
+
+Add to `.vscode/mcp.json`:
+
+```json
+{
+    "servers": {
+        "prevail-verifier": {
+            "type": "stdio",
+            "command": "bin/prevail_mcp"
+        }
+    }
+}
+```
+
+### Manual testing
+
+```bash
+echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}
+{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"verify_program","arguments":{"elf_path":"ebpf-samples/build/badhelpercall.o"}}}' | bin/prevail_mcp
+```
+
+## Tools
+
+| Tool | Description |
+|------|-------------|
+| `list_programs` | List all programs (sections/functions) in an ELF file |
+| `verify_program` | Run verification, get pass/fail with error summary and stats |
+| `get_invariant` | Get pre/post abstract state at one or more instructions |
+| `get_instruction` | Full detail: disassembly, assertions, invariants, source, CFG neighbors |
+| `get_errors` | All verification errors with pre-invariants and source lines |
+| `get_cfg` | Control-flow graph as JSON basic blocks or Graphviz DOT |
+| `get_source_mapping` | Bidirectional C source ↔ BPF instruction mapping (requires `-g`) |
+| `check_constraint` | Test if constraints are consistent with / proven by verifier state |
+| `get_slice` | Backward slice from an error or arbitrary PC with register relevance |
+| `get_disassembly` | Instruction listing with source lines for a PC range |
+| `verify_assembly` | Verify inline BPF assembly with options, pre-invariants, and observations |
+
+### Diagnostic Workflow
+
+These tools support the diagnostic protocol described in
+[docs/llm-context.md](../docs/llm-context.md):
+
+1. **`get_slice`** — Start here. Returns the error, pre-invariant, assertions,
+   source line, and a backward slice showing only the instructions that causally
+   contributed to the failure, with per-instruction register relevance tracking.
+2. **`check_constraint`** — Test hypotheses: "is `r1.type=packet` possible at PC 5?"
+   (`consistent` mode) or "does the verifier guarantee `packet_size >= 42`?"
+   (`proven` mode).
+3. **`get_instruction`** / **`get_invariant`** — Deep dive on specific instructions.
+4. **`get_source_mapping`** — Find the C source line for a BPF instruction or vice versa.
+
+### check_constraint Modes
+
+| Mode | Question it answers | Semantics |
+|------|-------------------|-----------|
+| `consistent` | "Is this possible?" | Constraints don't contradict the invariant (A ∩ C ≠ ⊥) |
+| `proven` | "Does the verifier guarantee this?" | Invariant implies the constraints (A ⊑ C) |
+| `entailed` | "Is this a sub-state?" | Observation is contained in invariant (C ⊑ A); requires near-complete constraint set |
+
+### Failure Slicing
+
+`get_slice` uses PREVAIL's backward dataflow slicing (same algorithm as
+`check --failure-slice`) to identify only the instructions that causally contributed
+to a verification failure. Each instruction in the slice includes:
+
+- The instruction text and PC
+- Which registers are relevant at that point
+- The post-invariant (constraints after the instruction)
+- Source line mapping (if BTF info is available)
+
+The `trace_depth` parameter (default: 200) controls the maximum backward traversal
+steps, matching `check --failure-slice-depth`.
+
+## Relationship to check
+
+| Feature | `check` | `prevail_mcp` |
+|---------|---------|---------------|
+| Interface | CLI (text output) | MCP (JSON-RPC over stdio) |
+| Invariant access | All-or-nothing (`-v` flag) | Per-instruction query |
+| Error diagnosis | `--failure-slice` | Built into `get_slice` |
+| Constraint testing | Not available | `check_constraint` with 3 modes |
+| Source mapping | `--line-info` flag | `get_source_mapping` tool |
+| CFG output | `--dot` to file | `get_cfg` returns JSON or DOT |
+| Platform | Linux | Cross-platform (Linux, Windows) |
+| Caching | None (single run) | LRU cache + live session reuse |

--- a/src/mcp/json_serializers.cpp
+++ b/src/mcp/json_serializers.cpp
@@ -1,0 +1,85 @@
+// Copyright (c) Prevail Verifier contributors.
+// SPDX-License-Identifier: MIT
+
+#include "json_serializers.hpp"
+
+#include <sstream>
+
+namespace prevail {
+
+nlohmann::json
+label_to_json(const prevail::Label& label)
+{
+    nlohmann::json j;
+    j["from"] = label.from;
+    j["to"] = label.to;
+    if (!label.stack_frame_prefix.empty()) {
+        j["stack_frame_prefix"] = label.stack_frame_prefix;
+    }
+    if (!label.special_label.empty()) {
+        j["special_label"] = label.special_label;
+    }
+    return j;
+}
+
+nlohmann::json
+invariant_to_json(const prevail::StringInvariant& inv)
+{
+    if (inv.is_bottom()) {
+        return nlohmann::json::array({"_|_"});
+    }
+    nlohmann::json arr = nlohmann::json::array();
+    for (const auto& s : inv.value()) {
+        arr.push_back(s);
+    }
+    return arr;
+}
+
+nlohmann::json
+error_to_json(const prevail::VerificationError& error)
+{
+    nlohmann::json j;
+    if (error.where.has_value()) {
+        j["label"] = label_to_json(*error.where);
+        j["pc"] = error.where->from;
+    }
+    j["message"] = error.what();
+    return j;
+}
+
+nlohmann::json
+instruction_to_json(const prevail::Instruction& inst)
+{
+    std::ostringstream os;
+    os << inst;
+    return nlohmann::json{{"text", os.str()}};
+}
+
+nlohmann::json
+assertion_to_json(const prevail::Assertion& assertion)
+{
+    std::ostringstream os;
+    os << assertion;
+    return nlohmann::json{{"text", os.str()}};
+}
+
+nlohmann::json
+line_info_to_json(const prevail::btf_line_info_t& info)
+{
+    return {
+        {"file", info.file_name},
+        {"line", info.line_number},
+        {"column", info.column_number},
+        {"source", info.source_line},
+    };
+}
+
+nlohmann::json
+interval_to_json(const prevail::Interval& interval)
+{
+    std::ostringstream os;
+    os << interval;
+    return nlohmann::json{{"text", os.str()}};
+}
+
+} // namespace prevail

--- a/src/mcp/json_serializers.hpp
+++ b/src/mcp/json_serializers.hpp
@@ -1,0 +1,37 @@
+// Copyright (c) Prevail Verifier contributors.
+// SPDX-License-Identifier: MIT
+#pragma once
+
+/// @file JSON serializers for PREVAIL verifier data structures.
+/// All serialization delegates to PREVAIL's own operator<< / to_string().
+
+#include "prevail_headers.hpp"
+
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable : 26495) // Uninitialized member variable (nlohmann::basic_json::m_data).
+#pragma warning(disable : 26819) // Unannotated fallthrough (nlohmann serializer).
+#endif
+#include <nlohmann/json.hpp>
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
+
+namespace prevail {
+
+nlohmann::json
+label_to_json(const prevail::Label& label);
+nlohmann::json
+invariant_to_json(const prevail::StringInvariant& inv);
+nlohmann::json
+error_to_json(const prevail::VerificationError& error);
+nlohmann::json
+instruction_to_json(const prevail::Instruction& inst);
+nlohmann::json
+assertion_to_json(const prevail::Assertion& assertion);
+nlohmann::json
+line_info_to_json(const prevail::btf_line_info_t& info);
+nlohmann::json
+interval_to_json(const prevail::Interval& interval);
+
+} // namespace prevail

--- a/src/mcp/mcp_server.cpp
+++ b/src/mcp/mcp_server.cpp
@@ -1,0 +1,99 @@
+// Copyright (c) Prevail Verifier contributors.
+// SPDX-License-Identifier: MIT
+
+#include "mcp_server.hpp"
+
+#include <stdexcept>
+
+namespace prevail {
+
+void
+McpServer::register_tool(ToolInfo tool)
+{
+    const std::string name = tool.name;
+    tools_.emplace(name, std::move(tool));
+}
+
+nlohmann::json
+McpServer::dispatch(const std::string& method, const nlohmann::json& params)
+{
+    if (method == "initialize") {
+        return handle_initialize(params);
+    }
+    if (method == "tools/list") {
+        return handle_tools_list(params);
+    }
+    if (method == "tools/call") {
+        return handle_tools_call(params);
+    }
+    if (method == "notifications/initialized" || method == "notifications/cancelled") {
+        return nullptr; // Notifications return nothing.
+    }
+
+    throw std::runtime_error("Unknown method: " + method);
+}
+
+nlohmann::json
+McpServer::handle_initialize(const nlohmann::json& /*params*/)
+{
+    return {
+        {"protocolVersion", "2024-11-05"},
+        {"capabilities",
+         {
+             {"tools", nlohmann::json::object()},
+         }},
+        {"serverInfo",
+         {
+             {"name", server_name_},
+             {"version", server_version_},
+         }},
+    };
+}
+
+nlohmann::json
+McpServer::handle_tools_list(const nlohmann::json& /*params*/)
+{
+    nlohmann::json tool_list = nlohmann::json::array();
+    for (const auto& [name, info] : tools_) {
+        tool_list.push_back({
+            {"name", info.name},
+            {"description", info.description},
+            {"inputSchema", info.input_schema},
+        });
+    }
+    return {{"tools", tool_list}};
+}
+
+nlohmann::json
+McpServer::handle_tools_call(const nlohmann::json& params)
+{
+    const std::string tool_name = params.value("name", "");
+    const nlohmann::json arguments = params.value("arguments", nlohmann::json::object());
+
+    auto it = tools_.find(tool_name);
+    if (it == tools_.end()) {
+        throw std::runtime_error("Unknown tool: " + tool_name);
+    }
+
+    try {
+        nlohmann::json result = it->second.handler(arguments);
+        return {
+            {"content",
+             {{
+                 {"type", "text"},
+                 {"text", result.dump(2)},
+             }}},
+        };
+    } catch (const std::exception& e) {
+        return {
+            {"content",
+             {{
+                 {"type", "text"},
+                 {"text", std::string("Error: ") + e.what()},
+             }}},
+            {"isError", true},
+        };
+    }
+}
+
+} // namespace prevail

--- a/src/mcp/mcp_server.hpp
+++ b/src/mcp/mcp_server.hpp
@@ -1,0 +1,61 @@
+// Copyright (c) Prevail Verifier contributors.
+// SPDX-License-Identifier: MIT
+#pragma once
+
+/// @file MCP server: tool registry, capability negotiation, and request dispatch.
+
+#include <functional>
+#include <map>
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable : 26495) // Uninitialized member variable (nlohmann::basic_json::m_data).
+#pragma warning(disable : 26819) // Unannotated fallthrough (nlohmann serializer).
+#endif
+#include <nlohmann/json.hpp>
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
+#include <string>
+
+namespace prevail {
+
+/// Metadata and handler for a single MCP tool.
+struct ToolInfo
+{
+    std::string name;
+    std::string description;
+    nlohmann::json input_schema; // JSON Schema object for the tool's parameters.
+    std::function<nlohmann::json(const nlohmann::json& arguments)> handler;
+};
+
+/// MCP server that registers tools and dispatches incoming requests.
+class McpServer
+{
+  public:
+    explicit McpServer(
+        const std::string& name = "prevail-verifier", const std::string& version = "0.1.0")
+        : server_name_(name), server_version_(version)
+    {
+    }
+
+    void
+    register_tool(ToolInfo tool);
+
+    /// Dispatch a JSON-RPC request.  Suitable as the handler for McpTransport::run().
+    nlohmann::json
+    dispatch(const std::string& method, const nlohmann::json& params);
+
+  private:
+    nlohmann::json
+    handle_initialize(const nlohmann::json& params);
+    nlohmann::json
+    handle_tools_list(const nlohmann::json& params);
+    nlohmann::json
+    handle_tools_call(const nlohmann::json& params);
+
+    std::map<std::string, ToolInfo> tools_;
+    std::string server_name_;
+    std::string server_version_;
+};
+
+} // namespace prevail

--- a/src/mcp/mcp_transport.cpp
+++ b/src/mcp/mcp_transport.cpp
@@ -1,0 +1,189 @@
+// Copyright (c) Prevail Verifier contributors.
+// SPDX-License-Identifier: MIT
+
+#include "mcp_transport.hpp"
+
+#include <cstdio>
+#include <iostream>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+
+namespace prevail {
+
+McpTransport::McpTransport(FILE* output) : output_(output) {}
+
+nlohmann::json
+McpTransport::read_content_length()
+{
+    // Read headers until blank line.
+    size_t content_length = 0;
+    bool found_content_length = false;
+
+    std::string line;
+    while (std::getline(std::cin, line)) {
+        // Remove trailing \r if present (Content-Length: N\r\n).
+        if (!line.empty() && line.back() == '\r') {
+            line.pop_back();
+        }
+        if (line.empty()) {
+            break; // End of headers.
+        }
+        const std::string prefix = "Content-Length: ";
+        if (line.size() >= prefix.size() && line.compare(0, prefix.size(), prefix) == 0) {
+            try {
+                content_length = std::stoull(line.substr(prefix.size()));
+                found_content_length = true;
+            } catch (const std::exception&) {
+                // Malformed Content-Length value — skip this header.
+            }
+        }
+        // Ignore other headers (Content-Type, etc.).
+    }
+
+    if (!found_content_length || std::cin.eof()) {
+        return nullptr;
+    }
+
+    // Cap allocation to prevent unbounded memory growth from malformed input.
+    constexpr size_t max_message_size = 64 * 1024 * 1024; // 64 MB.
+    if (content_length > max_message_size) {
+        std::cerr << "prevail: Content-Length " << content_length << " exceeds maximum ("
+                  << max_message_size << ")" << std::endl;
+        return nullptr;
+    }
+
+    // Read exactly content_length bytes of body.
+    std::string body(content_length, '\0');
+    std::cin.read(body.data(), static_cast<std::streamsize>(content_length));
+    if (std::cin.gcount() != static_cast<std::streamsize>(content_length)) {
+        return nullptr;
+    }
+
+    try {
+        return nlohmann::json::parse(body);
+    } catch (const nlohmann::json::parse_error&) {
+        return nullptr;
+    }
+}
+
+nlohmann::json
+McpTransport::read_ndjson()
+{
+    std::string line;
+    while (std::getline(std::cin, line)) {
+        if (!line.empty() && line.back() == '\r') {
+            line.pop_back();
+        }
+        if (line.empty()) {
+            continue; // Skip blank lines.
+        }
+        try {
+            return nlohmann::json::parse(line);
+        } catch (const nlohmann::json::parse_error&) {
+            return nullptr;
+        }
+    }
+    return nullptr; // EOF.
+}
+
+nlohmann::json
+McpTransport::read_message()
+{
+    if (framing_ == Framing::unknown) {
+        // Auto-detect: peek at the first non-whitespace byte.
+        // '{' → NDJSON, 'C' → Content-Length.
+        int ch;
+        while ((ch = std::cin.peek()) != EOF) {
+            if (ch == ' ' || ch == '\t' || ch == '\r' || ch == '\n') {
+                std::cin.get(); // Consume whitespace.
+                continue;
+            }
+            break;
+        }
+        if (ch == EOF) {
+            return nullptr;
+        }
+
+        if (ch == '{') {
+            framing_ = Framing::ndjson;
+            std::cerr << "prevail: using NDJSON framing" << std::endl;
+        } else {
+            framing_ = Framing::content_length;
+            std::cerr << "prevail: using Content-Length framing" << std::endl;
+        }
+    }
+
+    return (framing_ == Framing::ndjson) ? read_ndjson() : read_content_length();
+}
+
+void
+McpTransport::write_message(const nlohmann::json& msg)
+{
+    const std::string body = msg.dump();
+
+    if (framing_ == Framing::ndjson) {
+        // NDJSON: single line of JSON followed by newline.
+        fwrite(body.data(), 1, body.size(), output_);
+        fputc('\n', output_);
+    } else {
+        // Content-Length framing.
+        const std::string frame = "Content-Length: " + std::to_string(body.size()) + "\r\n\r\n" + body;
+        fwrite(frame.data(), 1, frame.size(), output_);
+    }
+    fflush(output_);
+}
+
+void
+McpTransport::run(Handler handler)
+{
+    while (true) {
+        nlohmann::json request = read_message();
+        if (request.is_null()) {
+            break; // EOF or read error.
+        }
+
+        try {
+            if (!request.is_object()) {
+                throw std::runtime_error("Request is not a JSON object");
+            }
+
+            const std::string method = request.value("method", "");
+            const nlohmann::json params = request.value("params", nlohmann::json::object());
+            const bool is_notification = !request.contains("id") || request["id"].is_null();
+
+            try {
+                nlohmann::json result = handler(method, params);
+
+                if (!is_notification) {
+                    nlohmann::json response = {
+                        {"jsonrpc", "2.0"},
+                        {"id", request["id"]},
+                        {"result", std::move(result)},
+                    };
+                    write_message(response);
+                }
+            } catch (const std::exception& e) {
+                if (!is_notification) {
+                    nlohmann::json error_response = {
+                        {"jsonrpc", "2.0"},
+                        {"id", request["id"]},
+                        {"error",
+                         {
+                             {"code", -32603}, // Internal error.
+                             {"message", e.what()},
+                         }},
+                    };
+                    write_message(error_response);
+                } else {
+                    std::cerr << "prevail: notification handler error: " << e.what() << std::endl;
+                }
+            }
+        } catch (const std::exception& e) {
+            // Malformed request (not an object, missing fields, etc.).
+            std::cerr << "prevail: malformed request: " << e.what() << std::endl;
+        }
+    }
+}
+
+} // namespace prevail

--- a/src/mcp/mcp_transport.hpp
+++ b/src/mcp/mcp_transport.hpp
@@ -1,0 +1,78 @@
+// Copyright (c) Prevail Verifier contributors.
+// SPDX-License-Identifier: MIT
+#pragma once
+
+/// @file MCP JSON-RPC 2.0 transport over stdio.
+///
+/// Supports two framing modes, auto-detected from the first byte of input:
+///   - Content-Length framing (VS Code, spec-compliant clients)
+///   - Newline-delimited JSON / NDJSON (GitHub Copilot CLI)
+
+#include <cstdio>
+#include <functional>
+#include <iostream>
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable : 26495) // Uninitialized member variable (nlohmann::basic_json::m_data).
+#pragma warning(disable : 26819) // Unannotated fallthrough (nlohmann serializer).
+#endif
+#include <nlohmann/json.hpp>
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
+#include <string>
+
+namespace prevail {
+
+/// Reads JSON-RPC 2.0 messages from stdin and writes responses to a dedicated
+/// output FILE* using either Content-Length or NDJSON framing.
+///
+/// The output FILE* should be the original stdout pipe, opened in binary mode
+/// with buffering disabled.  This separation allows linked libraries that write
+/// to std::cout / stdout (e.g. the PREVAIL verifier's dump_btf_types or the
+/// eBPF API's verbose parse-failure messages) to be safely redirected to stderr
+/// without corrupting the protocol framing.
+class McpTransport
+{
+  public:
+    /// @param output FILE* for writing MCP protocol messages.
+    ///        Must be in binary mode; caller should disable buffering with setvbuf.
+    explicit McpTransport(FILE* output);
+
+    /// Read one JSON-RPC message from stdin.
+    /// On the first call, peeks at stdin to auto-detect the framing mode.
+    /// @return Parsed JSON message, or nullptr on EOF/error.
+    nlohmann::json
+    read_message();
+
+    /// Write one JSON-RPC message to the MCP output stream.
+    void
+    write_message(const nlohmann::json& msg);
+
+    /// Main event loop.  Reads requests, dispatches to handler, writes responses.
+    /// The handler receives (method, params) and returns a result JSON.
+    /// For notifications (no "id") the handler is still called but the return value is ignored.
+    /// Handler exceptions are caught and returned as JSON-RPC error responses.
+    /// The loop exits on EOF or malformed input.
+    using Handler = std::function<nlohmann::json(const std::string& method, const nlohmann::json& params)>;
+    void
+    run(Handler handler);
+
+  private:
+    enum class Framing
+    {
+        unknown,
+        content_length, // "Content-Length: N\r\n\r\n{...}"
+        ndjson,         // "{...}\n"
+    };
+
+    nlohmann::json
+    read_content_length();
+    nlohmann::json
+    read_ndjson();
+
+    FILE* output_;
+    Framing framing_ = Framing::unknown;
+};
+
+} // namespace prevail

--- a/src/mcp/prevail_headers.hpp
+++ b/src/mcp/prevail_headers.hpp
@@ -1,0 +1,51 @@
+// Copyright (c) Prevail Verifier contributors.
+// SPDX-License-Identifier: MIT
+#pragma once
+
+/// @file Aggregate include for PREVAIL verifier headers used by the MCP server.
+/// On MSVC, suppresses warnings from PREVAIL headers that are treated as errors
+/// by projects with /W4 /WX (e.g. ebpf-for-windows). On GCC/Clang these are no-ops.
+
+// Pre-define the include guard for bpf_conformance's ebpf_inst.h to prevent it
+// from being included (its EbpfInst struct conflicts with prevail::EbpfInst).
+#ifndef BPF_CONFORMANCE_CORE_EBPF_INST_H
+#define BPF_CONFORMANCE_CORE_EBPF_INST_H
+#endif
+
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable : 4100) // Unreferenced formal parameter.
+#pragma warning(disable : 4244) // Conversion, possible loss of data.
+#pragma warning(disable : 4267) // Conversion from 'size_t' to 'int'.
+#pragma warning(disable : 4458) // Declaration hides class member.
+#pragma warning(disable : 26439) // Function may not throw.
+#pragma warning(disable : 26450) // Arithmetic overflow.
+#pragma warning(disable : 26451) // Arithmetic overflow.
+#pragma warning(disable : 26495) // Always initialize a member variable.
+#endif
+
+// Undef macros that conflict with PREVAIL headers on Windows.
+#undef FALSE
+#undef TRUE
+#undef min
+#undef max
+
+#include "cfg/cfg.hpp"
+#include "config.hpp"
+#include "ebpf_verifier.hpp"
+#include "ir/program.hpp"
+#include "ir/unmarshal.hpp"
+#include "platform.hpp"
+#include "result.hpp"
+#include "spec/type_descriptors.hpp"
+#include "string_constraints.hpp"
+#include "verifier.hpp"
+
+#ifdef _WIN32
+#define FALSE 0
+#define TRUE 1
+#endif
+
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif

--- a/src/mcp/tools.cpp
+++ b/src/mcp/tools.cpp
@@ -16,6 +16,27 @@ using json = nlohmann::json;
 
 namespace prevail {
 
+/// Build verifier options from JSON args, starting from engine defaults.
+/// Applies check_termination, allow_division_by_zero, strict, and
+/// sets verbosity flags needed for MCP tools (print_failures, print_line_info,
+/// collect_instruction_deps).
+static prevail::ebpf_verifier_options_t build_options(const json& args, AnalysisEngine& engine) {
+    prevail::ebpf_verifier_options_t options = engine.ops()->default_options();
+    if (args.contains("check_termination")) {
+        options.cfg_opts.check_for_termination = args["check_termination"].get<bool>();
+    }
+    if (args.contains("allow_division_by_zero")) {
+        options.allow_division_by_zero = args["allow_division_by_zero"].get<bool>();
+    }
+    if (args.contains("strict")) {
+        options.strict = args["strict"].get<bool>();
+    }
+    options.verbosity_opts.print_failures = true;
+    options.verbosity_opts.print_line_info = true;
+    options.verbosity_opts.collect_instruction_deps = true;
+    return options;
+}
+
 // Helper: find the primary label for a given PC in the analysis session.
 // Returns the first label with .to == -1 (sequential flow), or the first available label.
 static prevail::Label find_label_for_pc(const AnalysisSession& session, int pc) {
@@ -65,17 +86,9 @@ static json handle_verify_program(const json& args, AnalysisEngine& engine) {
     const std::string section = args.value("section", "");
     const std::string program = args.value("program", "");
     const std::string type = args.value("program_type", "");
-    const auto opt_termination = args.contains("check_termination")
-                                     ? std::optional<bool>(args["check_termination"].get<bool>())
-                                     : std::nullopt;
-    const auto opt_div_zero = args.contains("allow_division_by_zero")
-                                  ? std::optional<bool>(args["allow_division_by_zero"].get<bool>())
-                                  : std::nullopt;
-    const auto opt_strict =
-        args.contains("strict") ? std::optional<bool>(args["strict"].get<bool>()) : std::nullopt;
+    auto options = build_options(args, engine);
 
-    const auto& session =
-        engine.analyze(elf_path, section, program, type, opt_termination, opt_div_zero, opt_strict);
+    const auto& session = engine.analyze(elf_path, section, program, type, &options);
 
     // Count errors.
     int error_count = 0;
@@ -568,17 +581,9 @@ static json handle_get_slice(const json& args, AnalysisEngine& engine) {
     const std::string program = args.value("program", "");
     const std::string type = args.value("program_type", "");
     const size_t trace_depth = std::min(args.value("trace_depth", static_cast<size_t>(200)), static_cast<size_t>(10000));
-    const auto opt_termination = args.contains("check_termination")
-                                     ? std::optional<bool>(args["check_termination"].get<bool>())
-                                     : std::nullopt;
-    const auto opt_div_zero = args.contains("allow_division_by_zero")
-                                  ? std::optional<bool>(args["allow_division_by_zero"].get<bool>())
-                                  : std::nullopt;
-    const auto opt_strict =
-        args.contains("strict") ? std::optional<bool>(args["strict"].get<bool>()) : std::nullopt;
+    auto options = build_options(args, engine);
 
-    const auto& session =
-        engine.analyze(elf_path, section, program, type, opt_termination, opt_div_zero, opt_strict);
+    const auto& session = engine.analyze(elf_path, section, program, type, &options);
 
     prevail::Label target_label = prevail::Label::entry;
 
@@ -749,11 +754,8 @@ static json handle_verify_assembly(const json& args, AnalysisEngine& engine) {
         throw std::runtime_error("map_key_size and map_value_size must be positive");
     }
 
-    // Set up verification options.
-    prevail::ebpf_verifier_options_t options = engine.ops()->default_options();
-    options.cfg_opts.check_for_termination = engine.options().check_termination;
-    options.allow_division_by_zero = engine.options().allow_division_by_zero;
-    options.strict = engine.options().strict;
+    // Set up verification options from the current session (or platform defaults).
+    prevail::ebpf_verifier_options_t options = engine.session_options();
     if (args.contains("check_termination")) {
         options.cfg_opts.check_for_termination = args["check_termination"].get<bool>();
     }

--- a/src/mcp/tools.cpp
+++ b/src/mcp/tools.cpp
@@ -1,0 +1,1263 @@
+// Copyright (c) Prevail Verifier contributors.
+// SPDX-License-Identifier: MIT
+
+#include "tools.hpp"
+#include "json_serializers.hpp"
+
+#include <algorithm>
+#include <iostream>
+#include <regex>
+#include <set>
+#include <sstream>
+
+#include "ir/parse.hpp"
+
+using json = nlohmann::json;
+
+namespace prevail {
+
+// Helper: find the primary label for a given PC in the analysis session.
+// Returns the first label with .to == -1 (sequential flow), or the first available label.
+static prevail::Label find_label_for_pc(const AnalysisSession& session, int pc) {
+    auto it = session.pc_to_labels.find(pc);
+    if (it == session.pc_to_labels.end() || it->second.empty()) {
+        throw std::runtime_error("No label found for PC " + std::to_string(pc));
+    }
+    // Prefer the sequential (non-jump) label.
+    for (const auto& label : it->second) {
+        if (label.to == -1) {
+            return label;
+        }
+    }
+    return it->second.front();
+}
+
+// Helper: get all labels for a PC (may include jump edge labels).
+static const std::vector<prevail::Label>& find_labels_for_pc(const AnalysisSession& session, int pc) {
+    auto it = session.pc_to_labels.find(pc);
+    if (it == session.pc_to_labels.end()) {
+        static const std::vector<prevail::Label> empty;
+        return empty;
+    }
+    return it->second;
+}
+
+// ─── Tool: list_programs ───────────────────────────────────────────────────────
+
+static json handle_list_programs(const json& args, AnalysisEngine& engine) {
+    const std::string elf_path = args.at("elf_path").get<std::string>();
+    auto entries = engine.list_programs(elf_path);
+
+    json programs = json::array();
+    for (const auto& entry : entries) {
+        programs.push_back({
+            {"section", entry.section},
+            {"function", entry.function},
+        });
+    }
+    return {{"programs", programs}};
+}
+
+// ─── Tool: verify_program ──────────────────────────────────────────────────────
+
+static json handle_verify_program(const json& args, AnalysisEngine& engine) {
+    const std::string elf_path = args.at("elf_path").get<std::string>();
+    const std::string section = args.value("section", "");
+    const std::string program = args.value("program", "");
+    const std::string type = args.value("program_type", "");
+    const auto opt_termination = args.contains("check_termination")
+                                     ? std::optional<bool>(args["check_termination"].get<bool>())
+                                     : std::nullopt;
+    const auto opt_div_zero = args.contains("allow_division_by_zero")
+                                  ? std::optional<bool>(args["allow_division_by_zero"].get<bool>())
+                                  : std::nullopt;
+    const auto opt_strict =
+        args.contains("strict") ? std::optional<bool>(args["strict"].get<bool>()) : std::nullopt;
+
+    const auto& session =
+        engine.analyze(elf_path, section, program, type, opt_termination, opt_div_zero, opt_strict);
+
+    // Count errors.
+    int error_count = 0;
+    for (const auto& [label, inv_pair] : session.invariants) {
+        if (!inv_pair.pre_is_bottom && inv_pair.error_message.has_value()) {
+            error_count++;
+        }
+    }
+
+    // Count unreachable: post is bottom and instruction is Assume with no error.
+    int total_unreachable = 0;
+    for (const auto& [label, inv_pair] : session.invariants) {
+        if (inv_pair.pre_is_bottom) {
+            continue;
+        }
+        if (inv_pair.post.is_bottom() && !inv_pair.error_message.has_value()) {
+            if (std::get_if<prevail::Assume>(&session.program.instruction_at(label))) {
+                total_unreachable++;
+            }
+        }
+    }
+
+    json j = {
+        {"passed", !session.failed},
+        {"max_loop_count", session.max_loop_count},
+        {"exit_value", interval_to_json(session.exit_value)},
+        {"error_count", error_count},
+        {"total_unreachable", total_unreachable},
+        {"instruction_count", static_cast<int>(session.inst_seq.size())},
+        {"section", session.section},
+        {"function", session.program_name},
+    };
+
+    // Scan invariants for first error.
+    for (const auto& [label, inv_pair] : session.invariants) {
+        if (!inv_pair.pre_is_bottom && inv_pair.error_message.has_value()) {
+            json fe;
+            if (inv_pair.error_label.has_value()) {
+                fe["label"] = label_to_json(*inv_pair.error_label);
+                fe["pc"] = inv_pair.error_label->from;
+            }
+            fe["message"] = *inv_pair.error_message;
+            // Add source mapping if available.
+            if (inv_pair.error_label.has_value()) {
+                auto src_it = session.pc_to_source.find(inv_pair.error_label->from);
+                if (src_it != session.pc_to_source.end()) {
+                    fe["source"] = line_info_to_json(src_it->second);
+                }
+            }
+            j["first_error"] = fe;
+            break;
+        }
+    }
+
+    return j;
+}
+
+// ─── Tool: get_invariant ───────────────────────────────────────────────────────
+
+static json handle_get_invariant(const json& args, AnalysisEngine& engine) {
+    const std::string elf_path = args.at("elf_path").get<std::string>();
+    const std::string point_str = args.value("point", "pre");
+    const std::string section = args.value("section", "");
+    const std::string program = args.value("program", "");
+    const std::string type = args.value("program_type", "");
+
+    const auto& session = engine.analyze(elf_path, section, program, type);
+    const auto pcs = args.at("pcs").get<std::vector<int>>();
+
+    // Helper: get invariant results for a single PC.
+    auto get_invariant_for_pc = [&](int pc) -> json {
+        const auto& labels = find_labels_for_pc(session, pc);
+        if (labels.empty()) {
+            return {{"pc", pc}, {"error", "No label found for PC " + std::to_string(pc)}};
+        }
+
+        json results = json::array();
+        for (const auto& label : labels) {
+            auto inv_it = session.invariants.find(label);
+            if (inv_it == session.invariants.end()) {
+                continue;
+            }
+            const auto& inv_pair = inv_it->second;
+            const auto& domain = (point_str == "post") ? inv_pair.post : inv_pair.pre;
+
+            json entry = {
+                {"label", label_to_json(label)},
+                {"point", point_str},
+                {"constraints", invariant_to_json(domain)},
+            };
+            results.push_back(entry);
+        }
+
+        if (results.size() == 1) {
+            return results[0];
+        }
+        return {{"pc", pc}, {"labels", results}};
+    };
+
+    if (pcs.size() == 1) {
+        return get_invariant_for_pc(pcs[0]);
+    }
+
+    json batch_results = json::array();
+    for (int pc : pcs) {
+        json result = get_invariant_for_pc(pc);
+        result["pc"] = pc;
+        batch_results.push_back(result);
+    }
+    return {{"results", batch_results}};
+}
+
+// ─── Tool: get_instruction ─────────────────────────────────────────────────────
+
+static json handle_get_instruction(const json& args, AnalysisEngine& engine) {
+    const std::string elf_path = args.at("elf_path").get<std::string>();
+    const std::string section = args.value("section", "");
+    const std::string program = args.value("program", "");
+    const std::string type = args.value("program_type", "");
+
+    const auto& session = engine.analyze(elf_path, section, program, type);
+
+    const auto pcs = args.at("pcs").get<std::vector<int>>();
+
+    // Helper: get instruction detail for a single PC.
+    auto get_instruction_for_pc = [&](int pc) -> json {
+        const auto label = find_label_for_pc(session, pc);
+        json j = {{"pc", pc}, {"label", label_to_json(label)}};
+
+        // Instruction text.
+        j["text"] = instruction_to_json(session.program.instruction_at(label))["text"];
+
+        // Assertions.
+        json assertions = json::array();
+        for (const auto& a : session.program.assertions_at(label)) {
+            assertions.push_back(assertion_to_json(a)["text"]);
+        }
+        j["assertions"] = assertions;
+
+        // Invariants.
+        auto inv_it = session.invariants.find(label);
+        if (inv_it != session.invariants.end()) {
+            j["pre_invariant"] = invariant_to_json(inv_it->second.pre);
+            if (!inv_it->second.post.is_bottom()) {
+                j["post_invariant"] = invariant_to_json(inv_it->second.post);
+            } else {
+                j["post_invariant"] = nullptr;
+            }
+            if (inv_it->second.error_message.has_value()) {
+                j["error"] = *inv_it->second.error_message;
+            }
+        }
+
+        // Source mapping.
+        auto src_it = session.pc_to_source.find(pc);
+        if (src_it != session.pc_to_source.end()) {
+            j["source"] = line_info_to_json(src_it->second);
+        }
+
+        // CFG neighbors.
+        json successors = json::array();
+        for (const auto& child : session.program.cfg().children_of(label)) {
+            successors.push_back(child.from);
+        }
+        j["successors"] = successors;
+
+        json predecessors = json::array();
+        for (const auto& parent : session.program.cfg().parents_of(label)) {
+            predecessors.push_back(parent.from);
+        }
+        j["predecessors"] = predecessors;
+
+        return j;
+    };
+
+    // Build results, returning structured errors for invalid PCs.
+    json batch_results = json::array();
+    for (int pc : pcs) {
+        try {
+            batch_results.push_back(get_instruction_for_pc(pc));
+        } catch (const std::runtime_error& e) {
+            batch_results.push_back({{"pc", pc}, {"error", e.what()}});
+        }
+    }
+    return {{"results", batch_results}};
+}
+
+// ─── Tool: get_errors ──────────────────────────────────────────────────────────
+
+static json handle_get_errors(const json& args, AnalysisEngine& engine) {
+    const std::string elf_path = args.at("elf_path").get<std::string>();
+    const std::string section = args.value("section", "");
+    const std::string program = args.value("program", "");
+    const std::string type = args.value("program_type", "");
+
+    const auto& session = engine.analyze(elf_path, section, program, type);
+
+    json errors = json::array();
+    for (const auto& [label, inv_pair] : session.invariants) {
+        if (inv_pair.pre_is_bottom) {
+            continue;
+        }
+        if (inv_pair.error_message.has_value()) {
+            json e;
+            if (inv_pair.error_label.has_value()) {
+                e["label"] = label_to_json(*inv_pair.error_label);
+                e["pc"] = inv_pair.error_label->from;
+            }
+            e["message"] = *inv_pair.error_message;
+            e["pre_invariant"] = invariant_to_json(inv_pair.pre);
+            e["instruction"] = instruction_to_json(session.program.instruction_at(label))["text"];
+
+            auto src_it = session.pc_to_source.find(label.from);
+            if (src_it != session.pc_to_source.end()) {
+                e["source"] = line_info_to_json(src_it->second);
+            }
+            errors.push_back(e);
+        }
+    }
+
+    json unreachable = json::array();
+    for (const auto& [label, inv_pair] : session.invariants) {
+        if (inv_pair.pre_is_bottom) {
+            continue;
+        }
+        if (inv_pair.post.is_bottom() && !inv_pair.error_message.has_value()) {
+            if (const auto passume = std::get_if<prevail::Assume>(&session.program.instruction_at(label))) {
+                std::string msg =
+                    prevail::to_string(label) + ": Code becomes unreachable (" + prevail::to_string(*passume) + ")";
+                unreachable.push_back({{"label", label_to_json(label)}, {"message", msg}});
+            }
+        }
+    }
+
+    return {
+        {"passed", !session.failed},
+        {"errors", errors},
+        {"unreachable", unreachable},
+    };
+}
+
+// ─── Tool: get_cfg ─────────────────────────────────────────────────────────────
+
+static json handle_get_cfg(const json& args, AnalysisEngine& engine) {
+    const std::string elf_path = args.at("elf_path").get<std::string>();
+    const std::string format = args.value("format", "json");
+    const std::string section = args.value("section", "");
+    const std::string program = args.value("program", "");
+    const std::string type = args.value("program_type", "");
+
+    const auto& session = engine.analyze(elf_path, section, program, type);
+
+    if (format == "dot") {
+        // Generate DOT format inline (same logic as print_dot in printing.cpp).
+        std::ostringstream dot;
+        dot << "digraph program {\n";
+        dot << "    node [shape = rectangle];\n";
+        for (const auto& label : session.program.labels()) {
+            dot << "    \"" << label << "\"[label=\"";
+            for (const auto& pre : session.program.assertions_at(label)) {
+                dot << "assert " << pre << "\\l";
+            }
+            dot << session.program.instruction_at(label) << "\\l";
+            dot << "\"];\n";
+            for (const auto& next : session.program.cfg().children_of(label)) {
+                dot << "    \"" << label << "\" -> \"" << next << "\";\n";
+            }
+            dot << "\n";
+        }
+        dot << "}\n";
+        return {{"format", "dot"}, {"dot", dot.str()}};
+    }
+
+    // JSON mode: serialize basic blocks.
+    auto basic_blocks = prevail::BasicBlock::collect_basic_blocks(session.program.cfg(), true);
+    json blocks = json::array();
+    for (const auto& bb : basic_blocks) {
+        json block;
+        block["first_pc"] = bb.first_label().from;
+        block["last_pc"] = bb.last_label().from;
+
+        json pcs = json::array();
+        for (const auto& label : bb) {
+            pcs.push_back(label.from);
+        }
+        block["pcs"] = pcs;
+
+        json succs = json::array();
+        for (const auto& child : session.program.cfg().children_of(bb.last_label())) {
+            succs.push_back(child.from);
+        }
+        block["successors"] = succs;
+
+        blocks.push_back(block);
+    }
+
+    return {{"format", "json"}, {"basic_blocks", blocks}};
+}
+
+// ─── Tool: get_source_mapping ──────────────────────────────────────────────────
+
+static json handle_get_source_mapping(const json& args, AnalysisEngine& engine) {
+    const std::string elf_path = args.at("elf_path").get<std::string>();
+    const std::string section = args.value("section", "");
+    const std::string program = args.value("program", "");
+    const std::string type = args.value("program_type", "");
+
+    const auto& session = engine.analyze(elf_path, section, program, type);
+
+    if (args.contains("pc")) {
+        const int pc = args["pc"].get<int>();
+        auto it = session.pc_to_source.find(pc);
+        if (it == session.pc_to_source.end()) {
+            return {{"pc", pc}, {"source", nullptr}, {"note", "No BTF line info for this PC"}};
+        }
+        json j = {{"pc", pc}, {"source", line_info_to_json(it->second)}};
+        // Also include instruction text.
+        auto labels = find_labels_for_pc(session, pc);
+        if (!labels.empty()) {
+            j["instruction"] = instruction_to_json(session.program.instruction_at(labels.front()))["text"];
+        }
+        return j;
+    }
+
+    if (args.contains("source_line")) {
+        const int source_line = args["source_line"].get<int>();
+        const std::string source_file = args.value("source_file", "");
+
+        // Search all source mappings for matching line.
+        json matches = json::array();
+        for (const auto& [key, pcs] : session.source_to_pcs) {
+            if (key.second == source_line &&
+                (source_file.empty() || key.first == source_file || key.first.find(source_file) != std::string::npos)) {
+                for (int matched_pc : pcs) {
+                    json m = {{"pc", matched_pc}};
+                    auto labels = find_labels_for_pc(session, matched_pc);
+                    if (!labels.empty()) {
+                        m["instruction"] = instruction_to_json(session.program.instruction_at(labels.front()))["text"];
+                    }
+                    auto src_it = session.pc_to_source.find(matched_pc);
+                    if (src_it != session.pc_to_source.end()) {
+                        m["source"] = line_info_to_json(src_it->second);
+                    }
+                    matches.push_back(m);
+                }
+            }
+        }
+        return {{"source_line", source_line}, {"matches", matches}};
+    }
+
+    // Return entire source map.
+    if (session.pc_to_source.empty()) {
+        return {
+            {"note", "No BTF line info available. Compile with -g to enable source mapping."},
+            {"entries", json::array()},
+        };
+    }
+
+    json entries = json::array();
+    for (const auto& [pc, info] : session.pc_to_source) {
+        entries.push_back({{"pc", pc}, {"source", line_info_to_json(info)}});
+    }
+    return {{"entries", entries}};
+}
+
+// ─── Tool: check_constraint ────────────────────────────────────────────────────
+
+static json handle_check_constraint(const json& args, AnalysisEngine& engine) {
+    const std::string elf_path = args.at("elf_path").get<std::string>();
+    const std::string point_str = args.value("point", "pre");
+    const std::string mode_str = args.value("mode", "consistent");
+    const std::string section = args.value("section", "");
+    const std::string program = args.value("program", "");
+    const std::string type = args.value("program_type", "");
+
+    auto point = (point_str == "post") ? prevail::InvariantPoint::post : prevail::InvariantPoint::pre;
+
+    // Support single-check or batch-check.
+    // Single: { "pc": N, "constraints": [...] }
+    // Batch:  { "checks": [{ "pc": N, "constraints": [...], "mode": "...", "point": "..." }, ...] }
+    struct CheckQuery {
+        int pc{};
+        prevail::InvariantPoint pt{prevail::InvariantPoint::pre};
+        std::string md;
+        std::vector<std::string> constraints;
+    };
+
+    std::vector<CheckQuery> queries;
+
+    if (args.contains("checks")) {
+        // Batch mode.
+        for (const auto& check : args["checks"]) {
+            CheckQuery q;
+            q.pc = check.at("pc").get<int>();
+            q.constraints = check.at("constraints").get<std::vector<std::string>>();
+            auto qs = check.value("point", point_str);
+            q.pt = (qs == "post") ? prevail::InvariantPoint::post : prevail::InvariantPoint::pre;
+            q.md = check.value("mode", mode_str);
+            queries.push_back(std::move(q));
+        }
+    } else {
+        // Single mode.
+        CheckQuery q;
+        q.pc = args.at("pc").get<int>();
+        q.constraints = args.at("constraints").get<std::vector<std::string>>();
+        q.pt = point;
+        q.md = mode_str;
+        queries.push_back(std::move(q));
+    }
+
+    // Run analysis once (engine caches the live session for reuse across calls).
+    // We need the AnalysisSession for label lookup.
+    const auto& session = engine.analyze(elf_path, section, program, type);
+
+    // Process all queries against the same analysis.
+    json results = json::array();
+    for (const auto& q : queries) {
+        json entry = {{"pc", q.pc}};
+        try {
+            auto label = find_label_for_pc(session, q.pc);
+
+            std::set<std::string> constraint_set(q.constraints.begin(), q.constraints.end());
+            prevail::StringInvariant observation{std::move(constraint_set)};
+
+            auto check_result =
+                engine.check_constraint(elf_path, section, program, type, label, q.pt, observation, q.md);
+            entry["ok"] = check_result.ok;
+            entry["message"] = check_result.message;
+
+            // Include the invariant so agents can see what the verifier knows.
+            auto inv = engine.get_live_invariant(label, q.pt);
+            if (!inv.is_bottom()) {
+                entry["invariant"] = invariant_to_json(inv);
+            }
+        } catch (const std::runtime_error& e) {
+            entry["ok"] = false;
+            entry["message"] = e.what();
+        }
+        results.push_back(std::move(entry));
+    }
+
+    // Single-query returns the result directly; batch returns array.
+    if (!args.contains("checks") && results.size() == 1) {
+        return results[0];
+    }
+    return {{"results", results}};
+}
+
+// ─── Tool: get_slice ───────────────────────────────────────────────────
+
+// Serialize a failure slice into JSON.
+static json serialize_slice(const prevail::FailureSlice& slice, const AnalysisSession& session,
+                            const prevail::Label& target_label) {
+    json contributing = json::array();
+    auto impacted = slice.impacted_labels();
+    for (const auto& label : impacted) {
+        if (label == target_label) {
+            continue;
+        }
+        json step = {
+            {"pc", label.from},
+            {"text", instruction_to_json(session.program.instruction_at(label))["text"]},
+        };
+        auto rel_it = slice.relevance.find(label);
+        if (rel_it != slice.relevance.end()) {
+            json relevant_regs = json::array();
+            for (const auto& reg : rel_it->second.registers) {
+                relevant_regs.push_back("r" + std::to_string(reg.v));
+            }
+            if (!relevant_regs.empty()) {
+                step["relevant_registers"] = relevant_regs;
+            }
+        }
+        auto inv_it = session.invariants.find(label);
+        if (inv_it != session.invariants.end() && !inv_it->second.post.is_bottom()) {
+            step["post_invariant"] = invariant_to_json(inv_it->second.post);
+        }
+        auto trace_src = session.pc_to_source.find(label.from);
+        if (trace_src != session.pc_to_source.end()) {
+            step["source"] = line_info_to_json(trace_src->second);
+        }
+        contributing.push_back(step);
+    }
+    return contributing;
+}
+
+static json handle_get_slice(const json& args, AnalysisEngine& engine) {
+    const std::string elf_path = args.at("elf_path").get<std::string>();
+    const std::string section = args.value("section", "");
+    const std::string program = args.value("program", "");
+    const std::string type = args.value("program_type", "");
+    const size_t trace_depth = std::min(args.value("trace_depth", static_cast<size_t>(200)), static_cast<size_t>(10000));
+    const auto opt_termination = args.contains("check_termination")
+                                     ? std::optional<bool>(args["check_termination"].get<bool>())
+                                     : std::nullopt;
+    const auto opt_div_zero = args.contains("allow_division_by_zero")
+                                  ? std::optional<bool>(args["allow_division_by_zero"].get<bool>())
+                                  : std::nullopt;
+    const auto opt_strict =
+        args.contains("strict") ? std::optional<bool>(args["strict"].get<bool>()) : std::nullopt;
+
+    const auto& session =
+        engine.analyze(elf_path, section, program, type, opt_termination, opt_div_zero, opt_strict);
+
+    prevail::Label target_label = prevail::Label::entry;
+
+    if (args.contains("pc")) {
+        const int pc = args["pc"].get<int>();
+        target_label = find_label_for_pc(session, pc);
+    } else {
+        const int error_index = args.value("error_index", 0);
+        int idx = 0;
+        bool found_error = false;
+        for (const auto& [label, inv_pair] : session.invariants) {
+            if (inv_pair.pre_is_bottom) {
+                continue;
+            }
+            if (inv_pair.error_message.has_value()) {
+                if (idx == error_index) {
+                    target_label = label;
+                    found_error = true;
+                    break;
+                }
+                idx++;
+            }
+        }
+        if (!found_error) {
+            throw std::runtime_error("Error index " + std::to_string(error_index) + " not found");
+        }
+    }
+
+    const auto& inv = session.invariants.at(target_label);
+
+    json j = {{"pc", target_label.from}};
+    j["instruction"] = instruction_to_json(session.program.instruction_at(target_label))["text"];
+    j["pre_invariant"] = invariant_to_json(inv.pre);
+
+    if (inv.error_message.has_value()) {
+        json error_json;
+        if (inv.error_label.has_value()) {
+            error_json["label"] = label_to_json(*inv.error_label);
+            error_json["pc"] = inv.error_label->from;
+        }
+        error_json["message"] = *inv.error_message;
+        j["error"] = error_json;
+    }
+
+    json assertions = json::array();
+    for (const auto& a : session.program.assertions_at(target_label)) {
+        assertions.push_back(assertion_to_json(a)["text"]);
+    }
+    j["assertions"] = assertions;
+
+    auto src_it = session.pc_to_source.find(target_label.from);
+    if (src_it != session.pc_to_source.end()) {
+        j["source"] = line_info_to_json(src_it->second);
+    }
+
+    // Use backward slicing from the target label.
+    // compute_slice_from_label seeds from the instruction's read registers.
+    try {
+        auto slice = engine.compute_slice_from_label(elf_path, section, program, type, session.program, target_label,
+                                                     {}, trace_depth);
+        j["failure_slice"] = serialize_slice(slice, session, target_label);
+    } catch (const std::exception& e) {
+        std::cerr << "prevail: slicing failed: " << e.what() << std::endl;
+        j["failure_slice"] = json::array();
+    }
+
+    return j;
+}
+
+// ─── Tool: verify_assembly ─────────────────────────────────────────────────────
+
+/// Parse a code string into labeled blocks and build an InstructionSeq.
+/// Labels are lines matching `<name>:` (angle brackets required).
+/// All code before the first explicit label is placed in the `<start>` block.
+static prevail::InstructionSeq parse_assembly(const std::string& code, const prevail::ebpf_platform_t* platform) {
+    // Split code into lines.
+    std::vector<std::string> lines;
+    std::istringstream stream(code);
+    std::string line;
+    while (std::getline(stream, line)) {
+        // Trim whitespace.
+        const auto start = line.find_first_not_of(" \t\r\n");
+        if (start == std::string::npos) {
+            continue; // Skip blank lines.
+        }
+        const auto end = line.find_last_not_of(" \t\r\n");
+        lines.push_back(line.substr(start, end - start + 1));
+    }
+
+    // First pass: split into labeled blocks and count instructions for label resolution.
+    struct Block {
+        std::string label;  // With angle brackets (e.g., "<loop>").
+        std::vector<std::string> instructions;
+    };
+    std::vector<Block> blocks;
+    static const std::regex label_regex(R"(<(\w+)>:\s*)");
+
+    Block current_block{"<start>", {}};
+    for (const auto& l : lines) {
+        std::smatch m;
+        if (std::regex_match(l, m, label_regex)) {
+            if (!current_block.instructions.empty()) {
+                blocks.push_back(std::move(current_block));
+            }
+            current_block = Block{"<" + m[1].str() + ">", {}};
+        } else {
+            // Strip trailing comments ("; ...").
+            auto comment_pos = l.find(';');
+            std::string inst_text = (comment_pos != std::string::npos) ? l.substr(0, comment_pos) : l;
+            auto trimmed_end = inst_text.find_last_not_of(" \t");
+            if (trimmed_end != std::string::npos) {
+                current_block.instructions.push_back(inst_text.substr(0, trimmed_end + 1));
+            }
+        }
+    }
+    if (!current_block.instructions.empty()) {
+        blocks.push_back(std::move(current_block));
+    }
+
+    // Build label → PC map.
+    std::map<std::string, prevail::Label> label_map;
+    int pc = 0;
+    for (const auto& block : blocks) {
+        label_map.emplace(block.label, prevail::Label{pc, -1, {}});
+        pc += static_cast<int>(block.instructions.size());
+    }
+
+    // Second pass: parse each instruction.
+    // Intercept "call N" to resolve helpers through the server's platform (which may
+    // have platform-specific helpers not available on g_ebpf_platform_linux).
+    prevail::InstructionSeq result;
+    int label_index = 0;
+    static const std::regex call_regex(R"(call\s+(\d+).*)");
+    for (const auto& block : blocks) {
+        for (const auto& inst_text : block.instructions) {
+            try {
+                prevail::Instruction inst;
+                std::smatch call_match;
+                if (std::regex_match(inst_text, call_match, call_regex) && platform != nullptr) {
+                    const int func = std::stoi(call_match[1].str());
+                    inst = prevail::make_call(func, *platform);
+                } else {
+                    inst = prevail::parse_instruction(inst_text, label_map);
+                }
+                result.emplace_back(prevail::Label{label_index, -1, {}}, inst, std::optional<prevail::btf_line_info_t>());
+            } catch (const std::exception& e) {
+                throw std::runtime_error("Parse error at instruction " + std::to_string(label_index) + " (\"" +
+                                         inst_text + "\"): " + e.what());
+            }
+            label_index++;
+        }
+    }
+
+    if (result.empty()) {
+        throw std::runtime_error("No instructions parsed from code");
+    }
+
+    return result;
+}
+
+static json handle_verify_assembly(const json& args, AnalysisEngine& engine) {
+    const std::string code = args.at("code").get<std::string>();
+    const auto pre_vec = args.value("pre", std::vector<std::string>{});
+    const std::string type_name = args.value("program_type", "xdp");
+    const int map_key_size = args.value("map_key_size", 4);
+    const int map_value_size = args.value("map_value_size", 4);
+    if (map_key_size <= 0 || map_value_size <= 0) {
+        throw std::runtime_error("map_key_size and map_value_size must be positive");
+    }
+
+    // Set up verification options.
+    prevail::ebpf_verifier_options_t options = engine.ops()->default_options();
+    options.cfg_opts.check_for_termination = engine.options().check_termination;
+    options.allow_division_by_zero = engine.options().allow_division_by_zero;
+    options.strict = engine.options().strict;
+    if (args.contains("check_termination")) {
+        options.cfg_opts.check_for_termination = args["check_termination"].get<bool>();
+    }
+    if (args.contains("allow_division_by_zero")) {
+        options.allow_division_by_zero = args["allow_division_by_zero"].get<bool>();
+    }
+    if (args.contains("strict")) {
+        options.strict = args["strict"].get<bool>();
+    }
+    if (args.contains("big_endian")) {
+        options.big_endian = args["big_endian"].get<bool>();
+    }
+    options.verbosity_opts.print_failures = true;
+    options.verbosity_opts.collect_instruction_deps = true;
+
+    // Set up pre-invariant.
+    const bool custom_pre = !pre_vec.empty();
+    options.setup_constraints = !custom_pre;
+    // Assembly snippets don't need to end with exit (matching YAML test behavior).
+    options.cfg_opts.must_have_exit = false;
+
+    prevail::StringInvariant pre_invariant = prevail::StringInvariant::top();
+    if (custom_pre) {
+        std::set<std::string> pre_set(pre_vec.begin(), pre_vec.end());
+        pre_invariant = prevail::StringInvariant{std::move(pre_set)};
+    }
+
+    // Create a local platform copy with callx conformance group enabled
+    // (assembly testing should support all instruction types).
+    prevail::ebpf_platform_t local_platform = *engine.platform();
+    local_platform.supported_conformance_groups =
+        local_platform.supported_conformance_groups | bpf_conformance_groups_t::callx;
+
+    // Build ProgramInfo with default map descriptors.
+    // Two maps: index 0 (fd 0) and index 1 (fd 1) to support both map_by_idx(0) and map_fd 1.
+    prevail::EbpfMapDescriptor map_desc0{};
+    map_desc0.original_fd = 0;
+    map_desc0.type = 0;
+    map_desc0.key_size = static_cast<unsigned int>(map_key_size);
+    map_desc0.value_size = static_cast<unsigned int>(map_value_size);
+    map_desc0.max_entries = 4;
+    map_desc0.inner_map_fd = 0;
+
+    prevail::EbpfMapDescriptor map_desc1{};
+    map_desc1.original_fd = 1;
+    map_desc1.type = 0;
+    map_desc1.key_size = static_cast<unsigned int>(map_key_size);
+    map_desc1.value_size = static_cast<unsigned int>(map_value_size);
+    map_desc1.max_entries = 4;
+    map_desc1.inner_map_fd = 0;
+
+    // Set up TLS for analysis. Unlike the normal ELF path (which calls prepare_tls
+    // then read_elf), we set up thread-local state directly since there's no ELF.
+    // NOTE: We deliberately do NOT call prepare_tls here because it clears the
+    // _program_info_cache which is needed for is_helper_usable_windows. Instead,
+    // we get the program type (which populates the cache) and set TLS manually.
+    prevail::ThreadLocalGuard tls_guard;
+    prevail::thread_local_options = options;
+
+    const prevail::EbpfProgramType prog_type = local_platform.get_program_type(type_name, type_name);
+    const ebpf_context_descriptor_t* ctx_desc = prog_type.context_descriptor;
+    static const ebpf_context_descriptor_t fallback_ctx{64, 0, 4, -1};
+    prevail::EbpfProgramType effective_type = prog_type;
+    if (ctx_desc == nullptr) {
+        effective_type.name = type_name;
+        effective_type.context_descriptor = &fallback_ctx;
+    }
+
+    prevail::ProgramInfo info{&local_platform, {map_desc0, map_desc1}, effective_type};
+    prevail::thread_local_program_info = info;
+
+    // Parse assembly text into InstructionSeq (with TLS program info available).
+    prevail::InstructionSeq inst_seq = parse_assembly(code, &local_platform);
+
+    // Run analysis.
+    prevail::Program prog = prevail::Program::from_sequence(inst_seq, info, options);
+    prevail::AnalysisResult result = prevail::analyze(prog, pre_invariant);
+
+    // Build response.
+    json j = {
+        {"passed", !result.failed},
+        {"instruction_count", static_cast<int>(inst_seq.size())},
+    };
+
+    // Exit invariant.
+    prevail::StringInvariant exit_inv = result.invariant_at(prevail::Label::exit);
+    j["post_invariant"] = invariant_to_json(exit_inv);
+    j["exit_value"] = interval_to_json(result.exit_value);
+
+    // Collect errors.
+    json errors = json::array();
+    for (const auto& [label, inv_pair] : result.invariants) {
+        if (inv_pair.pre.is_bottom()) {
+            continue;
+        }
+        if (inv_pair.error.has_value()) {
+            json e;
+            e["pc"] = inv_pair.error->where.has_value() ? inv_pair.error->where->from : label.from;
+            e["message"] = inv_pair.error->what();
+            e["pre_invariant"] = invariant_to_json(inv_pair.pre.to_set());
+            errors.push_back(e);
+        }
+    }
+    j["errors"] = errors;
+
+    // Process observe assertions (check intermediate invariants).
+    if (args.contains("observe")) {
+        json obs_results = json::array();
+        for (const auto& obs : args["observe"]) {
+            const std::string point_str = obs.value("point", "pre");
+            const std::string mode_str = obs.value("mode", "consistent");
+            if (!obs.contains("constraints")) {
+                throw std::runtime_error("observe entry missing required 'constraints' field");
+            }
+            const auto constraints_vec = obs.at("constraints").get<std::vector<std::string>>();
+
+            // Determine the label: either "pc" (integer) or "label" (string, e.g. "exit").
+            prevail::Label label = prevail::Label::entry;
+            json obs_entry = json::object();
+            if (obs.contains("pc")) {
+                const int obs_pc = obs["pc"].get<int>();
+                if (obs_pc < 0) {
+                    throw std::runtime_error("Invalid observation PC: " + std::to_string(obs_pc));
+                }
+                label = prevail::Label{obs_pc, -1, {}};
+                obs_entry = {{"pc", obs_pc}};
+            } else if (obs.contains("label")) {
+                const std::string label_str = obs["label"].get<std::string>();
+                if (label_str == "exit") {
+                    label = prevail::Label::exit;
+                } else {
+                    obs_entry["ok"] = false;
+                    obs_entry["message"] = "Unknown label: " + label_str + " (supported: \"exit\")";
+                    obs_results.push_back(obs_entry);
+                    continue;
+                }
+                obs_entry = {{"label", label_str}};
+            }
+
+            try {
+                auto point = (point_str == "post") ? prevail::InvariantPoint::post : prevail::InvariantPoint::pre;
+                prevail::ObservationCheckMode mode;
+                if (mode_str == "entailed") {
+                    mode = prevail::ObservationCheckMode::entailed;
+                } else if (mode_str == "consistent") {
+                    mode = prevail::ObservationCheckMode::consistent;
+                } else {
+                    obs_entry["ok"] = false;
+                    obs_entry["message"] = "Unknown mode: " + mode_str;
+                    obs_results.push_back(obs_entry);
+                    continue;
+                }
+                std::set<std::string> constraint_set(constraints_vec.begin(), constraints_vec.end());
+                prevail::StringInvariant observation{std::move(constraint_set)};
+
+                auto check = result.check_observation_at_label(label, point, observation, mode);
+                obs_entry["ok"] = check.ok;
+                obs_entry["message"] = check.message;
+
+                // Include the invariant at this point.
+                auto it = result.invariants.find(label);
+                if (it != result.invariants.end()) {
+                    const auto& state = (point == prevail::InvariantPoint::post) ? it->second.post : it->second.pre;
+                    if (!state.is_bottom()) {
+                        obs_entry["invariant"] = invariant_to_json(state.to_set());
+                    }
+                }
+            } catch (const std::exception& e) {
+                obs_entry["ok"] = false;
+                obs_entry["message"] = e.what();
+            }
+            obs_results.push_back(obs_entry);
+        }
+        j["observations"] = obs_results;
+    }
+
+    return j;
+}
+
+// ─── Tool: get_disassembly ─────────────────────────────────────────────────────
+
+static json handle_get_disassembly(const json& args, AnalysisEngine& engine) {
+    const std::string elf_path = args.at("elf_path").get<std::string>();
+    const std::string section = args.value("section", "");
+    const std::string program = args.value("program", "");
+    const std::string type = args.value("program_type", "");
+    const int from_pc = args.value("from_pc", -1);
+    const int to_pc = args.value("to_pc", -1);
+
+    const auto& session = engine.analyze(elf_path, section, program, type);
+
+    json instructions = json::array();
+    int pc = 0;
+    for (const auto& [label, inst, line_info] : session.inst_seq) {
+        if ((from_pc >= 0 && pc < from_pc) || (to_pc >= 0 && pc > to_pc)) {
+            pc += prevail::size(inst);
+            continue;
+        }
+
+        json entry = {{"pc", pc}};
+        std::ostringstream os;
+        os << inst;
+        entry["text"] = os.str();
+
+        if (line_info.has_value()) {
+            entry["source"] = line_info_to_json(*line_info);
+        }
+
+        instructions.push_back(entry);
+        pc += prevail::size(inst);
+    }
+
+    return {{"instructions", instructions}, {"count", static_cast<int>(instructions.size())}};
+}
+
+// ─── Tool Registration ─────────────────────────────────────────────────────────
+
+void register_all_tools(McpServer& server, AnalysisEngine& engine) {
+    server.register_tool({
+        "list_programs",
+        "List all eBPF programs (sections and function names) in an ELF file.",
+        {{"type", "object"},
+         {"properties", {{"elf_path", {{"type", "string"}, {"description", "Path to .o ELF file"}}}}},
+         {"required", json::array({"elf_path"})}},
+        [&engine](const json& args) { return handle_list_programs(args, engine); },
+    });
+
+    server.register_tool({
+        "verify_program",
+        "Quick pass/fail check. Returns verification result, error count, exit value range, and instruction count. "
+        "Use this first to confirm whether a program passes or fails before deeper analysis with get_slice.",
+        {{"type", "object"},
+         {"properties",
+          {{"elf_path", {{"type", "string"}, {"description", "Path to .o ELF file"}}},
+           {"section", {{"type", "string"}, {"description", "ELF section name (optional)"}}},
+           {"program", {{"type", "string"}, {"description", "Program/function name (optional)"}}},
+           {"program_type",
+            {{"type", "string"}, {"description", "Program type name override (e.g. \"xdp\", \"bind\")"}}},
+           {"check_termination",
+            {{"type", "boolean"},
+             {"description",
+              "Check for termination (loop bounds). Default: platform-specific. Only override by user request."}}},
+           {"allow_division_by_zero",
+            {{"type", "boolean"},
+             {"description",
+              "Allow division by zero per BPF ISA semantics. Default: true. Only override by user request."}}},
+           {"strict",
+            {{"type", "boolean"},
+             {"description",
+              "Enable strict mode (additional runtime failure checks). Default: false. "
+              "Only override by user request."}}}}},
+         {"required", json::array({"elf_path"})}},
+        [&engine](const json& args) { return handle_verify_program(args, engine); },
+    });
+
+    server.register_tool({
+        "get_invariant",
+        "Get the pre or post invariant (abstract state) at one or more BPF instructions. Shows register types, value "
+        "ranges, and all constraints the verifier has proven at that point.",
+        {{"type", "object"},
+         {"properties",
+          {{"elf_path", {{"type", "string"}}},
+           {"pcs",
+            {{"type", "array"}, {"items", {{"type", "integer"}}}, {"description", "Program counter(s) to query"}}},
+           {"point", {{"type", "string"}, {"enum", json::array({"pre", "post"})}, {"default", "pre"}}},
+           {"section", {{"type", "string"}}},
+           {"program", {{"type", "string"}}},
+           {"program_type",
+            {{"type", "string"}, {"description", "Program type name override (e.g. \"xdp\", \"bind\")"}}}}},
+         {"required", json::array({"elf_path", "pcs"})}},
+        [&engine](const json& args) { return handle_get_invariant(args, engine); },
+    });
+
+    server.register_tool({
+        "get_instruction",
+        "Deep dive on specific instructions: disassembly text, safety assertions, pre/post invariants, "
+        "verification error (if any), source line, and CFG neighbors. Use after get_slice to inspect "
+        "individual instructions in detail, especially to compare pre vs post invariants across a helper call.",
+        {{"type", "object"},
+         {"properties",
+          {{"elf_path", {{"type", "string"}}},
+           {"pcs",
+            {{"type", "array"}, {"items", {{"type", "integer"}}}, {"description", "Program counter(s) to query"}}},
+           {"section", {{"type", "string"}}},
+           {"program", {{"type", "string"}}},
+           {"program_type",
+            {{"type", "string"}, {"description", "Program type name override (e.g. \"xdp\", \"bind\")"}}}}},
+         {"required", json::array({"elf_path", "pcs"})}},
+        [&engine](const json& args) { return handle_get_instruction(args, engine); },
+    });
+
+    server.register_tool({
+        "get_errors",
+        "List all verification errors with pre-invariants and source lines, plus unreachable code. "
+        "Use for a quick overview of all errors in a multi-error program. Does NOT include failure slices — "
+        "use get_slice with error_index for detailed causal analysis of a specific error.",
+        {{"type", "object"},
+         {"properties",
+          {{"elf_path", {{"type", "string"}}},
+           {"section", {{"type", "string"}}},
+           {"program", {{"type", "string"}}},
+           {"program_type",
+            {{"type", "string"}, {"description", "Program type name override (e.g. \"xdp\", \"bind\")"}}}}},
+         {"required", json::array({"elf_path"})}},
+        [&engine](const json& args) { return handle_get_errors(args, engine); },
+    });
+
+    server.register_tool({
+        "get_cfg",
+        "Get the control-flow graph: basic blocks with instruction PCs and edges. Supports JSON or DOT format.",
+        {{"type", "object"},
+         {"properties",
+          {{"elf_path", {{"type", "string"}}},
+           {"format", {{"type", "string"}, {"enum", json::array({"json", "dot"})}, {"default", "json"}}},
+           {"section", {{"type", "string"}}},
+           {"program", {{"type", "string"}}},
+           {"program_type",
+            {{"type", "string"}, {"description", "Program type name override (e.g. \"xdp\", \"bind\")"}}}}},
+         {"required", json::array({"elf_path"})}},
+        [&engine](const json& args) { return handle_get_cfg(args, engine); },
+    });
+
+    server.register_tool({
+        "get_source_mapping",
+        "Map between C source lines and BPF instructions. Query by PC to find source, by source_line to find BPF "
+        "instructions, or omit both to get the full map. Requires ELF compiled with -g.",
+        {{"type", "object"},
+         {"properties",
+          {{"elf_path", {{"type", "string"}}},
+           {"pc", {{"type", "integer"}, {"description", "BPF instruction PC to look up"}}},
+           {"source_line", {{"type", "integer"}, {"description", "C source line number to look up"}}},
+           {"source_file", {{"type", "string"}, {"description", "Source file name filter (optional)"}}},
+           {"section", {{"type", "string"}}},
+           {"program", {{"type", "string"}}},
+           {"program_type",
+            {{"type", "string"}, {"description", "Program type name override (e.g. \"xdp\", \"bind\")"}}}}},
+         {"required", json::array({"elf_path"})}},
+        [&engine](const json& args) { return handle_get_source_mapping(args, engine); },
+    });
+
+    server.register_tool({
+        "check_constraint",
+        "Test hypotheses about the verifier's abstract state at a given instruction. "
+        "Use 'proven' mode to test if the verifier guarantees a constraint (e.g., 'is packet_size >= 42 proven?'). "
+        "Use 'consistent' mode to test if a constraint is possible (not contradicted). "
+        "WARNING: 'consistent' returns ok=true for variables absent from the invariant (vacuously true) — "
+        "always check the 'invariant' field in the response to confirm the variable is tracked. "
+        "Supports batch mode: pass 'checks' array to test multiple hypotheses in a single call.",
+        {{"type", "object"},
+         {"properties",
+          {{"elf_path", {{"type", "string"}}},
+           {"pc", {{"type", "integer"}}},
+           {"constraints",
+            {{"type", "array"}, {"items", {{"type", "string"}}}, {"description", "Constraint strings to check"}}},
+           {"checks",
+            {{"type", "array"},
+             {"description", "Batch mode: array of checks to run in a single analysis pass. "
+                             "Each check has pc, constraints, and optional mode/point overrides."},
+             {"items",
+              {{"type", "object"},
+               {"properties",
+                {{"pc", {{"type", "integer"}}},
+                 {"constraints", {{"type", "array"}, {"items", {{"type", "string"}}}}},
+                 {"mode", {{"type", "string"}, {"enum", json::array({"consistent", "entailed", "proven"})}}},
+                 {"point", {{"type", "string"}, {"enum", json::array({"pre", "post"})}}}}},
+               {"required", json::array({"pc", "constraints"})}}}}},
+           {"point", {{"type", "string"}, {"enum", json::array({"pre", "post"})}, {"default", "pre"}}},
+           {"mode",
+            {{"type", "string"},
+             {"enum", json::array({"consistent", "entailed", "proven"})},
+             {"default", "consistent"},
+             {"description",
+              "consistent: constraints are possible (not contradicted). "
+              "proven: verifier guarantees the constraints (invariant implies observation). "
+              "entailed: observation is a sub-state of invariant (requires near-complete constraint set)."}}},
+           {"section", {{"type", "string"}}},
+           {"program", {{"type", "string"}}},
+           {"program_type",
+            {{"type", "string"}, {"description", "Program type name override (e.g. \"xdp\", \"bind\")"}}}}},
+         {"required", json::array({"elf_path"})}},
+        [&engine](const json& args) { return handle_check_constraint(args, engine); },
+    });
+
+    server.register_tool({
+        "get_slice",
+        "START HERE for failure diagnosis or understanding any instruction. Returns the pre-invariant, assertions, "
+        "source line, and a backward slice of only the instructions that causally contributed — with per-instruction "
+        "register relevance tracking. For errors: omit 'pc' to slice the first error. For passing programs: set 'pc' "
+        "to slice backward from any instruction (e.g., to understand why a read is safe or what feeds a helper call). "
+        "Read the pre-invariant directly: if a register is listed, it is proven; if absent, it was invalidated.",
+        {{"type", "object"},
+         {"properties",
+          {{"elf_path", {{"type", "string"}}},
+           {"error_index",
+            {{"type", "integer"}, {"default", 0}, {"description", "Which error to examine (0 = first)"}}},
+           {"pc",
+            {{"type", "integer"},
+             {"description", "Slice backward from this PC instead of an error (overrides error_index)"}}},
+           {"trace_depth",
+            {{"type", "integer"},
+             {"default", 200},
+             {"description", "Maximum backward steps for slicing (default: 200)"}}},
+           {"section", {{"type", "string"}}},
+           {"program", {{"type", "string"}}},
+           {"program_type",
+            {{"type", "string"}, {"description", "Program type name override (e.g. \"xdp\", \"bind\")"}}},
+           {"check_termination",
+            {{"type", "boolean"},
+             {"description",
+              "Check for termination (loop bounds). Default: platform-specific. Only override by user request."}}},
+           {"allow_division_by_zero",
+            {{"type", "boolean"},
+             {"description",
+              "Allow division by zero per BPF ISA semantics. Default: true. Only override by user request."}}},
+           {"strict",
+            {{"type", "boolean"},
+             {"description",
+              "Enable strict mode (additional runtime failure checks). Default: false. "
+              "Only override by user request."}}}}},
+         {"required", json::array({"elf_path"})}},
+        [&engine](const json& args) { return handle_get_slice(args, engine); },
+    });
+
+    server.register_tool({
+        "get_disassembly",
+        "Get the disassembly listing for a range of instructions. Returns instruction text and source lines. "
+        "Use from_pc/to_pc to limit the range, or omit for the full listing.",
+        {{"type", "object"},
+         {"properties",
+          {{"elf_path", {{"type", "string"}}},
+           {"from_pc", {{"type", "integer"}, {"description", "Start PC (inclusive, default: 0)"}}},
+           {"to_pc", {{"type", "integer"}, {"description", "End PC (inclusive, default: last)"}}},
+           {"section", {{"type", "string"}}},
+           {"program", {{"type", "string"}}},
+           {"program_type",
+            {{"type", "string"}, {"description", "Program type name override (e.g. \"xdp\", \"bind\")"}}}}},
+         {"required", json::array({"elf_path"})}},
+        [&engine](const json& args) { return handle_get_disassembly(args, engine); },
+    });
+
+    server.register_tool({
+        "verify_assembly",
+        "Verify a block of BPF assembly text without needing a compiled ELF file. "
+        "Useful for quickly testing instruction sequences, validating fix ideas, or exploring verifier behavior. "
+        "Syntax: one instruction per line (e.g., 'r0 = r1', 'call 1', 'if r0 == 0 goto <done>', 'exit'). "
+        "Labels: '<name>:' on a separate line. Helper IDs: 1=map_lookup, 2=map_update. "
+        "If 'pre' is omitted, uses standard program entry state (r1=ctx, r10=stack). "
+        "If 'pre' is provided, only those constraints apply (for testing specific register states).",
+        {{"type", "object"},
+         {"properties",
+          {{"code",
+            {{"type", "string"},
+             {"description",
+              "BPF assembly instructions, one per line. "
+              "Example: \"r0 = 0\\nexit\". Labels: \"<loop>:\\nr0 += 1\\nif r0 < 10 goto <loop>\\nexit\"."}}},
+           {"pre",
+            {{"type", "array"},
+             {"items", {{"type", "string"}}},
+             {"description",
+              "Pre-invariant constraints (e.g., [\"r1.type=map_fd\", \"r1.map_fd=1\"]). "
+              "If omitted, uses standard entry state (r1=ctx, r10=stack)."}}},
+           {"program_type",
+            {{"type", "string"},
+             {"default", "xdp"},
+             {"description",
+              "Program type name (e.g., \"xdp\", \"bind\"). Determines available helpers and context layout. "
+              "Default: \"xdp\"."}}},
+           {"map_key_size", {{"type", "integer"}, {"default", 4}, {"description", "Map key size in bytes."}}},
+           {"map_value_size", {{"type", "integer"}, {"default", 4}, {"description", "Map value size in bytes."}}},
+           {"check_termination",
+            {{"type", "boolean"},
+             {"description", "Check for termination. Default: platform-specific. Only override by user request."}}},
+           {"allow_division_by_zero",
+            {{"type", "boolean"},
+             {"description",
+              "Allow division by zero per BPF ISA semantics. Default: true. Only override by user request."}}},
+           {"strict",
+            {{"type", "boolean"},
+             {"description",
+              "Enable strict mode. Default: false. Only override by user request."}}},
+           {"big_endian",
+            {{"type", "boolean"},
+             {"default", false},
+             {"description", "Analyze as big-endian BPF program. Default: false (little-endian)."}}},
+           {"observe",
+            {{"type", "array"},
+             {"description",
+              "Check intermediate invariants at specific PCs. Each entry has pc, constraints, "
+              "and optional point (pre/post) and mode (consistent/entailed)."},
+             {"items",
+              {{"type", "object"},
+               {"properties",
+                {{"pc", {{"type", "integer"}, {"description", "Instruction PC to observe"}}},
+                 {"label", {{"type", "string"}, {"description", "Label to observe (e.g. \"exit\")"}}},
+                 {"constraints", {{"type", "array"}, {"items", {{"type", "string"}}}}},
+                 {"point", {{"type", "string"}, {"enum", json::array({"pre", "post"})}, {"default", "pre"}}},
+                 {"mode",
+                  {{"type", "string"},
+                   {"enum", json::array({"consistent", "entailed"})},
+                   {"default", "consistent"}}}}},
+               {"required", json::array({"constraints"})}}}}}}},
+         {"required", json::array({"code"})}},
+        [&engine](const json& args) { return handle_verify_assembly(args, engine); },
+    });
+}
+
+} // namespace prevail

--- a/src/mcp/tools.hpp
+++ b/src/mcp/tools.hpp
@@ -1,0 +1,16 @@
+// Copyright (c) Prevail Verifier contributors.
+// SPDX-License-Identifier: MIT
+#pragma once
+
+/// @file MCP tool declarations and registration.
+
+#include "analysis_engine.hpp"
+#include "mcp_server.hpp"
+
+namespace prevail {
+
+/// Register all PREVAIL MCP tools with the server.
+void
+register_all_tools(McpServer& server, AnalysisEngine& engine);
+
+} // namespace prevail

--- a/src/platform_ops.hpp
+++ b/src/platform_ops.hpp
@@ -1,0 +1,104 @@
+// Copyright (c) Prevail Verifier contributors.
+// SPDX-License-Identifier: MIT
+#pragma once
+
+/// @file Platform abstraction for the analysis engine.
+/// Implementations provide platform-specific ELF validation, program enumeration,
+/// TLS management, and verifier options. This allows the analysis engine to work
+/// with different eBPF platforms (Linux, Windows) without compile-time dependencies.
+
+// Undef Windows macros that conflict with PREVAIL headers (std::numeric_limits::min/max).
+#undef FALSE
+#undef TRUE
+#undef min
+#undef max
+
+// Pre-define the include guard for bpf_conformance's ebpf_inst.h to prevent it
+// from being included (its EbpfInst struct conflicts with prevail::EbpfInst).
+#ifndef BPF_CONFORMANCE_CORE_EBPF_INST_H
+#define BPF_CONFORMANCE_CORE_EBPF_INST_H
+#endif
+
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable : 4100) // Unreferenced formal parameter.
+#pragma warning(disable : 4244) // Conversion, possible loss of data.
+#pragma warning(disable : 4267) // Conversion from 'size_t' to 'int'.
+#pragma warning(disable : 4458) // Declaration hides class member.
+#pragma warning(disable : 26439) // Function may not throw.
+#pragma warning(disable : 26450) // Arithmetic overflow.
+#pragma warning(disable : 26451) // Arithmetic overflow.
+#pragma warning(disable : 26495) // Always initialize a member variable.
+#endif
+
+#include "ebpf_verifier.hpp"
+
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
+
+#ifdef _WIN32
+#define FALSE 0
+#define TRUE 1
+#endif
+
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace prevail {
+
+/// Entry in the program list returned by PlatformOps::list_programs().
+struct ProgramEntry
+{
+    std::string section;
+    std::string function;
+};
+
+/// Abstract interface for platform-specific operations.
+/// The analysis engine calls through this interface instead of directly using
+/// platform-specific APIs.
+struct PlatformOps
+{
+    virtual ~PlatformOps() = default;
+
+    /// Get the PREVAIL platform pointer for read_elf/unmarshal/analyze.
+    [[nodiscard]] virtual const prevail::ebpf_platform_t*
+    platform() const = 0;
+
+    /// List all programs (sections + function names) in an ELF file.
+    [[nodiscard]] virtual std::vector<ProgramEntry>
+    list_programs(const std::string& elf_path) = 0;
+
+    /// Validate ELF data before analysis.
+    /// @return true if valid (or if no validation is available).
+    virtual bool
+    validate_elf(const std::string& /*data*/)
+    {
+        return true;
+    }
+
+    /// Prepare thread-local state before analysis.
+    /// Clears any cached TLS data and optionally sets a program type override.
+    virtual void
+    prepare_tls(const std::string& type_override) = 0;
+
+    /// Get default verifier options for this platform.
+    [[nodiscard]] virtual prevail::ebpf_verifier_options_t
+    default_options() = 0;
+
+    /// Attempt fallback verification to produce a clean error message
+    /// when direct PREVAIL analysis fails (e.g. due to access violation on Windows).
+    /// @return Error message string, or empty string if no fallback is available.
+    virtual std::string
+    fallback_verify(
+        const std::string& /*data*/,
+        const std::string& /*section*/,
+        const std::string& /*program*/,
+        const std::string& /*type*/)
+    {
+        return "";
+    }
+};
+
+} // namespace prevail

--- a/src/platform_ops_prevail.hpp
+++ b/src/platform_ops_prevail.hpp
@@ -1,0 +1,69 @@
+// Copyright (c) Prevail Verifier contributors.
+// SPDX-License-Identifier: MIT
+#pragma once
+
+/// @file Linux/portable PlatformOps implementation using only PREVAIL APIs.
+
+#include "platform_ops.hpp"
+
+namespace prevail {
+
+/// PlatformOps implementation using only PREVAIL's public API.
+/// Works on Linux and Windows (when linking the PREVAIL library directly
+/// without ebpf-for-windows).
+class PrevailPlatformOps : public PlatformOps
+{
+  public:
+    explicit PrevailPlatformOps(const prevail::ebpf_platform_t* platform) : platform_(platform) {}
+
+    [[nodiscard]] const prevail::ebpf_platform_t*
+    platform() const override
+    {
+        return platform_;
+    }
+
+    [[nodiscard]] std::vector<ProgramEntry>
+    list_programs(const std::string& elf_path) override
+    {
+        prevail::ElfObject elf(elf_path, default_options(), platform_);
+        std::vector<ProgramEntry> result;
+        for (const auto& info : elf.list_programs()) {
+            if (prevail::ElfObject::is_valid(info)) {
+                result.push_back({info.section_name, info.function_name});
+            }
+        }
+        return result;
+    }
+
+    void
+    prepare_tls(const std::string& /*type_override*/) override
+    {
+        // PREVAIL's ThreadLocalGuard handles cleanup on scope exit.
+        // The Linux platform resolves program types from section names
+        // via the platform's get_program_type() callback, so no
+        // global type override is needed.
+        prevail::ebpf_verifier_clear_thread_local_state();
+    }
+
+    [[nodiscard]] prevail::ebpf_verifier_options_t
+    default_options() override
+    {
+        prevail::ebpf_verifier_options_t opts{};
+        // Match prevail defaults (termination not checked by default).
+        opts.mock_map_fds = true;
+        opts.setup_constraints = true;
+        opts.allow_division_by_zero = true;
+        opts.verbosity_opts.print_line_info = true;
+        return opts;
+    }
+
+    // validate_elf: default (always true) — PREVAIL's read_elf handles
+    // malformed ELFs via exceptions.
+
+    // fallback_verify: default (empty) — no SEH recovery needed on Linux.
+
+  private:
+    const prevail::ebpf_platform_t* platform_;
+};
+
+} // namespace prevail

--- a/src/platform_ops_prevail.hpp
+++ b/src/platform_ops_prevail.hpp
@@ -14,18 +14,19 @@ namespace prevail {
 class PrevailPlatformOps : public PlatformOps
 {
   public:
-    explicit PrevailPlatformOps(const prevail::ebpf_platform_t* platform) : platform_(platform) {}
+    explicit PrevailPlatformOps(const prevail::ebpf_platform_t* platform) : platform_(*platform) {}
+    explicit PrevailPlatformOps(prevail::ebpf_platform_t platform) : platform_(platform) {}
 
     [[nodiscard]] const prevail::ebpf_platform_t*
     platform() const override
     {
-        return platform_;
+        return &platform_;
     }
 
     [[nodiscard]] std::vector<ProgramEntry>
     list_programs(const std::string& elf_path) override
     {
-        prevail::ElfObject elf(elf_path, default_options(), platform_);
+        prevail::ElfObject elf(elf_path, default_options(), &platform_);
         std::vector<ProgramEntry> result;
         for (const auto& info : elf.list_programs()) {
             if (prevail::ElfObject::is_valid(info)) {
@@ -38,10 +39,6 @@ class PrevailPlatformOps : public PlatformOps
     void
     prepare_tls(const std::string& /*type_override*/) override
     {
-        // PREVAIL's ThreadLocalGuard handles cleanup on scope exit.
-        // The Linux platform resolves program types from section names
-        // via the platform's get_program_type() callback, so no
-        // global type override is needed.
         prevail::ebpf_verifier_clear_thread_local_state();
     }
 
@@ -49,7 +46,6 @@ class PrevailPlatformOps : public PlatformOps
     default_options() override
     {
         prevail::ebpf_verifier_options_t opts{};
-        // Match prevail defaults (termination not checked by default).
         opts.mock_map_fds = true;
         opts.setup_constraints = true;
         opts.allow_division_by_zero = true;
@@ -57,13 +53,8 @@ class PrevailPlatformOps : public PlatformOps
         return opts;
     }
 
-    // validate_elf: default (always true) — PREVAIL's read_elf handles
-    // malformed ELFs via exceptions.
-
-    // fallback_verify: default (empty) — no SEH recovery needed on Linux.
-
   private:
-    const prevail::ebpf_platform_t* platform_;
+    prevail::ebpf_platform_t platform_;
 };
 
 } // namespace prevail

--- a/src/prevail_mcp.cpp
+++ b/src/prevail_mcp.cpp
@@ -1,0 +1,66 @@
+// Copyright (c) Prevail Verifier contributors.
+// SPDX-License-Identifier: MIT
+
+/// @file Entry point for the PREVAIL MCP server (portable/Linux build).
+
+#include "analysis_engine.hpp"
+#include "mcp/mcp_server.hpp"
+#include "mcp/mcp_transport.hpp"
+#include "platform_ops_prevail.hpp"
+#include "mcp/tools.hpp"
+
+#include "linux/gpl/spec_type_descriptors.hpp"
+
+#include <cstdio>
+#include <iostream>
+
+#ifndef _WIN32
+#include <unistd.h>
+#endif
+
+int
+main()
+{
+    try {
+        // Set up the MCP output stream: duplicate stdout for exclusive MCP use,
+        // then redirect std::cout to std::cerr so that library diagnostics
+        // (e.g., verbose verifier output) don't corrupt the JSON-RPC framing.
+        // Note: fd-level stdout is left intact so that parent processes can pipe
+        // it normally (e.g., subprocess.Popen in Python, Start-Process in PowerShell).
+        FILE* mcp_out = stdout;
+#ifndef _WIN32
+        int mcp_fd = dup(fileno(stdout));
+        if (mcp_fd >= 0) {
+            mcp_out = fdopen(mcp_fd, "wb");
+            if (!mcp_out) {
+                close(mcp_fd);
+                mcp_out = stdout; // Fallback: use stdout directly.
+            }
+        }
+#endif
+        setvbuf(mcp_out, nullptr, _IONBF, 0);
+
+        // Redirect C++ std::cout to stderr so library diagnostics don't reach the client.
+        std::cout.rdbuf(std::cerr.rdbuf());
+
+        // Use the Linux eBPF platform from PREVAIL.
+        prevail::PrevailPlatformOps ops(&prevail::g_ebpf_platform_linux);
+
+        prevail::AnalysisEngine engine(&ops);
+        prevail::McpServer server;
+        prevail::register_all_tools(server, engine);
+
+        std::cerr << "prevail: server started" << std::endl;
+
+        prevail::McpTransport transport(mcp_out);
+        transport.run([&server](const std::string& method, const nlohmann::json& params) {
+            return server.dispatch(method, params);
+        });
+
+        std::cerr << "prevail: server stopped" << std::endl;
+        return 0;
+    } catch (const std::exception& e) {
+        std::cerr << "prevail: fatal error: " << e.what() << std::endl;
+        return 1;
+    }
+}

--- a/src/result.cpp
+++ b/src/result.cpp
@@ -377,30 +377,241 @@ std::set<Reg> extract_assertion_registers(const Assertion& assertion) {
         assertion);
 }
 
+FailureSlice AnalysisResult::compute_slice_from_label(const Program& prog, const Label& label,
+                                                      const RelevantState& seed_relevance, size_t max_steps) const {
+    FailureSlice slice{
+        .failing_label = label,
+        .error = VerificationError(""),
+        .relevance = {},
+    };
+
+    // Copy error if present at this label.
+    const auto label_it = invariants.find(label);
+    if (label_it != invariants.end() && label_it->second.error) {
+        slice.error = *label_it->second.error;
+    }
+
+    // `visited` tracks all explored labels for deduplication during backward traversal.
+    // `slice_labels` tracks only labels that interact with relevant registers (the output slice).
+    std::map<Label, RelevantState> visited;
+    std::set<Label> conservative_visited; // Dedup for empty-relevance labels in conservative mode
+    std::map<Label, RelevantState> slice_labels;
+
+    // Worklist: (label, relevant_state_after_this_label)
+    std::vector<std::pair<Label, RelevantState>> worklist;
+    worklist.emplace_back(label, seed_relevance);
+
+    // When the seed has no register/stack deps (e.g., BoundedLoopCount),
+    // perform a conservative backward walk so the slice still shows the
+    // loop structure and control flow leading to the failure.
+    const bool conservative_mode = seed_relevance.registers.empty() && seed_relevance.stack_offsets.empty();
+
+    size_t steps = 0;
+
+    // Hoist the parent lookup for the target label outside the hot loop;
+    // it is invariant and parents_of() may return a temporary.
+    const auto parents_of_target = prog.cfg().parents_of(label);
+
+    while (!worklist.empty() && steps < max_steps) {
+        auto [current_label, relevant_after] = worklist.back();
+        worklist.pop_back();
+
+        // Skip if nothing is relevant — unless we're in conservative mode
+        // (empty-seed assertions like BoundedLoopCount) or this is the target label.
+        if (!conservative_mode && current_label != label && relevant_after.registers.empty() &&
+            relevant_after.stack_offsets.empty()) {
+            continue;
+        }
+
+        // Merge with existing relevance at this label (for deduplication)
+        auto& existing = visited[current_label];
+        const size_t prev_size = existing.registers.size() + existing.stack_offsets.size();
+        existing.registers.insert(relevant_after.registers.begin(), relevant_after.registers.end());
+        existing.stack_offsets.insert(relevant_after.stack_offsets.begin(), relevant_after.stack_offsets.end());
+        const size_t new_size = existing.registers.size() + existing.stack_offsets.size();
+
+        // If no new relevance was added, skip (already processed with same or broader relevance).
+        // In conservative mode with empty relevance, use a separate visited set for dedup.
+        if (new_size == prev_size) {
+            if (prev_size > 0) {
+                continue;
+            }
+            // Empty relevance (conservative mode): skip if we already visited this label
+            if (!conservative_visited.insert(current_label).second) {
+                continue;
+            }
+        }
+
+        // Compute what's relevant BEFORE this instruction using deps
+        RelevantState relevant_before;
+        const auto inv_it = invariants.find(current_label);
+        if (inv_it != invariants.end() && inv_it->second.deps) {
+            const auto& deps = *inv_it->second.deps;
+
+            // Start with what's relevant after
+            relevant_before = relevant_after;
+
+            // Remove registers that are written by this instruction
+            // (they weren't relevant before their definition)
+            for (const auto& reg : deps.regs_written) {
+                relevant_before.registers.erase(reg);
+            }
+
+            // Remove registers that are clobbered (killed without reading).
+            // These stop propagation for post-instruction uses but don't add read-deps.
+            for (const auto& reg : deps.regs_clobbered) {
+                relevant_before.registers.erase(reg);
+            }
+
+            // Determine if this instruction contributes to the slice.
+            // An instruction contributes when it writes to a relevant register/stack slot,
+            // or when it is a control-flow decision (Jmp/Assume) that reads relevant registers.
+            bool instruction_contributes = false;
+            for (const auto& reg : deps.regs_written) {
+                if (relevant_after.registers.contains(reg)) {
+                    instruction_contributes = true;
+                    break;
+                }
+            }
+            for (const auto& offset : deps.stack_written) {
+                if (relevant_after.stack_offsets.contains(offset)) {
+                    instruction_contributes = true;
+                    break;
+                }
+            }
+
+            // Control-flow instructions (Jmp/Assume) that read relevant registers
+            // contribute to the slice because they shape the path to the target.
+            if (!instruction_contributes) {
+                const auto& ins = prog.instruction_at(current_label);
+                if (std::holds_alternative<Jmp>(ins) || std::holds_alternative<Assume>(ins)) {
+                    for (const auto& reg : deps.regs_read) {
+                        if (relevant_after.registers.contains(reg)) {
+                            instruction_contributes = true;
+                            break;
+                        }
+                    }
+                }
+            }
+
+            // Immediate path guard: when the current label is a direct predecessor
+            // of the target label and is an Assume instruction, its condition
+            // registers are causally relevant — they determine reachability.
+            if (std::holds_alternative<Assume>(prog.instruction_at(current_label))) {
+                if (std::find(parents_of_target.begin(), parents_of_target.end(), current_label) !=
+                    parents_of_target.end()) {
+                    instruction_contributes = true;
+                }
+            }
+
+            // At the target label, the assertion depends on registers the instruction
+            // reads (e.g., base pointer r3 in a store). Since stores write to memory
+            // not registers, instruction_contributes would be false without this.
+            if (current_label == label) {
+                instruction_contributes = true;
+            }
+
+            // In conservative mode (empty seed, e.g., BoundedLoopCount), include all
+            // reachable labels so the slice shows the loop structure and control flow.
+            if (conservative_mode) {
+                instruction_contributes = true;
+            }
+
+            if (instruction_contributes) {
+                for (const auto& reg : deps.regs_read) {
+                    relevant_before.registers.insert(reg);
+                }
+                for (const auto& offset : deps.stack_read) {
+                    relevant_before.stack_offsets.insert(offset);
+                }
+            }
+
+            // Remove stack locations that are written by this instruction,
+            // but preserve offsets that are also read (read-modify-write, e.g., Atomic).
+            for (const auto& offset : deps.stack_written) {
+                if (!deps.stack_read.contains(offset)) {
+                    relevant_before.stack_offsets.erase(offset);
+                }
+            }
+
+            if (instruction_contributes) {
+                // Only include contributing labels in the output slice.
+                slice_labels[current_label] = relevant_before;
+            }
+        } else {
+            // No deps available: conservatively treat this label as contributing
+            // and propagate all current relevance to predecessors.
+            relevant_before = relevant_after;
+            slice_labels[current_label] = relevant_before;
+        }
+
+        // Add predecessors to worklist
+        for (const auto& parent : prog.cfg().parents_of(current_label)) {
+            worklist.emplace_back(parent, relevant_before);
+        }
+
+        ++steps;
+    }
+
+    // Expand join points: for any traversed label that is a join point
+    // (≥2 predecessors) where at least one predecessor is already in the slice,
+    // add the join-point label itself and all predecessors that have invariants.
+    // This ensures the causal trace shows converging paths that cause precision loss.
+    // Note: predecessors may not be in `visited` if the worklist budget was exhausted
+    // before reaching them, so we check the invariant map directly.
+    std::map<Label, RelevantState> join_expansion;
+    for (const auto& [v_label, v_relevance] : visited) {
+        const auto& parents = prog.cfg().parents_of(v_label);
+        if (parents.size() < 2) {
+            continue;
+        }
+        // Check that at least one predecessor is in the slice (this join is relevant)
+        bool has_slice_parent = false;
+        for (const auto& parent : parents) {
+            if (slice_labels.contains(parent)) {
+                has_slice_parent = true;
+                break;
+            }
+        }
+        if (!has_slice_parent) {
+            continue;
+        }
+        // Include the join-point label itself so the printing code can display
+        // per-predecessor state at this join.
+        if (!slice_labels.contains(v_label)) {
+            join_expansion[v_label] = v_relevance;
+        }
+        // Include all predecessors so the join display is complete.
+        // Use visited relevance if available, otherwise use the join-point's relevance.
+        for (const auto& parent : parents) {
+            if (slice_labels.contains(parent) || join_expansion.contains(parent)) {
+                continue;
+            }
+            const auto& rel = visited.contains(parent) ? visited.at(parent) : v_relevance;
+            join_expansion[parent] = rel;
+        }
+    }
+    slice_labels.insert(join_expansion.begin(), join_expansion.end());
+
+    // Build the slice from contributing labels only
+    slice.relevance = std::move(slice_labels);
+    return slice;
+}
+
 std::vector<FailureSlice> AnalysisResult::compute_failure_slices(const Program& prog, const SliceParams params) const {
-    const auto max_steps = params.max_steps;
     const auto max_slices = params.max_slices;
     std::vector<FailureSlice> slices;
 
-    // Find all labels with errors
     for (const auto& [label, inv_pair] : invariants) {
         if (inv_pair.pre.is_bottom()) {
-            continue; // Unreachable
+            continue;
         }
         if (!inv_pair.error) {
-            continue; // No error here
+            continue;
         }
-
-        // Check if we've reached the max slices limit
         if (max_slices > 0 && slices.size() >= max_slices) {
             break;
         }
-
-        FailureSlice slice{
-            .failing_label = label,
-            .error = *inv_pair.error,
-            .relevance = {},
-        };
 
         // Seed relevant registers from the actual failing assertion.
         // Forward analysis stops at the first failing assertion, which may not be
@@ -428,218 +639,7 @@ std::vector<FailureSlice> AnalysisResult::compute_failure_slices(const Program& 
             }
         }
 
-        // Always include the failing label in the slice, even if no registers were extracted
-        // (e.g., BoundedLoopCount has no register deps)
-
-        // `visited` tracks all explored labels for deduplication during backward traversal.
-        // `slice_labels` tracks only labels that interact with relevant registers (the output slice).
-        std::map<Label, RelevantState> visited;
-        std::set<Label> conservative_visited; // Dedup for empty-relevance labels in conservative mode
-        std::map<Label, RelevantState> slice_labels;
-
-        // Worklist: (label, relevant_state_after_this_label)
-        std::vector<std::pair<Label, RelevantState>> worklist;
-        worklist.emplace_back(label, initial_relevance);
-
-        // When the seed has no register/stack deps (e.g., BoundedLoopCount),
-        // perform a conservative backward walk so the slice still shows the
-        // loop structure and control flow leading to the failure.
-        const bool conservative_mode = initial_relevance.registers.empty() && initial_relevance.stack_offsets.empty();
-
-        size_t steps = 0;
-
-        // Hoist the parent lookup for the failing label outside the hot loop;
-        // it is invariant and parents_of() may return a temporary.
-        const auto parents_of_fail = prog.cfg().parents_of(label);
-
-        while (!worklist.empty() && steps < max_steps) {
-            auto [current_label, relevant_after] = worklist.back();
-            worklist.pop_back();
-
-            // Skip if nothing is relevant — unless we're in conservative mode
-            // (empty-seed assertions like BoundedLoopCount) or this is the failing label.
-            if (!conservative_mode && current_label != label && relevant_after.registers.empty() &&
-                relevant_after.stack_offsets.empty()) {
-                continue;
-            }
-
-            // Merge with existing relevance at this label (for deduplication)
-            auto& existing = visited[current_label];
-            const size_t prev_size = existing.registers.size() + existing.stack_offsets.size();
-            existing.registers.insert(relevant_after.registers.begin(), relevant_after.registers.end());
-            existing.stack_offsets.insert(relevant_after.stack_offsets.begin(), relevant_after.stack_offsets.end());
-            const size_t new_size = existing.registers.size() + existing.stack_offsets.size();
-
-            // If no new relevance was added, skip (already processed with same or broader relevance).
-            // In conservative mode with empty relevance, use a separate visited set for dedup.
-            if (new_size == prev_size) {
-                if (prev_size > 0) {
-                    continue;
-                }
-                // Empty relevance (conservative mode): skip if we already visited this label
-                if (!conservative_visited.insert(current_label).second) {
-                    continue;
-                }
-            }
-
-            // Compute what's relevant BEFORE this instruction using deps
-            RelevantState relevant_before;
-            const auto inv_it = invariants.find(current_label);
-            if (inv_it != invariants.end() && inv_it->second.deps) {
-                const auto& deps = *inv_it->second.deps;
-
-                // Start with what's relevant after
-                relevant_before = relevant_after;
-
-                // Remove registers that are written by this instruction
-                // (they weren't relevant before their definition)
-                for (const auto& reg : deps.regs_written) {
-                    relevant_before.registers.erase(reg);
-                }
-
-                // Remove registers that are clobbered (killed without reading).
-                // These stop propagation for post-instruction uses but don't add read-deps.
-                for (const auto& reg : deps.regs_clobbered) {
-                    relevant_before.registers.erase(reg);
-                }
-
-                // Determine if this instruction contributes to the slice.
-                // An instruction contributes when it writes to a relevant register/stack slot,
-                // or when it is a control-flow decision (Jmp/Assume) that reads relevant registers.
-                bool instruction_contributes = false;
-                for (const auto& reg : deps.regs_written) {
-                    if (relevant_after.registers.contains(reg)) {
-                        instruction_contributes = true;
-                        break;
-                    }
-                }
-                for (const auto& offset : deps.stack_written) {
-                    if (relevant_after.stack_offsets.contains(offset)) {
-                        instruction_contributes = true;
-                        break;
-                    }
-                }
-
-                // Control-flow instructions (Jmp/Assume) that read relevant registers
-                // contribute to the slice because they shape the path to the failure.
-                if (!instruction_contributes) {
-                    const auto& ins = prog.instruction_at(current_label);
-                    if (std::holds_alternative<Jmp>(ins) || std::holds_alternative<Assume>(ins)) {
-                        for (const auto& reg : deps.regs_read) {
-                            if (relevant_after.registers.contains(reg)) {
-                                instruction_contributes = true;
-                                break;
-                            }
-                        }
-                    }
-                }
-
-                // Immediate path guard: when the current label is a direct predecessor
-                // of the failing label and is an Assume instruction, its condition
-                // registers are causally relevant — they determine reachability.
-                if (std::holds_alternative<Assume>(prog.instruction_at(current_label))) {
-                    if (std::find(parents_of_fail.begin(), parents_of_fail.end(), current_label) !=
-                        parents_of_fail.end()) {
-                        instruction_contributes = true;
-                    }
-                }
-
-                // At the failing label, the assertion depends on registers the instruction
-                // reads (e.g., base pointer r3 in a store). Since stores write to memory
-                // not registers, instruction_contributes would be false without this.
-                if (current_label == label) {
-                    instruction_contributes = true;
-                }
-
-                // In conservative mode (empty seed, e.g., BoundedLoopCount), include all
-                // reachable labels so the slice shows the loop structure and control flow.
-                if (conservative_mode) {
-                    instruction_contributes = true;
-                }
-
-                if (instruction_contributes) {
-                    for (const auto& reg : deps.regs_read) {
-                        relevant_before.registers.insert(reg);
-                    }
-                    for (const auto& offset : deps.stack_read) {
-                        relevant_before.stack_offsets.insert(offset);
-                    }
-                }
-
-                // Remove stack locations that are written by this instruction,
-                // but preserve offsets that are also read (read-modify-write, e.g., Atomic).
-                // Done before storing to slice_labels for consistency with register handling
-                // (written registers are removed before storage at lines 476-478).
-                for (const auto& offset : deps.stack_written) {
-                    if (!deps.stack_read.contains(offset)) {
-                        relevant_before.stack_offsets.erase(offset);
-                    }
-                }
-
-                if (instruction_contributes) {
-                    // Only include contributing labels in the output slice.
-                    // Store relevant_before so pre-invariant filtering shows the
-                    // instruction's read-deps (the true upstream dependencies).
-                    slice_labels[current_label] = relevant_before;
-                }
-            } else {
-                // No deps available: conservatively treat this label as contributing
-                // and propagate all current relevance to predecessors.
-                relevant_before = relevant_after;
-                slice_labels[current_label] = relevant_before;
-            }
-
-            // Add predecessors to worklist
-            for (const auto& parent : prog.cfg().parents_of(current_label)) {
-                worklist.emplace_back(parent, relevant_before);
-            }
-
-            ++steps;
-        }
-
-        // Expand join points: for any traversed label that is a join point
-        // (≥2 predecessors) where at least one predecessor is already in the slice,
-        // add the join-point label itself and all predecessors that have invariants.
-        // This ensures the causal trace shows converging paths that cause precision loss.
-        // Note: predecessors may not be in `visited` if the worklist budget was exhausted
-        // before reaching them, so we check the invariant map directly.
-        std::map<Label, RelevantState> join_expansion;
-        for (const auto& [v_label, v_relevance] : visited) {
-            const auto& parents = prog.cfg().parents_of(v_label);
-            if (parents.size() < 2) {
-                continue;
-            }
-            // Check that at least one predecessor is in the slice (this join is relevant)
-            bool has_slice_parent = false;
-            for (const auto& parent : parents) {
-                if (slice_labels.contains(parent)) {
-                    has_slice_parent = true;
-                    break;
-                }
-            }
-            if (!has_slice_parent) {
-                continue;
-            }
-            // Include the join-point label itself so the printing code can display
-            // per-predecessor state at this join.
-            if (!slice_labels.contains(v_label)) {
-                join_expansion[v_label] = v_relevance;
-            }
-            // Include all predecessors so the join display is complete.
-            // Use visited relevance if available, otherwise use the join-point's relevance.
-            for (const auto& parent : parents) {
-                if (slice_labels.contains(parent) || join_expansion.contains(parent)) {
-                    continue;
-                }
-                const auto& rel = visited.contains(parent) ? visited.at(parent) : v_relevance;
-                join_expansion[parent] = rel;
-            }
-        }
-        slice_labels.insert(join_expansion.begin(), join_expansion.end());
-
-        // Build the slice from contributing labels only
-        slice.relevance = std::move(slice_labels);
-        slices.push_back(std::move(slice));
+        slices.push_back(compute_slice_from_label(prog, label, initial_relevance, params.max_steps));
     }
 
     return slices;

--- a/src/result.cpp
+++ b/src/result.cpp
@@ -536,13 +536,21 @@ FailureSlice AnalysisResult::compute_slice_from_label(const Program& prog, const
 
             if (instruction_contributes) {
                 // Only include contributing labels in the output slice.
-                slice_labels[current_label] = relevant_before;
+                // Merge (not assign) because a label may be revisited from
+                // a different successor with additional relevance.
+                auto& existing = slice_labels[current_label];
+                existing.registers.insert(relevant_before.registers.begin(), relevant_before.registers.end());
+                existing.stack_offsets.insert(relevant_before.stack_offsets.begin(),
+                                             relevant_before.stack_offsets.end());
             }
         } else {
             // No deps available: conservatively treat this label as contributing
             // and propagate all current relevance to predecessors.
             relevant_before = relevant_after;
-            slice_labels[current_label] = relevant_before;
+            auto& existing = slice_labels[current_label];
+            existing.registers.insert(relevant_before.registers.begin(), relevant_before.registers.end());
+            existing.stack_offsets.insert(relevant_before.stack_offsets.begin(),
+                                         relevant_before.stack_offsets.end());
         }
 
         // Add predecessors to worklist
@@ -630,8 +638,10 @@ std::vector<FailureSlice> AnalysisResult::compute_failure_slices(const Program& 
             }
         }
         // Fallback: if no failing assertion was identified (shouldn't happen),
-        // or if the failing assertion has no register deps, aggregate all assertions.
-        if (!found_failing || initial_relevance.registers.empty()) {
+        // aggregate all assertions. When the failing assertion was found but has
+        // no register deps, leave the seed empty so compute_slice_from_label
+        // enters conservative mode.
+        if (!found_failing) {
             for (const auto& assertion : assertions) {
                 for (const auto& reg : extract_assertion_registers(assertion)) {
                     initial_relevance.registers.insert(reg);

--- a/src/result.hpp
+++ b/src/result.hpp
@@ -154,6 +154,18 @@ struct AnalysisResult {
     std::vector<FailureSlice> compute_failure_slices(const Program& prog) const {
         return compute_failure_slices(prog, SliceParams{});
     }
+
+    /// Compute a backward slice from an arbitrary label with a given seed relevance.
+    /// This is the general form used by both compute_failure_slices (for errors) and
+    /// the MCP server (for arbitrary-PC tracing).
+    /// @param prog The program CFG.
+    /// @param label The label to slice backward from.
+    /// @param seed_relevance The initial set of relevant registers/stack offsets.
+    /// @param max_steps Maximum worklist items to process.
+    /// @return A FailureSlice containing the impacted labels and per-label relevance.
+    [[nodiscard]]
+    FailureSlice compute_slice_from_label(const Program& prog, const Label& label, const RelevantState& seed_relevance,
+                                          size_t max_steps = 200) const;
 };
 
 void print_error(std::ostream& os, const VerificationError& error);

--- a/src/test/test_mcp.cpp
+++ b/src/test/test_mcp.cpp
@@ -950,15 +950,19 @@ TEST_CASE("engine invalidates session when options change", "[mcp][engine]") {
     bool failed1 = s1.failed;  // Save before session is replaced.
     REQUIRE(failed1 == false);  // Default: allow_division_by_zero = true.
 
-    const auto& s2 = engine.analyze(path, "", "", "", std::nullopt, false);
+    prevail::ebpf_verifier_options_t opts2 = ops.default_options();
+    opts2.allow_division_by_zero = false;
+    opts2.verbosity_opts.print_failures = true;
+    opts2.verbosity_opts.collect_instruction_deps = true;
+    const auto& s2 = engine.analyze(path, "", "", "", &opts2);
     REQUIRE(s2.failed == true);  // Now: allow_division_by_zero = false.
 }
 
-TEST_CASE("engine options getter reflects current state", "[mcp][engine]") {
+TEST_CASE("engine session_options reflects current state", "[mcp][engine]") {
     prevail::PrevailPlatformOps ops(&g_ebpf_platform_linux);
     prevail::AnalysisEngine engine(&ops);
 
-    auto initial = engine.options();
+    const auto& initial = engine.session_options();
     REQUIRE(initial.allow_division_by_zero == true);
 }
 

--- a/src/test/test_mcp.cpp
+++ b/src/test/test_mcp.cpp
@@ -1,0 +1,1193 @@
+// Copyright (c) Prevail Verifier contributors.
+// SPDX-License-Identifier: MIT
+
+#ifdef PREVAIL_HAS_MCP
+
+#include <catch2/catch_all.hpp>
+#include <climits>
+#include <filesystem>
+
+#include "analysis_engine.hpp"
+#include "mcp/json_serializers.hpp"
+#include "mcp/mcp_server.hpp"
+#include "mcp/mcp_transport.hpp"
+#include "platform_ops_prevail.hpp"
+#include "mcp/tools.hpp"
+
+#include "linux/gpl/spec_type_descriptors.hpp"
+
+using json = nlohmann::json;
+using namespace prevail;
+
+// ─── Test Harness ──────────────────────────────────────────────────────────────
+
+/// Reusable test harness that sets up a complete MCP server with all tools.
+struct McpTestHarness {
+    prevail::PrevailPlatformOps ops;
+    prevail::AnalysisEngine engine;
+    prevail::McpServer server;
+
+    McpTestHarness()
+        : ops(&g_ebpf_platform_linux), engine(&ops), server("test-server", "0.0.1") {
+        prevail::register_all_tools(server, engine);
+    }
+
+    /// Call a tool and return the parsed JSON result.
+    json call_tool(const std::string& name, const json& args = {}) {
+        auto response = server.dispatch("tools/call", {{"name", name}, {"arguments", args}});
+        auto text = response["content"][0]["text"].get<std::string>();
+        if (response.value("isError", false)) {
+            throw std::runtime_error(text);
+        }
+        return json::parse(text);
+    }
+
+    /// Call a tool and return the raw MCP response (for testing isError wrapping).
+    json call_tool_raw(const std::string& name, const json& args = {}) {
+        return server.dispatch("tools/call", {{"name", name}, {"arguments", args}});
+    }
+};
+
+/// Return sample path if the ELF file exists, otherwise SKIP.
+static std::string require_sample(const std::string& relative_path) {
+    if (!std::filesystem::exists(relative_path)) {
+        SKIP("Sample not found: " << relative_path);
+    }
+    return relative_path;
+}
+
+// ─── Protocol Tests ────────────────────────────────────────────────────────────
+
+TEST_CASE("MCP initialize returns protocol info", "[mcp][protocol]") {
+    McpTestHarness h;
+    auto result = h.server.dispatch("initialize", {});
+
+    REQUIRE(result["protocolVersion"].get<std::string>() == "2024-11-05");
+    REQUIRE(result["capabilities"]["tools"].is_object());
+    REQUIRE(result["serverInfo"]["name"] == "test-server");
+    REQUIRE(result["serverInfo"]["version"] == "0.0.1");
+}
+
+TEST_CASE("MCP tools/list returns all tools", "[mcp][protocol]") {
+    McpTestHarness h;
+    auto result = h.server.dispatch("tools/list", {});
+    auto tools = result["tools"];
+
+    REQUIRE(tools.is_array());
+
+    // Verify all expected tool names are present.
+    std::set<std::string> names;
+    for (const auto& t : tools) {
+        names.insert(t["name"].get<std::string>());
+        REQUIRE(t.contains("description"));
+        REQUIRE(t.contains("inputSchema"));
+    }
+    REQUIRE(names.count("list_programs"));
+    REQUIRE(names.count("verify_program"));
+    REQUIRE(names.count("get_invariant"));
+    REQUIRE(names.count("get_instruction"));
+    REQUIRE(names.count("get_errors"));
+    REQUIRE(names.count("get_cfg"));
+    REQUIRE(names.count("get_source_mapping"));
+    REQUIRE(names.count("check_constraint"));
+    REQUIRE(names.count("get_slice"));
+    REQUIRE(names.count("get_disassembly"));
+    REQUIRE(names.count("verify_assembly"));
+}
+
+TEST_CASE("MCP dispatch unknown method throws", "[mcp][protocol]") {
+    McpTestHarness h;
+    REQUIRE_THROWS_AS(h.server.dispatch("bogus/method", {}), std::runtime_error);
+}
+
+TEST_CASE("MCP dispatch unknown tool throws", "[mcp][protocol]") {
+    McpTestHarness h;
+    REQUIRE_THROWS_AS(
+        h.server.dispatch("tools/call", {{"name", "nonexistent_tool"}, {"arguments", {}}}),
+        std::runtime_error);
+}
+
+TEST_CASE("MCP notifications return null", "[mcp][protocol]") {
+    McpTestHarness h;
+    auto result = h.server.dispatch("notifications/initialized", {});
+    REQUIRE(result.is_null());
+}
+
+TEST_CASE("MCP tool exception produces isError response", "[mcp][protocol]") {
+    McpTestHarness h;
+    // Trigger a tool handler exception (missing required field).
+    auto response = h.call_tool_raw("verify_program", {});
+    REQUIRE(response.value("isError", false) == true);
+    auto text = response["content"][0]["text"].get<std::string>();
+    REQUIRE(text.find("Error:") != std::string::npos);
+}
+
+// ─── JSON Serializer Tests ─────────────────────────────────────────────────────
+
+TEST_CASE("label_to_json serializes correctly", "[mcp][serializer]") {
+    SECTION("simple label") {
+        Label label{5, -1, {}};
+        auto j = prevail::label_to_json(label);
+        REQUIRE(j["from"] == 5);
+        REQUIRE(j["to"] == -1);
+        REQUIRE_FALSE(j.contains("stack_frame_prefix"));
+        REQUIRE_FALSE(j.contains("special_label"));
+    }
+
+    SECTION("jump edge label") {
+        Label label{3, 10, {}};
+        auto j = prevail::label_to_json(label);
+        REQUIRE(j["from"] == 3);
+        REQUIRE(j["to"] == 10);
+    }
+
+    SECTION("label with stack frame") {
+        Label label{0, -1, "sub1/"};
+        auto j = prevail::label_to_json(label);
+        REQUIRE(j["stack_frame_prefix"] == "sub1/");
+    }
+
+    SECTION("exit label") {
+        auto j = prevail::label_to_json(Label::exit);
+        REQUIRE(j["from"] == INT_MAX);
+        REQUIRE(j["to"] == -1);
+    }
+}
+
+TEST_CASE("invariant_to_json serializes correctly", "[mcp][serializer]") {
+    SECTION("bottom invariant") {
+        auto j = prevail::invariant_to_json(StringInvariant::bottom());
+        REQUIRE(j.is_array());
+        REQUIRE(j.size() == 1);
+        REQUIRE(j[0] == "_|_");
+    }
+
+    SECTION("top invariant") {
+        auto j = prevail::invariant_to_json(StringInvariant::top());
+        REQUIRE(j.is_array());
+        REQUIRE(j.empty());
+    }
+
+    SECTION("non-empty invariant") {
+        std::set<std::string> constraints = {"r0.type=number", "r0.svalue=[0, 100]"};
+        auto j = prevail::invariant_to_json(StringInvariant{constraints});
+        REQUIRE(j.is_array());
+        REQUIRE(j.size() == 2);
+    }
+}
+
+TEST_CASE("interval_to_json serializes correctly", "[mcp][serializer]") {
+    auto j = prevail::interval_to_json(Interval::top());
+    REQUIRE(j.contains("text"));
+    REQUIRE(j["text"].is_string());
+}
+
+TEST_CASE("line_info_to_json serializes correctly", "[mcp][serializer]") {
+    btf_line_info_t info{"test.c", "int x = 0;", 42, 5};
+    auto j = prevail::line_info_to_json(info);
+    REQUIRE(j["file"] == "test.c");
+    REQUIRE(j["line"] == 42);
+    REQUIRE(j["column"] == 5);
+    REQUIRE(j["source"] == "int x = 0;");
+}
+
+TEST_CASE("error_to_json serializes correctly", "[mcp][serializer]") {
+    SECTION("error with location") {
+        VerificationError err("test error message");
+        err.where = Label{7, -1, {}};
+        auto j = prevail::error_to_json(err);
+        REQUIRE(j["message"] == "test error message");
+        REQUIRE(j["pc"] == 7);
+        REQUIRE(j["label"]["from"] == 7);
+    }
+
+    SECTION("error without location") {
+        VerificationError err("no location");
+        auto j = prevail::error_to_json(err);
+        REQUIRE(j["message"] == "no location");
+        REQUIRE_FALSE(j.contains("pc"));
+        REQUIRE_FALSE(j.contains("label"));
+    }
+}
+
+TEST_CASE("instruction_to_json produces text field", "[mcp][serializer]") {
+    Bin bin_add{Bin::Op::ADD, Reg{0}, Imm{1}, true, false};
+    Instruction inst = bin_add;
+    auto j = prevail::instruction_to_json(inst);
+    REQUIRE(j.contains("text"));
+    REQUIRE(j["text"].is_string());
+    REQUIRE_FALSE(j["text"].get<std::string>().empty());
+}
+
+TEST_CASE("assertion_to_json produces text field", "[mcp][serializer]") {
+    ValidDivisor vd{Reg{3}, false};
+    Assertion assertion = vd;
+    auto j = prevail::assertion_to_json(assertion);
+    REQUIRE(j.contains("text"));
+    REQUIRE(j["text"].is_string());
+    REQUIRE_FALSE(j["text"].get<std::string>().empty());
+}
+
+// ─── verify_assembly Tests ─────────────────────────────────────────────────────
+// These tests focus on tool-specific logic: assembly parsing, TLS/ProgramInfo setup,
+// option forwarding, observe plumbing, and error handling. Verifier semantics
+// (instruction behavior, type checking, map safety) are covered by the 726 YAML tests.
+
+TEST_CASE("verify_assembly: simple passing program", "[mcp][assembly]") {
+    McpTestHarness h;
+    auto result = h.call_tool("verify_assembly", {{"code", "r0 = 0\nexit"}});
+
+    REQUIRE(result["passed"] == true);
+    REQUIRE(result["errors"].empty());
+    REQUIRE(result["instruction_count"] == 2);
+    REQUIRE(result["post_invariant"].is_array());
+    REQUIRE(result["exit_value"].contains("text"));
+}
+
+TEST_CASE("verify_assembly: labels and jumps", "[mcp][assembly]") {
+    McpTestHarness h;
+    auto result = h.call_tool("verify_assembly", {
+        {"code",
+            "r0 = 1\n"
+            "if r0 == 0 goto <skip>\n"
+            "r0 = 42\n"
+            "<skip>:\n"
+            "exit"},
+    });
+
+    REQUIRE(result["passed"] == true);
+    REQUIRE(result["instruction_count"] == 4); // Labels don't count as instructions.
+}
+
+TEST_CASE("verify_assembly: custom pre-invariant", "[mcp][assembly]") {
+    McpTestHarness h;
+    // Without custom pre, r3 is uninitialized. With it, we define r3 as a number.
+    auto result = h.call_tool("verify_assembly", {
+        {"code", "r0 = r3\nexit"},
+        {"pre", json::array({"r3.type=number", "r3.svalue=99", "r3.uvalue=99"})},
+    });
+
+    REQUIRE(result["passed"] == true);
+}
+
+TEST_CASE("verify_assembly: observe at pc", "[mcp][assembly]") {
+    McpTestHarness h;
+    auto result = h.call_tool("verify_assembly", {
+        {"code", "r0 = 42\nexit"},
+        {"observe", json::array({
+            {{"pc", 1}, {"constraints", json::array({"r0.type=number"})}},
+        })},
+    });
+
+    REQUIRE(result["passed"] == true);
+    REQUIRE(result["observations"].is_array());
+    REQUIRE(result["observations"].size() == 1);
+    REQUIRE(result["observations"][0]["ok"] == true);
+}
+
+TEST_CASE("verify_assembly: observe at exit label", "[mcp][assembly]") {
+    McpTestHarness h;
+    auto result = h.call_tool("verify_assembly", {
+        {"code", "r0 = 0\nexit"},
+        {"observe", json::array({
+            {{"label", "exit"}, {"constraints", json::array({"r0.type=number"})}},
+        })},
+    });
+
+    REQUIRE(result["observations"][0]["ok"] == true);
+}
+
+TEST_CASE("verify_assembly: lddw wide instruction", "[mcp][assembly]") {
+    McpTestHarness h;
+    // lddw occupies 2 bytecode slots but is one instruction in the parsed sequence.
+    auto result = h.call_tool("verify_assembly", {
+        {"code", "r0 = 42 ll\nexit"},
+        {"observe", json::array({
+            {{"pc", 0}, {"constraints", json::array({"r0.type=number"})}},
+        })},
+    });
+
+    REQUIRE(result["passed"] == true);
+    REQUIRE(result["instruction_count"].get<int>() == 2);
+    REQUIRE(result["observations"].is_array());
+    REQUIRE(result["observations"][0]["ok"] == true);
+}
+
+TEST_CASE("verify_assembly: observe with unknown mode", "[mcp][assembly]") {
+    McpTestHarness h;
+    auto result = h.call_tool("verify_assembly", {
+        {"code", "r0 = 0\nexit"},
+        {"observe", json::array({
+            {{"pc", 0}, {"mode", "invalid_mode"}, {"constraints", json::array({"r0.type=number"})}},
+        })},
+    });
+
+    // Unknown mode should produce an error observation, not crash.
+    REQUIRE(result["observations"].is_array());
+    REQUIRE(result["observations"].size() == 1);
+    REQUIRE(result["observations"][0]["ok"] == false);
+    REQUIRE(result["observations"][0]["message"].get<std::string>().find("Unknown mode") != std::string::npos);
+}
+
+TEST_CASE("verify_assembly: program_type parameter", "[mcp][assembly]") {
+    McpTestHarness h;
+    for (const auto& type : {"xdp", "sk_skb", "socket_filter"}) {
+        DYNAMIC_SECTION("type: " << type) {
+            auto result = h.call_tool("verify_assembly", {
+                {"code", "r0 = 0\nexit"},
+                {"program_type", type},
+            });
+            REQUIRE(result["passed"] == true);
+        }
+    }
+}
+
+TEST_CASE("verify_assembly: helper call resolution", "[mcp][assembly]") {
+    McpTestHarness h;
+    // Tests the call N regex interception and make_call(func, *platform) routing.
+    auto result = h.call_tool("verify_assembly", {
+        {"code",
+            "r2 = r10\n"
+            "r2 += -4\n"
+            "*(u32 *)(r10 - 4) = r0\n"
+            "r1 = 1\n"
+            "r3 = r2\n"
+            "r4 = 0\n"
+            "call 2\n"  // bpf_map_update_elem
+            "r0 = 0\n"
+            "exit"},
+    });
+
+    REQUIRE(result.contains("passed"));
+    REQUIRE(result["instruction_count"] == 9);
+}
+
+TEST_CASE("verify_assembly: empty code is an error", "[mcp][assembly]") {
+    McpTestHarness h;
+    REQUIRE_THROWS(h.call_tool("verify_assembly", {{"code", ""}}));
+}
+
+TEST_CASE("verify_assembly: invalid instruction is an error", "[mcp][assembly]") {
+    McpTestHarness h;
+    REQUIRE_THROWS(h.call_tool("verify_assembly", {{"code", "not_a_valid_instruction"}}));
+}
+
+TEST_CASE("verify_assembly: verification options forwarding", "[mcp][assembly]") {
+    McpTestHarness h;
+
+    SECTION("allow_division_by_zero=true (default)") {
+        auto result = h.call_tool("verify_assembly", {
+            {"code", "r0 = 0\nr1 = 0\nr0 /= r1\nexit"},
+            {"pre", json::array({"r0.type=number", "r0.svalue=10", "r0.uvalue=10",
+                                 "r1.type=number", "r1.svalue=0", "r1.uvalue=0"})},
+            {"allow_division_by_zero", true},
+        });
+        REQUIRE(result["passed"] == true);
+    }
+
+    SECTION("allow_division_by_zero=false") {
+        auto result = h.call_tool("verify_assembly", {
+            {"code", "r0 = 0\nr1 = 0\nr0 /= r1\nexit"},
+            {"pre", json::array({"r0.type=number", "r0.svalue=10", "r0.uvalue=10",
+                                 "r1.type=number", "r1.svalue=0", "r1.uvalue=0"})},
+            {"allow_division_by_zero", false},
+        });
+        REQUIRE(result["passed"] == false);
+    }
+}
+
+TEST_CASE("verify_assembly: observe with unsupported label", "[mcp][assembly]") {
+    McpTestHarness h;
+    auto result = h.call_tool("verify_assembly", {
+        {"code", "r0 = 0\nexit"},
+        {"observe", json::array({
+            {{"label", "bogus"}, {"constraints", json::array({"r0.type=number"})}},
+        })},
+    });
+
+    // An unsupported label name is rejected with an error.
+    REQUIRE(result["observations"].is_array());
+    REQUIRE(result["observations"].size() == 1);
+    REQUIRE(result["observations"][0]["ok"] == false);
+    REQUIRE(result["observations"][0]["message"].get<std::string>().find("Unknown label") != std::string::npos);
+}
+
+// ─── list_programs ──────────────────────────────────────────────────────────────
+
+TEST_CASE("list_programs enumerates sections and functions", "[mcp][elf]") {
+    McpTestHarness h;
+    auto path = require_sample("ebpf-samples/build/twomaps.o");
+    auto result = h.call_tool("list_programs", {{"elf_path", path}});
+
+    REQUIRE(result["programs"].is_array());
+    REQUIRE_FALSE(result["programs"].empty());
+    for (const auto& prog : result["programs"]) {
+        REQUIRE(prog.contains("section"));
+        REQUIRE(prog.contains("function"));
+    }
+}
+
+// ─── verify_program ────────────────────────────────────────────────────────────
+
+TEST_CASE("verify_program on passing program", "[mcp][elf]") {
+    McpTestHarness h;
+    auto path = require_sample("ebpf-samples/build/stackok.o");
+    auto result = h.call_tool("verify_program", {{"elf_path", path}});
+
+    REQUIRE(result["passed"] == true);
+    REQUIRE(result["error_count"] == 0);
+    REQUIRE(result["instruction_count"] > 0);
+    REQUIRE(result["max_loop_count"].is_number());
+    REQUIRE(result["total_unreachable"].is_number());
+    REQUIRE(result.contains("exit_value"));
+    REQUIRE(result.contains("section"));
+    REQUIRE(result.contains("function"));
+    REQUIRE_FALSE(result.contains("first_error"));
+}
+
+TEST_CASE("verify_program on failing program", "[mcp][elf]") {
+    McpTestHarness h;
+    auto path = require_sample("ebpf-samples/build/badmapptr.o");
+    auto result = h.call_tool("verify_program", {{"elf_path", path}});
+
+    REQUIRE(result["passed"] == false);
+    REQUIRE(result["error_count"] > 0);
+    auto& fe = result["first_error"];
+    REQUIRE(fe.contains("message"));
+    REQUIRE(fe.contains("pc"));
+    REQUIRE(fe.contains("label"));
+}
+
+TEST_CASE("verify_program with nonexistent file is an error", "[mcp][elf]") {
+    McpTestHarness h;
+    REQUIRE_THROWS(h.call_tool("verify_program", {{"elf_path", "/nonexistent/file.o"}}));
+}
+
+TEST_CASE("verify_program with invalid section/program is an error", "[mcp][elf]") {
+    McpTestHarness h;
+    auto path = require_sample("ebpf-samples/build/stackok.o");
+    REQUIRE_THROWS(h.call_tool("verify_program", {
+        {"elf_path", path},
+        {"section", "nonexistent_section"},
+        {"program", "nonexistent_function"},
+    }));
+}
+
+TEST_CASE("verify_program: allow_division_by_zero option", "[mcp][elf]") {
+    McpTestHarness h;
+    auto path = require_sample("ebpf-samples/build/divzero.o");
+
+    SECTION("default allows division by zero") {
+        auto result = h.call_tool("verify_program", {{"elf_path", path}});
+        REQUIRE(result["passed"] == true);
+    }
+
+    SECTION("disabling division by zero causes failure") {
+        auto result = h.call_tool("verify_program", {
+            {"elf_path", path},
+            {"allow_division_by_zero", false},
+        });
+        REQUIRE(result["passed"] == false);
+    }
+}
+
+// ─── get_invariant ─────────────────────────────────────────────────────────────
+
+TEST_CASE("get_invariant: single PC returns flat result", "[mcp][elf]") {
+    McpTestHarness h;
+    auto path = require_sample("ebpf-samples/build/stackok.o");
+    auto result = h.call_tool("get_invariant", {{"elf_path", path}, {"pcs", json::array({0})}});
+
+    // Single PC returns flat (not wrapped in "results").
+    REQUIRE(result.contains("label"));
+    REQUIRE(result.contains("point"));
+    REQUIRE(result.contains("constraints"));
+    REQUIRE(result["constraints"].is_array());
+}
+
+TEST_CASE("get_invariant: batch returns results array", "[mcp][elf]") {
+    McpTestHarness h;
+    auto path = require_sample("ebpf-samples/build/stackok.o");
+    auto result = h.call_tool("get_invariant", {{"elf_path", path}, {"pcs", json::array({0, 1})}});
+
+    REQUIRE(result["results"].is_array());
+    REQUIRE(result["results"].size() == 2);
+    for (const auto& r : result["results"]) {
+        REQUIRE(r.contains("pc"));
+    }
+}
+
+TEST_CASE("get_invariant: invalid PC returns error field", "[mcp][elf]") {
+    McpTestHarness h;
+    auto path = require_sample("ebpf-samples/build/stackok.o");
+    auto result = h.call_tool("get_invariant", {{"elf_path", path}, {"pcs", json::array({9999})}});
+
+    REQUIRE(result.contains("error"));
+}
+
+TEST_CASE("get_invariant: pre and post points", "[mcp][elf]") {
+    McpTestHarness h;
+    auto path = require_sample("ebpf-samples/build/stackok.o");
+
+    auto pre = h.call_tool("get_invariant", {{"elf_path", path}, {"pcs", json::array({0})}, {"point", "pre"}});
+    auto post = h.call_tool("get_invariant", {{"elf_path", path}, {"pcs", json::array({0})}, {"point", "post"}});
+
+    REQUIRE(pre["point"] == "pre");
+    REQUIRE(post["point"] == "post");
+}
+
+TEST_CASE("get_invariant: branch PC returns multi-label", "[mcp][elf]") {
+    McpTestHarness h;
+    auto path = require_sample("ebpf-samples/build/correlated_branch.o");
+    // correlated_branch.o has branches — find a branch PC from the CFG.
+    auto cfg = h.call_tool("get_cfg", {{"elf_path", path}, {"format", "json"}});
+    // Find a block with multiple successors (a branch point).
+    int branch_pc = -1;
+    for (const auto& bb : cfg["basic_blocks"]) {
+        if (bb["successors"].size() > 1) {
+            branch_pc = bb["last_pc"].get<int>();
+            break;
+        }
+    }
+    REQUIRE(branch_pc >= 0);
+
+    auto result = h.call_tool("get_invariant", {{"elf_path", path}, {"pcs", json::array({branch_pc})}});
+    // A branch PC has both the sequential label and jump-edge label,
+    // so it may return the multi-label format with a "labels" array,
+    // or a single result if only one label has invariant data.
+    REQUIRE((result.contains("constraints") || result.contains("labels")));
+}
+
+// ─── get_instruction ───────────────────────────────────────────────────────────
+
+TEST_CASE("get_instruction: full response shape", "[mcp][elf]") {
+    McpTestHarness h;
+    auto path = require_sample("ebpf-samples/build/stackok.o");
+    auto result = h.call_tool("get_instruction", {{"elf_path", path}, {"pcs", json::array({0})}});
+
+    auto& inst = result["results"][0];
+    REQUIRE(inst["pc"] == 0);
+    REQUIRE(inst["text"].is_string());
+    REQUIRE(inst["assertions"].is_array());
+    REQUIRE(inst["pre_invariant"].is_array());
+    REQUIRE(inst["successors"].is_array());
+    REQUIRE(inst["predecessors"].is_array());
+    // post_invariant is either array or null (null = bottom/unreachable).
+    REQUIRE((inst["post_invariant"].is_array() || inst["post_invariant"].is_null()));
+}
+
+TEST_CASE("get_instruction: batch with valid and invalid PCs", "[mcp][elf]") {
+    McpTestHarness h;
+    auto path = require_sample("ebpf-samples/build/stackok.o");
+    auto result = h.call_tool("get_instruction", {{"elf_path", path}, {"pcs", json::array({0, 9999})}});
+
+    REQUIRE(result["results"].size() == 2);
+    REQUIRE(result["results"][0].contains("text"));     // Valid PC succeeds.
+    REQUIRE(result["results"][1].contains("error"));     // Invalid PC returns error.
+}
+
+TEST_CASE("get_instruction: error field on failing instruction", "[mcp][elf]") {
+    McpTestHarness h;
+    auto path = require_sample("ebpf-samples/build/badmapptr.o");
+    // First find the error PC.
+    auto verify = h.call_tool("verify_program", {{"elf_path", path}});
+    int error_pc = verify["first_error"]["pc"].get<int>();
+
+    auto result = h.call_tool("get_instruction", {{"elf_path", path}, {"pcs", json::array({error_pc})}});
+    auto& inst = result["results"][0];
+    REQUIRE(inst.contains("error"));
+    REQUIRE(inst["error"].is_string());
+}
+
+// ─── get_errors ────────────────────────────────────────────────────────────────
+
+TEST_CASE("get_errors: passing program has empty arrays", "[mcp][elf]") {
+    McpTestHarness h;
+    auto path = require_sample("ebpf-samples/build/stackok.o");
+    auto result = h.call_tool("get_errors", {{"elf_path", path}});
+
+    REQUIRE(result["passed"] == true);
+    REQUIRE(result["errors"].empty());
+    REQUIRE(result["unreachable"].is_array());
+}
+
+TEST_CASE("get_errors: failing program error entry structure", "[mcp][elf]") {
+    McpTestHarness h;
+    auto path = require_sample("ebpf-samples/build/badmapptr.o");
+    auto result = h.call_tool("get_errors", {{"elf_path", path}});
+
+    REQUIRE(result["passed"] == false);
+    REQUIRE(result["unreachable"].is_array());
+    auto& err = result["errors"][0];
+    REQUIRE(err.contains("message"));
+    REQUIRE(err.contains("pc"));
+    REQUIRE(err.contains("label"));
+    REQUIRE(err.contains("pre_invariant"));
+    REQUIRE(err["pre_invariant"].is_array());
+    REQUIRE(err.contains("instruction"));
+    REQUIRE(err["instruction"].is_string());
+}
+
+// ─── get_cfg ───────────────────────────────────────────────────────────────────
+
+TEST_CASE("get_cfg: json format with branching program", "[mcp][elf]") {
+    McpTestHarness h;
+    auto path = require_sample("ebpf-samples/build/correlated_branch.o");
+    auto result = h.call_tool("get_cfg", {{"elf_path", path}, {"format", "json"}});
+
+    REQUIRE(result["format"] == "json");
+    auto& blocks = result["basic_blocks"];
+    REQUIRE(blocks.is_array());
+    REQUIRE(blocks.size() > 1); // Branching program must have multiple blocks.
+
+    // Every block has required fields.
+    for (const auto& bb : blocks) {
+        REQUIRE(bb.contains("first_pc"));
+        REQUIRE(bb.contains("last_pc"));
+        REQUIRE(bb["pcs"].is_array());
+        REQUIRE_FALSE(bb["pcs"].empty());
+        REQUIRE(bb["successors"].is_array());
+    }
+
+    // At least one block must have multiple successors (a branch).
+    bool found_branch = false;
+    for (const auto& bb : blocks) {
+        if (bb["successors"].size() > 1) {
+            found_branch = true;
+            break;
+        }
+    }
+    REQUIRE(found_branch);
+}
+
+TEST_CASE("get_cfg: dot format", "[mcp][elf]") {
+    McpTestHarness h;
+    auto path = require_sample("ebpf-samples/build/stackok.o");
+    auto result = h.call_tool("get_cfg", {{"elf_path", path}, {"format", "dot"}});
+
+    REQUIRE(result["format"] == "dot");
+    auto dot = result["dot"].get<std::string>();
+    REQUIRE(dot.find("digraph program") != std::string::npos);
+    REQUIRE(dot.find("->") != std::string::npos); // Must have edges.
+}
+
+// ─── get_disassembly ───────────────────────────────────────────────────────────
+
+TEST_CASE("get_disassembly: full listing", "[mcp][elf]") {
+    McpTestHarness h;
+    auto path = require_sample("ebpf-samples/build/stackok.o");
+    auto result = h.call_tool("get_disassembly", {{"elf_path", path}});
+
+    REQUIRE(result["instructions"].is_array());
+    REQUIRE(result["count"].get<int>() == static_cast<int>(result["instructions"].size()));
+    REQUIRE(result["count"] > 0);
+
+    // PCs must be monotonically non-decreasing.
+    int prev_pc = -1;
+    for (const auto& inst : result["instructions"]) {
+        REQUIRE(inst.contains("pc"));
+        REQUIRE(inst.contains("text"));
+        REQUIRE(inst["pc"].get<int>() > prev_pc);
+        prev_pc = inst["pc"].get<int>();
+    }
+}
+
+TEST_CASE("get_disassembly: range filtering", "[mcp][elf]") {
+    McpTestHarness h;
+    auto path = require_sample("ebpf-samples/build/stackok.o");
+    auto result = h.call_tool("get_disassembly", {{"elf_path", path}, {"from_pc", 1}, {"to_pc", 3}});
+
+    for (const auto& inst : result["instructions"]) {
+        int pc = inst["pc"].get<int>();
+        REQUIRE(pc >= 1);
+        REQUIRE(pc <= 3);
+    }
+}
+
+// ─── get_source_mapping ────────────────────────────────────────────────────────
+
+TEST_CASE("get_source_mapping: full map with BTF", "[mcp][elf]") {
+    McpTestHarness h;
+    auto path = require_sample("ebpf-samples/build/twomaps_btf.o");
+    auto result = h.call_tool("get_source_mapping", {{"elf_path", path}});
+
+    REQUIRE(result.contains("entries"));
+    REQUIRE(result["entries"].is_array());
+    REQUIRE_FALSE(result["entries"].empty());
+    auto& first = result["entries"][0];
+    REQUIRE(first.contains("pc"));
+    REQUIRE(first["source"].contains("file"));
+    REQUIRE(first["source"].contains("line"));
+}
+
+TEST_CASE("get_source_mapping: query by PC", "[mcp][elf]") {
+    McpTestHarness h;
+    auto path = require_sample("ebpf-samples/build/twomaps_btf.o");
+
+    SECTION("PC with BTF info") {
+        auto result = h.call_tool("get_source_mapping", {{"elf_path", path}, {"pc", 0}});
+        REQUIRE(result["pc"] == 0);
+        REQUIRE(result["source"].contains("file"));
+        REQUIRE(result["source"].contains("line"));
+        REQUIRE(result.contains("instruction"));
+    }
+
+    SECTION("PC without BTF info") {
+        // Use a high PC that likely has no line info.
+        auto result = h.call_tool("get_source_mapping", {{"elf_path", path}, {"pc", 9999}});
+        REQUIRE(result["source"].is_null());
+        REQUIRE(result.contains("note"));
+    }
+}
+
+TEST_CASE("get_source_mapping: query by source line", "[mcp][elf]") {
+    McpTestHarness h;
+    auto path = require_sample("ebpf-samples/build/twomaps_btf.o");
+    // First get the full map to find a real line number.
+    auto full = h.call_tool("get_source_mapping", {{"elf_path", path}});
+    REQUIRE_FALSE(full["entries"].empty());
+    int line = full["entries"][0]["source"]["line"].get<int>();
+
+    auto result = h.call_tool("get_source_mapping", {{"elf_path", path}, {"source_line", line}});
+    REQUIRE(result["source_line"] == line);
+    REQUIRE(result["matches"].is_array());
+    REQUIRE_FALSE(result["matches"].empty());
+    REQUIRE(result["matches"][0].contains("pc"));
+}
+
+TEST_CASE("get_source_mapping: no-BTF program returns note", "[mcp][elf]") {
+    McpTestHarness h;
+    auto path = require_sample("ebpf-samples/build/stackok.o");
+    auto result = h.call_tool("get_source_mapping", {{"elf_path", path}});
+
+    // stackok.o has no BTF — should get note + empty entries.
+    REQUIRE(result.contains("entries"));
+    REQUIRE(result["entries"].is_array());
+    if (result["entries"].empty()) {
+        REQUIRE(result.contains("note"));
+    }
+}
+
+// ─── check_constraint ──────────────────────────────────────────────────────────
+
+TEST_CASE("check_constraint: consistent mode true", "[mcp][elf]") {
+    McpTestHarness h;
+    auto path = require_sample("ebpf-samples/build/stackok.o");
+    auto result = h.call_tool("check_constraint", {
+        {"elf_path", path}, {"pc", 0},
+        {"constraints", json::array({"r1.type=ctx"})},
+        {"mode", "consistent"},
+    });
+
+    REQUIRE(result["ok"] == true);
+    REQUIRE(result.contains("invariant"));
+    REQUIRE(result["invariant"].is_array());
+}
+
+TEST_CASE("check_constraint: proven mode", "[mcp][elf]") {
+    McpTestHarness h;
+    auto path = require_sample("ebpf-samples/build/stackok.o");
+
+    SECTION("proven true") {
+        auto result = h.call_tool("check_constraint", {
+            {"elf_path", path}, {"pc", 0},
+            {"constraints", json::array({"r1.type=ctx"})},
+            {"mode", "proven"},
+        });
+        REQUIRE(result["ok"] == true);
+    }
+
+    SECTION("proven false") {
+        auto result = h.call_tool("check_constraint", {
+            {"elf_path", path}, {"pc", 0},
+            {"constraints", json::array({"r1.type=number"})},
+            {"mode", "proven"},
+        });
+        REQUIRE(result["ok"] == false);
+        REQUIRE_FALSE(result["message"].get<std::string>().empty());
+    }
+}
+
+TEST_CASE("check_constraint: post point", "[mcp][elf]") {
+    McpTestHarness h;
+    auto path = require_sample("ebpf-samples/build/stackok.o");
+    auto result = h.call_tool("check_constraint", {
+        {"elf_path", path}, {"pc", 0}, {"point", "post"},
+        {"constraints", json::array({"r10.type=stack"})},
+    });
+
+    REQUIRE(result["ok"] == true);
+}
+
+TEST_CASE("check_constraint: entailed mode", "[mcp][elf]") {
+    McpTestHarness h;
+    auto path = require_sample("ebpf-samples/build/stackok.o");
+    auto result = h.call_tool("check_constraint", {
+        {"elf_path", path}, {"pc", 0},
+        {"constraints", json::array({"r1.type=ctx"})},
+        {"mode", "entailed"},
+    });
+
+    // Entailed checks if observation is a sub-state of the invariant.
+    REQUIRE(result.contains("ok"));
+    REQUIRE(result["ok"].is_boolean());
+}
+
+TEST_CASE("check_constraint: batch with per-check overrides", "[mcp][elf]") {
+    McpTestHarness h;
+    auto path = require_sample("ebpf-samples/build/stackok.o");
+    auto result = h.call_tool("check_constraint", {
+        {"elf_path", path},
+        {"checks", json::array({
+            {{"pc", 0}, {"constraints", json::array({"r1.type=ctx"})}, {"mode", "proven"}},
+            {{"pc", 0}, {"constraints", json::array({"r1.type=number"})}, {"mode", "proven"}},
+            {{"pc", 0}, {"constraints", json::array({"r10.type=stack"})}, {"point", "post"}},
+        })},
+    });
+
+    REQUIRE(result["results"].size() == 3);
+    REQUIRE(result["results"][0]["ok"] == true);   // r1 is ctx (proven).
+    REQUIRE(result["results"][1]["ok"] == false);   // r1 is not number.
+    REQUIRE(result["results"][2]["ok"] == true);     // r10 is stack at post.
+}
+
+TEST_CASE("check_constraint: invalid PC returns structured error", "[mcp][elf]") {
+    McpTestHarness h;
+    auto path = require_sample("ebpf-samples/build/stackok.o");
+    auto result = h.call_tool("check_constraint", {
+        {"elf_path", path}, {"pc", 9999},
+        {"constraints", json::array({"r0.type=number"})},
+    });
+
+    REQUIRE(result["ok"] == false);
+    REQUIRE_FALSE(result["message"].get<std::string>().empty());
+}
+
+// ─── get_slice ─────────────────────────────────────────────────────────────────
+
+TEST_CASE("get_slice: error slice structure", "[mcp][elf]") {
+    McpTestHarness h;
+    auto path = require_sample("ebpf-samples/build/badmapptr.o");
+    auto result = h.call_tool("get_slice", {{"elf_path", path}});
+
+    // Top-level fields.
+    REQUIRE(result["pc"].is_number());
+    REQUIRE(result["instruction"].is_string());
+    REQUIRE(result["pre_invariant"].is_array());
+    REQUIRE(result["assertions"].is_array());
+    REQUIRE(result["error"]["message"].is_string());
+    REQUIRE(result["error"].contains("pc"));
+
+    // Failure slice entries.
+    auto& slice = result["failure_slice"];
+    REQUIRE(slice.is_array());
+    REQUIRE_FALSE(slice.empty());
+    for (const auto& step : slice) {
+        REQUIRE(step.contains("pc"));
+        REQUIRE(step.contains("text"));
+        REQUIRE(step["text"].is_string());
+        // post_invariant is optional but when present must be array.
+        if (step.contains("post_invariant")) {
+            REQUIRE(step["post_invariant"].is_array());
+        }
+    }
+}
+
+TEST_CASE("get_slice: pc query on passing program", "[mcp][elf]") {
+    McpTestHarness h;
+    auto path = require_sample("ebpf-samples/build/stackok.o");
+    auto result = h.call_tool("get_slice", {{"elf_path", path}, {"pc", 0}});
+
+    REQUIRE(result["pc"] == 0);
+    REQUIRE(result.contains("instruction"));
+    REQUIRE(result.contains("pre_invariant"));
+    REQUIRE(result.contains("failure_slice"));
+    REQUIRE_FALSE(result.contains("error")); // No error on passing program.
+}
+
+TEST_CASE("get_slice: invalid error_index throws", "[mcp][elf]") {
+    McpTestHarness h;
+    auto path = require_sample("ebpf-samples/build/badmapptr.o");
+    REQUIRE_THROWS(h.call_tool("get_slice", {{"elf_path", path}, {"error_index", 999}}));
+}
+
+// ─── Engine Session Tests ──────────────────────────────────────────────────────
+
+TEST_CASE("engine reuses session for same program", "[mcp][engine]") {
+    auto path = require_sample("ebpf-samples/build/stackok.o");
+
+    prevail::PrevailPlatformOps ops(&g_ebpf_platform_linux);
+    prevail::AnalysisEngine engine(&ops);
+
+    const auto& s1 = engine.analyze(path);
+    const auto& s2 = engine.analyze(path);
+
+    // Same reference means same session object (no re-analysis).
+    REQUIRE(&s1 == &s2);
+}
+
+TEST_CASE("engine invalidates session for different program", "[mcp][engine]") {
+    auto path1 = require_sample("ebpf-samples/build/stackok.o");
+    auto path2 = require_sample("ebpf-samples/build/badmapptr.o");
+
+    prevail::PrevailPlatformOps ops(&g_ebpf_platform_linux);
+    prevail::AnalysisEngine engine(&ops);
+
+    const auto& s1 = engine.analyze(path1);
+    auto elf1 = s1.elf_path;  // Save before session is replaced.
+
+    const auto& s2 = engine.analyze(path2);
+    REQUIRE(elf1 != s2.elf_path);
+}
+
+TEST_CASE("engine invalidates session when options change", "[mcp][engine]") {
+    auto path = require_sample("ebpf-samples/build/divzero.o");
+
+    prevail::PrevailPlatformOps ops(&g_ebpf_platform_linux);
+    prevail::AnalysisEngine engine(&ops);
+
+    const auto& s1 = engine.analyze(path);
+    bool failed1 = s1.failed;  // Save before session is replaced.
+    REQUIRE(failed1 == false);  // Default: allow_division_by_zero = true.
+
+    const auto& s2 = engine.analyze(path, "", "", "", std::nullopt, false);
+    REQUIRE(s2.failed == true);  // Now: allow_division_by_zero = false.
+}
+
+TEST_CASE("engine options getter reflects current state", "[mcp][engine]") {
+    prevail::PrevailPlatformOps ops(&g_ebpf_platform_linux);
+    prevail::AnalysisEngine engine(&ops);
+
+    auto initial = engine.options();
+    REQUIRE(initial.allow_division_by_zero == true);
+}
+
+// ─── Error Handling Tests ──────────────────────────────────────────────────────
+
+TEST_CASE("verify_assembly: missing required 'code' field", "[mcp][error]") {
+    McpTestHarness h;
+    REQUIRE_THROWS(h.call_tool("verify_assembly", {}));
+}
+
+TEST_CASE("get_invariant: missing required fields", "[mcp][error]") {
+    McpTestHarness h;
+    auto path = require_sample("ebpf-samples/build/stackok.o");
+    REQUIRE_THROWS(h.call_tool("get_invariant", {{"elf_path", path}}));
+}
+
+// ─── Transport Tests ───────────────────────────────────────────────────────────
+
+/// RAII helper to redirect std::cin to a string and restore it afterward.
+/// Not thread-safe: modifies the global std::cin streambuf.
+struct CinRedirect {
+    std::istringstream fake_in;
+    std::streambuf* original;
+
+    explicit CinRedirect(const std::string& input) : fake_in(input), original(std::cin.rdbuf(fake_in.rdbuf())) {}
+    ~CinRedirect() {
+        std::cin.rdbuf(original);
+        std::cin.clear(); // Reset EOF/error flags set by the fake stream.
+    }
+    CinRedirect(const CinRedirect&) = delete;
+    CinRedirect& operator=(const CinRedirect&) = delete;
+};
+
+/// RAII wrapper for a temporary FILE* (from tmpfile()).
+struct TempFile {
+    FILE* f;
+    TempFile() : f(tmpfile()) {}
+    ~TempFile() { if (f) fclose(f); }
+    TempFile(const TempFile&) = delete;
+    TempFile& operator=(const TempFile&) = delete;
+    operator FILE*() const { return f; }
+};
+
+/// Read all content from a FILE* (rewound to start).
+static std::string read_file(FILE* f) {
+    fflush(f);
+    rewind(f);
+    std::string result;
+    char buf[4096];
+    size_t n;
+    while ((n = fread(buf, 1, sizeof(buf), f)) > 0) {
+        result.append(buf, n);
+    }
+    return result;
+}
+
+TEST_CASE("transport: NDJSON read and write", "[mcp][transport]") {
+    json msg = {{"jsonrpc", "2.0"}, {"method", "test"}, {"id", 1}};
+    std::string input = msg.dump() + "\n";
+
+    CinRedirect redir(input);
+    TempFile out;
+    REQUIRE(out.f != nullptr);
+
+    prevail::McpTransport transport(out);
+
+    auto read = transport.read_message();
+    REQUIRE_FALSE(read.is_null());
+    REQUIRE(read["method"] == "test");
+    REQUIRE(read["id"] == 1);
+
+    json response = {{"jsonrpc", "2.0"}, {"id", 1}, {"result", "ok"}};
+    transport.write_message(response);
+
+    std::string written = read_file(out);
+    REQUIRE_FALSE(written.empty());
+    REQUIRE(written.back() == '\n');
+    auto parsed = json::parse(written);
+    REQUIRE(parsed["result"] == "ok");
+}
+
+TEST_CASE("transport: Content-Length read and write", "[mcp][transport]") {
+    json msg = {{"jsonrpc", "2.0"}, {"method", "test"}, {"id", 2}};
+    std::string body = msg.dump();
+    std::string input = "Content-Length: " + std::to_string(body.size()) + "\r\n\r\n" + body;
+
+    CinRedirect redir(input);
+    TempFile out;
+    REQUIRE(out.f != nullptr);
+
+    prevail::McpTransport transport(out);
+
+    auto read = transport.read_message();
+    REQUIRE_FALSE(read.is_null());
+    REQUIRE(read["method"] == "test");
+
+    json response = {{"jsonrpc", "2.0"}, {"id", 2}, {"result", "ok"}};
+    transport.write_message(response);
+
+    std::string written = read_file(out);
+    REQUIRE(written.find("Content-Length: ") == 0);
+    REQUIRE(written.find("\r\n\r\n") != std::string::npos);
+    auto body_start = written.find("\r\n\r\n") + 4;
+    auto parsed = json::parse(written.substr(body_start));
+    REQUIRE(parsed["result"] == "ok");
+}
+
+TEST_CASE("transport: EOF returns null", "[mcp][transport]") {
+    CinRedirect redir("");
+    TempFile out;
+    REQUIRE(out.f != nullptr);
+
+    prevail::McpTransport transport(out);
+    auto read = transport.read_message();
+    REQUIRE(read.is_null());
+}
+
+TEST_CASE("transport: NDJSON skips blank lines", "[mcp][transport]") {
+    json msg = {{"jsonrpc", "2.0"}, {"method", "test"}, {"id", 1}};
+    std::string input = "\n\n" + msg.dump() + "\n";
+
+    CinRedirect redir(input);
+    TempFile out;
+    REQUIRE(out.f != nullptr);
+
+    prevail::McpTransport transport(out);
+    auto read = transport.read_message();
+    REQUIRE_FALSE(read.is_null());
+    REQUIRE(read["method"] == "test");
+}
+
+TEST_CASE("transport: Content-Length ignores extra headers", "[mcp][transport]") {
+    json msg = {{"jsonrpc", "2.0"}, {"method", "test"}, {"id", 1}};
+    std::string body = msg.dump();
+    std::string input = "Content-Type: application/json\r\n"
+                        "Content-Length: " + std::to_string(body.size()) + "\r\n"
+                        "X-Custom: ignored\r\n"
+                        "\r\n" + body;
+
+    CinRedirect redir(input);
+    TempFile out;
+    REQUIRE(out.f != nullptr);
+
+    prevail::McpTransport transport(out);
+    auto read = transport.read_message();
+    REQUIRE_FALSE(read.is_null());
+    REQUIRE(read["method"] == "test");
+}
+
+TEST_CASE("transport: Content-Length with truncated body returns null", "[mcp][transport]") {
+    // Declare 100 bytes but only provide 10.
+    std::string input = "Content-Length: 100\r\n\r\n0123456789";
+
+    CinRedirect redir(input);
+    TempFile out;
+    REQUIRE(out.f != nullptr);
+
+    prevail::McpTransport transport(out);
+    auto read = transport.read_message();
+    REQUIRE(read.is_null());
+}
+
+TEST_CASE("transport: malformed JSON returns null", "[mcp][transport]") {
+    std::string input = "not valid json\n";
+
+    CinRedirect redir(input);
+    TempFile out;
+    REQUIRE(out.f != nullptr);
+
+    prevail::McpTransport transport(out);
+    auto read = transport.read_message();
+    REQUIRE(read.is_null());
+}
+
+TEST_CASE("transport: run dispatches requests and writes responses", "[mcp][transport]") {
+    json req1 = {{"jsonrpc", "2.0"}, {"id", 1}, {"method", "echo"}, {"params", {{"x", 42}}}};
+    json req2 = {{"jsonrpc", "2.0"}, {"method", "notify"}, {"params", {}}};
+    std::string input = req1.dump() + "\n" + req2.dump() + "\n";
+
+    CinRedirect redir(input);
+    TempFile out;
+    REQUIRE(out.f != nullptr);
+
+    prevail::McpTransport transport(out);
+
+    int call_count = 0;
+    transport.run([&](const std::string& method, const json& params) -> json {
+        call_count++;
+        if (method == "echo") {
+            return {{"echoed", params["x"]}};
+        }
+        return nullptr;
+    });
+
+    REQUIRE(call_count == 2);
+
+    std::string written = read_file(out);
+    std::istringstream lines(written);
+    std::string line;
+    int response_count = 0;
+    while (std::getline(lines, line)) {
+        if (line.empty()) continue;
+        auto resp = json::parse(line);
+        REQUIRE(resp["jsonrpc"] == "2.0");
+        REQUIRE(resp["id"] == 1);
+        REQUIRE(resp["result"]["echoed"] == 42);
+        response_count++;
+    }
+    REQUIRE(response_count == 1);
+}
+
+TEST_CASE("transport: run sends error response on handler throw", "[mcp][transport]") {
+    json req = {{"jsonrpc", "2.0"}, {"id", 5}, {"method", "fail"}, {"params", {}}};
+    std::string input = req.dump() + "\n";
+
+    CinRedirect redir(input);
+    TempFile out;
+    REQUIRE(out.f != nullptr);
+
+    prevail::McpTransport transport(out);
+    transport.run([&](const std::string&, const json&) -> json {
+        throw std::runtime_error("test error");
+    });
+
+    std::string written = read_file(out);
+    auto resp = json::parse(written);
+    REQUIRE(resp["id"] == 5);
+    REQUIRE(resp["error"]["code"] == -32603);
+    REQUIRE(resp["error"]["message"] == "test error");
+}
+
+#endif // PREVAIL_HAS_MCP


### PR DESCRIPTION
JSON-RPC 2.0 server over stdio that exposes PREVAIL verification results as MCP tools. Uses the AnalysisEngine from the core library.

Transport: Auto-detects Content-Length framing (VS Code) or NDJSON (GitHub Copilot CLI).

Tools:

- list_programs — List programs in an ELF file
- verify_program — Quick pass/fail with error summary
- verify_assembly — Verify inline BPF assembly text
- get_slice — Backward slice from an error or arbitrary PC
- get_invariant — Pre/post abstract state at one or more PCs
- get_instruction — Full detail: disassembly, assertions, invariants, source, CFG neighbors
- get_errors — All errors with pre-invariants and source lines
- get_cfg — Control-flow graph (JSON or DOT)
- get_disassembly — Instruction listing with source lines
- get_source_mapping — Bidirectional C source ↔ BPF instruction mapping
- check_constraint — Test if constraints are consistent with / proven by verifier state

Build: Gated behind prevail_ENABLE_MCP (OFF by default). Fetches nlohmann_json v3.12.0 via FetchContent when enabled.

Tests: 74 test cases (521 assertions) covering transport framing, protocol semantics, JSON serialization, all tools, engine session behavior, and error cases.

Depends on #1061 (compute_slice_from_label) and #1062 (AnalysisEngine).

Files:

 - src/mcp/ — transport, server, tools, serializers, docs
 - src/prevail_mcp.cpp — entry point
 - src/test/test_mcp.cpp — tests
 - CMakeLists.txt — prevail_ENABLE_MCP option and targets


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional MCP server executable and toolset exposing verifier analysis over JSON‑RPC; new build option to enable it.
  * Live analysis endpoints: program listing, verification, invariant queries, constraint checks (multiple modes), failure slicing, CFG/disassembly, and source mapping.

* **Documentation**
  * New MCP server docs, tool reference, usage examples, and updated LLM‑context diagnostic workflows (README and docs updates).

* **Tests**
  * Comprehensive MCP protocol, transport, serialization, and analysis test suite.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->