### PR TITLE
C++23: Replace variant<T, string> with expected

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -249,7 +249,17 @@ install(TARGETS prevail libbtf GSL
 install(DIRECTORY "${prevail_source_dir}/src/"
   DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/prevail"
   FILES_MATCHING PATTERN "*.hpp" PATTERN "*.h"
-  PATTERN "test/*" EXCLUDE
+  PATTERN "test" EXCLUDE
+  PATTERN "ir" EXCLUDE
+)
+
+# ir/ holds both public and internal headers; list the public ones explicitly.
+install(FILES
+  "${prevail_source_dir}/src/ir/marshal.hpp"
+  "${prevail_source_dir}/src/ir/parse.hpp"
+  "${prevail_source_dir}/src/ir/program.hpp"
+  "${prevail_source_dir}/src/ir/syntax.hpp"
+  DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/prevail/ir"
 )
 
 # Install convenience header to top-level include/

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -19,6 +19,7 @@ ELF Binary -> Unmarshal -> Build CFG -> Abstract Interpretation -> Result
 3. **Semantic Translation**: Map hardware opcodes to semantic IR
 
 The unmarshaller handles:
+
 - Instruction decoding (opcode, registers, immediate values)
 - Wide instruction handling (64-bit immediates span two instructions)
 - Endianness conversion
@@ -36,6 +37,7 @@ The CFG builder transforms the linear instruction sequence into a control flow g
 4. **Function Inlining**: Inline local function calls with stack frame prefixes
 
 Key transformations:
+
 - Conditional jumps split into two paths with explicit `Assume` instructions
 - Loop heads are identified for widening
 - Exit nodes connect to a special exit label
@@ -57,6 +59,7 @@ The core verification uses forward abstract interpretation:
 **Files**: `src/result.cpp`
 
 The analysis produces:
+
 - **Invariants**: Pre/post states at each program point
 - **Errors**: List of safety violations
 - **Exit value**: Range of possible return values in R0
@@ -81,24 +84,24 @@ EbpfDomain = TypeToNumDomain × ArrayDomain
 
 Implements transfer functions for each instruction type:
 
-| Instruction | Semantic Effect |
-|-------------|-----------------|
-| `Bin` (ADD, SUB, ...) | Update numeric constraints |
-| `Mem` (load/store) | Read/write array domain |
-| `Call` | Apply helper function contracts |
-| `Assume` | Refine domain with branch condition |
-| `Jmp` | No state change (control flow only) |
+| Instruction           | Semantic Effect                     |
+|-----------------------|-------------------------------------|
+| `Bin` (ADD, SUB, ...) | Update numeric constraints          |
+| `Mem` (load/store)    | Read/write array domain             |
+| `Call`                | Apply helper function contracts     |
+| `Assume`              | Refine domain with branch condition |
+| `Jmp`                 | No state change (control flow only) |
 
 ### EbpfChecker (Assertion Verification)
 
 Verifies safety properties by checking domain entailment:
 
-| Assertion | Property Checked |
-|-----------|------------------|
-| `ValidAccess` | Memory access within bounds |
-| `ValidStore` | Type-correct store operation |
-| `ValidDivisor` | Non-zero divisor |
-| `BoundedLoopCount` | Loop iteration limit |
+| Assertion          | Property Checked             |
+|--------------------|------------------------------|
+| `ValidAccess`      | Memory access within bounds  |
+| `ValidStore`       | Type-correct store operation |
+| `ValidDivisor`     | Non-zero divisor             |
+| `BoundedLoopCount` | Loop iteration limit         |
 
 ## Data Flow
 
@@ -141,6 +144,7 @@ Verifies safety properties by checking domain entailment:
 ### 1. Forward Analysis
 
 Prevail uses forward (rather than backward) analysis because:
+
 - eBPF programs have a single entry point
 - Memory safety depends on tracking pointer provenance from entry
 - Type information flows naturally forward
@@ -149,6 +153,7 @@ Prevail uses forward (rather than backward) analysis because:
 ### 2. Composite Domain
 
 The domain hierarchy enables:
+
 - **Type-guided precision**: Different numeric tracking per pointer type
 - **Efficient joins**: Type mismatches detected early
 - **Modular extension**: New pointer types can be added
@@ -156,6 +161,7 @@ The domain hierarchy enables:
 ### 3. Weak Topological Ordering
 
 WTO-based iteration provides:
+
 - **Efficient convergence**: Widening applied only at loop heads
 - **Nested loop handling**: Inner loops stabilize before outer
 - **Deterministic order**: Reproducible analysis results
@@ -163,6 +169,7 @@ WTO-based iteration provides:
 ### 4. Assertion-Based Checking
 
 Separating assertions from semantics enables:
+
 - **Modular safety properties**: Easy to add new checks
 - **Precise error reporting**: Knows exactly which property failed
 - **Configurable strictness**: Can enable/disable specific checks
@@ -178,6 +185,7 @@ Separating assertions from semantics enables:
 ```
 
 Options:
+
 - `-q`/`--quiet`: No stdout output, exit code only
 - `--cfg`: Print control-flow graph and exit
 - `--failure-slice`: Print causal trace for failures
@@ -190,13 +198,10 @@ Options:
 ```cpp
 #include "ebpf_verifier.hpp"
 
-// Load and verify
 auto raw_progs = read_elf(filename, section, options, platform);
-auto prog = Program::from_sequence(instructions, info, options);
-auto result = analyze(prog);
-
-// Check result
-if (!result.failed) {
+std::vector<std::vector<std::string>> notes;
+auto prog = Program::from_raw(raw_progs.front(), notes, options);
+if (prog && verify(*prog)) {
     // Program is safe
 }
 ```
@@ -204,6 +209,7 @@ if (!result.failed) {
 ## Thread Safety
 
 The verifier uses thread-local storage for:
+
 - **Variable registry**: Maps variable names to indices
 - **Global program counter**: Tracks current instruction during analysis
 

--- a/src/ebpf_verifier.hpp
+++ b/src/ebpf_verifier.hpp
@@ -5,6 +5,5 @@
 #include "config.hpp"
 #include "io/elf_loader.hpp"
 #include "ir/program.hpp"
-#include "ir/unmarshal.hpp"
 #include "platform.hpp"
 #include "verifier.hpp"

--- a/src/ir/cfg_builder.cpp
+++ b/src/ir/cfg_builder.cpp
@@ -14,6 +14,7 @@
 #include "config.hpp"
 #include "ir/program.hpp"
 #include "ir/syntax.hpp"
+#include "ir/unmarshal.hpp"
 #include "platform.hpp"
 
 using std::optional;
@@ -713,6 +714,16 @@ Program Program::from_sequence(const InstructionSeq& inst_seq, const ProgramInfo
         builder.set_assertions(label, get_assertions(builder.prog.instruction_at(label), info, label));
     }
     return std::move(builder.prog);
+}
+
+std::optional<Program> Program::from_raw(const RawProgram& raw_prog, std::vector<std::vector<std::string>>& notes,
+                                         const ebpf_verifier_options_t& options) {
+    auto inst_seq = unmarshal(raw_prog, notes, options);
+    if (!inst_seq.has_value()) {
+        notes.push_back({std::move(inst_seq).error()});
+        return std::nullopt;
+    }
+    return from_sequence(*inst_seq, raw_prog.info, options);
 }
 
 std::set<BasicBlock> BasicBlock::collect_basic_blocks(const Cfg& cfg, const bool simplify) {

--- a/src/ir/program.hpp
+++ b/src/ir/program.hpp
@@ -3,6 +3,9 @@
 #pragma once
 
 #include <map>
+#include <optional>
+#include <ostream>
+#include <string>
 #include <vector>
 
 #include "cfg/cfg.hpp"
@@ -10,6 +13,7 @@
 #include "config.hpp"
 #include "crab_utils/debug.hpp"
 #include "ir/syntax.hpp"
+#include "spec/type_descriptors.hpp"
 
 namespace prevail {
 class Program {
@@ -55,6 +59,12 @@ class Program {
 
     static Program from_sequence(const InstructionSeq& inst_seq, const ProgramInfo& info,
                                  const ebpf_verifier_options_t& options);
+
+    /// Build a Program directly from a raw (ELF-bytecode) representation.
+    /// On failure returns std::nullopt and appends the error message to `notes`
+    /// (the same vector that collects unmarshal warnings).
+    static std::optional<Program> from_raw(const RawProgram& raw_prog, std::vector<std::vector<std::string>>& notes,
+                                           const ebpf_verifier_options_t& options);
 };
 
 class InvalidControlFlow final : public std::runtime_error {
@@ -67,4 +77,9 @@ std::vector<Assertion> get_assertions(const Instruction& ins, const ProgramInfo&
 
 void print_program(const Program& prog, std::ostream& os, bool simplify);
 void print_dot(const Program& prog, const std::string& outfile);
+
+/// Write a textual disassembly of `raw_prog` to `out`. On failure writes the
+/// error message to `out` and returns false.
+bool disassemble(const RawProgram& raw_prog, const ebpf_verifier_options_t& options, std::ostream& out,
+                 const std::optional<Label>& label_to_print = {}, bool print_line_info = false);
 } // namespace prevail

--- a/src/ir/syntax.hpp
+++ b/src/ir/syntax.hpp
@@ -457,7 +457,7 @@ inline std::ostream& operator<<(std::ostream& os, Value const& a) {
 std::ostream& operator<<(std::ostream& os, const Assertion& a);
 std::string to_string(const Assertion& constraint);
 
-void print(const InstructionSeq& insts, std::ostream& out, const std::optional<const Label>& label_to_print,
+void print(const InstructionSeq& insts, std::ostream& out, const std::optional<Label>& label_to_print,
            bool print_line_info = false);
 
 int size(const Instruction& inst);

--- a/src/ir/unmarshal.cpp
+++ b/src/ir/unmarshal.cpp
@@ -1,6 +1,7 @@
 // Copyright (c) Prevail Verifier contributors.
 // SPDX-License-Identifier: MIT
 #include <cassert>
+#include <expected>
 #include <iostream>
 #include <string>
 #include <vector>
@@ -782,8 +783,7 @@ struct Unmarshaller {
         }
     }
 
-    vector<LabeledInstruction> unmarshal(vector<EbpfInst> const& insts,
-                                         const prevail::ebpf_verifier_options_t& options) {
+    vector<LabeledInstruction> unmarshal(vector<EbpfInst> const& insts, const ebpf_verifier_options_t& options) {
         options.validate();
         subprogram_stack_size = options.subprogram_stack_size;
         vector<LabeledInstruction> prog;
@@ -882,20 +882,20 @@ struct Unmarshaller {
     }
 };
 
-std::variant<InstructionSeq, std::string> unmarshal(const RawProgram& raw_prog, vector<vector<string>>& notes,
-                                                    const prevail::ebpf_verifier_options_t& options) {
+std::expected<InstructionSeq, std::string> unmarshal(const RawProgram& raw_prog, vector<vector<string>>& notes,
+                                                     const ebpf_verifier_options_t& options) {
     thread_local_program_info = raw_prog.info;
     try {
         return Unmarshaller{notes, raw_prog.info}.unmarshal(raw_prog.prog, options);
     } catch (InvalidInstruction& arg) {
         std::ostringstream ss;
         ss << arg.pc << ": " << arg.what() << "\n";
-        return ss.str();
+        return std::unexpected(ss.str());
     }
 }
 
-std::variant<InstructionSeq, std::string> unmarshal(const RawProgram& raw_prog,
-                                                    const prevail::ebpf_verifier_options_t& options) {
+std::expected<InstructionSeq, std::string> unmarshal(const RawProgram& raw_prog,
+                                                     const ebpf_verifier_options_t& options) {
     vector<vector<string>> notes;
     return unmarshal(raw_prog, notes, options);
 }

--- a/src/ir/unmarshal.hpp
+++ b/src/ir/unmarshal.hpp
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: MIT
 #pragma once
 
+#include <expected>
 #include <string>
-#include <variant>
 #include <vector>
 
 #include "ir/syntax.hpp"
@@ -17,13 +17,14 @@ namespace prevail {
  *
  *  \param raw_prog is the input program to parse.
  *  \param[out] notes is a vector for storing errors and warnings.
+ *  \param options unmarshalling options
  *  \return a sequence of instructions if successful, an error string otherwise.
  */
-std::variant<InstructionSeq, std::string> unmarshal(const RawProgram& raw_prog,
-                                                    std::vector<std::vector<std::string>>& notes,
-                                                    const prevail::ebpf_verifier_options_t& options);
-std::variant<InstructionSeq, std::string> unmarshal(const RawProgram& raw_prog,
-                                                    const prevail::ebpf_verifier_options_t& options);
+std::expected<InstructionSeq, std::string> unmarshal(const RawProgram& raw_prog,
+                                                     std::vector<std::vector<std::string>>& notes,
+                                                     const ebpf_verifier_options_t& options);
+std::expected<InstructionSeq, std::string> unmarshal(const RawProgram& raw_prog,
+                                                     const ebpf_verifier_options_t& options);
 
 Call make_call(int imm, const ebpf_platform_t& platform);
 } // namespace prevail

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -201,16 +201,15 @@ int main(int argc, char** argv) {
     const RawProgram& raw_prog = raw_progs.back();
 
     // Convert the raw program section to a set of instructions.
-    std::variant<InstructionSeq, std::string> prog_or_error = unmarshal(raw_prog, ebpf_verifier_options);
-    if (auto prog = std::get_if<string>(&prog_or_error)) {
-        std::cout << "unmarshaling error at " << *prog << "\n";
+    const auto inst_seq = unmarshal(raw_prog, ebpf_verifier_options);
+    if (!inst_seq.has_value()) {
+        std::cout << "unmarshaling error at " << inst_seq.error() << "\n";
         return 1;
     }
 
-    auto& inst_seq = std::get<InstructionSeq>(prog_or_error);
     if (!asmfile.empty()) {
         std::ofstream out{asmfile};
-        print(inst_seq, out, {});
+        print(*inst_seq, out, {});
         print_map_descriptors(thread_local_program_info->map_descriptors, out);
     }
 
@@ -226,7 +225,7 @@ int main(int argc, char** argv) {
             }
         }
         const auto verbosity = ebpf_verifier_options.verbosity_opts;
-        const Program prog = Program::from_sequence(inst_seq, raw_prog.info, ebpf_verifier_options);
+        const Program prog = Program::from_sequence(*inst_seq, raw_prog.info, ebpf_verifier_options);
 
         if (!dotfile.empty()) {
             print_dot(prog, dotfile);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,8 +4,13 @@
 #include <ranges>
 #include <vector>
 
-#include "ebpf_verifier.hpp"
+#include "config.hpp"
 #include "io/elf_loader.hpp"
+#include "ir/program.hpp"
+#include "ir/unmarshal.hpp"
+#include "platform.hpp"
+#include "result.hpp"
+#include "verifier.hpp"
 
 // Avoid affecting other headers by macros.
 #include <CLI11/CLI11.hpp>

--- a/src/printing.cpp
+++ b/src/printing.cpp
@@ -13,7 +13,9 @@
 #include "crab/interval.hpp"
 #include "crab/type_encoding.hpp"
 #include "crab/var_registry.hpp"
+#include "ir/program.hpp"
 #include "ir/syntax.hpp"
+#include "ir/unmarshal.hpp"
 #include "platform.hpp"
 #include "spec/function_prototypes.hpp"
 #include "verifier.hpp"
@@ -670,7 +672,7 @@ auto get_labels(const InstructionSeq& insts) {
     return pc_of_label;
 }
 
-void print(const InstructionSeq& insts, std::ostream& out, const std::optional<const Label>& label_to_print,
+void print(const InstructionSeq& insts, std::ostream& out, const std::optional<Label>& label_to_print,
            const bool print_line_info) {
     const auto pc_of_label = get_labels(insts);
     Pc pc = 0;
@@ -723,6 +725,17 @@ void print_map_descriptors(const std::vector<EbpfMapDescriptor>& descriptors, st
         o << "map " << i << ":" << desc << "\n";
         i++;
     }
+}
+
+bool disassemble(const RawProgram& raw_prog, const ebpf_verifier_options_t& options, std::ostream& out,
+                 const std::optional<Label>& label_to_print, const bool print_line_info) {
+    auto inst_seq = unmarshal(raw_prog, options);
+    if (!inst_seq.has_value()) {
+        out << "unmarshaling error at " << inst_seq.error();
+        return false;
+    }
+    print(*inst_seq, out, label_to_print, print_line_info);
+    return true;
 }
 
 std::ostream& operator<<(std::ostream& os, const btf_line_info_t& line_info) {

--- a/src/test/ebpf_yaml.cpp
+++ b/src/test/ebpf_yaml.cpp
@@ -558,24 +558,22 @@ ConformanceTestResult run_conformance_test_case(const std::vector<uint8_t>& memo
     raw_prog.info.platform = &platform;
 
     // Convert the raw program section to a set of instructions.
-    std::variant<InstructionSeq, std::string> prog_or_error = unmarshal(raw_prog, {});
-    if (auto prog = std::get_if<std::string>(&prog_or_error)) {
-        std::cerr << "unmarshaling error at " << *prog << "\n";
-        return ConformanceTestResult{.success = false, .r0_value = Interval::top(), .error_reason = *prog};
+    const auto inst_seq = unmarshal(raw_prog, {});
+    if (!inst_seq.has_value()) {
+        std::cerr << "unmarshaling error at " << inst_seq.error() << "\n";
+        return ConformanceTestResult{.success = false, .r0_value = Interval::top(), .error_reason = inst_seq.error()};
     }
-
-    const InstructionSeq& inst_seq = std::get<InstructionSeq>(prog_or_error);
 
     ebpf_verifier_options_t options{};
     if (debug) {
-        print(inst_seq, std::cout, {});
+        print(*inst_seq, std::cout, {});
         options.verbosity_opts.print_failures = true;
         options.verbosity_opts.print_invariants = true;
         options.verbosity_opts.simplify = false;
     }
 
     try {
-        const Program prog = Program::from_sequence(inst_seq, info, options);
+        const Program prog = Program::from_sequence(*inst_seq, info, options);
         const AnalysisResult result = analyze(prog, pre_invariant);
         return ConformanceTestResult{.success = !result.failed, .r0_value = result.exit_value};
     } catch (const std::exception& ex) {

--- a/src/test/ebpf_yaml.cpp
+++ b/src/test/ebpf_yaml.cpp
@@ -16,9 +16,11 @@
 #include <yaml-cpp/yaml.h>
 
 #include "config.hpp"
-#include "ebpf_verifier.hpp"
 #include "ir/parse.hpp"
+#include "ir/program.hpp"
 #include "ir/syntax.hpp"
+#include "ir/unmarshal.hpp"
+#include "platform.hpp"
 #include "string_constraints.hpp"
 #include "test/ebpf_yaml.hpp"
 #include "verifier.hpp"

--- a/src/test/run_yaml.cpp
+++ b/src/test/run_yaml.cpp
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 #include <iostream>
 
-#include "ebpf_verifier.hpp"
+#include "ir/unmarshal.hpp"
 #include "test/ebpf_yaml.hpp"
 
 // Avoid affecting other headers by macros.

--- a/src/test/test_elf_loader.cpp
+++ b/src/test/test_elf_loader.cpp
@@ -559,9 +559,7 @@ TEST_CASE("rewrite_extern_constant_load bails out on values exceeding int32 rang
         REQUIRE(rewrite_extern_constant_load(insts, 0, 0xFFFFFFFFFFFFFFFFULL));
     }
 
-    SECTION("0x80000000 exceeds int32 — bails out without mutation") {
-        check_bailout_preserves_program(0x80000000ULL);
-    }
+    SECTION("0x80000000 exceeds int32 — bails out without mutation") { check_bailout_preserves_program(0x80000000ULL); }
 
     SECTION("0x100000000 exceeds int32 — bails out without mutation") {
         check_bailout_preserves_program(0x100000000ULL);

--- a/src/test/test_failure_slice.cpp
+++ b/src/test/test_failure_slice.cpp
@@ -5,7 +5,13 @@
 #include <filesystem>
 #include <sstream>
 
-#include "ebpf_verifier.hpp"
+#include "config.hpp"
+#include "io/elf_loader.hpp"
+#include "ir/program.hpp"
+#include "ir/unmarshal.hpp"
+#include "platform.hpp"
+#include "result.hpp"
+#include "verifier.hpp"
 
 using namespace prevail;
 

--- a/src/test/test_failure_slice.cpp
+++ b/src/test/test_failure_slice.cpp
@@ -22,9 +22,8 @@ static std::vector<FailureSlice> get_failure_slices(const std::string& filename,
     REQUIRE(raw_progs.size() == 1);
 
     const RawProgram& raw_prog = raw_progs.back();
-    auto prog_or_error = unmarshal(raw_prog, options);
-    auto inst_seq = std::get_if<InstructionSeq>(&prog_or_error);
-    REQUIRE(inst_seq != nullptr);
+    auto inst_seq = unmarshal(raw_prog, options);
+    REQUIRE(inst_seq.has_value());
 
     const Program prog = Program::from_sequence(*inst_seq, raw_prog.info, options);
     auto result = analyze(prog);
@@ -183,9 +182,8 @@ TEST_CASE("print_failure_slices produces structured output", "[failure_slice][pr
     REQUIRE(raw_progs.size() == 1);
 
     const RawProgram& raw_prog = raw_progs.back();
-    auto prog_or_error = unmarshal(raw_prog, options);
-    auto inst_seq = std::get_if<InstructionSeq>(&prog_or_error);
-    REQUIRE(inst_seq != nullptr);
+    auto inst_seq = unmarshal(raw_prog, options);
+    REQUIRE(inst_seq.has_value());
 
     const Program prog = Program::from_sequence(*inst_seq, raw_prog.info, options);
     auto result = analyze(prog);
@@ -218,9 +216,8 @@ TEST_CASE("passing program produces no failure slices", "[failure_slice][integra
     REQUIRE(raw_progs.size() == 1);
 
     const RawProgram& raw_prog = raw_progs.back();
-    auto prog_or_error = unmarshal(raw_prog, options);
-    auto inst_seq = std::get_if<InstructionSeq>(&prog_or_error);
-    REQUIRE(inst_seq != nullptr);
+    auto inst_seq = unmarshal(raw_prog, options);
+    REQUIRE(inst_seq.has_value());
 
     const Program prog = Program::from_sequence(*inst_seq, raw_prog.info, options);
     auto result = analyze(prog);
@@ -252,9 +249,8 @@ TEST_CASE("assume guard registers become relevant in slice", "[failure_slice][in
     ElfObject elf{sample, options, &g_ebpf_platform_linux};
     const auto& raw_progs = elf.get_programs("xdp");
     REQUIRE(raw_progs.size() == 1);
-    auto prog_or_error = unmarshal(raw_progs.back(), options);
-    auto inst_seq = std::get_if<InstructionSeq>(&prog_or_error);
-    REQUIRE(inst_seq != nullptr);
+    auto inst_seq = unmarshal(raw_progs.back(), options);
+    REQUIRE(inst_seq.has_value());
     const Program prog = Program::from_sequence(*inst_seq, raw_progs.back().info, options);
 
     bool found_assume_in_slice = false;

--- a/src/test/test_marshal.cpp
+++ b/src/test/test_marshal.cpp
@@ -9,7 +9,6 @@
 #include "ir/marshal.hpp"
 #include "ir/program.hpp"
 #include "ir/unmarshal.hpp"
-#include "linux/gpl/spec_type_descriptors.hpp"
 
 using namespace prevail;
 
@@ -214,9 +213,9 @@ static const EbpfInstructionTemplate instruction_template[] = {
 static void check_unmarshal_succeed(const EbpfInst& ins, const ebpf_platform_t& platform = g_ebpf_platform_linux) {
     const ProgramInfo info{.platform = &platform, .type = platform.get_program_type("unspec", "unspec")};
     constexpr EbpfInst exit{.opcode = INST_OP_EXIT};
-    const InstructionSeq parsed =
-        std::get<InstructionSeq>(unmarshal(RawProgram{"", "", 0, "", {ins, exit, exit}, info}, thread_local_options));
-    REQUIRE(parsed.size() == 3);
+    const auto inst_seq = unmarshal(RawProgram{"", "", 0, "", {ins, exit, exit}, info}, thread_local_options);
+    REQUIRE(inst_seq.has_value());
+    REQUIRE(inst_seq->size() == 3);
 }
 
 // Verify that we can successfully unmarshal a 64-bit immediate instruction.
@@ -224,21 +223,21 @@ static void check_unmarshal_succeed(EbpfInst inst1, EbpfInst inst2,
                                     const ebpf_platform_t& platform = g_ebpf_platform_linux) {
     const ProgramInfo info{.platform = &platform, .type = platform.get_program_type("unspec", "unspec")};
     constexpr EbpfInst exit{.opcode = INST_OP_EXIT};
-    const InstructionSeq parsed = std::get<InstructionSeq>(
-        unmarshal(RawProgram{"", "", 0, "", {inst1, inst2, exit, exit}, info}, thread_local_options));
-    REQUIRE(parsed.size() == 3);
+    const auto inst_seq = unmarshal(RawProgram{"", "", 0, "", {inst1, inst2, exit, exit}, info}, thread_local_options);
+    REQUIRE(inst_seq.has_value());
+    REQUIRE(inst_seq->size() == 3);
 }
 
 // Verify that if we unmarshal an instruction and then re-marshal it,
 // we get what we expect.
 static void compare_unmarshal_marshal(const EbpfInst& ins, const EbpfInst& expected_result,
                                       const ebpf_platform_t& platform = g_ebpf_platform_linux) {
-    ProgramInfo info{.platform = &platform, .type = platform.get_program_type("unspec", "unspec")};
+    const ProgramInfo info{.platform = &platform, .type = platform.get_program_type("unspec", "unspec")};
     constexpr EbpfInst exit{.opcode = INST_OP_EXIT};
-    const InstructionSeq inst_seq =
-        std::get<InstructionSeq>(unmarshal(RawProgram{"", "", 0, "", {ins, exit, exit}, info}, thread_local_options));
-    REQUIRE(inst_seq.size() == 3);
-    auto [_, single, _2] = inst_seq.front();
+    const auto inst_seq = unmarshal(RawProgram{"", "", 0, "", {ins, exit, exit}, info}, thread_local_options);
+    REQUIRE(inst_seq.has_value());
+    REQUIRE(inst_seq->size() == 3);
+    auto [_, single, _2] = inst_seq->front();
     (void)_;  // unused
     (void)_2; // unused
     std::vector<EbpfInst> marshaled = marshal(single, 0);
@@ -253,10 +252,10 @@ static void compare_unmarshal_marshal(const EbpfInst& ins1, const EbpfInst& ins2
     ProgramInfo info{.platform = &g_ebpf_platform_linux,
                      .type = g_ebpf_platform_linux.get_program_type("unspec", "unspec")};
     constexpr EbpfInst exit{.opcode = INST_OP_EXIT};
-    InstructionSeq parsed = std::get<InstructionSeq>(
-        unmarshal(RawProgram{"", "", 0, "", {ins1, ins2, exit, exit}, info}, thread_local_options));
-    REQUIRE(parsed.size() == 3);
-    auto [_, single, _2] = parsed.front();
+    const auto inst_seq = unmarshal(RawProgram{"", "", 0, "", {ins1, ins2, exit, exit}, info}, thread_local_options);
+    REQUIRE(inst_seq.has_value());
+    REQUIRE(inst_seq->size() == 3);
+    auto [_, single, _2] = inst_seq->front();
     (void)_;  // unused
     (void)_2; // unused
     std::vector<EbpfInst> marshaled = marshal(single, 0);
@@ -272,10 +271,10 @@ static void compare_unmarshal_marshal(const EbpfInst& ins1, const EbpfInst& ins2
     ProgramInfo info{.platform = &g_ebpf_platform_linux,
                      .type = g_ebpf_platform_linux.get_program_type("unspec", "unspec")};
     constexpr EbpfInst exit{.opcode = INST_OP_EXIT};
-    const InstructionSeq inst_seq = std::get<InstructionSeq>(
-        unmarshal(RawProgram{"", "", 0, "", {ins1, ins2, exit, exit}, info}, thread_local_options));
-    REQUIRE(inst_seq.size() == 3);
-    auto [_, single, _2] = inst_seq.front();
+    const auto inst_seq = unmarshal(RawProgram{"", "", 0, "", {ins1, ins2, exit, exit}, info}, thread_local_options);
+    REQUIRE(inst_seq.has_value());
+    REQUIRE(inst_seq->size() == 3);
+    auto [_, single, _2] = inst_seq->front();
     (void)_;  // unused
     (void)_2; // unused
     std::vector<EbpfInst> marshaled = marshal(single, 0);
@@ -290,11 +289,11 @@ static void compare_unmarshal_marshal(const EbpfInst& ins1, const EbpfInst& ins2
 // we get the original.
 static void compare_marshal_unmarshal(const Instruction& ins, bool double_cmd = false,
                                       const ebpf_platform_t& platform = g_ebpf_platform_linux) {
-    ProgramInfo info{.platform = &platform, .type = platform.get_program_type("unspec", "unspec")};
-    const InstructionSeq inst_seq =
-        std::get<InstructionSeq>(unmarshal(RawProgram{"", "", 0, "", marshal(ins, 0), info}, thread_local_options));
-    REQUIRE(inst_seq.size() == 1);
-    auto [_, single, _2] = inst_seq.back();
+    const ProgramInfo info{.platform = &platform, .type = platform.get_program_type("unspec", "unspec")};
+    const auto inst_seq = unmarshal(RawProgram{"", "", 0, "", marshal(ins, 0), info}, thread_local_options);
+    REQUIRE(inst_seq.has_value());
+    REQUIRE(inst_seq->size() == 1);
+    auto [_, single, _2] = inst_seq->back();
     (void)_;  // unused
     (void)_2; // unused
     REQUIRE(single == ins);
@@ -303,49 +302,44 @@ static void compare_marshal_unmarshal(const Instruction& ins, bool double_cmd = 
 static void check_marshal_unmarshal_fail(const Instruction& ins, const std::string& expected_error_message,
                                          const ebpf_platform_t& platform = g_ebpf_platform_linux) {
     const ProgramInfo info{.platform = &platform, .type = platform.get_program_type("unspec", "unspec")};
-    auto result = unmarshal(RawProgram{"", "", 0, "", marshal(ins, 0), info}, thread_local_options);
-    auto* error_message = std::get_if<std::string>(&result);
-    REQUIRE(error_message != nullptr);
-    REQUIRE(*error_message == expected_error_message);
+    const auto result = unmarshal(RawProgram{"", "", 0, "", marshal(ins, 0), info}, thread_local_options);
+    REQUIRE(!result.has_value());
+    REQUIRE(result.error() == expected_error_message);
 }
 
-static void check_unmarshal_fail(EbpfInst inst, const std::string& expected_error_message,
+static void check_unmarshal_fail(const EbpfInst inst, const std::string& expected_error_message,
                                  const ebpf_platform_t& platform = g_ebpf_platform_linux) {
-    ProgramInfo info{.platform = &platform, .type = platform.get_program_type("unspec", "unspec")};
-    std::vector insns = {inst};
-    auto result = unmarshal(RawProgram{"", "", 0, "", insns, info}, thread_local_options);
-    auto* error_message = std::get_if<std::string>(&result);
-    REQUIRE(error_message != nullptr);
-    REQUIRE(*error_message == expected_error_message);
+    const ProgramInfo info{.platform = &platform, .type = platform.get_program_type("unspec", "unspec")};
+    const std::vector insns = {inst};
+    auto inst_seq = unmarshal(RawProgram{"", "", 0, "", insns, info}, thread_local_options);
+    REQUIRE(!inst_seq.has_value());
+    REQUIRE(inst_seq.error() == expected_error_message);
 }
 
-static void check_unmarshal_fail_goto(EbpfInst inst, const std::string& expected_error_message,
+static void check_unmarshal_fail_goto(const EbpfInst inst, const std::string& expected_error_message,
                                       const ebpf_platform_t& platform = g_ebpf_platform_linux) {
-    ProgramInfo info{.platform = &platform, .type = platform.get_program_type("unspec", "unspec")};
+    const ProgramInfo info{.platform = &platform, .type = platform.get_program_type("unspec", "unspec")};
     constexpr EbpfInst exit{.opcode = INST_OP_EXIT};
-    std::vector insns{inst, exit, exit};
-    auto result = unmarshal(RawProgram{"", "", 0, "", insns, info}, thread_local_options);
-    auto* error_message = std::get_if<std::string>(&result);
-    REQUIRE(error_message != nullptr);
-    REQUIRE(*error_message == expected_error_message);
+    const std::vector insns{inst, exit, exit};
+    auto inst_seq = unmarshal(RawProgram{"", "", 0, "", insns, info}, thread_local_options);
+    REQUIRE(!inst_seq.has_value());
+    REQUIRE(inst_seq.error() == expected_error_message);
 }
 
 // Check that unmarshaling a 64-bit immediate instruction fails.
 static void check_unmarshal_fail(EbpfInst inst1, EbpfInst inst2, const std::string& expected_error_message,
                                  const ebpf_platform_t& platform = g_ebpf_platform_linux) {
-    ProgramInfo info{.platform = &platform, .type = platform.get_program_type("unspec", "unspec")};
-    std::vector insns{inst1, inst2};
-    auto result = unmarshal(RawProgram{"", "", 0, "", insns, info}, thread_local_options);
-    auto* error_message = std::get_if<std::string>(&result);
-    REQUIRE(error_message != nullptr);
-    REQUIRE(*error_message == expected_error_message);
+    const ProgramInfo info{.platform = &platform, .type = platform.get_program_type("unspec", "unspec")};
+    const std::vector insns{inst1, inst2};
+    auto inst_seq = unmarshal(RawProgram{"", "", 0, "", insns, info}, thread_local_options);
+    REQUIRE(!inst_seq.has_value());
+    REQUIRE(inst_seq.error() == expected_error_message);
 }
 
 static Call unmarshal_single_call(const EbpfInst& call_inst, const ProgramInfo& info) {
     constexpr EbpfInst exit{.opcode = INST_OP_EXIT};
-    const auto parsed = unmarshal(RawProgram{"", "", 0, "", {call_inst, exit, exit}, info}, thread_local_options);
-    auto* inst_seq = std::get_if<InstructionSeq>(&parsed);
-    REQUIRE(inst_seq != nullptr);
+    const auto inst_seq = unmarshal(RawProgram{"", "", 0, "", {call_inst, exit, exit}, info}, thread_local_options);
+    REQUIRE(inst_seq.has_value());
     REQUIRE(inst_seq->size() == 3);
     auto* call = std::get_if<Call>(&std::get<1>((*inst_seq)[0]));
     REQUIRE(call != nullptr);
@@ -940,15 +934,15 @@ TEST_CASE("unmarshal builtin calls only when relocation-gated", "[disasm][marsha
     REQUIRE(has_assertion(assertions, ValidSize{Reg{3}, false}));
     REQUIRE(has_assertion(assertions, ValidAccess{1, Reg{1}, 0, Value{Reg{3}}, false, AccessType::write}));
 }
-#define FAIL_UNMARSHAL(dirname, filename, sectionname)                                                       \
-    TEST_CASE("Try unmarshalling bad program: " dirname "/" filename " " sectionname, "[unmarshal]") {       \
-        thread_local_options = {};                                                                           \
-        ElfObject elf{"ebpf-samples/" dirname "/" filename, {}, &g_ebpf_platform_linux};                     \
-        const auto& raw_progs = elf.get_programs(sectionname);                                               \
-        REQUIRE(raw_progs.size() == 1);                                                                      \
-        const RawProgram& raw_prog = raw_progs.back();                                                       \
-        std::variant<InstructionSeq, std::string> prog_or_error = unmarshal(raw_prog, thread_local_options); \
-        REQUIRE(std::holds_alternative<std::string>(prog_or_error));                                         \
+#define FAIL_UNMARSHAL(dirname, filename, sectionname)                                                 \
+    TEST_CASE("Try unmarshalling bad program: " dirname "/" filename " " sectionname, "[unmarshal]") { \
+        thread_local_options = {};                                                                     \
+        ElfObject elf{"ebpf-samples/" dirname "/" filename, {}, &g_ebpf_platform_linux};               \
+        const auto& raw_progs = elf.get_programs(sectionname);                                         \
+        REQUIRE(raw_progs.size() == 1);                                                                \
+        const RawProgram& raw_prog = raw_progs.back();                                                 \
+        const auto inst_seq = unmarshal(raw_prog, thread_local_options);                               \
+        REQUIRE(!inst_seq.has_value());                                                                \
     }
 
 // Some intentional unmarshal failures
@@ -962,10 +956,10 @@ TEST_CASE("instruction feature handling after unmarshal", "[unmarshal]") {
     SECTION("unknown kfunc btf id") {
         RawProgram raw_prog{
             "", "", 0, "", {EbpfInst{.opcode = INST_OP_CALL, .src = INST_CALL_BTF_HELPER, .imm = 1}, exit}, info};
-        auto prog_or_error = unmarshal(raw_prog, {});
-        REQUIRE(std::holds_alternative<InstructionSeq>(prog_or_error));
+        auto inst_seq = unmarshal(raw_prog, {});
+        REQUIRE(inst_seq.has_value());
         REQUIRE_THROWS_WITH(
-            Program::from_sequence(std::get<InstructionSeq>(prog_or_error), info, {}),
+            Program::from_sequence(*inst_seq, info, {}),
             Catch::Matchers::ContainsSubstring("not implemented: kfunc prototype lookup failed for BTF id 1") &&
                 Catch::Matchers::ContainsSubstring("(at 0)"));
     }
@@ -973,9 +967,9 @@ TEST_CASE("instruction feature handling after unmarshal", "[unmarshal]") {
     SECTION("kfunc call by BTF id is accepted when prototype is known") {
         RawProgram raw_prog{
             "", "", 0, "", {EbpfInst{.opcode = INST_OP_CALL, .src = INST_CALL_BTF_HELPER, .imm = 1000}, exit}, info};
-        auto prog_or_error = unmarshal(raw_prog, {});
-        REQUIRE(std::holds_alternative<InstructionSeq>(prog_or_error));
-        const Program prog = Program::from_sequence(std::get<InstructionSeq>(prog_or_error), info, {});
+        auto inst_seq = unmarshal(raw_prog, {});
+        REQUIRE(inst_seq.has_value());
+        const Program prog = Program::from_sequence(*inst_seq, info, {});
         REQUIRE(verify(prog));
     }
 
@@ -987,9 +981,9 @@ TEST_CASE("instruction feature handling after unmarshal", "[unmarshal]") {
                             {EbpfInst{.opcode = INST_OP_CALL, .src = INST_CALL_LOCAL, .imm = 1}, exit,
                              EbpfInst{.opcode = INST_OP_CALL, .src = INST_CALL_BTF_HELPER, .imm = 1000}, exit},
                             info};
-        auto prog_or_error = unmarshal(raw_prog, {});
-        REQUIRE(std::holds_alternative<InstructionSeq>(prog_or_error));
-        const Program prog = Program::from_sequence(std::get<InstructionSeq>(prog_or_error), info, {});
+        auto inst_seq = unmarshal(raw_prog, {});
+        REQUIRE(inst_seq.has_value());
+        const Program prog = Program::from_sequence(*inst_seq, info, {});
         REQUIRE(verify(prog));
     }
 
@@ -1001,9 +995,9 @@ TEST_CASE("instruction feature handling after unmarshal", "[unmarshal]") {
                             {EbpfInst{.opcode = INST_OP_CALL, .src = INST_CALL_LOCAL, .imm = 1}, exit,
                              EbpfInst{.opcode = INST_OP_CALL, .src = INST_CALL_BTF_HELPER, .imm = 12}, exit},
                             info};
-        auto prog_or_error = unmarshal(raw_prog, {});
-        REQUIRE(std::holds_alternative<InstructionSeq>(prog_or_error));
-        const Program prog = Program::from_sequence(std::get<InstructionSeq>(prog_or_error), info, {});
+        auto inst_seq = unmarshal(raw_prog, {});
+        REQUIRE(inst_seq.has_value());
+        const Program prog = Program::from_sequence(*inst_seq, info, {});
         REQUIRE(verify(prog));
     }
 
@@ -1016,9 +1010,9 @@ TEST_CASE("instruction feature handling after unmarshal", "[unmarshal]") {
                             {EbpfInst{.opcode = INST_OP_CALL, .src = INST_CALL_BTF_HELPER, .imm = 1005},
                              EbpfInst{.opcode = mov64_imm, .dst = 0, .imm = 0}, exit},
                             info};
-        auto prog_or_error = unmarshal(raw_prog, {});
-        REQUIRE(std::holds_alternative<InstructionSeq>(prog_or_error));
-        const Program prog = Program::from_sequence(std::get<InstructionSeq>(prog_or_error), info, {});
+        auto inst_seq = unmarshal(raw_prog, {});
+        REQUIRE(inst_seq.has_value());
+        const Program prog = Program::from_sequence(*inst_seq, info, {});
         const auto* call = std::get_if<Call>(&prog.instruction_at(Label{0}));
         REQUIRE(call != nullptr);
         REQUIRE(call->is_map_lookup);
@@ -1028,9 +1022,9 @@ TEST_CASE("instruction feature handling after unmarshal", "[unmarshal]") {
     SECTION("kfunc with acquire flag is accepted") {
         RawProgram raw_prog{
             "", "", 0, "", {EbpfInst{.opcode = INST_OP_CALL, .src = INST_CALL_BTF_HELPER, .imm = 1002}, exit}, info};
-        auto prog_or_error = unmarshal(raw_prog, {});
-        REQUIRE(std::holds_alternative<InstructionSeq>(prog_or_error));
-        const Program prog = Program::from_sequence(std::get<InstructionSeq>(prog_or_error), info, {});
+        auto inst_seq = unmarshal(raw_prog, {});
+        REQUIRE(inst_seq.has_value());
+        const Program prog = Program::from_sequence(*inst_seq, info, {});
         const auto* call = std::get_if<Call>(&prog.instruction_at(Label{0}));
         REQUIRE(call != nullptr);
         REQUIRE(call->name == "kfunc_test_acquire_flag");
@@ -1039,9 +1033,9 @@ TEST_CASE("instruction feature handling after unmarshal", "[unmarshal]") {
     SECTION("kfunc with release flag is rejected") {
         RawProgram raw_prog{
             "", "", 0, "", {EbpfInst{.opcode = INST_OP_CALL, .src = INST_CALL_BTF_HELPER, .imm = 1008}, exit}, info};
-        auto prog_or_error = unmarshal(raw_prog, {});
-        REQUIRE(std::holds_alternative<InstructionSeq>(prog_or_error));
-        REQUIRE_THROWS_WITH(Program::from_sequence(std::get<InstructionSeq>(prog_or_error), info, {}),
+        auto inst_seq = unmarshal(raw_prog, {});
+        REQUIRE(inst_seq.has_value());
+        REQUIRE_THROWS_WITH(Program::from_sequence(*inst_seq, info, {}),
                             Catch::Matchers::ContainsSubstring("not implemented: kfunc has unsupported flags") &&
                                 Catch::Matchers::ContainsSubstring("(at 0)"));
     }
@@ -1049,10 +1043,10 @@ TEST_CASE("instruction feature handling after unmarshal", "[unmarshal]") {
     SECTION("kfunc program type gating is enforced") {
         RawProgram raw_prog{
             "", "", 0, "", {EbpfInst{.opcode = INST_OP_CALL, .src = INST_CALL_BTF_HELPER, .imm = 1003}, exit}, info};
-        auto prog_or_error = unmarshal(raw_prog, {});
-        REQUIRE(std::holds_alternative<InstructionSeq>(prog_or_error));
+        auto inst_seq = unmarshal(raw_prog, {});
+        REQUIRE(inst_seq.has_value());
         REQUIRE_THROWS_WITH(
-            Program::from_sequence(std::get<InstructionSeq>(prog_or_error), info, {}),
+            Program::from_sequence(*inst_seq, info, {}),
             Catch::Matchers::ContainsSubstring("not implemented: kfunc is unavailable for program type") &&
                 Catch::Matchers::ContainsSubstring("(at 0)"));
 
@@ -1060,19 +1054,19 @@ TEST_CASE("instruction feature handling after unmarshal", "[unmarshal]") {
         RawProgram xdp_raw_prog{
             "",      "", 0, "", {EbpfInst{.opcode = INST_OP_CALL, .src = INST_CALL_BTF_HELPER, .imm = 1003}, exit},
             xdp_info};
-        auto xdp_prog_or_error = unmarshal(xdp_raw_prog, {});
-        REQUIRE(std::holds_alternative<InstructionSeq>(xdp_prog_or_error));
-        const Program xdp_prog = Program::from_sequence(std::get<InstructionSeq>(xdp_prog_or_error), xdp_info, {});
+        auto xdp_inst_seq = unmarshal(xdp_raw_prog, {});
+        REQUIRE(xdp_inst_seq.has_value());
+        const Program xdp_prog = Program::from_sequence(*xdp_inst_seq, xdp_info, {});
         REQUIRE(verify(xdp_prog));
     }
 
     SECTION("kfunc privileged gating is enforced") {
         RawProgram raw_prog{
             "", "", 0, "", {EbpfInst{.opcode = INST_OP_CALL, .src = INST_CALL_BTF_HELPER, .imm = 1004}, exit}, info};
-        auto prog_or_error = unmarshal(raw_prog, {});
-        REQUIRE(std::holds_alternative<InstructionSeq>(prog_or_error));
+        auto inst_seq = unmarshal(raw_prog, {});
+        REQUIRE(inst_seq.has_value());
         REQUIRE_THROWS_WITH(
-            Program::from_sequence(std::get<InstructionSeq>(prog_or_error), info, {}),
+            Program::from_sequence(*inst_seq, info, {}),
             Catch::Matchers::ContainsSubstring("not implemented: kfunc requires privileged program type") &&
                 Catch::Matchers::ContainsSubstring("(at 0)"));
 
@@ -1083,10 +1077,9 @@ TEST_CASE("instruction feature handling after unmarshal", "[unmarshal]") {
         RawProgram kprobe_raw_prog{
             "",         "", 0, "", {EbpfInst{.opcode = INST_OP_CALL, .src = INST_CALL_BTF_HELPER, .imm = 1004}, exit},
             kprobe_info};
-        auto kprobe_prog_or_error = unmarshal(kprobe_raw_prog, {});
-        REQUIRE(std::holds_alternative<InstructionSeq>(kprobe_prog_or_error));
-        const Program kprobe_prog =
-            Program::from_sequence(std::get<InstructionSeq>(kprobe_prog_or_error), kprobe_info, {});
+        auto kprobe_inst_seq = unmarshal(kprobe_raw_prog, {});
+        REQUIRE(kprobe_inst_seq.has_value());
+        const Program kprobe_prog = Program::from_sequence(*kprobe_inst_seq, kprobe_info, {});
         REQUIRE(verify(kprobe_prog));
     }
 
@@ -1095,9 +1088,9 @@ TEST_CASE("instruction feature handling after unmarshal", "[unmarshal]") {
 
         RawProgram good_raw_prog{
             "", "", 0, "", {EbpfInst{.opcode = INST_OP_CALL, .src = INST_CALL_BTF_HELPER, .imm = 1001}, exit}, info};
-        auto good_prog_or_error = unmarshal(good_raw_prog, {});
-        REQUIRE(std::holds_alternative<InstructionSeq>(good_prog_or_error));
-        const Program good_prog = Program::from_sequence(std::get<InstructionSeq>(good_prog_or_error), info, {});
+        auto good_inst_seq = unmarshal(good_raw_prog, {});
+        REQUIRE(good_inst_seq.has_value());
+        const Program good_prog = Program::from_sequence(*good_inst_seq, info, {});
         REQUIRE(verify(good_prog));
 
         RawProgram bad_raw_prog{"",
@@ -1107,9 +1100,9 @@ TEST_CASE("instruction feature handling after unmarshal", "[unmarshal]") {
                                 {EbpfInst{.opcode = mov64_imm, .dst = 1, .imm = 0},
                                  EbpfInst{.opcode = INST_OP_CALL, .src = INST_CALL_BTF_HELPER, .imm = 1001}, exit},
                                 info};
-        auto bad_prog_or_error = unmarshal(bad_raw_prog, {});
-        REQUIRE(std::holds_alternative<InstructionSeq>(bad_prog_or_error));
-        const Program bad_prog = Program::from_sequence(std::get<InstructionSeq>(bad_prog_or_error), info, {});
+        auto bad_inst_seq = unmarshal(bad_raw_prog, {});
+        REQUIRE(bad_inst_seq.has_value());
+        const Program bad_prog = Program::from_sequence(*bad_inst_seq, info, {});
         REQUIRE_FALSE(verify(bad_prog));
     }
 
@@ -1124,9 +1117,9 @@ TEST_CASE("instruction feature handling after unmarshal", "[unmarshal]") {
                                   EbpfInst{.opcode = mov64_imm, .dst = 2, .imm = 0},
                                   EbpfInst{.opcode = INST_OP_CALL, .src = INST_CALL_BTF_HELPER, .imm = 1006}, exit},
                                  info};
-        auto good_prog_or_error = unmarshal(good_raw_prog, {});
-        REQUIRE(std::holds_alternative<InstructionSeq>(good_prog_or_error));
-        const Program good_prog = Program::from_sequence(std::get<InstructionSeq>(good_prog_or_error), info, {});
+        auto good_inst_seq = unmarshal(good_raw_prog, {});
+        REQUIRE(good_inst_seq.has_value());
+        const Program good_prog = Program::from_sequence(*good_inst_seq, info, {});
         REQUIRE(verify(good_prog));
 
         RawProgram bad_size_raw_prog{"",
@@ -1137,10 +1130,9 @@ TEST_CASE("instruction feature handling after unmarshal", "[unmarshal]") {
                                       EbpfInst{.opcode = mov64_imm, .dst = 2, .imm = -1},
                                       EbpfInst{.opcode = INST_OP_CALL, .src = INST_CALL_BTF_HELPER, .imm = 1006}, exit},
                                      info};
-        auto bad_size_prog_or_error = unmarshal(bad_size_raw_prog, {});
-        REQUIRE(std::holds_alternative<InstructionSeq>(bad_size_prog_or_error));
-        const Program bad_size_prog =
-            Program::from_sequence(std::get<InstructionSeq>(bad_size_prog_or_error), info, {});
+        auto bad_size_inst_seq = unmarshal(bad_size_raw_prog, {});
+        REQUIRE(bad_size_inst_seq.has_value());
+        const Program bad_size_prog = Program::from_sequence(*bad_size_inst_seq, info, {});
         REQUIRE_FALSE(verify(bad_size_prog));
 
         RawProgram bad_nullability_raw_prog{
@@ -1151,10 +1143,9 @@ TEST_CASE("instruction feature handling after unmarshal", "[unmarshal]") {
             {EbpfInst{.opcode = mov64_imm, .dst = 1, .imm = 1}, EbpfInst{.opcode = mov64_imm, .dst = 2, .imm = 0},
              EbpfInst{.opcode = INST_OP_CALL, .src = INST_CALL_BTF_HELPER, .imm = 1006}, exit},
             info};
-        auto bad_nullability_prog_or_error = unmarshal(bad_nullability_raw_prog, {});
-        REQUIRE(std::holds_alternative<InstructionSeq>(bad_nullability_prog_or_error));
-        const Program bad_nullability_prog =
-            Program::from_sequence(std::get<InstructionSeq>(bad_nullability_prog_or_error), info, {});
+        auto bad_nullability_inst_seq = unmarshal(bad_nullability_raw_prog, {});
+        REQUIRE(bad_nullability_inst_seq.has_value());
+        const Program bad_nullability_prog = Program::from_sequence(*bad_nullability_inst_seq, info, {});
         REQUIRE_FALSE(verify(bad_nullability_prog));
     }
 
@@ -1172,9 +1163,9 @@ TEST_CASE("instruction feature handling after unmarshal", "[unmarshal]") {
                                   EbpfInst{.opcode = mov64_imm, .dst = 2, .imm = 4},
                                   EbpfInst{.opcode = INST_OP_CALL, .src = INST_CALL_BTF_HELPER, .imm = 1007}, exit},
                                  info};
-        auto good_prog_or_error = unmarshal(good_raw_prog, {});
-        REQUIRE(std::holds_alternative<InstructionSeq>(good_prog_or_error));
-        const Program good_prog = Program::from_sequence(std::get<InstructionSeq>(good_prog_or_error), info, {});
+        auto good_inst_seq = unmarshal(good_raw_prog, {});
+        REQUIRE(good_inst_seq.has_value());
+        const Program good_prog = Program::from_sequence(*good_inst_seq, info, {});
         REQUIRE(verify(good_prog));
 
         RawProgram bad_nullability_raw_prog{
@@ -1185,10 +1176,9 @@ TEST_CASE("instruction feature handling after unmarshal", "[unmarshal]") {
             {EbpfInst{.opcode = mov64_imm, .dst = 1, .imm = 0}, EbpfInst{.opcode = mov64_imm, .dst = 2, .imm = 4},
              EbpfInst{.opcode = INST_OP_CALL, .src = INST_CALL_BTF_HELPER, .imm = 1007}, exit},
             info};
-        auto bad_nullability_prog_or_error = unmarshal(bad_nullability_raw_prog, {});
-        REQUIRE(std::holds_alternative<InstructionSeq>(bad_nullability_prog_or_error));
-        const Program bad_nullability_prog =
-            Program::from_sequence(std::get<InstructionSeq>(bad_nullability_prog_or_error), info, {});
+        auto bad_nullability_inst_seq = unmarshal(bad_nullability_raw_prog, {});
+        REQUIRE(bad_nullability_inst_seq.has_value());
+        const Program bad_nullability_prog = Program::from_sequence(*bad_nullability_inst_seq, info, {});
         REQUIRE_FALSE(verify(bad_nullability_prog));
 
         RawProgram bad_size_raw_prog{"",
@@ -1200,10 +1190,9 @@ TEST_CASE("instruction feature handling after unmarshal", "[unmarshal]") {
                                       EbpfInst{.opcode = mov64_imm, .dst = 2, .imm = 0},
                                       EbpfInst{.opcode = INST_OP_CALL, .src = INST_CALL_BTF_HELPER, .imm = 1007}, exit},
                                      info};
-        auto bad_size_prog_or_error = unmarshal(bad_size_raw_prog, {});
-        REQUIRE(std::holds_alternative<InstructionSeq>(bad_size_prog_or_error));
-        const Program bad_size_prog =
-            Program::from_sequence(std::get<InstructionSeq>(bad_size_prog_or_error), info, {});
+        auto bad_size_inst_seq = unmarshal(bad_size_raw_prog, {});
+        REQUIRE(bad_size_inst_seq.has_value());
+        const Program bad_size_prog = Program::from_sequence(*bad_size_inst_seq, info, {});
         REQUIRE_FALSE(verify(bad_size_prog));
     }
 
@@ -1211,9 +1200,9 @@ TEST_CASE("instruction feature handling after unmarshal", "[unmarshal]") {
         RawProgram raw_prog{
             "",  "", 0, "", {EbpfInst{.opcode = INST_OP_LDDW_IMM, .dst = 1, .src = 3, .imm = 7}, EbpfInst{}, exit},
             info};
-        auto prog_or_error = unmarshal(raw_prog, {});
-        REQUIRE(std::holds_alternative<InstructionSeq>(prog_or_error));
-        const Program prog = Program::from_sequence(std::get<InstructionSeq>(prog_or_error), info, {});
+        auto inst_seq = unmarshal(raw_prog, {});
+        REQUIRE(inst_seq.has_value());
+        const Program prog = Program::from_sequence(*inst_seq, info, {});
         const auto* bin = std::get_if<Bin>(&prog.instruction_at(Label{0}));
         REQUIRE(bin != nullptr);
         REQUIRE(bin->op == Bin::Op::MOV);
@@ -1229,9 +1218,9 @@ TEST_CASE("instruction feature handling after unmarshal", "[unmarshal]") {
         RawProgram raw_prog{
             "",  "", 0, "", {EbpfInst{.opcode = INST_OP_LDDW_IMM, .dst = 2, .src = 4, .imm = 11}, EbpfInst{}, exit},
             info};
-        auto prog_or_error = unmarshal(raw_prog, {});
-        REQUIRE(std::holds_alternative<InstructionSeq>(prog_or_error));
-        const Program prog = Program::from_sequence(std::get<InstructionSeq>(prog_or_error), info, {});
+        auto inst_seq = unmarshal(raw_prog, {});
+        REQUIRE(inst_seq.has_value());
+        const Program prog = Program::from_sequence(*inst_seq, info, {});
         const auto* pseudo = std::get_if<LoadPseudo>(&prog.instruction_at(Label{0}));
         REQUIRE(pseudo != nullptr);
         REQUIRE(pseudo->dst == Reg{2});
@@ -1247,9 +1236,9 @@ TEST_CASE("instruction feature handling after unmarshal", "[unmarshal]") {
             "",
             {EbpfInst{.opcode = INST_OP_LDDW_IMM, .dst = 3, .src = 0, .imm = 1}, EbpfInst{.imm = 2}, exit},
             info};
-        auto prog_or_error = unmarshal(raw_prog, {});
-        REQUIRE(std::holds_alternative<InstructionSeq>(prog_or_error));
-        const Program prog = Program::from_sequence(std::get<InstructionSeq>(prog_or_error), info, {});
+        auto inst_seq = unmarshal(raw_prog, {});
+        REQUIRE(inst_seq.has_value());
+        const Program prog = Program::from_sequence(*inst_seq, info, {});
         const auto* bin = std::get_if<Bin>(&prog.instruction_at(Label{0}));
         REQUIRE(bin != nullptr);
         REQUIRE(bin->op == Bin::Op::MOV);
@@ -1269,9 +1258,9 @@ TEST_CASE("instruction feature handling after unmarshal", "[unmarshal]") {
             "",
             {EbpfInst{.opcode = INST_OP_LDDW_IMM, .dst = 3, .src = 0, .imm = -1}, EbpfInst{.imm = 0}, exit},
             info};
-        auto prog_or_error = unmarshal(raw_prog, {});
-        REQUIRE(std::holds_alternative<InstructionSeq>(prog_or_error));
-        const Program prog = Program::from_sequence(std::get<InstructionSeq>(prog_or_error), info, {});
+        auto inst_seq = unmarshal(raw_prog, {});
+        REQUIRE(inst_seq.has_value());
+        const Program prog = Program::from_sequence(*inst_seq, info, {});
         const auto* bin = std::get_if<Bin>(&prog.instruction_at(Label{0}));
         REQUIRE(bin != nullptr);
         REQUIRE(bin->op == Bin::Op::MOV);
@@ -1291,9 +1280,9 @@ TEST_CASE("instruction feature handling after unmarshal", "[unmarshal]") {
             "",
             {EbpfInst{.opcode = INST_OP_LDDW_IMM, .dst = 2, .src = INST_LD_MODE_CODE_ADDR, .imm = 7}, EbpfInst{}, exit},
             info};
-        auto prog_or_error = unmarshal(raw_prog, {});
-        REQUIRE(std::holds_alternative<InstructionSeq>(prog_or_error));
-        const Program prog = Program::from_sequence(std::get<InstructionSeq>(prog_or_error), info, {});
+        auto inst_seq = unmarshal(raw_prog, {});
+        REQUIRE(inst_seq.has_value());
+        const Program prog = Program::from_sequence(*inst_seq, info, {});
         const auto* pseudo = std::get_if<LoadPseudo>(&prog.instruction_at(Label{0}));
         REQUIRE(pseudo != nullptr);
         REQUIRE(pseudo->addr.kind == PseudoAddress::Kind::CODE_ADDR);
@@ -1310,9 +1299,9 @@ TEST_CASE("instruction feature handling after unmarshal", "[unmarshal]") {
              EbpfInst{.opcode = mov64_imm, .dst = 1, .imm = 1}, EbpfInst{.opcode = mov64_imm, .dst = 3, .imm = 0},
              EbpfInst{.opcode = mov64_imm, .dst = 4, .imm = 0}, EbpfInst{.opcode = INST_OP_CALL, .imm = 181}, exit},
             info};
-        auto prog_or_error = unmarshal(raw_prog, {});
-        REQUIRE(std::holds_alternative<InstructionSeq>(prog_or_error));
-        const Program prog = Program::from_sequence(std::get<InstructionSeq>(prog_or_error), info, {});
+        auto inst_seq = unmarshal(raw_prog, {});
+        REQUIRE(inst_seq.has_value());
+        const Program prog = Program::from_sequence(*inst_seq, info, {});
         const auto* call = std::get_if<Call>(&prog.instruction_at(Label{5}));
         REQUIRE(call != nullptr);
         REQUIRE(call->is_supported);
@@ -1333,9 +1322,9 @@ TEST_CASE("instruction feature handling after unmarshal", "[unmarshal]") {
              EbpfInst{.opcode = mov64_imm, .dst = 4, .imm = 0}, EbpfInst{.opcode = INST_OP_CALL, .imm = 181}, exit,
              EbpfInst{.opcode = mov64_imm, .dst = 0, .imm = 0}, exit},
             info};
-        auto good_prog_or_error = unmarshal(good_raw_prog, {});
-        REQUIRE(std::holds_alternative<InstructionSeq>(good_prog_or_error));
-        const Program good_prog = Program::from_sequence(std::get<InstructionSeq>(good_prog_or_error), info, {});
+        auto good_inst_seq = unmarshal(good_raw_prog, {});
+        REQUIRE(good_inst_seq.has_value());
+        const Program good_prog = Program::from_sequence(*good_inst_seq, info, {});
         REQUIRE(verify(good_prog));
 
         RawProgram bad_raw_prog{
@@ -1347,9 +1336,9 @@ TEST_CASE("instruction feature handling after unmarshal", "[unmarshal]") {
              EbpfInst{.opcode = mov64_imm, .dst = 3, .imm = 0}, EbpfInst{.opcode = mov64_imm, .dst = 4, .imm = 0},
              EbpfInst{.opcode = INST_OP_CALL, .imm = 181}, exit},
             info};
-        auto bad_prog_or_error = unmarshal(bad_raw_prog, {});
-        REQUIRE(std::holds_alternative<InstructionSeq>(bad_prog_or_error));
-        const Program bad_prog = Program::from_sequence(std::get<InstructionSeq>(bad_prog_or_error), info, {});
+        auto bad_inst_seq = unmarshal(bad_raw_prog, {});
+        REQUIRE(bad_inst_seq.has_value());
+        const Program bad_prog = Program::from_sequence(*bad_inst_seq, info, {});
         REQUIRE_FALSE(verify(bad_prog));
     }
 
@@ -1365,9 +1354,9 @@ TEST_CASE("instruction feature handling after unmarshal", "[unmarshal]") {
              EbpfInst{.opcode = mov64_imm, .dst = 4, .imm = 0}, EbpfInst{.opcode = INST_OP_CALL, .imm = 181}, exit,
              EbpfInst{.opcode = mov64_imm, .dst = 0, .imm = 0}, exit},
             info};
-        auto good_prog_or_error = unmarshal(good_raw_prog, {});
-        REQUIRE(std::holds_alternative<InstructionSeq>(good_prog_or_error));
-        const Program good_prog = Program::from_sequence(std::get<InstructionSeq>(good_prog_or_error), info, {});
+        auto good_inst_seq = unmarshal(good_raw_prog, {});
+        REQUIRE(good_inst_seq.has_value());
+        const Program good_prog = Program::from_sequence(*good_inst_seq, info, {});
         REQUIRE(verify(good_prog));
 
         RawProgram bad_raw_prog{
@@ -1380,9 +1369,9 @@ TEST_CASE("instruction feature handling after unmarshal", "[unmarshal]") {
              EbpfInst{.opcode = mov64_imm, .dst = 4, .imm = 0}, EbpfInst{.opcode = INST_OP_CALL, .imm = 181}, exit,
              EbpfInst{.opcode = mov64_imm, .dst = 0, .imm = 0}, exit},
             info};
-        auto bad_prog_or_error = unmarshal(bad_raw_prog, {});
-        REQUIRE(std::holds_alternative<InstructionSeq>(bad_prog_or_error));
-        const Program bad_prog = Program::from_sequence(std::get<InstructionSeq>(bad_prog_or_error), info, {});
+        auto bad_inst_seq = unmarshal(bad_raw_prog, {});
+        REQUIRE(bad_inst_seq.has_value());
+        const Program bad_prog = Program::from_sequence(*bad_inst_seq, info, {});
         REQUIRE_FALSE(verify(bad_prog));
     }
 
@@ -1398,18 +1387,18 @@ TEST_CASE("instruction feature handling after unmarshal", "[unmarshal]") {
              EbpfInst{.opcode = mov64_imm, .dst = 4, .imm = 0}, EbpfInst{.opcode = INST_OP_CALL, .imm = 181}, exit,
              EbpfInst{.opcode = INST_OP_JA16, .offset = -1}},
             info};
-        auto bad_prog_or_error = unmarshal(bad_raw_prog, {});
-        REQUIRE(std::holds_alternative<InstructionSeq>(bad_prog_or_error));
-        const Program bad_prog = Program::from_sequence(std::get<InstructionSeq>(bad_prog_or_error), info, {});
+        auto bad_inst_seq = unmarshal(bad_raw_prog, {});
+        REQUIRE(bad_inst_seq.has_value());
+        const Program bad_prog = Program::from_sequence(*bad_inst_seq, info, {});
         REQUIRE_FALSE(verify(bad_prog));
     }
 
     SECTION("helper id not usable on platform") {
         RawProgram raw_prog{"", "", 0, "", {EbpfInst{.opcode = INST_OP_CALL, .imm = 0x7fff}, exit}, info};
-        auto prog_or_error = unmarshal(raw_prog, {});
-        REQUIRE(std::holds_alternative<InstructionSeq>(prog_or_error));
+        auto inst_seq = unmarshal(raw_prog, {});
+        REQUIRE(inst_seq.has_value());
         REQUIRE_THROWS_WITH(
-            Program::from_sequence(std::get<InstructionSeq>(prog_or_error), info, {}),
+            Program::from_sequence(*inst_seq, info, {}),
             Catch::Matchers::ContainsSubstring("rejected: helper function is unavailable on this platform") &&
                 Catch::Matchers::ContainsSubstring("(at 0)"));
     }
@@ -1427,9 +1416,9 @@ TEST_CASE("instruction feature handling after unmarshal", "[unmarshal]") {
                                       .imm = 64},
                              exit},
                             pinfo};
-        auto prog_or_error = unmarshal(raw_prog, {});
-        REQUIRE(std::holds_alternative<InstructionSeq>(prog_or_error));
-        REQUIRE_THROWS_WITH(Program::from_sequence(std::get<InstructionSeq>(prog_or_error), pinfo, {}),
+        auto inst_seq = unmarshal(raw_prog, {});
+        REQUIRE(inst_seq.has_value());
+        REQUIRE_THROWS_WITH(Program::from_sequence(*inst_seq, pinfo, {}),
                             Catch::Matchers::ContainsSubstring("rejected: requires conformance group base64") &&
                                 Catch::Matchers::ContainsSubstring("(at 0)"));
     }
@@ -1438,9 +1427,9 @@ TEST_CASE("instruction feature handling after unmarshal", "[unmarshal]") {
         RawProgram raw_prog{
             "",  "", 0, "", {EbpfInst{.opcode = INST_OP_CALLX, .dst = 0, .src = INST_CALL_BTF_HELPER, .imm = 1}, exit},
             info};
-        auto prog_or_error = unmarshal(raw_prog, {});
-        REQUIRE(std::holds_alternative<std::string>(prog_or_error));
-        REQUIRE_THAT(std::get<std::string>(prog_or_error), Catch::Matchers::ContainsSubstring("bad instruction"));
+        auto inst_seq = unmarshal(raw_prog, {});
+        REQUIRE(!inst_seq.has_value());
+        REQUIRE_THAT(inst_seq.error(), Catch::Matchers::ContainsSubstring("bad instruction"));
     }
 
     SECTION("tail call chain depth above 33 is rejected") {
@@ -1450,9 +1439,9 @@ TEST_CASE("instruction feature handling after unmarshal", "[unmarshal]") {
         }
         insts.push_back(exit);
         RawProgram raw_prog{"", "", 0, "", std::move(insts), info};
-        auto prog_or_error = unmarshal(raw_prog, {});
-        REQUIRE(std::holds_alternative<InstructionSeq>(prog_or_error));
-        REQUIRE_THROWS_WITH(Program::from_sequence(std::get<InstructionSeq>(prog_or_error), info, {}),
+        auto inst_seq = unmarshal(raw_prog, {});
+        REQUIRE(inst_seq.has_value());
+        REQUIRE_THROWS_WITH(Program::from_sequence(*inst_seq, info, {}),
                             Catch::Matchers::ContainsSubstring("tail call chain depth exceeds 33") &&
                                 Catch::Matchers::ContainsSubstring("(at"));
     }
@@ -1464,9 +1453,9 @@ TEST_CASE("instruction feature handling after unmarshal", "[unmarshal]") {
         }
         insts.push_back(exit);
         RawProgram raw_prog{"", "", 0, "", std::move(insts), info};
-        auto prog_or_error = unmarshal(raw_prog, {});
-        REQUIRE(std::holds_alternative<InstructionSeq>(prog_or_error));
-        REQUIRE_NOTHROW(Program::from_sequence(std::get<InstructionSeq>(prog_or_error), info, {}));
+        auto inst_seq = unmarshal(raw_prog, {});
+        REQUIRE(inst_seq.has_value());
+        REQUIRE_NOTHROW(Program::from_sequence(*inst_seq, info, {}));
     }
 
     SECTION("tail call cycle does not inflate chain depth") {
@@ -1480,9 +1469,9 @@ TEST_CASE("instruction feature handling after unmarshal", "[unmarshal]") {
                                 EbpfInst{.opcode = INST_OP_JA16, .offset = -2},
                             },
                             info};
-        auto prog_or_error = unmarshal(raw_prog, {});
-        REQUIRE(std::holds_alternative<InstructionSeq>(prog_or_error));
-        REQUIRE_NOTHROW(Program::from_sequence(std::get<InstructionSeq>(prog_or_error), info, {}));
+        auto inst_seq = unmarshal(raw_prog, {});
+        REQUIRE(inst_seq.has_value());
+        REQUIRE_NOTHROW(Program::from_sequence(*inst_seq, info, {}));
     }
 }
 
@@ -1494,9 +1483,9 @@ TEST_CASE("instruction feature handling after unmarshal", "[unmarshal]") {
         const auto& raw_progs = elf.get_programs(sectionname);                                                  \
         REQUIRE(raw_progs.size() == 1);                                                                         \
         RawProgram raw_prog = raw_progs.back();                                                                 \
-        std::variant<InstructionSeq, std::string> prog_or_error = unmarshal(raw_prog, {});                      \
-        REQUIRE(std::holds_alternative<InstructionSeq>(prog_or_error));                                         \
-        REQUIRE_THROWS_WITH(Program::from_sequence(std::get<InstructionSeq>(prog_or_error), raw_prog.info, {}), \
+        const auto inst_seq = unmarshal(raw_prog, {});                                                          \
+        REQUIRE(inst_seq.has_value());                                                                          \
+        REQUIRE_THROWS_WITH(Program::from_sequence(*inst_seq, raw_prog.info, {}),                               \
                             Catch::Matchers::ContainsSubstring("rejected: requires conformance group packet")); \
     }
 

--- a/src/test/test_marshal.cpp
+++ b/src/test/test_marshal.cpp
@@ -5,10 +5,12 @@
 
 #include <catch2/catch_all.hpp>
 
-#include "ebpf_verifier.hpp"
+#include "io/elf_loader.hpp"
 #include "ir/marshal.hpp"
 #include "ir/program.hpp"
 #include "ir/unmarshal.hpp"
+#include "platform.hpp"
+#include "verifier.hpp"
 
 using namespace prevail;
 

--- a/src/test/test_print.cpp
+++ b/src/test/test_print.cpp
@@ -6,7 +6,6 @@
 #include <cctype>
 #include <fstream>
 #include <string>
-#include <variant>
 
 #if !defined(MAX_PATH)
 #define MAX_PATH (256)
@@ -35,10 +34,9 @@ void verify_printed_string(const std::string& file) {
     ElfObject elf{std::string(TEST_OBJECT_FILE_DIRECTORY) + file + ".o", {}, &g_ebpf_platform_linux};
     const auto& raw_progs = elf.get_programs();
     const RawProgram& raw_prog = raw_progs.back();
-    std::variant<InstructionSeq, std::string> prog_or_error = unmarshal(raw_prog, thread_local_options);
-    auto program = std::get_if<InstructionSeq>(&prog_or_error);
-    REQUIRE(program != nullptr);
-    print(*program, generated_output, {});
+    std::expected<InstructionSeq, std::string> inst_seq = unmarshal(raw_prog, thread_local_options);
+    REQUIRE(inst_seq.has_value());
+    print(*inst_seq, generated_output, {});
     print_map_descriptors(raw_prog.info.map_descriptors, generated_output);
     std::ifstream expected_stream(std::string(TEST_ASM_FILE_DIRECTORY) + file + std::string(".asm"));
     REQUIRE(expected_stream);

--- a/src/test/test_verify.hpp
+++ b/src/test/test_verify.hpp
@@ -4,7 +4,6 @@
 
 #include <catch2/catch_all.hpp>
 #include <mutex>
-#include <ranges>
 #include <string>
 #include <string_view>
 #include <thread>
@@ -174,18 +173,16 @@ struct BoundedTestName {
                 matched_program = true;                                                                              \
                 INFO("function_name=" << raw_prog.function_name);                                                    \
                 if (should_pass) {                                                                                   \
-                    const auto prog_or_error = prevail::unmarshal(raw_prog, prevail::thread_local_options);          \
-                    const auto inst_seq = std::get_if<prevail::InstructionSeq>(&prog_or_error);                      \
-                    REQUIRE(inst_seq);                                                                               \
+                    const auto inst_seq = prevail::unmarshal(raw_prog, prevail::thread_local_options);               \
+                    REQUIRE(inst_seq.has_value());                                                                   \
                     const prevail::Program prog =                                                                    \
                         prevail::Program::from_sequence(*inst_seq, raw_prog.info, prevail::thread_local_options);    \
                     REQUIRE(prevail::verify(prog) == true);                                                          \
                 } else {                                                                                             \
                     bool rejected = false;                                                                           \
                     try {                                                                                            \
-                        const auto prog_or_error = prevail::unmarshal(raw_prog, prevail::thread_local_options);      \
-                        const auto inst_seq = std::get_if<prevail::InstructionSeq>(&prog_or_error);                  \
-                        if (!inst_seq) {                                                                             \
+                        const auto inst_seq = prevail::unmarshal(raw_prog, prevail::thread_local_options);           \
+                        if (!inst_seq.has_value()) {                                                                 \
                             rejected = true;                                                                         \
                         } else {                                                                                     \
                             const prevail::Program prog = prevail::Program::from_sequence(                           \

--- a/src/test/test_verify.hpp
+++ b/src/test/test_verify.hpp
@@ -9,8 +9,12 @@
 #include <thread>
 #include <unordered_map>
 
-#include "ebpf_verifier.hpp"
+#include "config.hpp"
 #include "io/elf_loader.hpp"
+#include "ir/program.hpp"
+#include "ir/unmarshal.hpp"
+#include "platform.hpp"
+#include "verifier.hpp"
 
 namespace verify_test {
 

--- a/src/test/test_verify_multithreading.cpp
+++ b/src/test/test_verify_multithreading.cpp
@@ -18,18 +18,16 @@ TEST_CASE("multithreading", "[verify][multithreading]") {
                                                           &prevail::g_ebpf_platform_linux);
     REQUIRE(raw_progs1.size() == 1);
     prevail::RawProgram raw_prog1 = raw_progs1.back();
-    auto prog_or_error1 = prevail::unmarshal(raw_prog1, {});
-    auto inst_seq1 = std::get_if<prevail::InstructionSeq>(&prog_or_error1);
-    REQUIRE(inst_seq1);
+    auto inst_seq1 = prevail::unmarshal(raw_prog1, {});
+    REQUIRE(inst_seq1.has_value());
     const prevail::Program prog1 = prevail::Program::from_sequence(*inst_seq1, raw_prog1.info, {});
 
     const auto& raw_progs2 = verify_test::read_elf_cached("ebpf-samples/bpf_cilium_test/bpf_netdev.o", "2/2", "", {},
                                                           &prevail::g_ebpf_platform_linux);
     REQUIRE(raw_progs2.size() == 1);
     prevail::RawProgram raw_prog2 = raw_progs2.back();
-    auto prog_or_error2 = prevail::unmarshal(raw_prog2, {});
-    auto inst_seq2 = std::get_if<prevail::InstructionSeq>(&prog_or_error2);
-    REQUIRE(inst_seq2);
+    auto inst_seq2 = prevail::unmarshal(raw_prog2, {});
+    REQUIRE(inst_seq2.has_value());
     const prevail::Program prog2 = prevail::Program::from_sequence(*inst_seq2, raw_prog2.info, {});
 
     bool res1 = false;

--- a/src/test/test_yaml.cpp
+++ b/src/test/test_yaml.cpp
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MIT
 #include <catch2/catch_all.hpp>
 
-#include "ebpf_verifier.hpp"
 #include "test/ebpf_yaml.hpp"
 
 #define YAML_CASE(path)                                                                           \


### PR DESCRIPTION
Part of #1027: replace `std::variant<InstructionSeq, std::string>` with `std::expected<InstructionSeq, std::string>`.
