### PR TITLE
Fix numeric store through imprecise stack pointer incorrectly marking bytes as non-numeric

### DIFF
--- a/src/crab/array_domain.cpp
+++ b/src/crab/array_domain.cpp
@@ -613,9 +613,17 @@ std::optional<Variable> ArrayDomain::store_type(TypeDomain& inv, const Interval&
         return v;
     } else {
         using namespace dsl_syntax;
-        // havoc the entire range
+        // Weak update: cannot perform a strong update because the index is
+        // not a singleton. Havoc the type cells in the range.
         const auto [lb, ub] = as_numbytes_range(idx, width);
-        num_bytes.havoc(lb, ub);
+        if (!is_num) {
+            // A non-numeric value may overwrite previously numeric bytes,
+            // so conservatively mark the range as non-numeric.
+            num_bytes.havoc(lb, ub);
+        }
+        // When is_num is true, the value being stored is numeric. Any byte
+        // that gets written will still be numeric, and bytes not written
+        // keep their existing status, so num_bytes is left unchanged.
     }
     return {};
 }

--- a/test-data/stack.yaml
+++ b/test-data/stack.yaml
@@ -768,6 +768,7 @@ post:
   - r5.stack_offset=[504, 508]
   - r5.type=stack
   - s[504...511].type=number
+---
 test-case: stack store 32bit records number type
 
 pre: ["r6.type=stack", "r6.stack_offset=0",

--- a/test-data/stack.yaml
+++ b/test-data/stack.yaml
@@ -769,6 +769,28 @@ post:
   - r5.type=stack
   - s[504...511].type=number
 ---
+test-case: non-numeric store through imprecise pointer havocs num_bytes
+
+pre: ["r2.type=stack", "r2.stack_offset=504",
+      "r3.type=stack", "r3.stack_offset=100",
+      "r5.type=stack", "r5.stack_offset=[504, 508]",
+      "r10.type=stack", "r10.stack_offset=512",
+      "s[504...511].type=number"]
+
+code:
+  <start>: |
+    *(u64 *)(r5 + 0) = r3
+
+post:
+  - r10.stack_offset=512
+  - r10.type=stack
+  - r2.stack_offset=504
+  - r2.type=stack
+  - r3.stack_offset=100
+  - r3.type=stack
+  - r5.stack_offset=[504, 508]
+  - r5.type=stack
+---
 test-case: stack store 32bit records number type
 
 pre: ["r6.type=stack", "r6.stack_offset=0",

--- a/test-data/stack.yaml
+++ b/test-data/stack.yaml
@@ -743,6 +743,31 @@ post:
   - s[0...7].svalue=0
   - s[0...7].uvalue=0
 ---
+test-case: numeric store through imprecise pointer preserves num_bytes
+
+pre: ["r2.type=stack", "r2.stack_offset=504",
+      "r3.type=number", "r3.svalue=0", "r3.uvalue=0",
+      "r5.type=stack", "r5.stack_offset=[504, 508]",
+      "r10.type=stack", "r10.stack_offset=512",
+      "s[504...511].type=number"]
+
+code:
+  <start>: |
+    *(u32 *)(r5 + 0) = r3
+
+post:
+  - r10.stack_offset=512
+  - r10.type=stack
+  - r2.stack_numeric_size=8
+  - r2.stack_offset=504
+  - r2.type=stack
+  - r3.svalue=0
+  - r3.type=number
+  - r3.uvalue=0
+  - r5.stack_numeric_size=4
+  - r5.stack_offset=[504, 508]
+  - r5.type=stack
+  - s[504...511].type=number
 test-case: stack store 32bit records number type
 
 pre: ["r6.type=stack", "r6.stack_offset=0",


### PR DESCRIPTION
## Summary

Fixes #1067 

When a store occurs through a derived stack pointer whose offset is an imprecise range (e.g., [504, 508] after a branch join or loop widening), 
`ArrayDomain::store_type()` unconditionally calls `num_bytes.havoc()` on the entire affected range. This sets bits in non_numerical_bytes, marking those bytes as
potentially non-numeric — even when the stored value is provably numeric. This destroys previously-proven numeric status for stack bytes, causing stack_numeric_size
to be recomputed as too small and leading to false "Stack content is not numeric" errors in helper calls that validate stack content (e.g., bpf_perf_event_output, 
bpf_map_update_elem).

## Regression

Introduced in 1d1d2460 (#916, "introduce TypeToNumDomain"). The original store_type only handled singleton addresses (strong update path). The refactoring in #916
added an else branch for imprecise addresses that unconditionally havocs num_bytes, but did not condition on whether the stored value is numeric.

## Fix

In the imprecise-address else branch of `ArrayDomain::store_type()`, only call `num_bytes.havoc()` when the stored value is not numeric (!is_num). When is_num is true,
leave num_bytes unchanged.

## Soundness argument

When is_num=true, for each byte in the affected range:

 - Previously numeric, overwritten: remains numeric (overwritten with numeric value) — bit stays 0 ✓
 - Previously numeric, not overwritten: unchanged — bit stays 0 ✓
 - Previously non-numeric, overwritten: becomes numeric, but we don't know if this specific byte was overwritten — bit stays 1 (conservative) ✓
 - Previously non-numeric, not overwritten: unchanged — bit stays 1 ✓

No byte is falsely marked as numeric. The is_num flag is trustworthy: it comes from is_in_group(*opt_val_reg, TS_NUM) (a sound subset check) or from storing an
immediate value (always numeric).

## Reproduction

```
 test-case: numeric store through imprecise pointer preserves num_bytes
 
 pre: ["r2.type=stack", "r2.stack_offset=504",
       "r3.type=number", "r3.svalue=0", "r3.uvalue=0",
       "r5.type=stack", "r5.stack_offset=[504, 508]",
       "r10.type=stack", "r10.stack_offset=512",
       "s[504...511].type=number"]
 
 code:
   <start>: |
     *(u32 *)(r5 + 0) = r3
 
 post:
   - r2.stack_numeric_size=8    # ← lost on main (regression)
   - s[504...511].type=number   # ← lost on main (regression)
   ...
```

On main, both r2.stack_numeric_size and s[504...511].type=number are lost after the store. With the fix, r2.stack_numeric_size=8 is correctly preserved.

## Testing

 - Added YAML regression test to test-data/stack.yaml

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Memory store handling refined: non-numeric stores now clear numeric type info only for affected bytes; numeric stores preserve numeric type info for bytes not overwritten.

* **Tests**
  * Added a test validating that a 32-bit numeric store via an imprecise pointer preserves numeric typing for unaffected bytes and stack objects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->