### PR TITLE
Remove thread_local_program_info; make Program self-contained

### DIFF
--- a/src/analysis_context.hpp
+++ b/src/analysis_context.hpp
@@ -2,10 +2,7 @@
 // SPDX-License-Identifier: MIT
 #pragma once
 
-#include <cassert>
-
 #include "config.hpp"
-#include "platform.hpp"
 #include "spec/type_descriptors.hpp"
 
 namespace prevail {
@@ -25,16 +22,5 @@ struct AnalysisContext {
     const ebpf_verifier_options_t& options;
     const ebpf_platform_t& platform;
 };
-
-[[nodiscard]]
-inline AnalysisContext thread_local_analysis_context() {
-    const ProgramInfo& program_info = thread_local_program_info.get();
-    assert(program_info.platform != nullptr && "program_info.platform must be set before analysis");
-    return AnalysisContext{
-        .program_info = program_info,
-        .options = thread_local_options,
-        .platform = *program_info.platform,
-    };
-}
 
 } // namespace prevail

--- a/src/crab/ebpf_checker.cpp
+++ b/src/crab/ebpf_checker.cpp
@@ -229,18 +229,18 @@ void EbpfChecker::operator()(const ValidCallbackTarget& s) const {
 void EbpfChecker::operator()(const ValidMapKeyValue& s) const {
     using namespace dsl_syntax;
 
-    const auto fd_type = dom.get_map_type(s.map_fd_reg, context.platform);
+    const auto fd_type = dom.get_map_type(s.map_fd_reg, context);
 
     const auto access_reg = reg_pack(s.access_reg);
     int width;
     if (s.key) {
-        const auto key_size = dom.get_map_key_size(s.map_fd_reg, context.platform).singleton();
+        const auto key_size = dom.get_map_key_size(s.map_fd_reg, context).singleton();
         if (!key_size.has_value()) {
             throw_fail("Map key size is not singleton");
         }
         width = key_size->narrow<int>();
     } else {
-        const auto value_size = dom.get_map_value_size(s.map_fd_reg, context.platform).singleton();
+        const auto value_size = dom.get_map_value_size(s.map_fd_reg, context).singleton();
         if (!value_size.has_value()) {
             throw_fail("Map value size is not singleton");
         }
@@ -271,7 +271,7 @@ void EbpfChecker::operator()(const ValidMapKeyValue& s) const {
                         Variable key_value =
                             variable_registry.cell_var(DataKind::svalues, offset_num.value(), sizeof(uint32_t));
 
-                        if (auto max_entries = dom.get_map_max_entries(s.map_fd_reg, context.platform).lb().number()) {
+                        if (auto max_entries = dom.get_map_max_entries(s.map_fd_reg, context).lb().number()) {
                             require_value(dom.state, key_value < *max_entries, "Array index overflow");
                         } else {
                             throw_fail("Max entries is not finite");

--- a/src/crab/ebpf_checker.cpp
+++ b/src/crab/ebpf_checker.cpp
@@ -80,11 +80,6 @@ std::optional<VerificationError> ebpf_domain_check(const EbpfDomain& dom, const 
     return {};
 }
 
-std::optional<VerificationError> ebpf_domain_check(const EbpfDomain& dom, const Assertion& assertion,
-                                                   const Label& where) {
-    return ebpf_domain_check(dom, assertion, where, thread_local_analysis_context());
-}
-
 void EbpfChecker::check_access_stack(const LinearExpression& lb, const LinearExpression& ub) const {
     using namespace dsl_syntax;
     require_value(dom.state, reg_pack(R10_STACK_POINTER).stack_offset - context.options.subprogram_stack_size <= lb,

--- a/src/crab/ebpf_checker.cpp
+++ b/src/crab/ebpf_checker.cpp
@@ -190,10 +190,10 @@ void EbpfChecker::operator()(const FuncConstraint& s) const {
         if (sn->fits<int32_t>()) {
             // We can now process it as if the id was immediate.
             const int32_t imm = sn->cast_to<int32_t>();
-            if (!context.platform.is_helper_usable(imm)) {
+            if (!context.platform.is_helper_usable(imm, context.program_info.type)) {
                 throw_fail("invalid helper function id " + std::to_string(imm));
             }
-            const Call call = make_call(imm, context.platform);
+            const Call call = make_call(imm, context.platform, context.program_info.type);
             for (const Assertion& sub_assertion : get_assertions(call, context.program_info, context.options, {})) {
                 // TODO: create explicit sub assertions elsewhere
                 EbpfChecker{dom, sub_assertion, context}.visit();

--- a/src/crab/ebpf_domain.cpp
+++ b/src/crab/ebpf_domain.cpp
@@ -264,7 +264,7 @@ bool EbpfDomain::get_map_fd_range(const Reg& map_fd_reg, int32_t* start_fd, int3
 }
 
 // All maps in the range must have the same type for us to use it.
-std::optional<uint32_t> EbpfDomain::get_map_type(const Reg& map_fd_reg, const ebpf_platform_t& platform) const {
+std::optional<uint32_t> EbpfDomain::get_map_type(const Reg& map_fd_reg, const AnalysisContext& context) const {
     int32_t start_fd, end_fd;
     if (!get_map_fd_range(map_fd_reg, &start_fd, &end_fd)) {
         return {};
@@ -272,21 +272,17 @@ std::optional<uint32_t> EbpfDomain::get_map_type(const Reg& map_fd_reg, const eb
 
     std::optional<uint32_t> type;
     for (int32_t map_fd = start_fd; map_fd <= end_fd; map_fd++) {
-        EbpfMapDescriptor* map = &platform.get_map_descriptor(map_fd);
-        if (map == nullptr) {
-            return {};
-        }
+        const auto& map = context.platform.get_map_descriptor(map_fd, context.program_info);
         if (!type.has_value()) {
-            type = map->type;
-        } else if (map->type != *type) {
+            type = map.type;
+        } else if (map.type != *type) {
             return {};
         }
     }
     return type;
 }
 
-// All maps in the range must have the same inner map fd for us to use it.
-std::optional<uint32_t> EbpfDomain::get_map_inner_map_fd(const Reg& map_fd_reg, const ebpf_platform_t& platform) const {
+std::optional<uint32_t> EbpfDomain::get_map_inner_map_fd(const Reg& map_fd_reg, const AnalysisContext& context) const {
     int start_fd, end_fd;
     if (!get_map_fd_range(map_fd_reg, &start_fd, &end_fd)) {
         return {};
@@ -294,21 +290,17 @@ std::optional<uint32_t> EbpfDomain::get_map_inner_map_fd(const Reg& map_fd_reg, 
 
     std::optional<uint32_t> inner_map_fd;
     for (int map_fd = start_fd; map_fd <= end_fd; map_fd++) {
-        EbpfMapDescriptor* map = &platform.get_map_descriptor(map_fd);
-        if (map == nullptr) {
-            return {};
-        }
+        const auto& map = context.platform.get_map_descriptor(map_fd, context.program_info);
         if (!inner_map_fd.has_value()) {
-            inner_map_fd = map->inner_map_fd;
-        } else if (map->inner_map_fd != *inner_map_fd) {
+            inner_map_fd = map.inner_map_fd;
+        } else if (map.inner_map_fd != *inner_map_fd) {
             return {};
         }
     }
     return inner_map_fd;
 }
 
-// We can deal with a range of key sizes.
-Interval EbpfDomain::get_map_key_size(const Reg& map_fd_reg, const ebpf_platform_t& platform) const {
+Interval EbpfDomain::get_map_key_size(const Reg& map_fd_reg, const AnalysisContext& context) const {
     int start_fd, end_fd;
     if (!get_map_fd_range(map_fd_reg, &start_fd, &end_fd)) {
         return Interval::top();
@@ -316,17 +308,13 @@ Interval EbpfDomain::get_map_key_size(const Reg& map_fd_reg, const ebpf_platform
 
     Interval result = Interval::bottom();
     for (int map_fd = start_fd; map_fd <= end_fd; map_fd++) {
-        if (const EbpfMapDescriptor* map = &platform.get_map_descriptor(map_fd)) {
-            result = result | Interval{map->key_size};
-        } else {
-            return Interval::top();
-        }
+        const auto& map = context.platform.get_map_descriptor(map_fd, context.program_info);
+        result = result | Interval{map.key_size};
     }
     return result;
 }
 
-// We can deal with a range of value sizes.
-Interval EbpfDomain::get_map_value_size(const Reg& map_fd_reg, const ebpf_platform_t& platform) const {
+Interval EbpfDomain::get_map_value_size(const Reg& map_fd_reg, const AnalysisContext& context) const {
     int start_fd, end_fd;
     if (!get_map_fd_range(map_fd_reg, &start_fd, &end_fd)) {
         return Interval::top();
@@ -334,17 +322,13 @@ Interval EbpfDomain::get_map_value_size(const Reg& map_fd_reg, const ebpf_platfo
 
     Interval result = Interval::bottom();
     for (int map_fd = start_fd; map_fd <= end_fd; map_fd++) {
-        if (const EbpfMapDescriptor* map = &platform.get_map_descriptor(map_fd)) {
-            result = result | Interval(map->value_size);
-        } else {
-            return Interval::top();
-        }
+        const auto& map = context.platform.get_map_descriptor(map_fd, context.program_info);
+        result = result | Interval(map.value_size);
     }
     return result;
 }
 
-// We can deal with a range of max_entries values.
-Interval EbpfDomain::get_map_max_entries(const Reg& map_fd_reg, const ebpf_platform_t& platform) const {
+Interval EbpfDomain::get_map_max_entries(const Reg& map_fd_reg, const AnalysisContext& context) const {
     int start_fd, end_fd;
     if (!get_map_fd_range(map_fd_reg, &start_fd, &end_fd)) {
         return Interval::top();
@@ -352,11 +336,8 @@ Interval EbpfDomain::get_map_max_entries(const Reg& map_fd_reg, const ebpf_platf
 
     Interval result = Interval::bottom();
     for (int map_fd = start_fd; map_fd <= end_fd; map_fd++) {
-        if (const EbpfMapDescriptor* map = &platform.get_map_descriptor(map_fd)) {
-            result = result | Interval(map->max_entries);
-        } else {
-            return Interval::top();
-        }
+        const auto& map = context.platform.get_map_descriptor(map_fd, context.program_info);
+        result = result | Interval(map.max_entries);
     }
     return result;
 }

--- a/src/crab/ebpf_domain.cpp
+++ b/src/crab/ebpf_domain.cpp
@@ -14,7 +14,6 @@
 #include "crab/array_domain.hpp"
 #include "crab/ebpf_domain.hpp"
 #include "crab/var_registry.hpp"
-#include "crab_utils/lazy_allocator.hpp"
 #include "ir/unmarshal.hpp"
 
 namespace prevail {
@@ -282,13 +281,13 @@ std::optional<uint32_t> EbpfDomain::get_map_type(const Reg& map_fd_reg, const An
     return type;
 }
 
-std::optional<uint32_t> EbpfDomain::get_map_inner_map_fd(const Reg& map_fd_reg, const AnalysisContext& context) const {
+std::optional<int> EbpfDomain::get_map_inner_map_fd(const Reg& map_fd_reg, const AnalysisContext& context) const {
     int start_fd, end_fd;
     if (!get_map_fd_range(map_fd_reg, &start_fd, &end_fd)) {
         return {};
     }
 
-    std::optional<uint32_t> inner_map_fd;
+    std::optional<int> inner_map_fd;
     for (int map_fd = start_fd; map_fd <= end_fd; map_fd++) {
         const auto& map = context.platform.get_map_descriptor(map_fd, context.program_info);
         if (!inner_map_fd.has_value()) {

--- a/src/crab/ebpf_domain.hpp
+++ b/src/crab/ebpf_domain.hpp
@@ -38,8 +38,6 @@ std::string to_string(const VerificationError& error);
 void ebpf_domain_transform(EbpfDomain& inv, const Instruction& ins, const AnalysisContext& context);
 std::optional<VerificationError> ebpf_domain_check(const EbpfDomain& dom, const Assertion& assertion,
                                                    const Label& where, const AnalysisContext& context);
-std::optional<VerificationError> ebpf_domain_check(const EbpfDomain& dom, const Assertion& assertion,
-                                                   const Label& where);
 
 // TODO: make this an explicit instruction
 void ebpf_domain_initialize_loop_counter(EbpfDomain& dom, const Label& label, const AnalysisContext& context);
@@ -114,7 +112,7 @@ class EbpfDomain final {
     [[nodiscard]]
     std::optional<uint32_t> get_map_type(const Reg& map_fd_reg, const AnalysisContext& context) const;
     [[nodiscard]]
-    std::optional<uint32_t> get_map_inner_map_fd(const Reg& map_fd_reg, const AnalysisContext& context) const;
+    std::optional<int> get_map_inner_map_fd(const Reg& map_fd_reg, const AnalysisContext& context) const;
     [[nodiscard]]
     Interval get_map_key_size(const Reg& map_fd_reg, const AnalysisContext& context) const;
     [[nodiscard]]

--- a/src/crab/ebpf_domain.hpp
+++ b/src/crab/ebpf_domain.hpp
@@ -112,15 +112,15 @@ class EbpfDomain final {
     std::optional<int64_t> get_stack_offset(const Reg& reg) const;
 
     [[nodiscard]]
-    std::optional<uint32_t> get_map_type(const Reg& map_fd_reg, const ebpf_platform_t& platform) const;
+    std::optional<uint32_t> get_map_type(const Reg& map_fd_reg, const AnalysisContext& context) const;
     [[nodiscard]]
-    std::optional<uint32_t> get_map_inner_map_fd(const Reg& map_fd_reg, const ebpf_platform_t& platform) const;
+    std::optional<uint32_t> get_map_inner_map_fd(const Reg& map_fd_reg, const AnalysisContext& context) const;
     [[nodiscard]]
-    Interval get_map_key_size(const Reg& map_fd_reg, const ebpf_platform_t& platform) const;
+    Interval get_map_key_size(const Reg& map_fd_reg, const AnalysisContext& context) const;
     [[nodiscard]]
-    Interval get_map_value_size(const Reg& map_fd_reg, const ebpf_platform_t& platform) const;
+    Interval get_map_value_size(const Reg& map_fd_reg, const AnalysisContext& context) const;
     [[nodiscard]]
-    Interval get_map_max_entries(const Reg& map_fd_reg, const ebpf_platform_t& platform) const;
+    Interval get_map_max_entries(const Reg& map_fd_reg, const AnalysisContext& context) const;
 
     bool get_map_fd_range(const Reg& map_fd_reg, int32_t* start_fd, int32_t* end_fd) const;
 

--- a/src/crab/ebpf_transformer.cpp
+++ b/src/crab/ebpf_transformer.cpp
@@ -938,7 +938,7 @@ void EbpfTransformer::operator()(const Call& call) {
         if (context.platform.get_map_type(*map_type).value_type == EbpfMapValueType::MAP) {
             // Map-of-maps: r0 is an inner map fd if known, otherwise an opaque shared pointer.
             if (const auto inner_map_fd = dom.get_map_inner_map_fd(*maybe_fd_reg, context)) {
-                do_load_mapfd(r0_reg, to_signed(*inner_map_fd), true);
+                do_load_mapfd(r0_reg, *inner_map_fd, true);
             } else {
                 assign_shared_map_value(std::nullopt);
             }

--- a/src/crab/ebpf_transformer.cpp
+++ b/src/crab/ebpf_transformer.cpp
@@ -930,14 +930,14 @@ void EbpfTransformer::operator()(const Call& call) {
             assign_shared_map_value(std::nullopt);
             return;
         }
-        const auto map_type = dom.get_map_type(*maybe_fd_reg, context.platform);
+        const auto map_type = dom.get_map_type(*maybe_fd_reg, context);
         if (!map_type) {
             assign_shared_map_value(std::nullopt);
             return;
         }
         if (context.platform.get_map_type(*map_type).value_type == EbpfMapValueType::MAP) {
             // Map-of-maps: r0 is an inner map fd if known, otherwise an opaque shared pointer.
-            if (const auto inner_map_fd = dom.get_map_inner_map_fd(*maybe_fd_reg, context.platform)) {
+            if (const auto inner_map_fd = dom.get_map_inner_map_fd(*maybe_fd_reg, context)) {
                 do_load_mapfd(r0_reg, to_signed(*inner_map_fd), true);
             } else {
                 assign_shared_map_value(std::nullopt);
@@ -945,7 +945,7 @@ void EbpfTransformer::operator()(const Call& call) {
             return;
         }
         // Regular map: r0 is a shared pointer with known value size.
-        assign_shared_map_value(dom.get_map_value_size(*maybe_fd_reg, context.platform));
+        assign_shared_map_value(dom.get_map_value_size(*maybe_fd_reg, context));
     };
     if (call.is_map_lookup) {
         resolve_map_lookup();
@@ -1006,7 +1006,7 @@ void EbpfTransformer::operator()(const Callx& callx) {
 }
 
 void EbpfTransformer::do_load_mapfd(const Reg& dst_reg, const int mapfd, const bool maybe_null) {
-    const EbpfMapDescriptor& desc = context.platform.get_map_descriptor(mapfd);
+    const auto& desc = context.platform.get_map_descriptor(mapfd, context.program_info);
     const EbpfMapType& type = context.platform.get_map_type(desc.type);
     const RegPack& dst = reg_pack(dst_reg);
     if (type.value_type == EbpfMapValueType::PROGRAM) {
@@ -1027,7 +1027,7 @@ void EbpfTransformer::operator()(const LoadMapFd& ins) {
 }
 
 void EbpfTransformer::do_load_map_address(const Reg& dst_reg, const int mapfd, const int32_t offset) {
-    const EbpfMapDescriptor& desc = context.platform.get_map_descriptor(mapfd);
+    const auto& desc = context.platform.get_map_descriptor(mapfd, context.program_info);
     const EbpfMapType& type = context.platform.get_map_type(desc.type);
 
     if (type.value_type == EbpfMapValueType::PROGRAM) {

--- a/src/crab/ebpf_transformer.cpp
+++ b/src/crab/ebpf_transformer.cpp
@@ -996,10 +996,10 @@ void EbpfTransformer::operator()(const Callx& callx) {
         if (sn->fits<int32_t>()) {
             // We can now process it as if the id was immediate.
             const int32_t imm = sn->cast_to<int32_t>();
-            if (!context.platform.is_helper_usable(imm)) {
+            if (!context.platform.is_helper_usable(imm, context.program_info.type)) {
                 return;
             }
-            const Call call = make_call(imm, context.platform);
+            const Call call = make_call(imm, context.platform, context.program_info.type);
             (*this)(call);
         }
     }

--- a/src/fwd_analyzer.cpp
+++ b/src/fwd_analyzer.cpp
@@ -161,14 +161,24 @@ class InterleavedFwdFixpointIterator final {
     static AnalysisResult run(const Program& prog, const AnalysisContext& context, EbpfDomain entry_inv);
 };
 
-AnalysisResult analyze(const Program& prog) {
+static AnalysisContext make_context(const Program& prog, const ebpf_verifier_options_t& options) {
     const auto& info = prog.info();
-    return analyze(prog, AnalysisContext{info, thread_local_options, *info.platform});
+    return AnalysisContext{info, options, *info.platform};
 }
 
+AnalysisResult analyze(const Program& prog, const ebpf_verifier_options_t& options) {
+    return analyze(prog, make_context(prog, options));
+}
+
+AnalysisResult analyze(const Program& prog, const StringInvariant& entry_invariant,
+                       const ebpf_verifier_options_t& options) {
+    return analyze(prog, entry_invariant, make_context(prog, options));
+}
+
+AnalysisResult analyze(const Program& prog) { return analyze(prog, thread_local_options); }
+
 AnalysisResult analyze(const Program& prog, const StringInvariant& entry_invariant) {
-    const auto& info = prog.info();
-    return analyze(prog, entry_invariant, AnalysisContext{info, thread_local_options, *info.platform});
+    return analyze(prog, entry_invariant, thread_local_options);
 }
 
 AnalysisResult analyze(const Program& prog, const AnalysisContext& context) {

--- a/src/fwd_analyzer.cpp
+++ b/src/fwd_analyzer.cpp
@@ -16,15 +16,11 @@
 
 namespace prevail {
 
-thread_local LazyAllocator<ProgramInfo> thread_local_program_info;
 thread_local ebpf_verifier_options_t thread_local_options;
 
-// The ArrayDomain keeps a thread-local cache that is per-analysis state,
-// not per-caller state; reset it at the start of every run.
 static void clear_analysis_thread_local_state() { clear_thread_local_state(); }
 
 void ebpf_verifier_clear_thread_local_state() {
-    thread_local_program_info.clear();
     clear_thread_local_state();
     ZoneDomain::clear_thread_local_state();
 }
@@ -165,11 +161,14 @@ class InterleavedFwdFixpointIterator final {
     static AnalysisResult run(const Program& prog, const AnalysisContext& context, EbpfDomain entry_inv);
 };
 
-// Back-compat shims for callers that don't construct an AnalysisContext.
-AnalysisResult analyze(const Program& prog) { return analyze(prog, thread_local_analysis_context()); }
+AnalysisResult analyze(const Program& prog) {
+    const auto& info = prog.info();
+    return analyze(prog, AnalysisContext{info, thread_local_options, *info.platform});
+}
 
 AnalysisResult analyze(const Program& prog, const StringInvariant& entry_invariant) {
-    return analyze(prog, entry_invariant, thread_local_analysis_context());
+    const auto& info = prog.info();
+    return analyze(prog, entry_invariant, AnalysisContext{info, thread_local_options, *info.platform});
 }
 
 AnalysisResult analyze(const Program& prog, const AnalysisContext& context) {

--- a/src/io/elf_loader.cpp
+++ b/src/io/elf_loader.cpp
@@ -255,16 +255,6 @@ const std::vector<RawProgram>& ElfObject::get_programs(const std::string& desire
 // Free functions
 // ---------------------------------------------------------------------------
 
-int create_map_crab(const EbpfMapType& map_type, const uint32_t key_size, const uint32_t value_size,
-                    const uint32_t max_entries, ebpf_verifier_options_t, std::map<EquivalenceKey, int>& cache) {
-    const EquivalenceKey equiv{map_type.value_type, key_size, value_size, map_type.is_array ? max_entries : 0};
-    if (!cache.contains(equiv)) {
-        // +1 so 0 is the null FD
-        cache[equiv] = gsl::narrow<int>(cache.size()) + 1;
-    }
-    return cache.at(equiv);
-}
-
 const EbpfMapDescriptor* find_map_descriptor(const int map_fd, const ProgramInfo& info) {
     for (const EbpfMapDescriptor& map : info.map_descriptors) {
         if (map.original_fd == map_fd) {

--- a/src/io/elf_loader.cpp
+++ b/src/io/elf_loader.cpp
@@ -265,8 +265,8 @@ int create_map_crab(const EbpfMapType& map_type, const uint32_t key_size, const 
     return cache.at(equiv);
 }
 
-EbpfMapDescriptor* find_map_descriptor(const int map_fd) {
-    for (EbpfMapDescriptor& map : thread_local_program_info->map_descriptors) {
+const EbpfMapDescriptor* find_map_descriptor(const int map_fd, const ProgramInfo& info) {
+    for (const EbpfMapDescriptor& map : info.map_descriptors) {
         if (map.original_fd == map_fd) {
             return &map;
         }

--- a/src/io/elf_loader.cpp
+++ b/src/io/elf_loader.cpp
@@ -256,13 +256,13 @@ const std::vector<RawProgram>& ElfObject::get_programs(const std::string& desire
 // ---------------------------------------------------------------------------
 
 int create_map_crab(const EbpfMapType& map_type, const uint32_t key_size, const uint32_t value_size,
-                    const uint32_t max_entries, ebpf_verifier_options_t) {
+                    const uint32_t max_entries, ebpf_verifier_options_t, std::map<EquivalenceKey, int>& cache) {
     const EquivalenceKey equiv{map_type.value_type, key_size, value_size, map_type.is_array ? max_entries : 0};
-    if (!thread_local_program_info->cache.contains(equiv)) {
+    if (!cache.contains(equiv)) {
         // +1 so 0 is the null FD
-        thread_local_program_info->cache[equiv] = gsl::narrow<int>(thread_local_program_info->cache.size()) + 1;
+        cache[equiv] = gsl::narrow<int>(cache.size()) + 1;
     }
-    return thread_local_program_info->cache.at(equiv);
+    return cache.at(equiv);
 }
 
 EbpfMapDescriptor* find_map_descriptor(const int map_fd) {

--- a/src/io/elf_loader.hpp
+++ b/src/io/elf_loader.hpp
@@ -22,9 +22,6 @@ class MalformedElf final : public UnmarshalError {
     explicit MalformedElf(const std::string& what) : UnmarshalError(what) {}
 };
 
-int create_map_crab(const EbpfMapType& map_type, uint32_t key_size, uint32_t value_size, uint32_t max_entries,
-                    ebpf_verifier_options_t options, std::map<EquivalenceKey, int>& cache);
-
 const EbpfMapDescriptor* find_map_descriptor(int map_fd, const ProgramInfo& info);
 
 struct ElfProgramInfo {

--- a/src/io/elf_loader.hpp
+++ b/src/io/elf_loader.hpp
@@ -23,7 +23,7 @@ class MalformedElf final : public UnmarshalError {
 };
 
 int create_map_crab(const EbpfMapType& map_type, uint32_t key_size, uint32_t value_size, uint32_t max_entries,
-                    ebpf_verifier_options_t options);
+                    ebpf_verifier_options_t options, std::map<EquivalenceKey, int>& cache);
 
 EbpfMapDescriptor* find_map_descriptor(int map_fd);
 

--- a/src/io/elf_loader.hpp
+++ b/src/io/elf_loader.hpp
@@ -25,7 +25,7 @@ class MalformedElf final : public UnmarshalError {
 int create_map_crab(const EbpfMapType& map_type, uint32_t key_size, uint32_t value_size, uint32_t max_entries,
                     ebpf_verifier_options_t options, std::map<EquivalenceKey, int>& cache);
 
-EbpfMapDescriptor* find_map_descriptor(int map_fd);
+const EbpfMapDescriptor* find_map_descriptor(int map_fd, const ProgramInfo& info);
 
 struct ElfProgramInfo {
     std::string section_name;

--- a/src/ir/cfg_builder.cpp
+++ b/src/ir/cfg_builder.cpp
@@ -704,8 +704,6 @@ Program Program::from_sequence(const InstructionSeq& inst_seq, ProgramInfo& info
         }
     }
 
-    thread_local_program_info.set(info);
-
     // Detect loops using Weak Topological Ordering (WTO) and insert counters at loop entry points. WTO provides a
     // hierarchical decomposition of the CFG that identifies all strongly connected components (cycles) and their entry
     // points. These entry points serve as natural locations for loop counters that help verify program termination.
@@ -719,6 +717,7 @@ Program Program::from_sequence(const InstructionSeq& inst_seq, ProgramInfo& info
     for (const auto& label : builder.prog.labels()) {
         builder.set_assertions(label, get_assertions(builder.prog.instruction_at(label), info, options, label));
     }
+    builder.prog.m_info = std::move(info);
     return std::move(builder.prog);
 }
 

--- a/src/ir/cfg_builder.cpp
+++ b/src/ir/cfg_builder.cpp
@@ -498,19 +498,22 @@ static CfgBuilder instruction_seq_to_cfg(const InstructionSeq& insts, const Prog
     return builder;
 }
 
-static bool is_tail_call_helper(const Call& call, const ebpf_platform_t& platform) {
+static bool is_tail_call_helper(const Call& call, const ebpf_platform_t& platform,
+                                const EbpfProgramType& program_type) {
     if (call.kind != CallKind::helper) {
         return false;
     }
-    if (!platform.is_helper_usable(call.func)) {
+    if (!platform.is_helper_usable(call.func, program_type)) {
         return false;
     }
-    return platform.get_helper_prototype(call.func).return_type == EBPF_RETURN_TYPE_INTEGER_OR_NO_RETURN_IF_SUCCEED;
+    return platform.get_helper_prototype(call.func, program_type).return_type ==
+           EBPF_RETURN_TYPE_INTEGER_OR_NO_RETURN_IF_SUCCEED;
 }
 
-static bool is_tail_call_site(const Instruction& ins, const ebpf_platform_t& platform) {
+static bool is_tail_call_site(const Instruction& ins, const ebpf_platform_t& platform,
+                              const EbpfProgramType& program_type) {
     if (const auto* call = std::get_if<Call>(&ins)) {
-        return is_tail_call_helper(*call, platform);
+        return is_tail_call_helper(*call, platform, program_type);
     }
     if (std::holds_alternative<Callx>(ins)) {
         // At CFG-construction time, callx target ids are not available.
@@ -534,7 +537,8 @@ static void collect_wto_labels(const CycleOrLabel& component, std::set<Label>& l
 /// Count tail-call sites over the reachable maximal-SCC DAG so cycles do not inflate depth.
 /// Maximal SCCs are obtained from WTO nesting: all labels in the same outermost WTO cycle
 /// are mutually reachable and therefore belong to the same maximal SCC.
-static void validate_tail_call_chain_depth(const Program& prog, const Wto& wto, const ebpf_platform_t& platform) {
+static void validate_tail_call_chain_depth(const Program& prog, const Wto& wto, const ebpf_platform_t& platform,
+                                           const EbpfProgramType& program_type) {
     constexpr int tail_call_chain_limit = 33;
 
     // WTO only covers labels reachable from entry.
@@ -566,7 +570,7 @@ static void validate_tail_call_chain_depth(const Program& prog, const Wto& wto, 
 
     for (const auto& label : reachable) {
         const Label src_scc = maximal_scc_of.at(label);
-        if (is_tail_call_site(prog.instruction_at(label), platform)) {
+        if (is_tail_call_site(prog.instruction_at(label), platform, program_type)) {
             ++tail_sites_per_scc.at(src_scc);
             auto& representative = representative_tail_label.at(src_scc);
             if (!representative.has_value()) {
@@ -640,9 +644,8 @@ static void validate_tail_call_chain_depth(const Program& prog, const Wto& wto, 
     }
 }
 
-Program Program::from_sequence(const InstructionSeq& inst_seq, const ProgramInfo& info,
+Program Program::from_sequence(const InstructionSeq& inst_seq, ProgramInfo& info,
                                const ebpf_verifier_options_t& options) {
-    thread_local_program_info.set(info);
     options.validate();
     thread_local_options = options;
     assert(info.platform != nullptr && "platform must be set before instruction feature validation");
@@ -654,12 +657,12 @@ Program Program::from_sequence(const InstructionSeq& inst_seq, const ProgramInfo
                                                 options.max_call_stack_frames, resolved_kfunc_calls);
 
     const Wto wto{builder.prog.cfg()};
-    validate_tail_call_chain_depth(builder.prog, wto, *info.platform);
+    validate_tail_call_chain_depth(builder.prog, wto, *info.platform, info.type);
 
     // Record valid callback targets for PTR_TO_FUNC: top-level concrete instruction labels
     // (no stack-frame prefix, not synthetic jump labels, and not Exit instructions).
-    thread_local_program_info->callback_target_labels.clear();
-    thread_local_program_info->callback_targets_with_exit.clear();
+    info.callback_target_labels.clear();
+    info.callback_targets_with_exit.clear();
     for (const Label& label : builder.prog.labels()) {
         if (label == Label::entry || label == Label::exit || label.isjump() || !label.stack_frame_prefix.empty()) {
             continue;
@@ -667,7 +670,7 @@ Program Program::from_sequence(const InstructionSeq& inst_seq, const ProgramInfo
         if (std::holds_alternative<Exit>(builder.prog.instruction_at(label))) {
             continue;
         }
-        thread_local_program_info->callback_target_labels.insert(label.from);
+        info.callback_target_labels.insert(label.from);
     }
 
     // Basic callback body check: callback target must be able to reach a top-level Exit.
@@ -694,12 +697,14 @@ Program Program::from_sequence(const InstructionSeq& inst_seq, const ProgramInfo
         }
         return false;
     };
-    for (const int32_t label_num : thread_local_program_info->callback_target_labels) {
+    for (const int32_t label_num : info.callback_target_labels) {
         const Label label{gsl::narrow<int>(label_num)};
         if (has_reachable_top_level_exit(label)) {
-            thread_local_program_info->callback_targets_with_exit.insert(label_num);
+            info.callback_targets_with_exit.insert(label_num);
         }
     }
+
+    thread_local_program_info.set(info);
 
     // Detect loops using Weak Topological Ordering (WTO) and insert counters at loop entry points. WTO provides a
     // hierarchical decomposition of the CFG that identifies all strongly connected components (cycles) and their entry

--- a/src/ir/cfg_builder.cpp
+++ b/src/ir/cfg_builder.cpp
@@ -644,8 +644,9 @@ static void validate_tail_call_chain_depth(const Program& prog, const Wto& wto, 
     }
 }
 
-Program Program::from_sequence(const InstructionSeq& inst_seq, ProgramInfo& info,
+Program Program::from_sequence(const InstructionSeq& inst_seq, const ProgramInfo& info,
                                const ebpf_verifier_options_t& options) {
+    ProgramInfo mutable_info = info;
     options.validate();
     thread_local_options = options;
     assert(info.platform != nullptr && "platform must be set before instruction feature validation");
@@ -661,8 +662,8 @@ Program Program::from_sequence(const InstructionSeq& inst_seq, ProgramInfo& info
 
     // Record valid callback targets for PTR_TO_FUNC: top-level concrete instruction labels
     // (no stack-frame prefix, not synthetic jump labels, and not Exit instructions).
-    info.callback_target_labels.clear();
-    info.callback_targets_with_exit.clear();
+    mutable_info.callback_target_labels.clear();
+    mutable_info.callback_targets_with_exit.clear();
     for (const Label& label : builder.prog.labels()) {
         if (label == Label::entry || label == Label::exit || label.isjump() || !label.stack_frame_prefix.empty()) {
             continue;
@@ -670,7 +671,7 @@ Program Program::from_sequence(const InstructionSeq& inst_seq, ProgramInfo& info
         if (std::holds_alternative<Exit>(builder.prog.instruction_at(label))) {
             continue;
         }
-        info.callback_target_labels.insert(label.from);
+        mutable_info.callback_target_labels.insert(label.from);
     }
 
     // Basic callback body check: callback target must be able to reach a top-level Exit.
@@ -697,10 +698,10 @@ Program Program::from_sequence(const InstructionSeq& inst_seq, ProgramInfo& info
         }
         return false;
     };
-    for (const int32_t label_num : info.callback_target_labels) {
+    for (const int32_t label_num : mutable_info.callback_target_labels) {
         const Label label{gsl::narrow<int>(label_num)};
         if (has_reachable_top_level_exit(label)) {
-            info.callback_targets_with_exit.insert(label_num);
+            mutable_info.callback_targets_with_exit.insert(label_num);
         }
     }
 
@@ -717,7 +718,7 @@ Program Program::from_sequence(const InstructionSeq& inst_seq, ProgramInfo& info
     for (const auto& label : builder.prog.labels()) {
         builder.set_assertions(label, get_assertions(builder.prog.instruction_at(label), info, options, label));
     }
-    builder.prog.m_info = std::move(info);
+    builder.prog.m_info = std::move(mutable_info);
     return std::move(builder.prog);
 }
 

--- a/src/ir/parse.cpp
+++ b/src/ir/parse.cpp
@@ -153,7 +153,8 @@ static Deref deref(const std::string& /*is_signed*/, const std::string& width, c
     };
 }
 
-Instruction parse_instruction(const std::string& line, const std::map<std::string, Label>& label_name_to_label) {
+Instruction parse_instruction(const std::string& line, const std::map<std::string, Label>& label_name_to_label,
+                              const EbpfProgramType& program_type) {
     // treat ";" as a comment
     std::string text = line.substr(0, line.find(';'));
     const size_t end = text.find_last_not_of(' ');
@@ -166,7 +167,7 @@ Instruction parse_instruction(const std::string& line, const std::map<std::strin
     }
     if (regex_match(text, m, regex("call " FUNC))) {
         const int func = to_int(m[1]);
-        return make_call(func, g_ebpf_platform_linux);
+        return make_call(func, g_ebpf_platform_linux, program_type);
     }
     if (regex_match(text, m, regex("call " WRAPPED_LABEL))) {
         return CallLocal{.target = label_name_to_label.at(m[1])};
@@ -302,7 +303,7 @@ static InstructionSeq parse_program(std::istream& is) {
         if (line.empty()) {
             continue;
         }
-        Instruction ins = parse_instruction(line, {});
+        Instruction ins = parse_instruction(line, {}, {});
         if (std::holds_alternative<Undefined>(ins)) {
             continue;
         }

--- a/src/ir/parse.hpp
+++ b/src/ir/parse.hpp
@@ -5,9 +5,11 @@
 #include <string>
 
 #include "ir/syntax.hpp"
+#include "spec/type_descriptors.hpp"
 
 namespace prevail {
 
-Instruction parse_instruction(const std::string& line, const std::map<std::string, Label>& label_name_to_label);
+Instruction parse_instruction(const std::string& line, const std::map<std::string, Label>& label_name_to_label,
+                              const EbpfProgramType& program_type);
 
 }

--- a/src/ir/program.hpp
+++ b/src/ir/program.hpp
@@ -10,6 +10,7 @@
 #include "config.hpp"
 #include "crab_utils/debug.hpp"
 #include "ir/syntax.hpp"
+#include "spec/type_descriptors.hpp"
 
 namespace prevail {
 class Program {
@@ -21,10 +22,11 @@ class Program {
     std::map<Label, std::vector<Assertion>> m_assertions{{Label::entry, {}}, {Label::exit, {}}};
     Cfg m_cfg;
 
-    // TODO: add ProgramInfo field
+    ProgramInfo m_info;
 
   public:
     const Cfg& cfg() const { return m_cfg; }
+    const ProgramInfo& info() const { return m_info; }
 
     //! return a view of the labels, including entry and exit
     [[nodiscard]]

--- a/src/ir/program.hpp
+++ b/src/ir/program.hpp
@@ -53,7 +53,7 @@ class Program {
         return m_assertions.at(label);
     }
 
-    static Program from_sequence(const InstructionSeq& inst_seq, const ProgramInfo& info,
+    static Program from_sequence(const InstructionSeq& inst_seq, ProgramInfo& info,
                                  const ebpf_verifier_options_t& options);
 };
 

--- a/src/ir/program.hpp
+++ b/src/ir/program.hpp
@@ -55,7 +55,7 @@ class Program {
         return m_assertions.at(label);
     }
 
-    static Program from_sequence(const InstructionSeq& inst_seq, ProgramInfo& info,
+    static Program from_sequence(const InstructionSeq& inst_seq, const ProgramInfo& info,
                                  const ebpf_verifier_options_t& options);
 };
 

--- a/src/ir/unmarshal.cpp
+++ b/src/ir/unmarshal.cpp
@@ -491,7 +491,7 @@ struct Unmarshaller {
 
     [[nodiscard]]
     auto makeCall(const int32_t imm) const -> Call {
-        const EbpfHelperPrototype proto = info.platform->get_helper_prototype(imm);
+        const EbpfHelperPrototype proto = info.platform->get_helper_prototype(imm, info.type);
         auto helper_prototype_name = proto.name ? proto.name : std::to_string(imm);
         Call res;
         res.func = imm;
@@ -703,11 +703,12 @@ struct Unmarshaller {
                             .is_supported = false,
                             .unsupported_reason = "helper function is unavailable on this platform"};
             }
-            if (info.platform->is_helper_usable(inst.imm)) {
+            if (info.platform->is_helper_usable(inst.imm, info.type)) {
                 return makeCall(inst.imm);
             } else {
                 std::string function_name = std::to_string(inst.imm);
-                auto function_name_from_helper_prototype = info.platform->get_helper_prototype(inst.imm).name;
+                auto function_name_from_helper_prototype =
+                    info.platform->get_helper_prototype(inst.imm, info.type).name;
                 if (function_name_from_helper_prototype) {
                     function_name = function_name_from_helper_prototype;
                 }
@@ -885,7 +886,6 @@ struct Unmarshaller {
 
 std::variant<InstructionSeq, std::string> unmarshal(const RawProgram& raw_prog, vector<vector<string>>& notes,
                                                     const prevail::ebpf_verifier_options_t& options) {
-    thread_local_program_info = raw_prog.info;
     try {
         return Unmarshaller{notes, raw_prog.info}.unmarshal(raw_prog.prog, options);
     } catch (InvalidInstruction& arg) {
@@ -901,9 +901,9 @@ std::variant<InstructionSeq, std::string> unmarshal(const RawProgram& raw_prog,
     return unmarshal(raw_prog, notes, options);
 }
 
-Call make_call(const int imm, const ebpf_platform_t& platform) {
+Call make_call(const int imm, const ebpf_platform_t& platform, const EbpfProgramType& program_type) {
     vector<vector<string>> notes;
-    const ProgramInfo info{.platform = &platform};
+    const ProgramInfo info{.platform = &platform, .type = program_type};
     return Unmarshaller{notes, info}.makeCall(imm);
 }
 } // namespace prevail

--- a/src/ir/unmarshal.hpp
+++ b/src/ir/unmarshal.hpp
@@ -25,5 +25,5 @@ std::variant<InstructionSeq, std::string> unmarshal(const RawProgram& raw_prog,
 std::variant<InstructionSeq, std::string> unmarshal(const RawProgram& raw_prog,
                                                     const prevail::ebpf_verifier_options_t& options);
 
-Call make_call(int imm, const ebpf_platform_t& platform);
+Call make_call(int imm, const ebpf_platform_t& platform, const EbpfProgramType& program_type);
 } // namespace prevail

--- a/src/linux/gpl/spec_prototypes.cpp
+++ b/src/linux/gpl/spec_prototypes.cpp
@@ -1,5 +1,6 @@
 #include "linux/gpl/spec_type_descriptors.hpp"
 #include "platform.hpp"
+#include <set>
 #include <string_view>
 
 namespace prevail {
@@ -2627,7 +2628,7 @@ std::optional<int32_t> resolve_helper_id_linux(const std::string& name) {
     return std::nullopt;
 }
 
-bool is_helper_usable_linux(const int32_t n) {
+bool is_helper_usable_linux(const int32_t n, const EbpfProgramType& program_type) {
     if (n >= static_cast<int>(std::size(prototypes)) || n < 0) {
         return false;
     }
@@ -2641,27 +2642,25 @@ bool is_helper_usable_linux(const int32_t n) {
     // Until attach-type-level helper gating is modeled, keep a conservative
     // program-type allowlist here instead of treating them as fully generic.
     if (n == 46) { // bpf_get_socket_cookie
-        const std::string_view program_type = thread_local_program_info->type.name;
-        const bool allowed = program_type == "socket_filter" || program_type == "sched_act" ||
-                             program_type == "sched_cls" || program_type == "sk_skb" || program_type == "cgroup_skb" ||
-                             program_type == "cgroup_sock" || program_type == "cgroup_sock_addr" ||
-                             program_type == "sock_ops" || program_type == "sk_reuseport" || program_type == "tracing";
-        if (!allowed) {
+        static const std::set<std::string_view> socket_cookie_types = {
+            "socket_filter", "sched_act",        "sched_cls", "sk_skb",       "cgroup_skb",
+            "cgroup_sock",   "cgroup_sock_addr", "sock_ops",  "sk_reuseport", "tracing",
+        };
+        if (!socket_cookie_types.contains(program_type.name)) {
             return false;
         }
     }
 
     // If the helper has a context_descriptor, it must match the hook's context_descriptor.
-    if (prototypes[n].context_descriptor &&
-        prototypes[n].context_descriptor != thread_local_program_info->type.context_descriptor) {
+    if (prototypes[n].context_descriptor && prototypes[n].context_descriptor != program_type.context_descriptor) {
         return false;
     }
 
     return true;
 }
 
-EbpfHelperPrototype get_helper_prototype_linux(const int32_t n) {
-    if (!is_helper_usable_linux(n)) {
+EbpfHelperPrototype get_helper_prototype_linux(const int32_t n, const EbpfProgramType& program_type) {
+    if (!is_helper_usable_linux(n, program_type)) {
         return EbpfHelperPrototype{};
     }
     return prototypes[n];

--- a/src/linux/linux_platform.cpp
+++ b/src/linux/linux_platform.cpp
@@ -113,7 +113,7 @@ struct BpfLoadMapDef {
 };
 
 static int create_map_linux(uint32_t map_type, uint32_t key_size, uint32_t value_size, uint32_t max_entries,
-                            ebpf_verifier_options_t options, std::map<EquivalenceKey, int>& cache);
+                            ebpf_verifier_options_t);
 
 // Allow for comma as a separator between multiple prefixes, to make
 // the preprocessor treat a prefix list as one macro argument.
@@ -253,10 +253,26 @@ EbpfMapType get_map_type_linux(uint32_t platform_specific_type) {
     return type;
 }
 
+// Assign a synthetic mock FD for a map, deduplicating against already-parsed descriptors.
+// Pure function of the accumulated descriptor table — no external state needed.
+static int allocate_mock_map_fd(const std::vector<EbpfMapDescriptor>& map_descriptors, const EbpfMapType& map_type,
+                                const uint32_t key_size, const uint32_t value_size, const uint32_t max_entries) {
+    const EquivalenceKey equiv{map_type.value_type, key_size, value_size, map_type.is_array ? max_entries : 0};
+    for (const auto& desc : map_descriptors) {
+        const EbpfMapType existing_type = get_map_type_linux(desc.type);
+        const EquivalenceKey existing{existing_type.value_type, desc.key_size, desc.value_size,
+                                      existing_type.is_array ? desc.max_entries : 0};
+        if (existing == equiv) {
+            return desc.original_fd;
+        }
+    }
+    // +1 so 0 is the null FD
+    return gsl::narrow<int>(map_descriptors.size()) + 1;
+}
+
 void parse_maps_section_linux(std::vector<EbpfMapDescriptor>& map_descriptors, const char* data,
                               const size_t map_def_size, const int map_count, const ebpf_platform_t* platform,
                               const ebpf_verifier_options_t options) {
-    // Copy map definitions from the ELF section into a local list.
     auto mapdefs = std::vector<BpfLoadMapDef>();
     for (int i = 0; i < map_count; i++) {
         BpfLoadMapDef def = {0};
@@ -264,18 +280,18 @@ void parse_maps_section_linux(std::vector<EbpfMapDescriptor>& map_descriptors, c
         mapdefs.emplace_back(def);
     }
 
-    // Add map definitions into the map_descriptors list.
-    std::map<EquivalenceKey, int> cache;
     for (const auto& s : mapdefs) {
-        EbpfMapType type = get_map_type_linux(s.type);
+        const int fd = options.mock_map_fds
+                           ? allocate_mock_map_fd(map_descriptors, get_map_type_linux(s.type), s.key_size, s.value_size,
+                                                  s.max_entries)
+                           : create_map_linux(s.type, s.key_size, s.value_size, s.max_entries, options);
         map_descriptors.emplace_back(EbpfMapDescriptor{
-            .original_fd = create_map_linux(s.type, s.key_size, s.value_size, s.max_entries, options, cache),
+            .original_fd = fd,
             .type = s.type,
             .key_size = s.key_size,
             .value_size = s.value_size,
             .max_entries = s.max_entries,
-            .inner_map_fd = gsl::narrow<int32_t>(s.inner_map_idx) // Temporarily fill in the index. This will be
-                                                                  // replaced in the resolve_inner_map_references pass.
+            .inner_map_fd = gsl::narrow<int32_t>(s.inner_map_idx),
         });
     }
 }
@@ -300,13 +316,7 @@ static int do_bpf(const bpf_cmd cmd, bpf_attr& attr) { return syscall(321, cmd, 
  *  This function requires admin privileges.
  */
 static int create_map_linux(const uint32_t map_type, const uint32_t key_size, const uint32_t value_size,
-                            const uint32_t max_entries, const ebpf_verifier_options_t options,
-                            std::map<EquivalenceKey, int>& cache) {
-    if (options.mock_map_fds) {
-        const EbpfMapType type = get_map_type_linux(map_type);
-        return create_map_crab(type, key_size, value_size, max_entries, options, cache);
-    }
-
+                            const uint32_t max_entries, const ebpf_verifier_options_t) {
 #if __linux__
     bpf_attr attr{};
     memset(&attr, '\0', sizeof(attr));

--- a/src/linux/linux_platform.cpp
+++ b/src/linux/linux_platform.cpp
@@ -332,18 +332,11 @@ static int create_map_linux(const uint32_t map_type, const uint32_t key_size, co
 #endif
 }
 
-EbpfMapDescriptor& get_map_descriptor_linux(const int map_fd) {
-    // First check if we already have the map descriptor cached.
-    EbpfMapDescriptor* map = find_map_descriptor(map_fd);
+const EbpfMapDescriptor& get_map_descriptor_linux(const int map_fd, const ProgramInfo& info) {
+    const EbpfMapDescriptor* map = find_map_descriptor(map_fd, info);
     if (map != nullptr) {
         return *map;
     }
-
-    // This fd was not created from the maps section of an ELF file,
-    // but it may be an fd created by an app before calling the verifier.
-    // In this case, we would like to query the map descriptor info
-    // (key size, value size) from the execution context, but this is
-    // not yet supported on Linux.
 
     throw UnmarshalError("map_fd " + std::to_string(map_fd) + " not found");
 }

--- a/src/linux/linux_platform.cpp
+++ b/src/linux/linux_platform.cpp
@@ -113,7 +113,7 @@ struct BpfLoadMapDef {
 };
 
 static int create_map_linux(uint32_t map_type, uint32_t key_size, uint32_t value_size, uint32_t max_entries,
-                            ebpf_verifier_options_t options);
+                            ebpf_verifier_options_t options, std::map<EquivalenceKey, int>& cache);
 
 // Allow for comma as a separator between multiple prefixes, to make
 // the preprocessor treat a prefix list as one macro argument.
@@ -265,10 +265,11 @@ void parse_maps_section_linux(std::vector<EbpfMapDescriptor>& map_descriptors, c
     }
 
     // Add map definitions into the map_descriptors list.
+    std::map<EquivalenceKey, int> cache;
     for (const auto& s : mapdefs) {
         EbpfMapType type = get_map_type_linux(s.type);
         map_descriptors.emplace_back(EbpfMapDescriptor{
-            .original_fd = create_map_linux(s.type, s.key_size, s.value_size, s.max_entries, options),
+            .original_fd = create_map_linux(s.type, s.key_size, s.value_size, s.max_entries, options, cache),
             .type = s.type,
             .key_size = s.key_size,
             .value_size = s.value_size,
@@ -299,10 +300,11 @@ static int do_bpf(const bpf_cmd cmd, bpf_attr& attr) { return syscall(321, cmd, 
  *  This function requires admin privileges.
  */
 static int create_map_linux(const uint32_t map_type, const uint32_t key_size, const uint32_t value_size,
-                            const uint32_t max_entries, const ebpf_verifier_options_t options) {
+                            const uint32_t max_entries, const ebpf_verifier_options_t options,
+                            std::map<EquivalenceKey, int>& cache) {
     if (options.mock_map_fds) {
         const EbpfMapType type = get_map_type_linux(map_type);
-        return create_map_crab(type, key_size, value_size, max_entries, options);
+        return create_map_crab(type, key_size, value_size, max_entries, options, cache);
     }
 
 #if __linux__

--- a/src/linux/linux_platform.hpp
+++ b/src/linux/linux_platform.hpp
@@ -8,8 +8,8 @@
 #include "platform.hpp"
 
 namespace prevail {
-EbpfHelperPrototype get_helper_prototype_linux(int32_t n);
-bool is_helper_usable_linux(int32_t n);
+EbpfHelperPrototype get_helper_prototype_linux(int32_t n, const EbpfProgramType& program_type);
+bool is_helper_usable_linux(int32_t n, const EbpfProgramType& program_type);
 std::optional<int32_t> resolve_helper_id_linux(const std::string& name);
 std::optional<int32_t> resolve_builtin_call_linux(const std::string& name);
 std::optional<KsymBtfId> resolve_ksym_btf_id_linux(const std::string& name);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -198,7 +198,7 @@ int main(int argc, char** argv) {
         }
         return load_error.has_value() ? 1 : 64;
     }
-    const RawProgram& raw_prog = raw_progs.back();
+    RawProgram& raw_prog = raw_progs.back();
 
     // Convert the raw program section to a set of instructions.
     std::variant<InstructionSeq, std::string> prog_or_error = unmarshal(raw_prog, ebpf_verifier_options);
@@ -211,7 +211,7 @@ int main(int argc, char** argv) {
     if (!asmfile.empty()) {
         std::ofstream out{asmfile};
         print(inst_seq, out, {});
-        print_map_descriptors(thread_local_program_info->map_descriptors, out);
+        print_map_descriptors(raw_prog.info.map_descriptors, out);
     }
 
     // Convert the instruction sequence to a control-flow graph.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -244,7 +244,7 @@ int main(int argc, char** argv) {
             }
             if (verbosity.print_failures) {
                 if (auto verification_error = result.find_first_error()) {
-                    print_error(std::cout, *verification_error);
+                    print_error(std::cout, *verification_error, prog);
                 }
             }
             if (failure_slice && result.failed) {
@@ -252,7 +252,8 @@ int main(int argc, char** argv) {
                 AnalysisResult::SliceParams slice_params;
                 slice_params.max_steps = failure_slice_depth;
                 slice_params.max_slices = 1;
-                auto slices = result.compute_failure_slices(prog, slice_params);
+                const AnalysisContext context{prog.info(), ebpf_verifier_options, *prog.info().platform};
+                auto slices = result.compute_failure_slices(prog, slice_params, context);
                 print_failure_slices(std::cout, prog, verbosity.simplify, result, slices);
             } else if (failure_slice && !result.failed) {
                 std::cout << "Program passed verification; no failure slices to display.\n";
@@ -274,7 +275,7 @@ int main(int argc, char** argv) {
                 // Print the first error if not already printed by -v or -f.
                 if (!verbosity.print_invariants && !verbosity.print_failures && !failure_slice) {
                     if (auto verification_error = result.find_first_error()) {
-                        print_error(std::cout, *verification_error);
+                        print_error(std::cout, *verification_error, prog);
                     }
                     std::cout << "Hint: run with --failure-slice for a causal trace, or -v for full invariants.\n";
                 }

--- a/src/platform.hpp
+++ b/src/platform.hpp
@@ -6,10 +6,10 @@
 // that supports eBPF can have an ebpf_platform_t struct that the verifier
 // can use to call platform-specific functions.
 
-#include <bpf_conformance_core/bpf_conformance.h>
-#include <cstdint>
 #include <optional>
 #include <string>
+
+#include <bpf_conformance_core/bpf_conformance.h>
 
 #include "config.hpp"
 #include "spec/function_prototypes.hpp"
@@ -39,11 +39,6 @@ typedef std::optional<Call> (*ebpf_get_builtin_call_fn)(int32_t id);
 typedef std::optional<Call> (*ebpf_resolve_kfunc_call_fn)(int32_t btf_id, const ProgramInfo* info,
                                                           std::string* why_not);
 
-#if 0
-// Return an fd for a map created with the given parameters.
-typedef int (*ebpf_create_map_fn)(uint32_t map_type, uint32_t key_size, uint32_t value_size, uint32_t max_entries, ebpf_verifier_options_t options);
-#endif
-
 // Parse map records and allocate map fd's.
 // In the future we may want to move map fd allocation after the verifier step.
 typedef void (*ebpf_parse_maps_section_fn)(std::vector<EbpfMapDescriptor>& map_descriptors, const char* data,
@@ -51,7 +46,7 @@ typedef void (*ebpf_parse_maps_section_fn)(std::vector<EbpfMapDescriptor>& map_d
                                            ebpf_verifier_options_t options);
 typedef void (*ebpf_resolve_inner_map_references_fn)(std::vector<EbpfMapDescriptor>& map_descriptors);
 
-typedef EbpfMapDescriptor& (*ebpf_get_map_descriptor_fn)(int map_fd);
+typedef const EbpfMapDescriptor& (*ebpf_get_map_descriptor_fn)(int map_fd, const ProgramInfo& info);
 
 struct ebpf_platform_t {
     ebpf_get_program_type_fn get_program_type;
@@ -71,7 +66,7 @@ struct ebpf_platform_t {
     ebpf_resolve_inner_map_references_fn resolve_inner_map_references;
     bpf_conformance_groups_t supported_conformance_groups;
 
-    bool supports_group(bpf_conformance_groups_t group) const {
+    bool supports_group(const bpf_conformance_groups_t group) const {
         return (supported_conformance_groups & group) == group;
     }
 };

--- a/src/platform.hpp
+++ b/src/platform.hpp
@@ -28,9 +28,9 @@ typedef EbpfProgramType (*ebpf_get_program_type_fn)(const std::string& section, 
 
 typedef EbpfMapType (*ebpf_get_map_type_fn)(uint32_t platform_specific_type);
 
-typedef EbpfHelperPrototype (*ebpf_get_helper_prototype_fn)(int32_t n);
+typedef EbpfHelperPrototype (*ebpf_get_helper_prototype_fn)(int32_t n, const EbpfProgramType& program_type);
 
-typedef bool (*ebpf_is_helper_usable_fn)(int32_t n);
+typedef bool (*ebpf_is_helper_usable_fn)(int32_t n, const EbpfProgramType& program_type);
 
 typedef std::optional<int32_t> (*ebpf_resolve_builtin_call_fn)(const std::string& name);
 typedef std::optional<KsymBtfId> (*ebpf_resolve_ksym_btf_id_fn)(const std::string& name);

--- a/src/printing.cpp
+++ b/src/printing.cpp
@@ -15,7 +15,6 @@
 #include "crab/var_registry.hpp"
 #include "ir/syntax.hpp"
 #include "platform.hpp"
-#include "spec/function_prototypes.hpp"
 #include "verifier.hpp"
 
 using std::optional;
@@ -106,13 +105,13 @@ string to_string(Label const& label) {
 
 struct LineInfoPrinter {
     std::ostream& os;
+    const std::map<size_t, btf_line_info_t> line_info_map;
+    bool print_line_info_enabled{};
     std::string previous_source_line;
 
     void print_line_info(const Label& label) {
-        if (thread_local_options.verbosity_opts.print_line_info) {
-            const auto& line_info_map = thread_local_program_info.get().line_info;
+        if (print_line_info_enabled) {
             const auto& line_info = line_info_map.find(label.from);
-            // Print line info only once.
             if (line_info != line_info_map.end() && line_info->second.source_line != previous_source_line) {
                 os << "\n" << line_info->second << "\n";
                 previous_source_line = line_info->second.source_line;
@@ -124,7 +123,8 @@ struct LineInfoPrinter {
 struct DetailedPrinter : LineInfoPrinter {
     const Program& prog;
 
-    DetailedPrinter(std::ostream& os, const Program& prog) : LineInfoPrinter{os}, prog(prog) {}
+    DetailedPrinter(std::ostream& os, const Program& prog)
+        : LineInfoPrinter{os, prog.info().line_info, thread_local_options.verbosity_opts.print_line_info}, prog(prog) {}
 
     void print_labels(const std::string& direction, const std::set<Label>& labels) {
         auto [it, et] = std::pair{labels.begin(), labels.end()};
@@ -190,7 +190,7 @@ void print_invariants(std::ostream& os, const Program& prog, const bool simplify
                 if (label != bb.last_label()) {
                     os << "After " << current.pre << "\n";
                 }
-                print_error(os, *current.error);
+                print_error(os, *current.error, prog);
                 os << "\n";
                 return;
             }
@@ -250,8 +250,8 @@ std::string to_string(const VerificationError& error) {
     return ss.str();
 }
 
-void print_error(std::ostream& os, const VerificationError& error) {
-    LineInfoPrinter printer{os};
+void print_error(std::ostream& os, const VerificationError& error, const Program& prog) {
+    LineInfoPrinter printer{os, prog.info().line_info, thread_local_options.verbosity_opts.print_line_info};
     if (const auto& label = error.where) {
         printer.print_line_info(*label);
         os << *label << ": ";
@@ -434,8 +434,6 @@ struct AssertionPrinterVisitor {
 // ReSharper disable CppMemberFunctionMayBeConst
 struct CommandPrinterVisitor {
     std::ostream& os_;
-
-    void visit(const auto& item) { std::visit(*this, item); }
 
     void operator()(Undefined const& a) { os_ << "Undefined{" << a.opcode << "}"; }
 
@@ -931,7 +929,7 @@ void print_invariants_filtered(std::ostream& os, const Program& prog, const bool
             const auto& current = result.invariants.at(label);
             if (current.error) {
                 os << "\nVerification error:\n";
-                print_error(os, *current.error);
+                print_error(os, *current.error, prog);
                 os << "\n";
             }
         }

--- a/src/result.cpp
+++ b/src/result.cpp
@@ -110,8 +110,8 @@ bool RelevantState::is_relevant_constraint(const std::string& constraint) const 
     return true;
 }
 
-bool AnalysisResult::is_valid_after(const Label& label, const StringInvariant& state) const {
-    const AnalysisContext context = thread_local_analysis_context();
+bool AnalysisResult::is_valid_after(const Label& label, const StringInvariant& state,
+                                    const AnalysisContext& context) const {
     const EbpfDomain abstract_state =
         EbpfDomain::from_constraints(state.value(), context.options.setup_constraints, context);
     return abstract_state <= invariants.at(label).post;
@@ -119,7 +119,8 @@ bool AnalysisResult::is_valid_after(const Label& label, const StringInvariant& s
 
 ObservationCheckResult AnalysisResult::check_observation_at_label(const Label& label, const InvariantPoint point,
                                                                   const StringInvariant& observation,
-                                                                  const ObservationCheckMode mode) const {
+                                                                  const ObservationCheckMode mode,
+                                                                  const AnalysisContext& context) const {
     const auto it = invariants.find(label);
     if (it == invariants.end()) {
         return {.ok = false, .message = "No invariant available for label " + to_string(label)};
@@ -127,7 +128,6 @@ ObservationCheckResult AnalysisResult::check_observation_at_label(const Label& l
     const auto& inv_pair = it->second;
     const EbpfDomain& abstract_state = (point == InvariantPoint::pre) ? inv_pair.pre : inv_pair.post;
 
-    const AnalysisContext context = thread_local_analysis_context();
     const EbpfDomain observed_state =
         observation.is_bottom()
             ? EbpfDomain::bottom()
@@ -159,12 +159,18 @@ ObservationCheckResult AnalysisResult::check_observation_at_label(const Label& l
     return {.ok = false, .message = "Unsupported observation check mode"};
 }
 
-bool AnalysisResult::is_consistent_before(const Label& label, const StringInvariant& observation) const {
-    return check_observation_at_label(label, InvariantPoint::pre, observation, ObservationCheckMode::consistent).ok;
+bool AnalysisResult::is_consistent_before(const Label& label, const StringInvariant& observation,
+                                          const AnalysisContext& context) const {
+    return check_observation_at_label(label, InvariantPoint::pre, observation, ObservationCheckMode::consistent,
+                                      context)
+        .ok;
 }
 
-bool AnalysisResult::is_consistent_after(const Label& label, const StringInvariant& observation) const {
-    return check_observation_at_label(label, InvariantPoint::post, observation, ObservationCheckMode::consistent).ok;
+bool AnalysisResult::is_consistent_after(const Label& label, const StringInvariant& observation,
+                                         const AnalysisContext& context) const {
+    return check_observation_at_label(label, InvariantPoint::post, observation, ObservationCheckMode::consistent,
+                                      context)
+        .ok;
 }
 
 StringInvariant AnalysisResult::invariant_at(const Label& label) const { return invariants.at(label).post.to_set(); }
@@ -610,8 +616,8 @@ FailureSlice AnalysisResult::compute_slice_from_label(const Program& prog, const
     return slice;
 }
 
-std::vector<FailureSlice> AnalysisResult::compute_failure_slices(const Program& prog, const SliceParams params) const {
-    const AnalysisContext context = thread_local_analysis_context();
+std::vector<FailureSlice> AnalysisResult::compute_failure_slices(const Program& prog, const SliceParams params,
+                                                                 const AnalysisContext& context) const {
     const auto max_slices = params.max_slices;
     std::vector<FailureSlice> slices;
 

--- a/src/result.hpp
+++ b/src/result.hpp
@@ -120,18 +120,20 @@ struct AnalysisResult {
     Interval exit_value = Interval::top();
 
     [[nodiscard]]
-    bool is_valid_after(const Label& label, const StringInvariant& state) const;
+    bool is_valid_after(const Label& label, const StringInvariant& state, const AnalysisContext& context) const;
 
     [[nodiscard]]
-    ObservationCheckResult
-    check_observation_at_label(const Label& label, InvariantPoint point, const StringInvariant& observation,
-                               ObservationCheckMode mode = ObservationCheckMode::consistent) const;
+    ObservationCheckResult check_observation_at_label(const Label& label, InvariantPoint point,
+                                                      const StringInvariant& observation, ObservationCheckMode mode,
+                                                      const AnalysisContext& context) const;
 
     [[nodiscard]]
-    bool is_consistent_before(const Label& label, const StringInvariant& observation) const;
+    bool is_consistent_before(const Label& label, const StringInvariant& observation,
+                              const AnalysisContext& context) const;
 
     [[nodiscard]]
-    bool is_consistent_after(const Label& label, const StringInvariant& observation) const;
+    bool is_consistent_after(const Label& label, const StringInvariant& observation,
+                             const AnalysisContext& context) const;
 
     [[nodiscard]]
     StringInvariant invariant_at(const Label& label) const;
@@ -151,11 +153,12 @@ struct AnalysisResult {
     /// Compute failure slices for verification errors.
     /// Returns one slice per failure, each containing the set of impacted labels.
     [[nodiscard]]
-    std::vector<FailureSlice> compute_failure_slices(const Program& prog, SliceParams params) const;
+    std::vector<FailureSlice> compute_failure_slices(const Program& prog, SliceParams params,
+                                                     const AnalysisContext& context) const;
 
     [[nodiscard]]
-    std::vector<FailureSlice> compute_failure_slices(const Program& prog) const {
-        return compute_failure_slices(prog, SliceParams{});
+    std::vector<FailureSlice> compute_failure_slices(const Program& prog, const AnalysisContext& context) const {
+        return compute_failure_slices(prog, SliceParams{}, context);
     }
 
     /// Compute a backward slice from an arbitrary label with a given seed relevance.
@@ -171,7 +174,7 @@ struct AnalysisResult {
                                           size_t max_steps = 200) const;
 };
 
-void print_error(std::ostream& os, const VerificationError& error);
+void print_error(std::ostream& os, const VerificationError& error, const Program& prog);
 void print_invariants(std::ostream& os, const Program& prog, bool simplify, const AnalysisResult& result);
 void print_unreachable(std::ostream& os, const Program& prog, const AnalysisResult& result);
 

--- a/src/spec/type_descriptors.hpp
+++ b/src/spec/type_descriptors.hpp
@@ -9,7 +9,6 @@
 #include <string>
 #include <vector>
 
-#include "crab_utils/lazy_allocator.hpp"
 #include "spec/ebpf_base.h"
 #include "spec/vm_isa.hpp"
 
@@ -85,5 +84,4 @@ void print_map_descriptors(const std::vector<EbpfMapDescriptor>& descriptors, st
 
 std::ostream& operator<<(std::ostream& os, const btf_line_info_t& line_info);
 
-extern thread_local LazyAllocator<ProgramInfo> thread_local_program_info;
 } // namespace prevail

--- a/src/spec/type_descriptors.hpp
+++ b/src/spec/type_descriptors.hpp
@@ -62,7 +62,6 @@ struct ProgramInfo {
     const struct ebpf_platform_t* platform{};
     std::vector<EbpfMapDescriptor> map_descriptors{};
     EbpfProgramType type{};
-    std::map<EquivalenceKey, int> cache{};
     std::map<size_t, btf_line_info_t> line_info{};
     // Valid top-level instruction labels that can be used as callback entry targets via PTR_TO_FUNC.
     std::set<int32_t> callback_target_labels{};

--- a/src/test/ebpf_yaml.cpp
+++ b/src/test/ebpf_yaml.cpp
@@ -87,7 +87,7 @@ static EbpfMapDescriptor test_map_descriptor = {.original_fd = 0,
                                                 .max_entries = 4,
                                                 .inner_map_fd = 0};
 
-static EbpfMapDescriptor& ebpf_get_map_descriptor(int) { return test_map_descriptor; }
+static const EbpfMapDescriptor& ebpf_get_map_descriptor(int, const ProgramInfo&) { return test_map_descriptor; }
 
 ebpf_platform_t g_platform_test = {.get_program_type = ebpf_get_program_type,
                                    .get_helper_prototype = ebpf_get_helper_prototype,

--- a/src/test/ebpf_yaml.cpp
+++ b/src/test/ebpf_yaml.cpp
@@ -418,7 +418,7 @@ std::optional<Failure> run_yaml_test_case(TestCase test_case, bool debug) {
     try {
         const Program prog = Program::from_sequence(test_case.instruction_seq, info, test_case.options);
         const AnalysisContext context{prog.info(), test_case.options, *prog.info().platform};
-        const AnalysisResult result = analyze(prog, test_case.assumed_pre_invariant);
+        const AnalysisResult result = analyze(prog, test_case.assumed_pre_invariant, context);
         const StringInvariant actual_last_invariant = result.invariant_at(Label::exit);
         std::set<string> actual_messages;
         if (auto error = result.find_first_error()) {
@@ -567,7 +567,7 @@ ConformanceTestResult run_conformance_test_case(const std::vector<uint8_t>& memo
 
     try {
         const Program prog = Program::from_sequence(inst_seq, info, options);
-        const AnalysisResult result = analyze(prog, pre_invariant);
+        const AnalysisResult result = analyze(prog, pre_invariant, options);
         return ConformanceTestResult{.success = !result.failed, .r0_value = result.exit_value};
     } catch (const std::exception& ex) {
         // Catch exceptions thrown in ebpf_domain.cpp.

--- a/src/test/ebpf_yaml.cpp
+++ b/src/test/ebpf_yaml.cpp
@@ -40,11 +40,13 @@ static EbpfMapType ebpf_get_map_type(const uint32_t platform_specific_type) {
     return g_ebpf_platform_linux.get_map_type(platform_specific_type);
 }
 
-static EbpfHelperPrototype ebpf_get_helper_prototype(const int32_t n) {
-    return g_ebpf_platform_linux.get_helper_prototype(n);
+static EbpfHelperPrototype ebpf_get_helper_prototype(const int32_t n, const EbpfProgramType& program_type) {
+    return g_ebpf_platform_linux.get_helper_prototype(n, program_type);
 }
 
-static bool ebpf_is_helper_usable(const int32_t n) { return g_ebpf_platform_linux.is_helper_usable(n); }
+static bool ebpf_is_helper_usable(const int32_t n, const EbpfProgramType& program_type) {
+    return g_ebpf_platform_linux.is_helper_usable(n, program_type);
+}
 
 static std::optional<int32_t> ebpf_resolve_builtin_call(const std::string& name) {
     if (!g_ebpf_platform_linux.resolve_builtin_call) {
@@ -292,7 +294,7 @@ static InstructionSeq raw_cfg_to_instruction_seq(const vector<std::tuple<string,
     for (const auto& [label_name, raw_block] : raw_blocks) {
         for (const string& line : raw_block) {
             try {
-                const Instruction& ins = parse_instruction(line, label_name_to_label);
+                const Instruction& ins = parse_instruction(line, label_name_to_label, {});
                 if (std::holds_alternative<Undefined>(ins)) {
                     std::cout << "text:" << line << "; ins: " << ins << "\n";
                 }

--- a/src/test/ebpf_yaml.cpp
+++ b/src/test/ebpf_yaml.cpp
@@ -417,6 +417,7 @@ std::optional<Failure> run_yaml_test_case(TestCase test_case, bool debug) {
     thread_local_options = test_case.options;
     try {
         const Program prog = Program::from_sequence(test_case.instruction_seq, info, test_case.options);
+        const AnalysisContext context{prog.info(), test_case.options, *prog.info().platform};
         const AnalysisResult result = analyze(prog, test_case.assumed_pre_invariant);
         const StringInvariant actual_last_invariant = result.invariant_at(Label::exit);
         std::set<string> actual_messages;
@@ -432,7 +433,7 @@ std::optional<Failure> run_yaml_test_case(TestCase test_case, bool debug) {
         // Evaluate optional observation checks.
         for (const auto& obs : test_case.observations) {
             const ObservationCheckResult check =
-                result.check_observation_at_label(obs.label, obs.point, obs.constraints, obs.mode);
+                result.check_observation_at_label(obs.label, obs.point, obs.constraints, obs.mode, context);
             if (!check.ok) {
                 const std::string point_s = (obs.point == InvariantPoint::pre) ? "pre" : "post";
                 const std::string mode_s = (obs.mode == ObservationCheckMode::consistent) ? "consistent" : "entailed";
@@ -470,17 +471,6 @@ std::optional<Failure> run_yaml_test_case(TestCase test_case, bool debug) {
             .messages = make_diff(actual_messages, test_case.expected_messages),
         };
     }
-}
-
-template <typename T>
-    requires std::is_trivially_copyable_v<T>
-static vector<T> vector_of(const std::vector<std::byte>& bytes) {
-    auto data = bytes.data();
-    const auto size = bytes.size();
-    if (size % sizeof(T) != 0 || size > std::numeric_limits<uint32_t>::max() || !data) {
-        throw std::runtime_error("Invalid argument to vector_of");
-    }
-    return {reinterpret_cast<const T*>(data), reinterpret_cast<const T*>(data + size)};
 }
 
 template <std::signed_integral TS>
@@ -529,8 +519,7 @@ StringInvariant stack_contents_invariant(const std::vector<std::byte>& memory_by
 // Helper to convert uint8_t memory to stack invariant
 static StringInvariant stack_contents_invariant(const std::vector<uint8_t>& memory_bytes) {
     std::vector<std::byte> bytes(memory_bytes.size());
-    std::transform(memory_bytes.begin(), memory_bytes.end(), bytes.begin(),
-                   [](uint8_t b) { return static_cast<std::byte>(b); });
+    std::ranges::transform(memory_bytes, bytes.begin(), [](uint8_t b) { return static_cast<std::byte>(b); });
     return stack_contents_invariant(bytes);
 }
 

--- a/src/test/test_failure_slice.cpp
+++ b/src/test/test_failure_slice.cpp
@@ -27,7 +27,7 @@ static std::vector<FailureSlice> get_failure_slices(const std::string& filename,
     REQUIRE(inst_seq != nullptr);
 
     const Program prog = Program::from_sequence(*inst_seq, raw_prog.info, options);
-    auto result = analyze(prog);
+    auto result = analyze(prog, options);
     const AnalysisContext context{prog.info(), options, *prog.info().platform};
 
     return result.compute_failure_slices(prog, context);
@@ -189,7 +189,7 @@ TEST_CASE("print_failure_slices produces structured output", "[failure_slice][pr
     REQUIRE(inst_seq != nullptr);
 
     const Program prog = Program::from_sequence(*inst_seq, raw_prog.info, options);
-    auto result = analyze(prog);
+    auto result = analyze(prog, options);
     const AnalysisContext context{prog.info(), options, *prog.info().platform};
     auto slices = result.compute_failure_slices(prog, context);
 
@@ -225,7 +225,7 @@ TEST_CASE("passing program produces no failure slices", "[failure_slice][integra
     REQUIRE(inst_seq != nullptr);
 
     const Program prog = Program::from_sequence(*inst_seq, raw_prog.info, options);
-    auto result = analyze(prog);
+    auto result = analyze(prog, options);
 
     REQUIRE_FALSE(result.failed);
 
@@ -253,7 +253,9 @@ TEST_CASE("assume guard registers become relevant in slice", "[failure_slice][in
     ebpf_verifier_options_t options{};
     options.verbosity_opts.collect_instruction_deps = true;
     ElfObject elf{sample, options, &g_ebpf_platform_linux};
-    RawProgram raw_prog = elf.get_programs("xdp").back();
+    const auto& raw_progs = elf.get_programs("xdp");
+    REQUIRE(raw_progs.size() == 1);
+    RawProgram raw_prog = raw_progs.back();
     auto prog_or_error = unmarshal(raw_prog, options);
     auto inst_seq = std::get_if<InstructionSeq>(&prog_or_error);
     REQUIRE(inst_seq != nullptr);

--- a/src/test/test_failure_slice.cpp
+++ b/src/test/test_failure_slice.cpp
@@ -28,8 +28,9 @@ static std::vector<FailureSlice> get_failure_slices(const std::string& filename,
 
     const Program prog = Program::from_sequence(*inst_seq, raw_prog.info, options);
     auto result = analyze(prog);
+    const AnalysisContext context{prog.info(), options, *prog.info().platform};
 
-    return result.compute_failure_slices(prog);
+    return result.compute_failure_slices(prog, context);
 }
 
 // Test that extract_instruction_deps correctly identifies register reads/writes
@@ -189,7 +190,8 @@ TEST_CASE("print_failure_slices produces structured output", "[failure_slice][pr
 
     const Program prog = Program::from_sequence(*inst_seq, raw_prog.info, options);
     auto result = analyze(prog);
-    auto slices = result.compute_failure_slices(prog);
+    const AnalysisContext context{prog.info(), options, *prog.info().platform};
+    auto slices = result.compute_failure_slices(prog, context);
 
     std::stringstream output;
     print_failure_slices(output, prog, false, result, slices);
@@ -227,7 +229,8 @@ TEST_CASE("passing program produces no failure slices", "[failure_slice][integra
 
     REQUIRE_FALSE(result.failed);
 
-    auto slices = result.compute_failure_slices(prog);
+    const AnalysisContext context{prog.info(), options, *prog.info().platform};
+    auto slices = result.compute_failure_slices(prog, context);
     REQUIRE(slices.empty());
 }
 

--- a/src/test/test_failure_slice.cpp
+++ b/src/test/test_failure_slice.cpp
@@ -21,7 +21,7 @@ static std::vector<FailureSlice> get_failure_slices(const std::string& filename,
     const auto& raw_progs = elf.get_programs(section);
     REQUIRE(raw_progs.size() == 1);
 
-    const RawProgram& raw_prog = raw_progs.back();
+    RawProgram raw_prog = raw_progs.back();
     auto prog_or_error = unmarshal(raw_prog, options);
     auto inst_seq = std::get_if<InstructionSeq>(&prog_or_error);
     REQUIRE(inst_seq != nullptr);
@@ -182,7 +182,7 @@ TEST_CASE("print_failure_slices produces structured output", "[failure_slice][pr
     const auto& raw_progs = elf.get_programs("test");
     REQUIRE(raw_progs.size() == 1);
 
-    const RawProgram& raw_prog = raw_progs.back();
+    RawProgram raw_prog = raw_progs.back();
     auto prog_or_error = unmarshal(raw_prog, options);
     auto inst_seq = std::get_if<InstructionSeq>(&prog_or_error);
     REQUIRE(inst_seq != nullptr);
@@ -217,7 +217,7 @@ TEST_CASE("passing program produces no failure slices", "[failure_slice][integra
     const auto& raw_progs = elf.get_programs(".text");
     REQUIRE(raw_progs.size() == 1);
 
-    const RawProgram& raw_prog = raw_progs.back();
+    RawProgram raw_prog = raw_progs.back();
     auto prog_or_error = unmarshal(raw_prog, options);
     auto inst_seq = std::get_if<InstructionSeq>(&prog_or_error);
     REQUIRE(inst_seq != nullptr);
@@ -250,12 +250,11 @@ TEST_CASE("assume guard registers become relevant in slice", "[failure_slice][in
     ebpf_verifier_options_t options{};
     options.verbosity_opts.collect_instruction_deps = true;
     ElfObject elf{sample, options, &g_ebpf_platform_linux};
-    const auto& raw_progs = elf.get_programs("xdp");
-    REQUIRE(raw_progs.size() == 1);
-    auto prog_or_error = unmarshal(raw_progs.back(), options);
+    RawProgram raw_prog = elf.get_programs("xdp").back();
+    auto prog_or_error = unmarshal(raw_prog, options);
     auto inst_seq = std::get_if<InstructionSeq>(&prog_or_error);
     REQUIRE(inst_seq != nullptr);
-    const Program prog = Program::from_sequence(*inst_seq, raw_progs.back().info, options);
+    const Program prog = Program::from_sequence(*inst_seq, raw_prog.info, options);
 
     bool found_assume_in_slice = false;
     for (const auto& [label, relevance] : slice.relevance) {

--- a/src/test/test_platform_tables.cpp
+++ b/src/test/test_platform_tables.cpp
@@ -208,26 +208,22 @@ TEST_CASE("linux ksym relocation resolver maps known kfunc symbols", "[platform]
 }
 
 TEST_CASE("helper prototypes with unmodeled ABI classes are conservatively rejected", "[platform][tables]") {
-    ProgramInfo info{
-        .platform = &g_ebpf_platform_linux,
-        .type = g_ebpf_platform_linux.get_program_type("socket", ""),
-    };
-    thread_local_program_info = info;
+    const auto program_type = g_ebpf_platform_linux.get_program_type("socket", "");
 
     size_t usable_helpers = 0;
     size_t unmodeled_helpers = 0;
     for (int32_t id = 0; id <= 211; ++id) {
-        if (!g_ebpf_platform_linux.is_helper_usable(id)) {
+        if (!g_ebpf_platform_linux.is_helper_usable(id, program_type)) {
             continue;
         }
         ++usable_helpers;
-        const EbpfHelperPrototype proto = g_ebpf_platform_linux.get_helper_prototype(id);
+        const EbpfHelperPrototype proto = g_ebpf_platform_linux.get_helper_prototype(id, program_type);
         if (!has_unmodeled_abi_type(proto)) {
             continue;
         }
 
         ++unmodeled_helpers;
-        const Call call = make_call(id, g_ebpf_platform_linux);
+        const Call call = make_call(id, g_ebpf_platform_linux, program_type);
         CAPTURE(id, proto.name);
         REQUIRE_FALSE(call.is_supported);
         REQUIRE_FALSE(call.unsupported_reason.empty());
@@ -238,14 +234,10 @@ TEST_CASE("helper prototypes with unmodeled ABI classes are conservatively rejec
 }
 
 TEST_CASE("new helper ABI classes map to modeled call contracts", "[platform][tables]") {
-    ProgramInfo info{
-        .platform = &g_ebpf_platform_linux,
-        .type = g_ebpf_platform_linux.get_program_type("socket", ""),
-    };
-    thread_local_program_info = info;
+    const auto program_type = g_ebpf_platform_linux.get_program_type("socket", "");
 
-    const auto require_supported = [](const int32_t id) -> Call {
-        const Call call = make_call(id, g_ebpf_platform_linux);
+    const auto require_supported = [&](const int32_t id) -> Call {
+        const Call call = make_call(id, g_ebpf_platform_linux, program_type);
         CAPTURE(id, call.name, call.unsupported_reason);
         REQUIRE(call.is_supported);
         return call;
@@ -289,36 +281,22 @@ TEST_CASE("new helper ABI classes map to modeled call contracts", "[platform][ta
 }
 
 TEST_CASE("PTR_TO_CONST_STR helpers remain explicitly unsupported", "[platform][tables]") {
-    ProgramInfo info{
-        .platform = &g_ebpf_platform_linux,
-        .type = g_ebpf_platform_linux.get_program_type("socket", ""),
-    };
-    thread_local_program_info = info;
+    const auto program_type = g_ebpf_platform_linux.get_program_type("socket", "");
 
-    const Call strncmp = make_call(182, g_ebpf_platform_linux);
+    const Call strncmp = make_call(182, g_ebpf_platform_linux, program_type);
     CAPTURE(strncmp.name, strncmp.unsupported_reason);
     REQUIRE_FALSE(strncmp.is_supported);
     REQUIRE_FALSE(strncmp.unsupported_reason.empty());
 }
 
 TEST_CASE("socket cookie helper availability is not treated as fully context-agnostic", "[platform][tables]") {
-    thread_local_program_info = ProgramInfo{
-        .platform = &g_ebpf_platform_linux,
-        .type = g_ebpf_platform_linux.get_program_type("cgroup/connect4", ""),
-    };
-    REQUIRE(g_ebpf_platform_linux.is_helper_usable(46)); // get_socket_cookie
+    const auto cgroup_type = g_ebpf_platform_linux.get_program_type("cgroup/connect4", "");
+    REQUIRE(g_ebpf_platform_linux.is_helper_usable(46, cgroup_type)); // get_socket_cookie
 
-    thread_local_program_info = ProgramInfo{
-        .platform = &g_ebpf_platform_linux,
-        .type = g_ebpf_platform_linux.get_program_type("xdp", ""),
-    };
-    REQUIRE_FALSE(g_ebpf_platform_linux.is_helper_usable(46));
+    const auto xdp_type = g_ebpf_platform_linux.get_program_type("xdp", "");
+    REQUIRE_FALSE(g_ebpf_platform_linux.is_helper_usable(46, xdp_type));
 
-    thread_local_program_info = ProgramInfo{
-        .platform = &g_ebpf_platform_linux,
-        .type = g_ebpf_platform_linux.get_program_type("cgroup/connect4", ""),
-    };
-    REQUIRE_FALSE(g_ebpf_platform_linux.is_helper_usable(47)); // get_socket_uid remains skb-only
+    REQUIRE_FALSE(g_ebpf_platform_linux.is_helper_usable(47, cgroup_type)); // get_socket_uid remains skb-only
 }
 
 TEST_CASE("new Linux context descriptors keep expected layout constants", "[platform][tables]") {

--- a/src/test/test_verify.hpp
+++ b/src/test/test_verify.hpp
@@ -162,45 +162,45 @@ struct BoundedTestName {
     TEST_CASE(PREVAIL_BOUNDED_NAME.data, tags)
 
 // Verify a program in a section that may have multiple programs in it.
-#define VERIFY_PROGRAM(dirname, filename, section_name, program_name, _options, platform, should_pass, count)        \
-    do {                                                                                                             \
-        prevail::thread_local_options = _options;                                                                    \
-        const auto& raw_progs = verify_test::read_elf_cached("ebpf-samples/" dirname "/" filename, section_name, "", \
-                                                             prevail::thread_local_options, platform);               \
-        REQUIRE(raw_progs.size() == count);                                                                          \
-        bool matched_program = false;                                                                                \
-        for (const auto& raw_prog : raw_progs) {                                                                     \
-            if (count == 1 || raw_prog.function_name == program_name) {                                              \
-                matched_program = true;                                                                              \
-                INFO("function_name=" << raw_prog.function_name);                                                    \
-                if (should_pass) {                                                                                   \
-                    const auto prog_or_error = prevail::unmarshal(raw_prog, prevail::thread_local_options);          \
-                    const auto inst_seq = std::get_if<prevail::InstructionSeq>(&prog_or_error);                      \
-                    REQUIRE(inst_seq);                                                                               \
-                    const prevail::Program prog =                                                                    \
-                        prevail::Program::from_sequence(*inst_seq, raw_prog.info, prevail::thread_local_options);    \
-                    REQUIRE(prevail::verify(prog) == true);                                                          \
-                } else {                                                                                             \
-                    bool rejected = false;                                                                           \
-                    try {                                                                                            \
-                        const auto prog_or_error = prevail::unmarshal(raw_prog, prevail::thread_local_options);      \
-                        const auto inst_seq = std::get_if<prevail::InstructionSeq>(&prog_or_error);                  \
-                        if (!inst_seq) {                                                                             \
-                            rejected = true;                                                                         \
-                        } else {                                                                                     \
-                            const prevail::Program prog = prevail::Program::from_sequence(                           \
-                                *inst_seq, raw_prog.info, prevail::thread_local_options);                            \
-                            rejected = (prevail::verify(prog) == false);                                             \
-                        }                                                                                            \
-                    } catch (const std::runtime_error& ex) {                                                         \
-                        INFO("rejected_by_exception=" << ex.what());                                                 \
-                        rejected = true;                                                                             \
-                    }                                                                                                \
-                    REQUIRE(rejected);                                                                               \
-                }                                                                                                    \
-            }                                                                                                        \
-        }                                                                                                            \
-        REQUIRE(matched_program);                                                                                    \
+#define VERIFY_PROGRAM(dirname, filename, section_name, program_name, _options, platform, should_pass, count)     \
+    do {                                                                                                          \
+        prevail::thread_local_options = _options;                                                                 \
+        auto raw_progs = verify_test::read_elf_cached("ebpf-samples/" dirname "/" filename, section_name, "",     \
+                                                      prevail::thread_local_options, platform);                   \
+        REQUIRE(raw_progs.size() == count);                                                                       \
+        bool matched_program = false;                                                                             \
+        for (auto& raw_prog : raw_progs) {                                                                        \
+            if (count == 1 || raw_prog.function_name == program_name) {                                           \
+                matched_program = true;                                                                           \
+                INFO("function_name=" << raw_prog.function_name);                                                 \
+                if (should_pass) {                                                                                \
+                    const auto prog_or_error = prevail::unmarshal(raw_prog, prevail::thread_local_options);       \
+                    const auto inst_seq = std::get_if<prevail::InstructionSeq>(&prog_or_error);                   \
+                    REQUIRE(inst_seq);                                                                            \
+                    const prevail::Program prog =                                                                 \
+                        prevail::Program::from_sequence(*inst_seq, raw_prog.info, prevail::thread_local_options); \
+                    REQUIRE(prevail::verify(prog) == true);                                                       \
+                } else {                                                                                          \
+                    bool rejected = false;                                                                        \
+                    try {                                                                                         \
+                        const auto prog_or_error = prevail::unmarshal(raw_prog, prevail::thread_local_options);   \
+                        const auto inst_seq = std::get_if<prevail::InstructionSeq>(&prog_or_error);               \
+                        if (!inst_seq) {                                                                          \
+                            rejected = true;                                                                      \
+                        } else {                                                                                  \
+                            const prevail::Program prog = prevail::Program::from_sequence(                        \
+                                *inst_seq, raw_prog.info, prevail::thread_local_options);                         \
+                            rejected = (prevail::verify(prog) == false);                                          \
+                        }                                                                                         \
+                    } catch (const std::runtime_error& ex) {                                                      \
+                        INFO("rejected_by_exception=" << ex.what());                                              \
+                        rejected = true;                                                                          \
+                    }                                                                                             \
+                    REQUIRE(rejected);                                                                            \
+                }                                                                                                 \
+            }                                                                                                     \
+        }                                                                                                         \
+        REQUIRE(matched_program);                                                                                 \
     } while (0)
 
 // Verify a section with only one program in it.

--- a/src/test/test_verify_multithreading.cpp
+++ b/src/test/test_verify_multithreading.cpp
@@ -3,9 +3,8 @@
 
 #include "test_verify.hpp"
 
-static void test_analyze_thread(const prevail::Program* prog, prevail::ProgramInfo* info, bool* res) {
+static void test_analyze_thread(const prevail::Program* prog, bool* res) {
     try {
-        prevail::thread_local_program_info.set(*info);
         *res = prevail::verify(*prog);
     } catch (...) {
         *res = false;
@@ -34,8 +33,8 @@ TEST_CASE("multithreading", "[verify][multithreading]") {
 
     bool res1 = false;
     bool res2 = false;
-    std::thread a(test_analyze_thread, &prog1, &raw_prog1.info, &res1);
-    std::thread b(test_analyze_thread, &prog2, &raw_prog2.info, &res2);
+    std::thread a(test_analyze_thread, &prog1, &res1);
+    std::thread b(test_analyze_thread, &prog2, &res2);
     a.join();
     b.join();
 

--- a/src/test/test_verify_multithreading.cpp
+++ b/src/test/test_verify_multithreading.cpp
@@ -3,7 +3,7 @@
 
 #include "test_verify.hpp"
 
-static void test_analyze_thread(const prevail::Program* prog, const prevail::ProgramInfo* info, bool* res) {
+static void test_analyze_thread(const prevail::Program* prog, prevail::ProgramInfo* info, bool* res) {
     try {
         prevail::thread_local_program_info.set(*info);
         *res = prevail::verify(*prog);

--- a/src/verifier.hpp
+++ b/src/verifier.hpp
@@ -10,11 +10,22 @@
 
 namespace prevail {
 
+AnalysisResult analyze(const Program& prog, const ebpf_verifier_options_t& options);
+AnalysisResult analyze(const Program& prog, const StringInvariant& entry_invariant,
+                       const ebpf_verifier_options_t& options);
 AnalysisResult analyze(const Program& prog);
 AnalysisResult analyze(const Program& prog, const StringInvariant& entry_invariant);
 AnalysisResult analyze(const Program& prog, const AnalysisContext& context);
 AnalysisResult analyze(const Program& prog, const StringInvariant& entry_invariant, const AnalysisContext& context);
 void ebpf_verifier_clear_thread_local_state();
+inline bool verify(const Program& prog, const ebpf_verifier_options_t& options) {
+    try {
+        return !analyze(prog, options).failed;
+    } catch (const std::exception&) {
+        ebpf_verifier_clear_thread_local_state();
+        return false;
+    }
+}
 inline bool verify(const Program& prog) {
     try {
         return !analyze(prog).failed;


### PR DESCRIPTION
## Summary

- Thread `EbpfProgramType` explicitly through platform helper functions (`is_helper_usable`, `get_helper_prototype`), removing implicit `thread_local_program_info` reads from the platform layer
- Thread `ProgramInfo` through `get_map_descriptor` platform function, eliminating `thread_local_program_info` from `elf_loader.cpp`
- Move the map equivalence cache from `ProgramInfo` into a local variable in `parse_maps_section_linux`, fixing a pre-existing test-ordering bug where stale cache entries caused FD mismatches
- Store `ProgramInfo` in `Program` (resolves #1082), making prepared programs self-contained
- Remove `thread_local_program_info` entirely — variable, extern declaration, `LazyAllocator` include, `thread_local_analysis_context()` bridge, and dead `ebpf_domain_check` overload

Continues #1088. `thread_local_options` and the domain-internal thread-locals (`array_map`, `SplitDBM::scratch_`) remain for a future PR.

## Test plan

- [x] Full test suite passes with default seed
- [x] Full test suite passes with seed 2276513626 (previously exposed the map cache ordering bug)
- [x] Full test suite passes with seed 99999

🤖 Generated with [Claude Code](https://claude.com/claude-code)