### PR TITLE
C++23: Use std::unreachable() instead of assert(false)

### DIFF
--- a/src/crab/ebpf_checker.cpp
+++ b/src/crab/ebpf_checker.cpp
@@ -372,13 +372,13 @@ void EbpfChecker::operator()(const ValidAccess& s) const {
                 }
             }
             break;
-        case T_MAP:
+        case T_MAP: [[fallthrough]];
         case T_MAP_PROGRAMS:
             if (!is_comparison_check) {
                 throw_fail("FDs cannot be dereferenced directly");
             }
             break;
-        case T_SOCKET:
+        case T_SOCKET: [[fallthrough]];
         case T_BTF_ID:
             // TODO: implement proper access checks for these pointer types.
             if (!is_comparison_check) {

--- a/src/crab/ebpf_transformer.cpp
+++ b/src/crab/ebpf_transformer.cpp
@@ -1179,8 +1179,8 @@ void EbpfTransformer::operator()(const Bin& bin) {
             dom.state.assign_type(bin.dst, T_NUM);
             dom.state.havoc_offsets(bin.dst);
             break;
-        case Bin::Op::MOVSX8:
-        case Bin::Op::MOVSX16:
+        case Bin::Op::MOVSX8: [[fallthrough]];
+        case Bin::Op::MOVSX16: [[fallthrough]];
         case Bin::Op::MOVSX32: CRAB_ERROR("Unsupported operation");
         case Bin::Op::ADD:
             if (imm == 0) {

--- a/src/crab/finite_domain.cpp
+++ b/src/crab/finite_domain.cpp
@@ -684,8 +684,7 @@ std::vector<LinearConstraint> FiniteDomain::assume_cst_reg(const Condition::Op o
         case Op::LT: return assume_unsigned_cst_interval(op, is64, dst_svalue, dst_uvalue, src_svalue, src_uvalue);
         }
     }
-    assert(false);
-    throw std::exception();
+    std::unreachable();
 }
 
 void FiniteDomain::assign(const Variable x, const std::optional<LinearExpression>& e) { dom.assign(x, e); }
@@ -711,7 +710,7 @@ void FiniteDomain::apply(const ArithBinOp op, const Variable x, const Variable y
     case ArithBinOp::ADD: assign(x, LinearExpression(y).plus(z)); break;
     case ArithBinOp::SUB: assign(x, LinearExpression(y).subtract(z)); break;
     case ArithBinOp::MUL: set(x, eval_interval(y, finite_width) * eval_interval(z, finite_width)); break;
-    default: CRAB_ERROR("DBM: unreachable");
+    default: std::unreachable();
     }
 }
 
@@ -721,7 +720,7 @@ void FiniteDomain::apply(const ArithBinOp op, const Variable x, const Variable y
     case ArithBinOp::ADD: assign(x, LinearExpression(y).plus(z)); break;
     case ArithBinOp::SUB: assign(x, LinearExpression(y).subtract(z)); break;
     case ArithBinOp::MUL: set(x, eval_interval(y, finite_width) * Interval{z}); break;
-    default: CRAB_ERROR("DBM: unreachable");
+    default: std::unreachable();
     }
 }
 
@@ -752,7 +751,7 @@ void FiniteDomain::apply(const SignedArithBinOp op, const Variable x, const Vari
     case SignedArithBinOp::UREM:
         set(x, eval_interval(y, finite_width).urem(Interval{read_imm_for_udiv_or_umod(k, finite_width)}));
         break;
-    default: CRAB_ERROR("DBM: unreachable");
+    default: std::unreachable();
     }
 }
 
@@ -763,7 +762,7 @@ void FiniteDomain::apply(const SignedArithBinOp op, const Variable x, const Vari
     case SignedArithBinOp::UDIV: set(x, eval_interval(y, finite_width).udiv(eval_interval(z, finite_width))); break;
     case SignedArithBinOp::SREM: set(x, eval_interval(y, finite_width).srem(eval_interval(z, finite_width))); break;
     case SignedArithBinOp::UREM: set(x, eval_interval(y, finite_width).urem(eval_interval(z, finite_width))); break;
-    default: CRAB_ERROR("DBM: unreachable");
+    default: std::unreachable();
     }
 }
 
@@ -783,7 +782,7 @@ void FiniteDomain::apply(const BitwiseBinOp op, const Variable x, const Variable
     case BitwiseBinOp::SHL: xi = yi.shl(zi); break;
     case BitwiseBinOp::LSHR: xi = yi.lshr(zi); break;
     case BitwiseBinOp::ASHR: xi = yi.ashr(zi); break;
-    default: CRAB_ERROR("DBM: unreachable");
+    default: std::unreachable();
     }
     xi.mask_value(finite_width);
     set(x, xi);
@@ -807,7 +806,7 @@ void FiniteDomain::apply(const BitwiseBinOp op, const Variable x, const Variable
     case BitwiseBinOp::SHL: xi = yi.shl(zi); break;
     case BitwiseBinOp::LSHR: xi = yi.lshr(zi); break;
     case BitwiseBinOp::ASHR: xi = yi.ashr(zi); break;
-    default: CRAB_ERROR("DBM: unreachable");
+    default: std::unreachable();
     }
     xi.mask_value(finite_width);
     set(x, xi);

--- a/src/crab/zone_domain.cpp
+++ b/src/crab/zone_domain.cpp
@@ -645,7 +645,7 @@ void ZoneDomain::apply(const ArithBinOp op, const Variable x, const Variable y, 
     case ArithBinOp::SUB: assign(x, LinearExpression(y).subtract(z)); break;
     // For the rest of operations, we fall back on intervals.
     case ArithBinOp::MUL: set(x, get_interval(y) * get_interval(z)); break;
-    default: CRAB_ERROR("DBM: unreachable");
+    default: std::unreachable();
     }
     normalize();
 }

--- a/src/ir/assertions.cpp
+++ b/src/ir/assertions.cpp
@@ -38,10 +38,7 @@ class AssertExtractor {
     explicit AssertExtractor(const ProgramInfo& info, const std::optional<Label>& label)
         : info{info}, current_label{label} {}
 
-    vector<Assertion> operator()(const Undefined&) const {
-        // assert(false);
-        return {};
-    }
+    vector<Assertion> operator()(const Undefined&) const { return {}; }
 
     vector<Assertion> operator()(const IncrementLoopCounter& ipc) const { return {{BoundedLoopCount{ipc.name}}}; }
 
@@ -52,8 +49,8 @@ class AssertExtractor {
         case PseudoAddress::Kind::CODE_ADDR:
             // Type/offset semantics are handled during abstract transformation.
             return {};
-        case PseudoAddress::Kind::VARIABLE_ADDR:
-        case PseudoAddress::Kind::MAP_BY_IDX:
+        case PseudoAddress::Kind::VARIABLE_ADDR: [[fallthrough]];
+        case PseudoAddress::Kind::MAP_BY_IDX: [[fallthrough]];
         case PseudoAddress::Kind::MAP_VALUE_BY_IDX:
             assert(false && "unexpected LoadPseudo kind after CFG construction");
             return {};
@@ -92,7 +89,7 @@ class AssertExtractor {
                 res.emplace_back(TypeConstraint{arg.reg, TypeGroup::map_fd});
                 map_fd_reg = arg.reg;
                 break;
-            case ArgSingle::Kind::PTR_TO_MAP_KEY:
+            case ArgSingle::Kind::PTR_TO_MAP_KEY: [[fallthrough]];
             case ArgSingle::Kind::PTR_TO_MAP_VALUE:
                 assert(map_fd_reg);
                 res.emplace_back(TypeConstraint{arg.reg, TypeGroup::mem});
@@ -327,7 +324,7 @@ class AssertExtractor {
                 return {Assertion{TypeConstraint{ins.dst, TypeGroup::number}}};
             }
         }
-        assert(false);
+        std::unreachable();
     }
 };
 

--- a/src/ir/assertions.cpp
+++ b/src/ir/assertions.cpp
@@ -183,7 +183,7 @@ class AssertExtractor {
                 case Condition::Op::SLE: allow_pointers = false; break;
                 case Condition::Op::SGT: allow_pointers = false; break;
                 case Condition::Op::SGE: allow_pointers = false; break;
-                default: assert(!"unexpected condition");
+                default: std::unreachable();
                 }
 
                 // Only permit pointer comparisons if the operation is 64-bit.

--- a/src/ir/cfg_builder.cpp
+++ b/src/ir/cfg_builder.cpp
@@ -107,8 +107,7 @@ static Condition::Op reverse(const Condition::Op op) {
     case Condition::Op::SET: return Condition::Op::NSET;
     case Condition::Op::NSET: return Condition::Op::SET;
     }
-    assert(false);
-    return {};
+    std::unreachable();
 }
 
 /// Get the inverse of a given comparison condition.

--- a/src/ir/marshal.cpp
+++ b/src/ir/marshal.cpp
@@ -8,6 +8,8 @@
 #include "crab_utils/num_safety.hpp"
 #include "ir/marshal.hpp"
 
+#include "crab_utils/debug.hpp"
+
 using std::vector;
 
 namespace prevail {
@@ -19,7 +21,7 @@ static uint8_t op(const Condition::Op op) {
     case Op::GT: return 0x2;
     case Op::GE: return 0x3;
     case Op::SET: return 0x4;
-    case Op::NSET: std::unreachable();
+    case Op::NSET: CRAB_ERROR("Cannot marshal Condition::Op::NSET (operator `&!=`)");
     case Op::NE: return 0x5;
     case Op::SGT: return 0x6;
     case Op::SGE: return 0x7;

--- a/src/ir/marshal.cpp
+++ b/src/ir/marshal.cpp
@@ -19,7 +19,7 @@ static uint8_t op(const Condition::Op op) {
     case Op::GT: return 0x2;
     case Op::GE: return 0x3;
     case Op::SET: return 0x4;
-    case Op::NSET: assert(false);
+    case Op::NSET: std::unreachable();
     case Op::NE: return 0x5;
     case Op::SGT: return 0x6;
     case Op::SGE: return 0x7;
@@ -28,8 +28,7 @@ static uint8_t op(const Condition::Op op) {
     case Op::SLT: return 0xc;
     case Op::SLE: return 0xd;
     }
-    assert(false);
-    return {};
+    std::unreachable();
 }
 
 static uint8_t op(const Bin::Op op) {
@@ -38,23 +37,22 @@ static uint8_t op(const Bin::Op op) {
     case Op::ADD: return 0x0;
     case Op::SUB: return 0x1;
     case Op::MUL: return 0x2;
-    case Op::SDIV:
+    case Op::SDIV: [[fallthrough]];
     case Op::UDIV: return 0x3;
     case Op::OR: return 0x4;
     case Op::AND: return 0x5;
     case Op::LSH: return 0x6;
     case Op::RSH: return 0x7;
-    case Op::SMOD:
+    case Op::SMOD: [[fallthrough]];
     case Op::UMOD: return 0x9;
     case Op::XOR: return 0xa;
-    case Op::MOV:
-    case Op::MOVSX8:
-    case Op::MOVSX16:
+    case Op::MOV: [[fallthrough]];
+    case Op::MOVSX8: [[fallthrough]];
+    case Op::MOVSX16: [[fallthrough]];
     case Op::MOVSX32: return 0xb;
     case Op::ARSH: return 0xc;
     }
-    assert(false);
-    return {};
+    std::unreachable();
 }
 
 static int16_t offset(const Bin::Op op) {
@@ -72,7 +70,7 @@ static int16_t offset(const Bin::Op op) {
 static uint8_t imm_endian(const Un::Op op) {
     using Op = Un::Op;
     switch (op) {
-    case Op::NEG: assert(false); return 0;
+    case Op::NEG: std::unreachable();
     case Op::BE16:
     case Op::LE16:
     case Op::SWAP16: return 16;
@@ -83,8 +81,7 @@ static uint8_t imm_endian(const Un::Op op) {
     case Op::LE64:
     case Op::SWAP64: return 64;
     }
-    assert(false);
-    return {};
+    std::unreachable();
 }
 
 struct MarshalVisitor {
@@ -102,10 +99,7 @@ struct MarshalVisitor {
     std::function<auto(Label)->int16_t> label_to_offset16;
     std::function<auto(Label)->int32_t> label_to_offset32;
 
-    vector<EbpfInst> operator()(Undefined const& a) const {
-        assert(false);
-        return {};
-    }
+    vector<EbpfInst> operator()(Undefined const& a) const { return {}; }
 
     vector<EbpfInst> operator()(LoadMapFd const& b) const { return makeLddw(b.dst, INST_LD_MODE_MAP_FD, b.mapfd, 0); }
 
@@ -187,8 +181,7 @@ struct MarshalVisitor {
                 .imm = imm_endian(b.op),
             }};
         }
-        assert(false);
-        return {};
+        std::unreachable();
     }
 
     vector<EbpfInst> operator()(Call const& b) const {

--- a/src/printing.cpp
+++ b/src/printing.cpp
@@ -279,8 +279,7 @@ std::ostream& operator<<(std::ostream& os, const ArgSingle::Kind kind) {
     case ArgSingle::Kind::PTR_TO_WRITABLE_LONG: return os << "out_long";
     case ArgSingle::Kind::PTR_TO_WRITABLE_INT: return os << "out_int";
     }
-    assert(false);
-    return os;
+    std::unreachable();
 }
 
 std::ostream& operator<<(std::ostream& os, const ArgPair::Kind kind) {
@@ -288,8 +287,7 @@ std::ostream& operator<<(std::ostream& os, const ArgPair::Kind kind) {
     case ArgPair::Kind::PTR_TO_READABLE_MEM: return os << "mem";
     case ArgPair::Kind::PTR_TO_WRITABLE_MEM: return os << "out";
     }
-    assert(false);
-    return os;
+    std::unreachable();
 }
 
 std::ostream& operator<<(std::ostream& os, const ArgSingle arg) {
@@ -335,8 +333,7 @@ std::ostream& operator<<(std::ostream& os, const Bin::Op op) {
     case Op::ARSH: return os << ">>>";
     case Op::XOR: return os << "^";
     }
-    assert(false);
-    return os;
+    std::unreachable();
 }
 
 std::ostream& operator<<(std::ostream& os, const Condition::Op op) {
@@ -355,8 +352,7 @@ std::ostream& operator<<(std::ostream& os, const Condition::Op op) {
     case Op::SGT: return os << "s>";
     case Op::SGE: return os << "s>=";
     }
-    assert(false);
-    return os;
+    std::unreachable();
 }
 
 static string size(const int w, const bool is_signed = false) {


### PR DESCRIPTION
Part of #1027.

Also use [[falltrhough]] for switch statements.