### PR TITLE
Make stack size and call depth runtime parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,10 @@ Features:
           --allow-division-by-zero, --no-division-by-zero{false}
                               Handling potential division by zero. Default: allow
   -s,     --strict            Apply additional checks that would cause runtime failures
+          --stack-size INT:INT in [1 - 1048576]
+                              Per-subprogram stack frame size in bytes (default: 512)
+          --max-call-stack-frames INT:INT in [1 - 128]
+                              Maximum number of nested function calls (default: 8)
           --include_groups GROUPS:{atomic32,atomic64,base32,base64,callx,divmul32,divmul64,packet}
                               Include conformance groups
           --exclude_groups GROUPS:{atomic32,atomic64,base32,base64,callx,divmul32,divmul64,packet}

--- a/docs/abstract-domains.md
+++ b/docs/abstract-domains.md
@@ -49,7 +49,7 @@ EbpfDomain EbpfDomain::setup_entry(bool check_termination) {
     
     // R10 = stack frame pointer
     inv.assign_type(R10, T_STACK);
-    inv.assign(R10.stack_offset, EBPF_TOTAL_STACK_SIZE);
+    inv.assign(R10.stack_offset, total_stack_size);
     
     // R0, R2-R9 = uninitialized
     for (r in {R0, R2..R9}) {

--- a/docs/feature-support-matrix.md
+++ b/docs/feature-support-matrix.md
@@ -72,7 +72,7 @@ Capability and configuration checks are described in `Notes / Evidence`; they do
 | Helper arg/return typing model | Supported | `src/ir/unmarshal.cpp`: `makeCall`; `src/platform.hpp`: `get_helper_prototype` |
 | Helper unavailable in platform tables | Supported | `src/ir/unmarshal.cpp`: helper-unavailable path in `makeJmp`; `src/ir/cfg_builder.cpp`: `check_instruction_feature_support` |
 | BPF-to-BPF non-recursive local call expansion | Supported | `src/ir/cfg_builder.cpp`; `src/elf_loader.cpp` |
-| Maximum call depth guard | Supported | `src/ir/cfg_builder.cpp`: `MAX_CALL_STACK_FRAMES` |
+| Maximum call depth guard | Supported | `src/ir/cfg_builder.cpp`: `max_call_stack_frames` option (default 8) |
 | Tail call chain depth guard | Supported | `src/ir/cfg_builder.cpp`: `validate_tail_call_chain_depth` (limit 33) |
 
 ### BTF/ELF Language-Relevant Handling

--- a/docs/llm-context.md
+++ b/docs/llm-context.md
@@ -93,7 +93,7 @@ Stack memory is tracked separately:
 
 **Stack Numbers summary**: The line `Stack: Numbers -> {[A...B], [C...D]}` shows which byte ranges are known to contain numeric (non-pointer) data. Empty `{}` means no stack bytes are proven numeric.
 
-Stack offsets `N` in `s[N]` / `s[N...M]` are absolute byte offsets within the total eBPF stack (`0..EBPF_TOTAL_STACK_SIZE-1`). For a given program point, the active stack frame is the interval `[r10.stack_offset-EBPF_SUBPROGRAM_STACK_SIZE, r10.stack_offset)`.
+Stack offsets `N` in `s[N]` / `s[N...M]` are absolute byte offsets within the total eBPF stack (`0..total_stack_size-1`). For a given program point, the active stack frame is the interval `[r10.stack_offset-subprogram_stack_size, r10.stack_offset)`.
 
 ### 2.4 Global State Variables
 
@@ -168,7 +168,7 @@ Where:
 | `Lower bound must be at least 0` | Offset is negative when it shouldn't be |
 | `Upper bound must be at most X` | Access extends past end of region |
 | `Lower bound must be at least meta_offset` | Packet access before metadata start |
-| `Lower bound must be at least r10.stack_offset - EBPF_SUBPROGRAM_STACK_SIZE` | Stack underflow |
+| `Lower bound must be at least r10.stack_offset - subprogram_stack_size` | Stack underflow |
 | `Stack content is not numeric` | Reading non-numeric data from stack |
 | `Possible null access` | Pointer might be NULL |
 | `Nonzero context offset` | Context pointer was modified before passing to helper |
@@ -219,7 +219,7 @@ if (data + sizeof(__u64) > data_end) return XDP_DROP;
 
 ### 4.3 Stack Out-of-Bounds Access
 
-**Symptom**: `Lower bound must be at least r10.stack_offset - EBPF_SUBPROGRAM_STACK_SIZE`
+**Symptom**: `Lower bound must be at least r10.stack_offset - subprogram_stack_size`
 
 **Cause**: Accessing stack memory beyond the allocated frame.
 
@@ -228,7 +228,7 @@ if (data + sizeof(__u64) > data_end) return XDP_DROP;
 ```text
 Pre-invariant:[r10.type=stack, r10.stack_offset=1024]
    0: *(u8 *)(r10 - 513) = 0
-Error: 0: Lower bound must be at least r10.stack_offset - EBPF_SUBPROGRAM_STACK_SIZE
+Error: 0: Lower bound must be at least r10.stack_offset - subprogram_stack_size
 ```
 
 **Fix**: Keep stack accesses within -512 to -1 of r10, or reduce local variable size.

--- a/docs/llm-context.md
+++ b/docs/llm-context.md
@@ -134,7 +134,7 @@ Where:
 |------|-------------|
 | `number` | A scalar integer (not a pointer) |
 | `ctx` | Pointer to program context structure (e.g., `xdp_md`, `sk_buff`) |
-| `stack` | Pointer to stack memory (512 bytes per stack frame) |
+| `stack` | Pointer to stack memory |
 | `packet` | Pointer to packet data |
 | `shared` | Pointer to shared memory (e.g., map values) |
 | `map_fd` | Map file descriptor (not directly dereferenceable) |
@@ -543,9 +543,9 @@ For map-related errors, request:
 
 ### Stack Layout
 
-- Main program: offsets 0-511 (accessed as r10-1 through r10-512)
-- Subprograms: additional 512 bytes per call depth
-- Total: up to 4KB (8 frames × 512 bytes)
+- Main program: offsets 0 to subprogram_stack_size-1 (accessed as r10-1 through r10-subprogram_stack_size)
+- Subprograms: additional subprogram_stack_size bytes per call depth
+- Total: up to subprogram_stack_size × max_call_stack_frames
 
 ### Common Helper Patterns
 

--- a/docs/llm-context.md
+++ b/docs/llm-context.md
@@ -231,7 +231,7 @@ Pre-invariant:[r10.type=stack, r10.stack_offset=1024]
 Error: 0: Lower bound must be at least r10.stack_offset - subprogram_stack_size
 ```
 
-**Fix**: Keep stack accesses within -512 to -1 of r10, or reduce local variable size.
+**Fix**: Keep stack accesses within -subprogram_stack_size to -1 of r10, or reduce local variable size.
 
 ---
 

--- a/docs/memory-model.md
+++ b/docs/memory-model.md
@@ -6,23 +6,23 @@ This document describes how Prevail models memory regions.
 
 eBPF programs can access several memory regions:
 
-| Region | Register | Description |
-|--------|----------|-------------|
-| Stack | R10 | Private stack (configurable, default 512 bytes per frame) |
-| Context | R1 | Program context (varies by type) |
-| Packet | Derived | Network packet data |
-| Shared | Derived | Shared memory regions |
-| Map Values | Derived | BPF map contents |
+| Region     | Register | Description                                               |
+|------------|----------|-----------------------------------------------------------|
+| Stack      | R10      | Private stack (configurable, default 512 bytes per frame) |
+| Context    | R1       | Program context (varies by type)                          |
+| Packet     | Derived  | Network packet data                                       |
+| Shared     | Derived  | Shared memory regions                                     |
+| Map Values | Derived  | BPF map contents                                          |
 
 ## Stack Memory
 
 ### Stack Layout
 
 ```text
-R10 (frame pointer) ────────────────┐
-                                    │
-    ┌───────────────────────────────▼───────┐
-    │  Subprogram frame               │  offset: -stack_size to 0
+R10 (frame pointer) ───────────┐
+                               │
+    ┌──────────────────────────▼───────┐
+    │  Subprogram frame                │  offset: -stack_size to 0
     ├──────────────────────────────────┤
     │  Parent frame                    │  offset: -2*stack_size to -stack_size
     ├──────────────────────────────────┤
@@ -118,11 +118,11 @@ The context is a structure passed to the eBPF program.
 
 Different program types have different contexts:
 
-| Program Type | Context | Example Fields |
-|--------------|---------|----------------|
-| XDP | `xdp_md` | data, data_end, data_meta |
-| Socket Filter | `__sk_buff` | data, data_end, protocol |
-| Tracepoint | varies | Architecture-specific |
+| Program Type  | Context     | Example Fields            |
+|---------------|-------------|---------------------------|
+| XDP           | `xdp_md`    | data, data_end, data_meta |
+| Socket Filter | `__sk_buff` | data, data_end, protocol  |
+| Tracepoint    | varies      | Architecture-specific     |
 
 ### Context Access
 
@@ -290,15 +290,15 @@ void check_map_access(Reg ptr, int offset, int width) {
 
 ### Valid Operations
 
-| Base Type | Operation | Result Type |
-|-----------|-----------|-------------|
-| STACK | + number | STACK |
-| PACKET | + number | PACKET |
-| CTX | + number | CTX (if valid field) |
-| MAP | + number | MAP |
-| SHARED | + number | SHARED |
-| NUMBER | + pointer | Same as pointer |
-| Pointer | - pointer | NUMBER (if same type) |
+| Base Type | Operation | Result Type           |
+|-----------|-----------|-----------------------|
+| STACK     | + number  | STACK                 |
+| PACKET    | + number  | PACKET                |
+| CTX       | + number  | CTX (if valid field)  |
+| MAP       | + number  | MAP                   |
+| SHARED    | + number  | SHARED                |
+| NUMBER    | + pointer | Same as pointer       |
+| Pointer   | - pointer | NUMBER (if same type) |
 
 ### Offset Tracking
 
@@ -356,6 +356,7 @@ ldxdw r2, [r10-8]    ; r2 becomes CTX pointer
 ## Memory Aliasing
 
 Prevail assumes no aliasing between:
+
 - Stack and other memory regions
 - Different map values
 - Packet and context

--- a/docs/memory-model.md
+++ b/docs/memory-model.md
@@ -8,7 +8,7 @@ eBPF programs can access several memory regions:
 
 | Region | Register | Description |
 |--------|----------|-------------|
-| Stack | R10 | Private stack (512 bytes per frame) |
+| Stack | R10 | Private stack (configurable, default 512 bytes per frame) |
 | Context | R1 | Program context (varies by type) |
 | Packet | Derived | Network packet data |
 | Shared | Derived | Shared memory regions |
@@ -22,14 +22,15 @@ eBPF programs can access several memory regions:
 R10 (frame pointer) ────────────────┐
                                     │
     ┌───────────────────────────────▼───────┐
-    │  Subprogram frame (512 bytes)         │  offset: -512 to 0
-    ├───────────────────────────────────────┤
-    │  Parent frame (512 bytes)             │  offset: -1024 to -512
-    ├───────────────────────────────────────┤
-    │  ...                                  │
-    └───────────────────────────────────────┘
-    
-Total: 512 bytes × max_call_depth
+    │  Subprogram frame               │  offset: -stack_size to 0
+    ├──────────────────────────────────┤
+    │  Parent frame                    │  offset: -2*stack_size to -stack_size
+    ├──────────────────────────────────┤
+    │  ...                             │
+    └──────────────────────────────────┘
+
+stack_size = subprogram_stack_size (default 512)
+Total: stack_size × max_call_stack_frames (default 8)
 ```
 
 ### Stack Tracking
@@ -104,8 +105,8 @@ void check_stack_access(Reg base, int offset, int width) {
     int abs_offset = stack_off.lb + offset;
     
     // Check bounds: must be within current frame
-    require(abs_offset >= EBPF_TOTAL_STACK_SIZE - EBPF_SUBPROGRAM_STACK_SIZE);
-    require(abs_offset + width <= EBPF_TOTAL_STACK_SIZE);
+    require(abs_offset >= total_stack_size - subprogram_stack_size);
+    require(abs_offset + width <= total_stack_size);
 }
 ```
 

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: MIT
 #pragma once
 
+#include "spec/ebpf_base.h"
+
 namespace prevail {
 struct prepare_cfg_options {
     /// When true, verifies that the program terminates.
@@ -51,6 +53,15 @@ struct ebpf_verifier_options_t {
 
     // True if the ELF file is built on a big endian system.
     bool big_endian = false;
+
+    // Per-subprogram stack frame size in bytes.
+    int subprogram_stack_size = EBPF_SUBPROGRAM_STACK_SIZE;
+
+    // Total stack size across all nested frames.
+    [[nodiscard]]
+    int total_stack_size() const noexcept {
+        return MAX_CALL_STACK_FRAMES * subprogram_stack_size;
+    }
 
     verbosity_options_t verbosity_opts;
 };

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -58,7 +58,7 @@ struct ebpf_verifier_options_t {
     bool big_endian = false;
 
     // Per-subprogram stack frame size in bytes.
-    int subprogram_stack_size = EBPF_SUBPROGRAM_STACK_SIZE;
+    int subprogram_stack_size = 512;
 
     // Maximum valid subprogram stack size. 1 MB per frame is far beyond any realistic use.
     static constexpr int max_subprogram_stack_size = 1024 * 1024;

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MIT
 #pragma once
 
-#include <limits>
 #include <stdexcept>
 #include <string>
 
@@ -61,8 +60,8 @@ struct ebpf_verifier_options_t {
     // Per-subprogram stack frame size in bytes.
     int subprogram_stack_size = EBPF_SUBPROGRAM_STACK_SIZE;
 
-    // Maximum valid subprogram stack size (bounded by int32 range used in the numeric domain).
-    static constexpr int max_subprogram_stack_size = std::numeric_limits<int32_t>::max() / MAX_CALL_STACK_FRAMES;
+    // Maximum valid subprogram stack size. 1 MB per frame is far beyond any realistic use.
+    static constexpr int max_subprogram_stack_size = 1024 * 1024;
 
     // Total stack size across all nested frames.
     [[nodiscard]]

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -2,6 +2,10 @@
 // SPDX-License-Identifier: MIT
 #pragma once
 
+#include <limits>
+#include <stdexcept>
+#include <string>
+
 #include "spec/ebpf_base.h"
 
 namespace prevail {
@@ -57,10 +61,25 @@ struct ebpf_verifier_options_t {
     // Per-subprogram stack frame size in bytes.
     int subprogram_stack_size = EBPF_SUBPROGRAM_STACK_SIZE;
 
+    // Maximum valid subprogram stack size (bounded by int32 range used in the numeric domain).
+    static constexpr int max_subprogram_stack_size = std::numeric_limits<int32_t>::max() / MAX_CALL_STACK_FRAMES;
+
     // Total stack size across all nested frames.
     [[nodiscard]]
     int total_stack_size() const noexcept {
         return MAX_CALL_STACK_FRAMES * subprogram_stack_size;
+    }
+
+    // Validate that the stack size is within acceptable bounds.
+    void validate_stack_size() const {
+        if (subprogram_stack_size <= 0) {
+            throw std::invalid_argument("subprogram_stack_size must be positive, got " +
+                                        std::to_string(subprogram_stack_size));
+        }
+        if (subprogram_stack_size > max_subprogram_stack_size) {
+            throw std::invalid_argument("subprogram_stack_size " + std::to_string(subprogram_stack_size) +
+                                        " is too large (max " + std::to_string(max_subprogram_stack_size) + ")");
+        }
     }
 
     verbosity_options_t verbosity_opts;

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -5,8 +5,6 @@
 #include <stdexcept>
 #include <string>
 
-#include "spec/ebpf_base.h"
-
 namespace prevail {
 struct prepare_cfg_options {
     /// When true, verifies that the program terminates.
@@ -60,24 +58,27 @@ struct ebpf_verifier_options_t {
     // Per-subprogram stack frame size in bytes.
     int subprogram_stack_size = 512;
 
-    // Maximum valid subprogram stack size. 1 MB per frame is far beyond any realistic use.
-    static constexpr int max_subprogram_stack_size = 1024 * 1024;
+    // Maximum number of nested function calls.
+    int max_call_stack_frames = 8;
 
-    // Total stack size across all nested frames.
+    static constexpr int MAX_SUBPROGRAM_STACK_SIZE = 1024 * 1024;
+    static constexpr int MAX_CALL_STACK_FRAMES_LIMIT = 128;
+
     [[nodiscard]]
     int total_stack_size() const noexcept {
-        return MAX_CALL_STACK_FRAMES * subprogram_stack_size;
+        return max_call_stack_frames * subprogram_stack_size;
     }
 
-    // Validate that the stack size is within acceptable bounds.
-    void validate_stack_size() const {
-        if (subprogram_stack_size <= 0) {
-            throw std::invalid_argument("subprogram_stack_size must be positive, got " +
+    void validate() const {
+        if (subprogram_stack_size <= 0 || subprogram_stack_size > MAX_SUBPROGRAM_STACK_SIZE) {
+            throw std::invalid_argument("subprogram_stack_size must be in [1, " +
+                                        std::to_string(MAX_SUBPROGRAM_STACK_SIZE) + "], got " +
                                         std::to_string(subprogram_stack_size));
         }
-        if (subprogram_stack_size > max_subprogram_stack_size) {
-            throw std::invalid_argument("subprogram_stack_size " + std::to_string(subprogram_stack_size) +
-                                        " is too large (max " + std::to_string(max_subprogram_stack_size) + ")");
+        if (max_call_stack_frames <= 0 || max_call_stack_frames > MAX_CALL_STACK_FRAMES_LIMIT) {
+            throw std::invalid_argument("max_call_stack_frames must be in [1, " +
+                                        std::to_string(MAX_CALL_STACK_FRAMES_LIMIT) + "], got " +
+                                        std::to_string(max_call_stack_frames));
         }
     }
 

--- a/src/crab/array_domain.cpp
+++ b/src/crab/array_domain.cpp
@@ -47,7 +47,7 @@ struct Cell final {
 };
 
 static Interval cell_to_interval(const offset_t o, const unsigned size) {
-    assert(o <= EBPF_TOTAL_STACK_SIZE && "offset out of bounds");
+    assert(o <= thread_local_options.total_stack_size() && "offset out of bounds");
     const Number lb{gsl::narrow<int>(o)};
     return {lb, lb + size - 1};
 }
@@ -366,11 +366,11 @@ static std::optional<std::pair<offset_t, unsigned>> kill_and_find_var(const Havo
     return res;
 }
 static std::tuple<int, int> as_numbytes_range(const Interval& index, const Interval& width) {
-    return (index | (index + width)).bound(0, EBPF_TOTAL_STACK_SIZE);
+    return (index | (index + width)).bound(0, thread_local_options.total_stack_size());
 }
 
 bool ArrayDomain::all_num_lb_ub(const Interval& lb, const Interval& ub) const {
-    const auto [min_lb, max_ub] = (lb | ub).bound(0, EBPF_TOTAL_STACK_SIZE);
+    const auto [min_lb, max_ub] = (lb | ub).bound(0, thread_local_options.total_stack_size());
     if (min_lb > max_ub) {
         return false;
     }
@@ -653,9 +653,9 @@ void ArrayDomain::store_numbers(const Interval& _idx, const Interval& _width) {
         return;
     }
 
-    if (*idx_n + *width > EBPF_TOTAL_STACK_SIZE) {
-        CRAB_WARN("array expansion store range ignored because ",
-                  "the number of elements is larger than default limit of ", EBPF_TOTAL_STACK_SIZE);
+    if (*idx_n + *width > thread_local_options.total_stack_size()) {
+        CRAB_WARN("array expansion store range ignored because ", "the number of elements is larger than limit of ",
+                  thread_local_options.total_stack_size());
         return;
     }
     num_bytes.reset(idx_n->narrow<int>(), width->narrow<int>());

--- a/src/crab/array_domain.cpp
+++ b/src/crab/array_domain.cpp
@@ -38,7 +38,7 @@ struct Cell final {
     auto operator<=>(const Cell&) const = default;
 
     // Return true if [o, o + sz) definitely overlaps with the cell.
-    // Offsets are bounded by EBPF_TOTAL_STACK_SIZE (4096), so wraparound cannot occur.
+    // Offsets are bounded by total_stack_size, so wraparound cannot occur.
     [[nodiscard]]
     bool overlap(const offset_t o, const unsigned sz) const {
         assert(sz > 0 && "overlap query with zero width");

--- a/src/crab/bitset_domain.cpp
+++ b/src/crab/bitset_domain.cpp
@@ -7,25 +7,26 @@
 
 namespace prevail {
 std::ostream& operator<<(std::ostream& o, const BitsetDomain& b) {
+    const auto total = static_cast<int>(b.non_numerical_bytes.size());
     o << "Numbers -> {";
     bool first = true;
-    for (int i = -EBPF_TOTAL_STACK_SIZE; i < 0; i++) {
-        if (b.non_numerical_bytes[EBPF_TOTAL_STACK_SIZE + i]) {
+    for (int i = -total; i < 0; i++) {
+        if (b.non_numerical_bytes[total + i]) {
             continue;
         }
         if (!first) {
             o << ", ";
         }
         first = false;
-        o << "[" << EBPF_TOTAL_STACK_SIZE + i;
+        o << "[" << total + i;
         int j = i + 1;
         for (; j < 0; j++) {
-            if (b.non_numerical_bytes[EBPF_TOTAL_STACK_SIZE + j]) {
+            if (b.non_numerical_bytes[total + j]) {
                 break;
             }
         }
         if (j > i + 1) {
-            o << "..." << EBPF_TOTAL_STACK_SIZE + j - 1;
+            o << "..." << total + j - 1;
         }
         o << "]";
         i = j;
@@ -42,20 +43,21 @@ StringInvariant BitsetDomain::to_set() const {
         return StringInvariant::top();
     }
 
+    const auto total = static_cast<int>(non_numerical_bytes.size());
     std::set<std::string> result;
-    for (int i = -EBPF_TOTAL_STACK_SIZE; i < 0; i++) {
-        if (non_numerical_bytes[EBPF_TOTAL_STACK_SIZE + i]) {
+    for (int i = -total; i < 0; i++) {
+        if (non_numerical_bytes[total + i]) {
             continue;
         }
-        std::string value = "s[" + std::to_string(EBPF_TOTAL_STACK_SIZE + i);
+        std::string value = "s[" + std::to_string(total + i);
         int j = i + 1;
         for (; j < 0; j++) {
-            if (non_numerical_bytes[EBPF_TOTAL_STACK_SIZE + j]) {
+            if (non_numerical_bytes[total + j]) {
                 break;
             }
         }
         if (j > i + 1) {
-            value += "..." + std::to_string(EBPF_TOTAL_STACK_SIZE + j - 1);
+            value += "..." + std::to_string(total + j - 1);
         }
         value += "].type=number";
         result.insert(value);

--- a/src/crab/bitset_domain.hpp
+++ b/src/crab/bitset_domain.hpp
@@ -41,31 +41,40 @@ class BitsetDomain final {
     [[nodiscard]]
     StringInvariant to_set() const;
 
-    bool operator<=(const BitsetDomain& other) const noexcept {
+    bool operator<=(const BitsetDomain& other) const {
+        assert(non_numerical_bytes.size() == other.non_numerical_bytes.size());
         return (non_numerical_bytes | other.non_numerical_bytes) == other.non_numerical_bytes;
     }
 
-    bool operator==(const BitsetDomain& other) const noexcept {
+    bool operator==(const BitsetDomain& other) const {
+        assert(non_numerical_bytes.size() == other.non_numerical_bytes.size());
         return non_numerical_bytes == other.non_numerical_bytes;
     }
 
-    void operator|=(const BitsetDomain& other) noexcept { non_numerical_bytes |= other.non_numerical_bytes; }
+    void operator|=(const BitsetDomain& other) {
+        assert(non_numerical_bytes.size() == other.non_numerical_bytes.size());
+        non_numerical_bytes |= other.non_numerical_bytes;
+    }
 
-    BitsetDomain operator|(const BitsetDomain& other) const noexcept {
+    BitsetDomain operator|(const BitsetDomain& other) const {
+        assert(non_numerical_bytes.size() == other.non_numerical_bytes.size());
         return BitsetDomain{non_numerical_bytes | other.non_numerical_bytes};
     }
 
-    BitsetDomain operator&(const BitsetDomain& other) const noexcept {
+    BitsetDomain operator&(const BitsetDomain& other) const {
+        assert(non_numerical_bytes.size() == other.non_numerical_bytes.size());
         return BitsetDomain{non_numerical_bytes & other.non_numerical_bytes};
     }
 
     [[nodiscard]]
-    BitsetDomain widen(const BitsetDomain& other) const noexcept {
+    BitsetDomain widen(const BitsetDomain& other) const {
+        assert(non_numerical_bytes.size() == other.non_numerical_bytes.size());
         return BitsetDomain{non_numerical_bytes | other.non_numerical_bytes};
     }
 
     [[nodiscard]]
-    BitsetDomain narrow(const BitsetDomain& other) const noexcept {
+    BitsetDomain narrow(const BitsetDomain& other) const {
+        assert(non_numerical_bytes.size() == other.non_numerical_bytes.size());
         return BitsetDomain{non_numerical_bytes & other.non_numerical_bytes};
     }
 

--- a/src/crab/bitset_domain.hpp
+++ b/src/crab/bitset_domain.hpp
@@ -2,28 +2,26 @@
 // SPDX-License-Identifier: MIT
 #pragma once
 #include <algorithm>
-#include <bitset>
 #include <cassert>
 
-#include "spec/ebpf_base.h"
+#include <boost/dynamic_bitset.hpp>
+
+#include "config.hpp"
 #include "string_constraints.hpp"
 
 namespace prevail {
 class BitsetDomain final {
   private:
-    using bits_t = std::bitset<EBPF_TOTAL_STACK_SIZE>;
+    using bits_t = boost::dynamic_bitset<>;
     bits_t non_numerical_bytes;
 
   public:
-    BitsetDomain() noexcept { non_numerical_bytes.set(); }
+    BitsetDomain() : non_numerical_bytes(thread_local_options.total_stack_size()) { non_numerical_bytes.set(); }
 
-    // no performant move constructor to std::bitset, and therefore no copy-then-move for BitsetDomain
-    explicit BitsetDomain(const bits_t& non_numerical_bytes) noexcept : non_numerical_bytes{non_numerical_bytes} {}
-    BitsetDomain(const BitsetDomain& non_numerical_bytes) = default;
-
-    // This is just to make the compiler happy in certain situations
-    BitsetDomain(BitsetDomain&& non_numerical_bytes) = default;
-    BitsetDomain& operator=(const BitsetDomain&) noexcept = default;
+    explicit BitsetDomain(bits_t non_numerical_bytes) noexcept : non_numerical_bytes{std::move(non_numerical_bytes)} {}
+    BitsetDomain(const BitsetDomain&) = default;
+    BitsetDomain(BitsetDomain&&) noexcept = default;
+    BitsetDomain& operator=(const BitsetDomain&) = default;
     BitsetDomain& operator=(BitsetDomain&&) noexcept = default;
 
     void set_to_top() noexcept { non_numerical_bytes.set(); }
@@ -73,10 +71,10 @@ class BitsetDomain final {
 
     [[nodiscard]]
     std::pair<bool, bool> uniformity(const size_t lb, int width) const noexcept {
-        if (lb >= EBPF_TOTAL_STACK_SIZE) {
+        if (lb >= non_numerical_bytes.size()) {
             return {true, true};
         }
-        width = std::min(width, gsl::narrow_cast<int>(EBPF_TOTAL_STACK_SIZE - lb));
+        width = std::min(width, gsl::narrow_cast<int>(non_numerical_bytes.size() - lb));
         bool only_num = true;
         bool only_non_num = true;
         for (int j = 0; j < width; j++) {
@@ -90,31 +88,31 @@ class BitsetDomain final {
     // Get the number of bytes, starting at lb, known to be numbers.
     [[nodiscard]]
     int all_num_width(const size_t lb) const noexcept {
-        if (lb >= EBPF_TOTAL_STACK_SIZE) {
+        if (lb >= non_numerical_bytes.size()) {
             return 0;
         }
         size_t ub = lb;
-        while (ub < EBPF_TOTAL_STACK_SIZE && !non_numerical_bytes[ub]) {
+        while (ub < non_numerical_bytes.size() && !non_numerical_bytes[ub]) {
             ub++;
         }
         return static_cast<int>(ub - lb);
     }
 
     void reset(const size_t lb, int n) noexcept {
-        if (lb >= EBPF_TOTAL_STACK_SIZE) {
+        if (lb >= non_numerical_bytes.size()) {
             return;
         }
-        n = std::min(n, gsl::narrow_cast<int>(EBPF_TOTAL_STACK_SIZE - lb));
+        n = std::min(n, gsl::narrow_cast<int>(non_numerical_bytes.size() - lb));
         for (int i = 0; i < n; i++) {
             non_numerical_bytes.reset(lb + i);
         }
     }
 
     void havoc(const size_t lb, int width) noexcept {
-        if (lb >= EBPF_TOTAL_STACK_SIZE) {
+        if (lb >= non_numerical_bytes.size()) {
             return;
         }
-        width = std::min(width, static_cast<int>(EBPF_TOTAL_STACK_SIZE - lb));
+        width = std::min(width, static_cast<int>(non_numerical_bytes.size() - lb));
         for (int i = 0; i < width; i++) {
             non_numerical_bytes.set(lb + i);
         }
@@ -129,7 +127,7 @@ class BitsetDomain final {
             return true;
         }
         lb = std::max(lb, 0);
-        ub = std::min(ub, EBPF_TOTAL_STACK_SIZE);
+        ub = std::min(ub, gsl::narrow_cast<int32_t>(non_numerical_bytes.size()));
         assert(lb <= ub);
 
         for (int i = lb; i < ub; i++) {

--- a/src/crab/ebpf_checker.cpp
+++ b/src/crab/ebpf_checker.cpp
@@ -80,9 +80,11 @@ std::optional<VerificationError> ebpf_domain_check(const EbpfDomain& dom, const 
 
 void EbpfChecker::check_access_stack(const LinearExpression& lb, const LinearExpression& ub) const {
     using namespace dsl_syntax;
-    require_value(dom.state, reg_pack(R10_STACK_POINTER).stack_offset - EBPF_SUBPROGRAM_STACK_SIZE <= lb,
-                  "Lower bound must be at least r10.stack_offset - EBPF_SUBPROGRAM_STACK_SIZE");
-    require_value(dom.state, ub <= EBPF_TOTAL_STACK_SIZE, "Upper bound must be at most EBPF_TOTAL_STACK_SIZE");
+    require_value(dom.state,
+                  reg_pack(R10_STACK_POINTER).stack_offset - thread_local_options.subprogram_stack_size <= lb,
+                  "Lower bound must be at least r10.stack_offset - subprogram_stack_size");
+    require_value(dom.state, ub <= thread_local_options.total_stack_size(),
+                  "Upper bound must be at most total_stack_size");
 }
 
 void EbpfChecker::check_access_context(const LinearExpression& lb, const LinearExpression& ub) const {

--- a/src/crab/ebpf_checker.cpp
+++ b/src/crab/ebpf_checker.cpp
@@ -126,8 +126,8 @@ void EbpfChecker::operator()(const Comparable& s) const {
             throw_fail("Cannot subtract pointers to non-singleton regions");
         }
         // And, to avoid wraparound errors, they must be within bounds.
-        this->operator()(ValidAccess{MAX_CALL_STACK_FRAMES, s.r1, 0, Imm{0}, false});
-        this->operator()(ValidAccess{MAX_CALL_STACK_FRAMES, s.r2, 0, Imm{0}, false});
+        this->operator()(ValidAccess{thread_local_options.max_call_stack_frames, s.r1, 0, Imm{0}, false});
+        this->operator()(ValidAccess{thread_local_options.max_call_stack_frames, s.r2, 0, Imm{0}, false});
     } else {
         // _Maybe_ different types, so r2 must be a number.
         // We checked in a previous assertion that r1 is a pointer or a number.

--- a/src/crab/ebpf_domain.cpp
+++ b/src/crab/ebpf_domain.cpp
@@ -150,7 +150,7 @@ EbpfDomain EbpfDomain::calculate_constant_limits() {
         inv.add_value_constraint(r.svalue >= std::numeric_limits<int32_t>::min());
         inv.add_value_constraint(r.uvalue <= std::numeric_limits<uint32_t>::max());
         inv.add_value_constraint(r.uvalue >= 0);
-        inv.add_value_constraint(r.stack_offset <= EBPF_TOTAL_STACK_SIZE);
+        inv.add_value_constraint(r.stack_offset <= thread_local_options.total_stack_size());
         inv.add_value_constraint(r.stack_offset >= 0);
         inv.add_value_constraint(r.shared_offset <= r.shared_region_size);
         inv.add_value_constraint(r.shared_offset >= 0);
@@ -406,9 +406,10 @@ EbpfDomain EbpfDomain::setup_entry(const bool init_r1) {
 
     const auto r10 = reg_pack(R10_STACK_POINTER);
     constexpr Reg r10_reg{R10_STACK_POINTER};
-    inv.state.values.add_constraint(EBPF_TOTAL_STACK_SIZE <= r10.svalue);
+    const auto total_stack = thread_local_options.total_stack_size();
+    inv.state.values.add_constraint(total_stack <= r10.svalue);
     inv.state.values.add_constraint(r10.svalue <= PTR_MAX);
-    inv.state.values.assign(r10.stack_offset, EBPF_TOTAL_STACK_SIZE);
+    inv.state.values.assign(r10.stack_offset, total_stack);
     // stack_numeric_size would be 0, but TOP has the same result
     // so no need to assign it.
     inv.state.assign_type(r10_reg, T_STACK);

--- a/src/crab/ebpf_transformer.cpp
+++ b/src/crab/ebpf_transformer.cpp
@@ -187,10 +187,11 @@ void EbpfTransformer::havoc_subprogram_stack(const std::string& prefix) {
     if (!intv.is_singleton()) {
         return;
     }
-    const int64_t stack_start = intv.singleton()->cast_to<int64_t>() - EBPF_SUBPROGRAM_STACK_SIZE;
-    stack.havoc_type(dom.state.types, Interval{stack_start}, Interval{EBPF_SUBPROGRAM_STACK_SIZE});
+    const auto frame_size = thread_local_options.subprogram_stack_size;
+    const int64_t stack_start = intv.singleton()->cast_to<int64_t>() - frame_size;
+    stack.havoc_type(dom.state.types, Interval{stack_start}, Interval{frame_size});
     for (const DataKind kind : iterate_kinds()) {
-        stack.havoc(dom.state.values, kind, Interval{stack_start}, Interval{EBPF_SUBPROGRAM_STACK_SIZE});
+        stack.havoc(dom.state.values, kind, Interval{stack_start}, Interval{frame_size});
     }
 }
 
@@ -412,7 +413,7 @@ void EbpfTransformer::operator()(const Exit& a) {
 
     // Restore r10.
     constexpr Reg r10_reg{R10_STACK_POINTER};
-    add(r10_reg, EBPF_SUBPROGRAM_STACK_SIZE, 64);
+    add(r10_reg, thread_local_options.subprogram_stack_size, 64);
 
     // Scratch r1-r5: the callee may have clobbered them (caller-saved per BPF ABI).
     scratch_caller_saved_registers();
@@ -969,7 +970,7 @@ void EbpfTransformer::operator()(const CallLocal& call) {
 
     // Update r10.
     constexpr Reg r10_reg{R10_STACK_POINTER};
-    add(r10_reg, -EBPF_SUBPROGRAM_STACK_SIZE, 64);
+    add(r10_reg, -thread_local_options.subprogram_stack_size, 64);
 }
 
 void EbpfTransformer::operator()(const Callx& callx) {

--- a/src/ir/assertions.cpp
+++ b/src/ir/assertions.cpp
@@ -5,6 +5,7 @@
 #include <utility>
 #include <vector>
 
+#include "config.hpp"
 #include "ir/syntax.hpp"
 #include "platform.hpp"
 
@@ -232,7 +233,7 @@ class AssertExtractor {
         const int offset = ins.access.offset;
         if (basereg.v == R10_STACK_POINTER) {
             // We know we are accessing the stack.
-            if (offset < -EBPF_SUBPROGRAM_STACK_SIZE || offset + static_cast<int>(width.v) > 0) {
+            if (offset < -thread_local_options.subprogram_stack_size || offset + static_cast<int>(width.v) > 0) {
                 // This assertion will fail
                 res.emplace_back(make_valid_access(basereg, offset, width, false,
                                                    ins.is_load ? AccessType::read : AccessType::write));

--- a/src/ir/cfg_builder.cpp
+++ b/src/ir/cfg_builder.cpp
@@ -281,6 +281,12 @@ static void validate_instruction_feature_support(const InstructionSeq& insts, co
 
 /// Update a control-flow graph to inline function macros.
 static void add_cfg_nodes(CfgBuilder& builder, const Label& caller_label, const Label& entry_label) {
+    const string caller_label_str = to_string(caller_label);
+    const long stack_frame_depth = std::ranges::count(caller_label_str, STACK_FRAME_DELIMITER) + 2;
+    if (stack_frame_depth > thread_local_options.max_call_stack_frames) {
+        throw InvalidControlFlow{"too many call stack frames"};
+    }
+
     bool first = true;
 
     // Get the label of the node to go to on returning from the macro.
@@ -354,14 +360,9 @@ static void add_cfg_nodes(CfgBuilder& builder, const Label& caller_label, const 
     builder.remove_child(caller_label, exit_to_label);
 
     // Finally, recurse to replace any nested function macros.
-    string caller_label_str = to_string(caller_label);
-    const long stack_frame_depth = std::ranges::count(caller_label_str, STACK_FRAME_DELIMITER) + 2;
     for (const auto& macro_label : seen_labels) {
         const Label label{macro_label.from, macro_label.to, caller_label_str};
         if (const auto pins = std::get_if<CallLocal>(&builder.prog.instruction_at(label))) {
-            if (stack_frame_depth >= thread_local_options.max_call_stack_frames) {
-                throw InvalidControlFlow{"too many call stack frames"};
-            }
             add_cfg_nodes(builder, label, pins->target);
         }
     }

--- a/src/ir/cfg_builder.cpp
+++ b/src/ir/cfg_builder.cpp
@@ -641,6 +641,7 @@ static void validate_tail_call_chain_depth(const Program& prog, const Wto& wto, 
 Program Program::from_sequence(const InstructionSeq& inst_seq, const ProgramInfo& info,
                                const ebpf_verifier_options_t& options) {
     thread_local_program_info.set(info);
+    options.validate_stack_size();
     thread_local_options = options;
     assert(info.platform != nullptr && "platform must be set before instruction feature validation");
     ResolvedKfuncCalls resolved_kfunc_calls;

--- a/src/ir/cfg_builder.cpp
+++ b/src/ir/cfg_builder.cpp
@@ -359,7 +359,7 @@ static void add_cfg_nodes(CfgBuilder& builder, const Label& caller_label, const 
     for (const auto& macro_label : seen_labels) {
         const Label label{macro_label.from, macro_label.to, caller_label_str};
         if (const auto pins = std::get_if<CallLocal>(&builder.prog.instruction_at(label))) {
-            if (stack_frame_depth >= MAX_CALL_STACK_FRAMES) {
+            if (stack_frame_depth >= thread_local_options.max_call_stack_frames) {
                 throw InvalidControlFlow{"too many call stack frames"};
             }
             add_cfg_nodes(builder, label, pins->target);
@@ -641,7 +641,7 @@ static void validate_tail_call_chain_depth(const Program& prog, const Wto& wto, 
 Program Program::from_sequence(const InstructionSeq& inst_seq, const ProgramInfo& info,
                                const ebpf_verifier_options_t& options) {
     thread_local_program_info.set(info);
-    options.validate_stack_size();
+    options.validate();
     thread_local_options = options;
     assert(info.platform != nullptr && "platform must be set before instruction feature validation");
     ResolvedKfuncCalls resolved_kfunc_calls;

--- a/src/ir/unmarshal.cpp
+++ b/src/ir/unmarshal.cpp
@@ -83,7 +83,7 @@ static Instruction shift32(const Reg dst, const Bin::Op op) {
 struct Unmarshaller {
     vector<vector<string>>& notes;
     const ProgramInfo& info;
-    int total_stack_size = MAX_CALL_STACK_FRAMES * 512;
+    int total_stack_size = 8 * 512;
     // ReSharper disable once CppMemberFunctionMayBeConst
     void note(const string& what) { notes.back().emplace_back(what); }
     // ReSharper disable once CppMemberFunctionMayBeConst

--- a/src/ir/unmarshal.cpp
+++ b/src/ir/unmarshal.cpp
@@ -5,7 +5,6 @@
 #include <string>
 #include <vector>
 
-#include "config.hpp"
 #include "crab_utils/debug.hpp"
 #include "crab_utils/num_safety.hpp"
 #include "ir/unmarshal.hpp"
@@ -84,6 +83,7 @@ static Instruction shift32(const Reg dst, const Bin::Op op) {
 struct Unmarshaller {
     vector<vector<string>>& notes;
     const ProgramInfo& info;
+    int total_stack_size = EBPF_TOTAL_STACK_SIZE;
     // ReSharper disable once CppMemberFunctionMayBeConst
     void note(const string& what) { notes.back().emplace_back(what); }
     // ReSharper disable once CppMemberFunctionMayBeConst
@@ -294,8 +294,8 @@ struct Unmarshaller {
             assert(!(isLoad && isImm));
             const uint8_t basereg = isLoad ? inst.src : inst.dst;
 
-            if (basereg == R10_STACK_POINTER && (inst.offset + opcode_to_width(inst.opcode) > 0 ||
-                                                 inst.offset < -thread_local_options.total_stack_size())) {
+            if (basereg == R10_STACK_POINTER &&
+                (inst.offset + opcode_to_width(inst.opcode) > 0 || inst.offset < -total_stack_size)) {
                 note("Stack access out of bounds");
             }
             auto res = Mem{
@@ -323,8 +323,8 @@ struct Unmarshaller {
             if (inst.imm != 0) {
                 throw InvalidInstruction(pc, make_opcode_message("nonzero imm for", inst.opcode));
             }
-            if (inst.src == R10_STACK_POINTER && (inst.offset + opcode_to_width(inst.opcode) > 0 ||
-                                                  inst.offset < -thread_local_options.total_stack_size())) {
+            if (inst.src == R10_STACK_POINTER &&
+                (inst.offset + opcode_to_width(inst.opcode) > 0 || inst.offset < -total_stack_size)) {
                 note("Stack access out of bounds");
             }
             return Mem{
@@ -784,6 +784,7 @@ struct Unmarshaller {
 
     vector<LabeledInstruction> unmarshal(vector<EbpfInst> const& insts,
                                          const prevail::ebpf_verifier_options_t& options) {
+        total_stack_size = options.total_stack_size();
         vector<LabeledInstruction> prog;
         int exit_count = 0;
         if (insts.empty()) {

--- a/src/ir/unmarshal.cpp
+++ b/src/ir/unmarshal.cpp
@@ -5,6 +5,7 @@
 #include <string>
 #include <vector>
 
+#include "config.hpp"
 #include "crab_utils/debug.hpp"
 #include "crab_utils/num_safety.hpp"
 #include "ir/unmarshal.hpp"
@@ -293,8 +294,8 @@ struct Unmarshaller {
             assert(!(isLoad && isImm));
             const uint8_t basereg = isLoad ? inst.src : inst.dst;
 
-            if (basereg == R10_STACK_POINTER &&
-                (inst.offset + opcode_to_width(inst.opcode) > 0 || inst.offset < -EBPF_TOTAL_STACK_SIZE)) {
+            if (basereg == R10_STACK_POINTER && (inst.offset + opcode_to_width(inst.opcode) > 0 ||
+                                                 inst.offset < -thread_local_options.total_stack_size())) {
                 note("Stack access out of bounds");
             }
             auto res = Mem{
@@ -322,8 +323,8 @@ struct Unmarshaller {
             if (inst.imm != 0) {
                 throw InvalidInstruction(pc, make_opcode_message("nonzero imm for", inst.opcode));
             }
-            if (inst.src == R10_STACK_POINTER &&
-                (inst.offset + opcode_to_width(inst.opcode) > 0 || inst.offset < -EBPF_TOTAL_STACK_SIZE)) {
+            if (inst.src == R10_STACK_POINTER && (inst.offset + opcode_to_width(inst.opcode) > 0 ||
+                                                  inst.offset < -thread_local_options.total_stack_size())) {
                 note("Stack access out of bounds");
             }
             return Mem{

--- a/src/ir/unmarshal.cpp
+++ b/src/ir/unmarshal.cpp
@@ -83,7 +83,7 @@ static Instruction shift32(const Reg dst, const Bin::Op op) {
 struct Unmarshaller {
     vector<vector<string>>& notes;
     const ProgramInfo& info;
-    int total_stack_size = EBPF_TOTAL_STACK_SIZE;
+    int total_stack_size = MAX_CALL_STACK_FRAMES * 512;
     // ReSharper disable once CppMemberFunctionMayBeConst
     void note(const string& what) { notes.back().emplace_back(what); }
     // ReSharper disable once CppMemberFunctionMayBeConst

--- a/src/ir/unmarshal.cpp
+++ b/src/ir/unmarshal.cpp
@@ -83,7 +83,7 @@ static Instruction shift32(const Reg dst, const Bin::Op op) {
 struct Unmarshaller {
     vector<vector<string>>& notes;
     const ProgramInfo& info;
-    int total_stack_size = 8 * 512;
+    int subprogram_stack_size = 512;
     // ReSharper disable once CppMemberFunctionMayBeConst
     void note(const string& what) { notes.back().emplace_back(what); }
     // ReSharper disable once CppMemberFunctionMayBeConst
@@ -295,7 +295,7 @@ struct Unmarshaller {
             const uint8_t basereg = isLoad ? inst.src : inst.dst;
 
             if (basereg == R10_STACK_POINTER &&
-                (inst.offset + opcode_to_width(inst.opcode) > 0 || inst.offset < -total_stack_size)) {
+                (inst.offset + opcode_to_width(inst.opcode) > 0 || inst.offset < -subprogram_stack_size)) {
                 note("Stack access out of bounds");
             }
             auto res = Mem{
@@ -324,7 +324,7 @@ struct Unmarshaller {
                 throw InvalidInstruction(pc, make_opcode_message("nonzero imm for", inst.opcode));
             }
             if (inst.src == R10_STACK_POINTER &&
-                (inst.offset + opcode_to_width(inst.opcode) > 0 || inst.offset < -total_stack_size)) {
+                (inst.offset + opcode_to_width(inst.opcode) > 0 || inst.offset < -subprogram_stack_size)) {
                 note("Stack access out of bounds");
             }
             return Mem{
@@ -784,7 +784,8 @@ struct Unmarshaller {
 
     vector<LabeledInstruction> unmarshal(vector<EbpfInst> const& insts,
                                          const prevail::ebpf_verifier_options_t& options) {
-        total_stack_size = options.total_stack_size();
+        options.validate();
+        subprogram_stack_size = options.subprogram_stack_size;
         vector<LabeledInstruction> prog;
         int exit_count = 0;
         if (insts.empty()) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -87,6 +87,11 @@ int main(int argc, char** argv) {
                  "Apply additional checks that would cause runtime failures")
         ->group("Features");
 
+    app.add_option("--stack-size", ebpf_verifier_options.subprogram_stack_size,
+                   "Per-subprogram stack frame size in bytes (default: 512)")
+        ->group("Features")
+        ->check(CLI::PositiveNumber);
+
     std::set<std::string> include_groups = get_conformance_group_names();
     app.add_option("--include_groups", include_groups, "Include conformance groups")
         ->group("Features")

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -90,7 +90,12 @@ int main(int argc, char** argv) {
     app.add_option("--stack-size", ebpf_verifier_options.subprogram_stack_size,
                    "Per-subprogram stack frame size in bytes (default: 512)")
         ->group("Features")
-        ->check(CLI::Range(1, ebpf_verifier_options_t::max_subprogram_stack_size));
+        ->check(CLI::Range(1, ebpf_verifier_options_t::MAX_SUBPROGRAM_STACK_SIZE));
+
+    app.add_option("--max-call-stack-frames", ebpf_verifier_options.max_call_stack_frames,
+                   "Maximum number of nested function calls (default: 8)")
+        ->group("Features")
+        ->check(CLI::Range(1, ebpf_verifier_options_t::MAX_CALL_STACK_FRAMES_LIMIT));
 
     std::set<std::string> include_groups = get_conformance_group_names();
     app.add_option("--include_groups", include_groups, "Include conformance groups")

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -90,7 +90,7 @@ int main(int argc, char** argv) {
     app.add_option("--stack-size", ebpf_verifier_options.subprogram_stack_size,
                    "Per-subprogram stack frame size in bytes (default: 512)")
         ->group("Features")
-        ->check(CLI::PositiveNumber);
+        ->check(CLI::Range(1, ebpf_verifier_options_t::max_subprogram_stack_size));
 
     std::set<std::string> include_groups = get_conformance_group_names();
     app.add_option("--include_groups", include_groups, "Include conformance groups")

--- a/src/result.cpp
+++ b/src/result.cpp
@@ -7,6 +7,7 @@
 #include <sstream>
 #include <type_traits>
 
+#include "config.hpp"
 #include "crab/ebpf_domain.hpp"
 #include "ir/program.hpp"
 #include "result.hpp"
@@ -63,7 +64,7 @@ bool RelevantState::is_relevant_constraint(const std::string& constraint) const 
     std::vector<int64_t> abs_stack_offsets;
     abs_stack_offsets.reserve(stack_offsets.size());
     for (const auto& rel_offset : stack_offsets) {
-        abs_stack_offsets.push_back(EBPF_TOTAL_STACK_SIZE + rel_offset);
+        abs_stack_offsets.push_back(thread_local_options.total_stack_size() + rel_offset);
     }
 
     // Check for stack range pattern: s[start...end]
@@ -233,8 +234,10 @@ InstructionDeps extract_instruction_deps(const Instruction& ins, const EbpfDomai
                     } else if (const auto stack_off = pre_state.get_stack_offset(v.access.basereg)) {
                         // basereg is a stack pointer with known offset from R10
                         // Compute the actual stack slot: stack_off is absolute (e.g., 4096),
-                        // convert to relative from R10: relative = offset + (stack_off - EBPF_TOTAL_STACK_SIZE)
-                        deps.stack_read.insert(v.access.offset + (*stack_off - EBPF_TOTAL_STACK_SIZE));
+                        // convert to relative from R10: relative = offset + (stack_off -
+                        // thread_local_options.total_stack_size())
+                        deps.stack_read.insert(v.access.offset +
+                                               (*stack_off - thread_local_options.total_stack_size()));
                     }
                 } else {
                     // Store: *(basereg + offset) = value
@@ -245,7 +248,8 @@ InstructionDeps extract_instruction_deps(const Instruction& ins, const EbpfDomai
                     if (v.access.basereg.v == R10_STACK_POINTER) {
                         deps.stack_written.insert(v.access.offset);
                     } else if (const auto stack_off = pre_state.get_stack_offset(v.access.basereg)) {
-                        deps.stack_written.insert(v.access.offset + (*stack_off - EBPF_TOTAL_STACK_SIZE));
+                        deps.stack_written.insert(v.access.offset +
+                                                  (*stack_off - thread_local_options.total_stack_size()));
                     }
                 }
             } else if constexpr (std::is_same_v<T, Atomic>) {
@@ -259,7 +263,7 @@ InstructionDeps extract_instruction_deps(const Instruction& ins, const EbpfDomai
                     deps.stack_read.insert(v.access.offset);
                     deps.stack_written.insert(v.access.offset);
                 } else if (const auto stack_off = pre_state.get_stack_offset(v.access.basereg)) {
-                    const auto adjusted_off = v.access.offset + (*stack_off - EBPF_TOTAL_STACK_SIZE);
+                    const auto adjusted_off = v.access.offset + (*stack_off - thread_local_options.total_stack_size());
                     deps.stack_read.insert(adjusted_off);
                     deps.stack_written.insert(adjusted_off);
                 }

--- a/src/result.cpp
+++ b/src/result.cpp
@@ -234,8 +234,8 @@ InstructionDeps extract_instruction_deps(const Instruction& ins, const EbpfDomai
                     } else if (const auto stack_off = pre_state.get_stack_offset(v.access.basereg)) {
                         // basereg is a stack pointer with known offset from R10
                         // Compute the actual stack slot: stack_off is absolute (e.g., 4096),
-                        // convert to relative from R10: relative = offset + (stack_off -
-                        // thread_local_options.total_stack_size())
+                        // convert to relative from R10:
+                        //  relative = offset + (stack_off - thread_local_options.total_stack_size())
                         deps.stack_read.insert(v.access.offset +
                                                (*stack_off - thread_local_options.total_stack_size()));
                     }

--- a/src/spec/ebpf_base.h
+++ b/src/spec/ebpf_base.h
@@ -77,12 +77,3 @@ typedef struct _ebpf_context_descriptor {
 #ifndef MAX_CALL_STACK_FRAMES
 #define MAX_CALL_STACK_FRAMES 8
 #endif
-
-// Stack space allocated for each subprogram (in bytes).
-// This ensures each function call has its own dedicated stack space.
-#ifndef EBPF_SUBPROGRAM_STACK_SIZE
-#define EBPF_SUBPROGRAM_STACK_SIZE 512
-#endif
-
-// Total stack space usable with nested subprogram calls.
-#define EBPF_TOTAL_STACK_SIZE (MAX_CALL_STACK_FRAMES * EBPF_SUBPROGRAM_STACK_SIZE)

--- a/src/spec/ebpf_base.h
+++ b/src/spec/ebpf_base.h
@@ -71,9 +71,3 @@ typedef struct _ebpf_context_descriptor {
     int end;  // Offset into ctx struct of pointer to end of data.
     int meta; // Offset into ctx struct of pointer to metadata.
 } ebpf_context_descriptor_t;
-
-// Maximum number of nested function calls allowed in eBPF programs.
-// This limit helps prevent stack overflow and ensures predictable behavior.
-#ifndef MAX_CALL_STACK_FRAMES
-#define MAX_CALL_STACK_FRAMES 8
-#endif

--- a/src/test/ebpf_yaml.cpp
+++ b/src/test/ebpf_yaml.cpp
@@ -15,6 +15,7 @@
 
 #include <yaml-cpp/yaml.h>
 
+#include "config.hpp"
 #include "ebpf_verifier.hpp"
 #include "ir/parse.hpp"
 #include "ir/syntax.hpp"
@@ -485,7 +486,7 @@ void add_stack_variable(std::set<std::string>& more, int& offset, const std::vec
     using TU = std::make_unsigned_t<TS>;
     constexpr size_t size = sizeof(TS);
     static_assert(sizeof(TU) == size);
-    const auto src = memory_bytes.data() + offset + memory_bytes.size() - EBPF_TOTAL_STACK_SIZE;
+    const auto src = memory_bytes.data() + offset + memory_bytes.size() - thread_local_options.total_stack_size();
     TS svalue;
     std::memcpy(&svalue, src, size);
     TU uvalue;
@@ -497,15 +498,16 @@ void add_stack_variable(std::set<std::string>& more, int& offset, const std::vec
 }
 
 StringInvariant stack_contents_invariant(const std::vector<std::byte>& memory_bytes) {
-    std::set<std::string> more = {"r1.type=stack",
-                                  "r1.stack_offset=" + std::to_string(EBPF_TOTAL_STACK_SIZE - memory_bytes.size()),
-                                  "r1.stack_numeric_size=" + std::to_string(memory_bytes.size()),
-                                  "r10.type=stack",
-                                  "r10.stack_offset=" + std::to_string(EBPF_TOTAL_STACK_SIZE),
-                                  "s[" + std::to_string(EBPF_TOTAL_STACK_SIZE - memory_bytes.size()) + "..." +
-                                      std::to_string(EBPF_TOTAL_STACK_SIZE - 1) + "].type=number"};
+    std::set<std::string> more = {
+        "r1.type=stack",
+        "r1.stack_offset=" + std::to_string(thread_local_options.total_stack_size() - memory_bytes.size()),
+        "r1.stack_numeric_size=" + std::to_string(memory_bytes.size()),
+        "r10.type=stack",
+        "r10.stack_offset=" + std::to_string(thread_local_options.total_stack_size()),
+        "s[" + std::to_string(thread_local_options.total_stack_size() - memory_bytes.size()) + "..." +
+            std::to_string(thread_local_options.total_stack_size() - 1) + "].type=number"};
 
-    int offset = EBPF_TOTAL_STACK_SIZE - gsl::narrow<int>(memory_bytes.size());
+    int offset = thread_local_options.total_stack_size() - gsl::narrow<int>(memory_bytes.size());
     if (offset % 2 != 0) {
         add_stack_variable<int8_t>(more, offset, memory_bytes);
     }
@@ -515,7 +517,7 @@ StringInvariant stack_contents_invariant(const std::vector<std::byte>& memory_by
     if (offset % 8 != 0) {
         add_stack_variable<int32_t>(more, offset, memory_bytes);
     }
-    while (offset < EBPF_TOTAL_STACK_SIZE) {
+    while (offset < thread_local_options.total_stack_size()) {
         add_stack_variable<int64_t>(more, offset, memory_bytes);
     }
 
@@ -543,7 +545,7 @@ ConformanceTestResult run_conformance_test_case(const std::vector<uint8_t>& memo
     StringInvariant pre_invariant = StringInvariant::top();
 
     if (!memory_bytes.empty()) {
-        if (memory_bytes.size() > EBPF_TOTAL_STACK_SIZE) {
+        if (memory_bytes.size() > thread_local_options.total_stack_size()) {
             std::cerr << "memory size overflow\n";
             return {};
         }

--- a/src/test/ebpf_yaml.cpp
+++ b/src/test/ebpf_yaml.cpp
@@ -534,6 +534,7 @@ static StringInvariant stack_contents_invariant(const std::vector<uint8_t>& memo
 
 ConformanceTestResult run_conformance_test_case(const std::vector<uint8_t>& memory_bytes,
                                                 std::span<const EbpfInst> instructions, bool debug) {
+    thread_local_options = {};
     ebpf_context_descriptor_t context_descriptor{64, -1, -1, -1};
     EbpfProgramType program_type = make_program_type("conformance_check", &context_descriptor);
 

--- a/test-data/jump.yaml
+++ b/test-data/jump.yaml
@@ -1164,4 +1164,4 @@ code:
 
 post: []
 messages:
-  - "0: Lower bound must be at least r10.stack_offset - EBPF_SUBPROGRAM_STACK_SIZE (valid_access(r1.offset) for comparison/subtraction)"
+  - "0: Lower bound must be at least r10.stack_offset - subprogram_stack_size (valid_access(r1.offset) for comparison/subtraction)"

--- a/test-data/llm-context-tests.md
+++ b/test-data/llm-context-tests.md
@@ -218,9 +218,9 @@ Skip any test marked as SLOW unless specifically requested.
 ./bin/prevail ebpf-samples/build/badhelpercall.o .text -v
 ```
 
-**Expected error**: `Upper bound must be at most EBPF_TOTAL_STACK_SIZE (valid_access(r1.offset, width=r2) for write)`
+**Expected error**: `Upper bound must be at most total_stack_size (valid_access(r1.offset, width=r2) for write)`
 **Pattern**: 4.3 - Stack Out-of-Bounds Access
-**Key invariant**: `r1.stack_offset=4095` with `r2.svalue=20` — writing 20 bytes at stack offset 4095 exceeds EBPF_TOTAL_STACK_SIZE (4096)
+**Key invariant**: `r1.stack_offset=4095` with `r2.svalue=20` — writing 20 bytes at stack offset 4095 exceeds total_stack_size (4096)
 **Fix**: Ensure stack pointer + access width stays within the current 512-byte stack frame (absolute offsets 3584–4096 for the main frame)
 
 ---

--- a/test-data/stack.yaml
+++ b/test-data/stack.yaml
@@ -639,7 +639,7 @@ code:
 post: []
 
 messages:
-  - "0: Lower bound must be at least r10.stack_offset - EBPF_SUBPROGRAM_STACK_SIZE (valid_access(r10.offset-513, width=1) for write)"
+  - "0: Lower bound must be at least r10.stack_offset - subprogram_stack_size (valid_access(r10.offset-513, width=1) for write)"
 
 ---
 test-case: Round trip min int on stack

--- a/test-data/subtract.yaml
+++ b/test-data/subtract.yaml
@@ -141,4 +141,4 @@ code:
 post: []
 
 messages:
-  - "0: Upper bound must be at most EBPF_TOTAL_STACK_SIZE (r2.type == number or r1.type == r2.type in {ctx, stack, packet})"
+  - "0: Upper bound must be at most total_stack_size (r2.type == number or r1.type == r2.type in {ctx, stack, packet})"


### PR DESCRIPTION
- Add `--stack-size` (default 512) and `--max-call-stack-frames` (default 8) CLI options, backed by fields in `ebpf_verifier_options_t`
- Replace `std::bitset<EBPF_TOTAL_STACK_SIZE>` with `boost::dynamic_bitset<>` in BitsetDomain to support runtime-sized stacks
- Remove the `EBPF_SUBPROGRAM_STACK_SIZE`, `EBPF_TOTAL_STACK_SIZE`, and `MAX_CALL_STACK_FRAMES` macros from `ebpf_base.h`
- Validate inputs: stack size capped at 1 MB, call depth at 128
- Move call-depth check to the entry of `add_cfg_nodes` so it guards all invocations uniformly

#1060 and #1063 made the macros compile-time parameters; this PR makes them command-line arguments.
