### PR TITLE
Add map name in `EbpfMapDescriptor`, and make map related functions public in `EbpfDomain`

### DIFF
--- a/src/crab/ebpf_domain.hpp
+++ b/src/crab/ebpf_domain.hpp
@@ -87,11 +87,6 @@ class EbpfDomain final {
     [[nodiscard]]
     std::optional<int64_t> get_stack_offset(const Reg& reg) const;
 
-  private:
-    // private generic domain functions
-    void add_value_constraint(const LinearConstraint& cst);
-    void havoc(Variable var);
-
     [[nodiscard]]
     std::optional<uint32_t> get_map_type(const Reg& map_fd_reg) const;
     [[nodiscard]]
@@ -104,6 +99,11 @@ class EbpfDomain final {
     Interval get_map_max_entries(const Reg& map_fd_reg) const;
 
     bool get_map_fd_range(const Reg& map_fd_reg, int32_t* start_fd, int32_t* end_fd) const;
+
+  private:
+    // private generic domain functions
+    void add_value_constraint(const LinearConstraint& cst);
+    void havoc(Variable var);
 
     /// Type + numeric tracking
     TypeToNumDomain state;

--- a/src/io/elf_map_parser.cpp
+++ b/src/io/elf_map_parser.cpp
@@ -55,6 +55,7 @@ void add_global_variable_maps(const ELFIO::elfio& reader, ElfGlobalData& global,
             .value_size = gsl::narrow<uint32_t>(section->get_size()),
             .max_entries = 1,
             .inner_map_fd = DEFAULT_MAP_FD,
+            .name = section->get_name(),
         });
 
         global.variable_section_indices.insert(section->get_index());

--- a/src/io/elf_map_parser.cpp
+++ b/src/io/elf_map_parser.cpp
@@ -91,6 +91,7 @@ ElfGlobalData parse_btf_section(const parse_params_t& parse_params, const ELFIO:
                 .value_size = map.value_size,
                 .max_entries = map.max_entries,
                 .inner_map_fd = map.inner_map_type_id == 0 ? DEFAULT_MAP_FD : gsl::narrow<int>(map.inner_map_type_id),
+                .name = map.name,
             });
         }
     } catch (const std::exception& e) {
@@ -139,6 +140,7 @@ ElfGlobalData create_global_variable_maps(const ELFIO::elfio& reader) {
             .value_size = gsl::narrow<uint32_t>(section->get_size()),
             .max_entries = 1,
             .inner_map_fd = DEFAULT_MAP_FD,
+            .name = section->get_name(),
         });
 
         global.variable_section_indices.insert(section->get_index());
@@ -267,6 +269,7 @@ ElfGlobalData parse_map_sections(const parse_params_t& parse_params, const ELFIO
         }
 
         map_offsets[sym_details.name] = descriptor_index;
+        global.map_descriptors[descriptor_index].name = sym_details.name;
     }
 
     for (const auto section : global_sections(reader)) {
@@ -278,6 +281,7 @@ ElfGlobalData parse_map_sections(const parse_params_t& parse_params, const ELFIO
             .value_size = gsl::narrow<uint32_t>(section->get_size()),
             .max_entries = 1,
             .inner_map_fd = DEFAULT_MAP_FD,
+            .name = section->get_name(),
         });
         global.variable_section_indices.insert(section->get_index());
     }

--- a/src/printing.cpp
+++ b/src/printing.cpp
@@ -714,7 +714,8 @@ void print(const InstructionSeq& insts, std::ostream& out, const std::optional<c
 std::ostream& operator<<(std::ostream& o, const EbpfMapDescriptor& desc) {
     return o << "(" << "original_fd = " << desc.original_fd << ", " << "inner_map_fd = " << desc.inner_map_fd << ", "
              << "type = " << desc.type << ", " << "max_entries = " << desc.max_entries << ", "
-             << "value_size = " << desc.value_size << ", " << "key_size = " << desc.key_size << ")";
+             << "value_size = " << desc.value_size << ", " << "key_size = " << desc.key_size << ", "
+             << "name = " << desc.name << ")";
 }
 
 void print_map_descriptors(const std::vector<EbpfMapDescriptor>& descriptors, std::ostream& o) {

--- a/src/printing.cpp
+++ b/src/printing.cpp
@@ -714,8 +714,7 @@ void print(const InstructionSeq& insts, std::ostream& out, const std::optional<c
 std::ostream& operator<<(std::ostream& o, const EbpfMapDescriptor& desc) {
     return o << "(" << "original_fd = " << desc.original_fd << ", " << "inner_map_fd = " << desc.inner_map_fd << ", "
              << "type = " << desc.type << ", " << "max_entries = " << desc.max_entries << ", "
-             << "value_size = " << desc.value_size << ", " << "key_size = " << desc.key_size << ", "
-             << "name = " << desc.name << ")";
+             << "value_size = " << desc.value_size << ", " << "key_size = " << desc.key_size << ")";
 }
 
 void print_map_descriptors(const std::vector<EbpfMapDescriptor>& descriptors, std::ostream& o) {

--- a/src/spec/type_descriptors.hpp
+++ b/src/spec/type_descriptors.hpp
@@ -30,6 +30,7 @@ struct EbpfMapDescriptor {
     unsigned int value_size;
     unsigned int max_entries;
     int inner_map_fd;
+    std::string name; // Map name from ELF (empty if not available).
 };
 
 struct EbpfProgramType {


### PR DESCRIPTION
This PR contains few changes that enable ebpf-for-windows to gather sufficient information to optimize array map operations in the native mode:

Summary of changes:
1. Support for tracking and storing the name of eBPF maps throughout the parsing process by adding map name in `EbpfMapDescriptor` struct.
2. Mark map related APIs in `EbpfDomain` class public, so that they can be invoked by ebpf-for-windows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * eBPF map descriptors now record ELF/BTF-derived map names when available.
  * Map-parsing logic updated to populate and preserve names from sections, symbols, and metadata.
  * Diagnostic and printed output now include map names, improving identification and troubleshooting of eBPF maps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->