### PR TITLE
Fix spurious widening precision loss in EbpfDomain (#1071)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v0.2.2 (2026-04-15)
+
+### Bug fixes
+
+- Fix spurious widening precision loss in `EbpfDomain` that rejected
+  concretely-safe programs using numeric counters stored on the stack
+  across loops (#1071). Regression from #916.
+
 ## v0.2.1 (2026-04-14)
 
 Bug fixes, API enhancements, and infrastructure updates.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ if (NOT DEFINED CMAKE_MSVC_RUNTIME_LIBRARY)
   set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL")
 endif ()
 
-project(prevail VERSION 0.2.1)
+project(prevail VERSION 0.2.2)
 
 # NOTE: Do not use CMAKE_SOURCE_DIR in this project.
 # When prevail is consumed via add_subdirectory()/FetchContent, CMAKE_SOURCE_DIR refers to

--- a/examples/using_installed_package/CMakeLists.txt
+++ b/examples/using_installed_package/CMakeLists.txt
@@ -9,7 +9,7 @@ set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # This will fail if prevail wasn't installed correctly
-find_package(prevail 0.2.1 REQUIRED)
+find_package(prevail 0.2.2 REQUIRED)
 
 add_executable(install_test main.cpp)
 target_link_libraries(install_test PRIVATE prevail::prevail)

--- a/examples/using_installed_package/README.md
+++ b/examples/using_installed_package/README.md
@@ -44,7 +44,7 @@ build\Release\install_test.exe
 ### CMakeLists.txt
 
 ```cmake
-find_package(prevail 0.2.1 REQUIRED)
+find_package(prevail 0.2.2 REQUIRED)
 
 add_executable(myapp main.cpp)
 target_link_libraries(myapp PRIVATE prevail::prevail)

--- a/examples/using_installed_package/TESTING_DETAILS.md
+++ b/examples/using_installed_package/TESTING_DETAILS.md
@@ -13,7 +13,7 @@ installation mechanism (not API stability).
     - Proper permissions are set
 
 2. **CMake Package Discovery**
-    - `find_package(prevail 0.2.1 REQUIRED)` succeeds
+    - `find_package(prevail 0.2.2 REQUIRED)` succeeds
     - Version checking works correctly
     - Package config files are valid
 

--- a/src/crab/ebpf_domain.cpp
+++ b/src/crab/ebpf_domain.cpp
@@ -180,6 +180,12 @@ static const EbpfDomain& get_constant_limits() { return constant_limits.get(); }
 void EbpfDomain::clear_thread_local_state() { constant_limits.clear(); }
 
 EbpfDomain EbpfDomain::widen(const EbpfDomain& other, const bool to_constants) const {
+    if (is_bottom()) {
+        return other;
+    }
+    if (other.is_bottom()) {
+        return *this;
+    }
     EbpfDomain res{this->state.widen(other.state), stack.widen(other.stack)};
 
     if (to_constants) {

--- a/src/test/test_verify_linux_selftests.cpp
+++ b/src/test/test_verify_linux_selftests.cpp
@@ -71,9 +71,7 @@ TEST_PROGRAM_FAIL("linux-selftests", "bloom_filter_map.o", "fentry/__x64_sys_get
 // register type refinement is too imprecise in this control-flow pattern
 TEST_SECTION_FAIL("linux-selftests", "freplace_get_constant.o", "freplace/get_constant",
                   verify_test::VerifyIssueKind::VerifierTypeTracking)
-// Type precision lost through loop join: r3 loaded from stack loses type after widening
-TEST_SECTION_FAIL("linux-selftests", "loop3.o", "raw_tracepoint/consume_skb",
-                  verify_test::VerifyIssueKind::VerifierTypeTracking)
+TEST_SECTION("linux-selftests", "loop3.o", "raw_tracepoint/consume_skb")
 // register type refinement is too imprecise in this control-flow pattern
 TEST_PROGRAM_FAIL("linux-selftests", "map_ptr_kern.o", ".text", "check", 19,
                   verify_test::VerifyIssueKind::VerifierTypeTracking)

--- a/test-data/elf_inventory.json
+++ b/test-data/elf_inventory.json
@@ -8230,15 +8230,6 @@
                 "invalid": false
               }
             ]
-          },
-          "test_overrides": {
-            "sections": {
-              "raw_tracepoint/consume_skb": {
-                "kind": "VerifierTypeTracking",
-                "reason": "Type precision lost through loop join: r3 loaded from stack loses type after widening",
-                "status": "expected_failure"
-              }
-            }
           }
         },
         "loop4.o": {

--- a/test-data/loop.yaml
+++ b/test-data/loop.yaml
@@ -558,3 +558,51 @@ post:
   - pc[1]=r0.svalue+1
 
 messages: []
+
+---
+test-case: stack counter type preserved through widening (issue 1071)
+
+pre: [
+  "r1.type=ctx", "r1.ctx_offset=0", "r1.svalue=[1, 2147418112]",
+  "r2.type=number", "r2.svalue=4294967296", "r2.uvalue=4294967296",
+  "r10.type=stack", "r10.stack_offset=4096", "r10.svalue=[4096, 2147418112]",
+  "meta_offset=0",
+  "packet_size=0",
+]
+
+code:
+  <init>: |
+    r3 = 0
+    *(u64 *)(r10 - 8) = r3
+  <loop>: |
+    r3 = *(u64 *)(r10 - 8)
+    r3 += 1
+    *(u64 *)(r10 - 8) = r3
+    if r3 < r2 goto <loop>
+  <exit>: |
+    r0 = *(u64 *)(r10 - 8)
+    exit
+
+post:
+  - r0.type=number
+  - r0.svalue=4294967296
+  - r0.uvalue=4294967296
+  - r2.type=number
+  - r2.svalue=4294967296
+  - r2.uvalue=r2.svalue
+  - r3.type=number
+  - r3.svalue=r2.svalue
+  - r3.uvalue=r2.svalue
+  - r10.type=stack
+  - r10.stack_offset=4096
+  - r10.svalue=[4096, 2147418112]
+  - r1.type=ctx
+  - r1.ctx_offset=0
+  - r1.svalue=[1, 2147418112]
+  - s[4088...4095].type=number
+  - s[4088...4095].svalue=r2.svalue
+  - s[4088...4095].uvalue=r2.svalue
+  - meta_offset=0
+  - packet_size=0
+
+messages: []


### PR DESCRIPTION
## Summary

- Short-circuit `EbpfDomain::widen` on bottom inputs so widening is independent of how bottom is represented, matching `AddBottom::widen` at the numeric layer.
- Fixes #1071: `loop3.o raw_tracepoint/consume_skb while_true` flips from rejected to accepted.

## Background

`EbpfDomain::widen` did not check for bottom. When `res & get_constant_limits()` produced bottom on the first widening iteration (because widened values like `r3.uvalue = +∞` violated `u32::max()`), the next iteration computed `bottom.widen(new_pre)` by delegating to `TypeDomain::widen` (join) and `ArrayDomain::widen` over bottom's residual structure (`TypeDomain::top()`, default stack). That wiped register-to-stack correlations such as `s[4088…4095].svalue = r3.svalue`, so the reloaded counter lost its numeric type across loop iterations.

Short-circuiting `widen` on bottom makes the widened result only depend on the non-bottom side, which is the theoretical expectation for a domain with a unique bottom element.

## Regression history

The precision loss was introduced by `1d1d2460` (introduce TypeToNumDomain, #916, 2025-10-05). Prior to that commit, `EbpfDomain::operator&` was a single line that returned the meet result regardless of bottom — no fresh `bottom()` was constructed, so residual structure was implicitly preserved. #916 added the `if (!res.is_bottom()) ... return bottom();` branch, which discards the stack and any variable/edge layout from the post-meet state.

## Changes

- `src/crab/ebpf_domain.cpp`: bottom short-circuit in `EbpfDomain::widen`.
- `test-data/loop.yaml`: new YAML reproducer (`stack counter type preserved through widening (issue 1071)`).
- `src/test/test_verify_linux_selftests.cpp`: `loop3.o` moved from `TEST_SECTION_FAIL` to `TEST_SECTION`.
- `test-data/elf_inventory.json`: removed the `test_overrides` entry for `loop3.o`.

## Test plan

- [x] YAML reproducer fails without the fix, passes with it
- [x] `bin/prevail ebpf-samples/linux-selftests/loop3.o raw_tracepoint/consume_skb while_true` passes
- [x] `bin/tests "~[slow]"`: 1296 passed, 0 failed, 236 failed as expected (no regressions)
- [x] `bin/tests "[!shouldfail]" "[linux-selftests]"`: all 34 remaining shouldfail tests still fail as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)