### PR TITLE
Mark inner map template descriptors in `EbpfMapDescriptor`

### DIFF
--- a/src/io/elf_map_parser.cpp
+++ b/src/io/elf_map_parser.cpp
@@ -310,35 +310,26 @@ void mark_inner_map_templates(ElfGlobalData& global) {
 
 ElfGlobalData extract_global_data(const parse_params_t& params, const ELFIO::elfio& reader,
                                   const ELFIO::const_symbol_section_accessor& symbols) {
+    ElfGlobalData global;
+
     if (reader.sections[".BTF"] && reader.sections[".maps"]) {
         try {
-            auto global = parse_btf_section(params, reader);
-            mark_inner_map_templates(global);
-            return global;
+            global = parse_btf_section(params, reader);
         } catch (const UnmarshalError& e) {
             // BTF-defined maps can't be decoded; fall back to section-based map descriptors.
             std::cerr << "BTF map parsing failed, falling back to section-based maps: " << e.what() << std::endl;
+            global = parse_map_sections(params, reader, symbols);
         }
-        auto global = parse_map_sections(params, reader, symbols);
-        mark_inner_map_templates(global);
-        return global;
+    } else if (std::ranges::any_of(reader.sections, [](const auto& s) { return is_map_section(s->get_name()); })) {
+        global = parse_map_sections(params, reader, symbols);
+    } else if (reader.sections[".BTF"]) {
+        global = parse_btf_section(params, reader);
+    } else {
+        global = create_global_variable_maps(reader);
     }
 
-    const bool has_legacy_maps =
-        std::ranges::any_of(reader.sections, [](const auto& s) { return is_map_section(s->get_name()); });
-    if (has_legacy_maps) {
-        auto global = parse_map_sections(params, reader, symbols);
-        mark_inner_map_templates(global);
-        return global;
-    }
-
-    if (reader.sections[".BTF"]) {
-        auto global = parse_btf_section(params, reader);
-        mark_inner_map_templates(global);
-        return global;
-    }
-
-    return create_global_variable_maps(reader);
+    mark_inner_map_templates(global);
+    return global;
 }
 
 void update_line_info(std::vector<RawProgram>& raw_programs, const ELFIO::section* btf_section,

--- a/src/io/elf_map_parser.cpp
+++ b/src/io/elf_map_parser.cpp
@@ -291,28 +291,51 @@ ElfGlobalData parse_map_sections(const parse_params_t& parse_params, const ELFIO
     return global;
 }
 
+/// @brief Mark descriptors that serve only as inner map templates. At runtime
+/// the actual inner map can be any map with matching structure, not necessarily
+/// the template defined in the ELF.
+void mark_inner_map_templates(ElfGlobalData& global) {
+    for (const auto& desc : global.map_descriptors) {
+        if (desc.inner_map_fd != DEFAULT_MAP_FD) {
+            for (auto& inner_desc : global.map_descriptors) {
+                if (inner_desc.original_fd == desc.inner_map_fd) {
+                    inner_desc.is_inner_map_template = true;
+                }
+            }
+        }
+    }
+}
+
 } // namespace
 
 ElfGlobalData extract_global_data(const parse_params_t& params, const ELFIO::elfio& reader,
                                   const ELFIO::const_symbol_section_accessor& symbols) {
     if (reader.sections[".BTF"] && reader.sections[".maps"]) {
         try {
-            return parse_btf_section(params, reader);
+            auto global = parse_btf_section(params, reader);
+            mark_inner_map_templates(global);
+            return global;
         } catch (const UnmarshalError& e) {
             // BTF-defined maps can't be decoded; fall back to section-based map descriptors.
             std::cerr << "BTF map parsing failed, falling back to section-based maps: " << e.what() << std::endl;
         }
-        return parse_map_sections(params, reader, symbols);
+        auto global = parse_map_sections(params, reader, symbols);
+        mark_inner_map_templates(global);
+        return global;
     }
 
     const bool has_legacy_maps =
         std::ranges::any_of(reader.sections, [](const auto& s) { return is_map_section(s->get_name()); });
     if (has_legacy_maps) {
-        return parse_map_sections(params, reader, symbols);
+        auto global = parse_map_sections(params, reader, symbols);
+        mark_inner_map_templates(global);
+        return global;
     }
 
     if (reader.sections[".BTF"]) {
-        return parse_btf_section(params, reader);
+        auto global = parse_btf_section(params, reader);
+        mark_inner_map_templates(global);
+        return global;
     }
 
     return create_global_variable_maps(reader);

--- a/src/io/elf_map_parser.cpp
+++ b/src/io/elf_map_parser.cpp
@@ -291,10 +291,32 @@ ElfGlobalData parse_map_sections(const parse_params_t& parse_params, const ELFIO
     return global;
 }
 
-/// @brief Mark descriptors that serve only as inner map templates. At runtime
-/// the actual inner map can be any map with matching structure, not necessarily
-/// the template defined in the ELF.
-void mark_inner_map_templates(ElfGlobalData& global) {
+} // namespace
+
+ElfGlobalData extract_global_data(const parse_params_t& params, const ELFIO::elfio& reader,
+                                  const ELFIO::const_symbol_section_accessor& symbols) {
+    ElfGlobalData global = [&] {
+        if (reader.sections[".BTF"] && reader.sections[".maps"]) {
+            try {
+                return parse_btf_section(params, reader);
+            } catch (const UnmarshalError& e) {
+                // BTF-defined maps can't be decoded; fall back to section-based map descriptors.
+                std::cerr << "BTF map parsing failed, falling back to section-based maps: " << e.what() << std::endl;
+                return parse_map_sections(params, reader, symbols);
+            }
+        }
+        if (std::ranges::any_of(reader.sections, [](const auto& s) { return is_map_section(s->get_name()); })) {
+            return parse_map_sections(params, reader, symbols);
+        }
+        if (reader.sections[".BTF"]) {
+            return parse_btf_section(params, reader);
+        }
+        return create_global_variable_maps(reader);
+    }();
+
+    /// Mark descriptors that serve only as inner map templates.
+    /// At runtime the actual inner map can be any map with matching structure,
+    /// not necessarily the template defined in the ELF.
     for (const auto& desc : global.map_descriptors) {
         if (desc.inner_map_fd != DEFAULT_MAP_FD) {
             for (auto& inner_desc : global.map_descriptors) {
@@ -304,31 +326,6 @@ void mark_inner_map_templates(ElfGlobalData& global) {
             }
         }
     }
-}
-
-} // namespace
-
-ElfGlobalData extract_global_data(const parse_params_t& params, const ELFIO::elfio& reader,
-                                  const ELFIO::const_symbol_section_accessor& symbols) {
-    ElfGlobalData global;
-
-    if (reader.sections[".BTF"] && reader.sections[".maps"]) {
-        try {
-            global = parse_btf_section(params, reader);
-        } catch (const UnmarshalError& e) {
-            // BTF-defined maps can't be decoded; fall back to section-based map descriptors.
-            std::cerr << "BTF map parsing failed, falling back to section-based maps: " << e.what() << std::endl;
-            global = parse_map_sections(params, reader, symbols);
-        }
-    } else if (std::ranges::any_of(reader.sections, [](const auto& s) { return is_map_section(s->get_name()); })) {
-        global = parse_map_sections(params, reader, symbols);
-    } else if (reader.sections[".BTF"]) {
-        global = parse_btf_section(params, reader);
-    } else {
-        global = create_global_variable_maps(reader);
-    }
-
-    mark_inner_map_templates(global);
     return global;
 }
 

--- a/src/spec/type_descriptors.hpp
+++ b/src/spec/type_descriptors.hpp
@@ -31,7 +31,7 @@ struct EbpfMapDescriptor {
     unsigned int max_entries;
     int inner_map_fd;
     std::string name;                  // Map name from ELF (empty if not available).
-    bool is_inner_map_template{false}; // True if this descriptor is only an inner map template.
+    bool is_inner_map_template{false}; // True if this descriptor is referenced as an inner map template.
 };
 
 struct EbpfProgramType {

--- a/src/spec/type_descriptors.hpp
+++ b/src/spec/type_descriptors.hpp
@@ -30,7 +30,8 @@ struct EbpfMapDescriptor {
     unsigned int value_size;
     unsigned int max_entries;
     int inner_map_fd;
-    std::string name; // Map name from ELF (empty if not available).
+    std::string name;                  // Map name from ELF (empty if not available).
+    bool is_inner_map_template{false}; // True if this descriptor is only an inner map template.
 };
 
 struct EbpfProgramType {


### PR DESCRIPTION
## Problem
PR #1066 added map names to `EbpfMapDescriptor. However, for HASH_OF_MAP or ARRAY_OF_MAP map types, the inner map defined in the ELF is only a structural template — at runtime, the actual inner map can be any map with a matching layout. The verifier was treating the template's ELF name as if it were the definitive name of the inner map, which is incorrect and could mislead downstream consumers.

## Solution
Add an `is_inner_map_template` flag to `EbpfMapDescriptor` so that consumers can distinguish inner map templates from concrete maps. The name is preserved for informational purposes, but the flag signals that it should not be treated as the identity of the inner map at runtime.

## Summary of changes
1. `type_descriptors.hpp`: Added bool is_inner_map_template{false} to `EbpfMapDescriptor`.
2. `elf_map_parser.cpp`: Added `mark_inner_map_templates()` which iterates over all map descriptors after parsing and sets is_inner_map_template = true on any descriptor referenced by another descriptor's `inner_map_fd`. Called from all code paths in `extract_global_data()`

## Testing
1. Existing tests pass (tests.exe).
2. No behavioral change to the verifier — `is_inner_map_template` is not used for analysis correctness, only as metadata for downstream consumers.