### PR TITLE
Remove thread_local_options; pass options explicitly

### DIFF
--- a/src/config.hpp
+++ b/src/config.hpp
@@ -98,5 +98,4 @@ struct ebpf_verifier_stats_t {
     int max_loop_count{};
 };
 
-extern thread_local ebpf_verifier_options_t thread_local_options;
 } // namespace prevail

--- a/src/crab/array_domain.cpp
+++ b/src/crab/array_domain.cpp
@@ -47,7 +47,6 @@ struct Cell final {
 };
 
 static Interval cell_to_interval(const offset_t o, const unsigned size) {
-    assert(o <= thread_local_options.total_stack_size() && "offset out of bounds");
     const Number lb{gsl::narrow<int>(o)};
     return {lb, lb + size - 1};
 }
@@ -266,13 +265,15 @@ std::ostream& operator<<(std::ostream& o, offset_map_t& m) {
 }
 
 // Create a new cell that is a subset of an existing cell.
-void ArrayDomain::split_cell(NumAbsDomain& inv, const DataKind kind, const int cell_start_index,
-                             const unsigned int len) const {
+void ArrayDomain::split_cell(NumAbsDomain& inv, const DataKind kind, const int cell_start_index, const unsigned int len,
+                             const bool big_endian) const {
     assert(kind == DataKind::svalues || kind == DataKind::uvalues);
 
     // Get the values from the indicated stack range.
-    const std::optional<LinearExpression> svalue = load(inv, DataKind::svalues, Interval{cell_start_index}, len);
-    const std::optional<LinearExpression> uvalue = load(inv, DataKind::uvalues, Interval{cell_start_index}, len);
+    const std::optional<LinearExpression> svalue =
+        load(inv, DataKind::svalues, Interval{cell_start_index}, len, big_endian);
+    const std::optional<LinearExpression> uvalue =
+        load(inv, DataKind::uvalues, Interval{cell_start_index}, len, big_endian);
 
     // Create a new cell for that range.
     offset_map_t& offset_map = lookup_array_map(kind);
@@ -283,8 +284,8 @@ void ArrayDomain::split_cell(NumAbsDomain& inv, const DataKind kind, const int c
 
 // Prepare to havoc bytes in the middle of a cell by potentially splitting the cell if it is numeric,
 // into the part to the left of the havoced portion, and the part to the right of the havoced portion.
-void ArrayDomain::split_number_var(NumAbsDomain& inv, DataKind kind, const Interval& ii,
-                                   const Interval& elem_size) const {
+void ArrayDomain::split_number_var(NumAbsDomain& inv, DataKind kind, const Interval& ii, const Interval& elem_size,
+                                   const bool big_endian) const {
     assert(kind == DataKind::svalues || kind == DataKind::uvalues);
     offset_map_t& offset_map = lookup_array_map(kind);
     const std::optional<Number> n = ii.singleton();
@@ -315,12 +316,12 @@ void ArrayDomain::split_number_var(NumAbsDomain& inv, DataKind kind, const Inter
         }
         if (gsl::narrow_cast<Index>(cell_start_index) < o) {
             // Use the bytes to the left of the specified range.
-            split_cell(inv, kind, cell_start_index, gsl::narrow<unsigned int>(o - cell_start_index));
+            split_cell(inv, kind, cell_start_index, gsl::narrow<unsigned int>(o - cell_start_index), big_endian);
         }
         if (o + size < cell_end_index + 1UL) {
             // Use the bytes to the right of the specified range.
             split_cell(inv, kind, gsl::narrow<int>(o + size),
-                       gsl::narrow<unsigned int>(cell_end_index - (o + size - 1)));
+                       gsl::narrow<unsigned int>(cell_end_index - (o + size - 1)), big_endian);
         }
     }
 }
@@ -365,12 +366,12 @@ static std::optional<std::pair<offset_t, unsigned>> kill_and_find_var(const Havo
     }
     return res;
 }
-static std::tuple<int, int> as_numbytes_range(const Interval& index, const Interval& width) {
-    return (index | (index + width)).bound(0, thread_local_options.total_stack_size());
+static std::tuple<int, int> as_numbytes_range(const Interval& index, const Interval& width, const int stack_size) {
+    return (index | (index + width)).bound(0, stack_size);
 }
 
 bool ArrayDomain::all_num_lb_ub(const Interval& lb, const Interval& ub) const {
-    const auto [min_lb, max_ub] = (lb | ub).bound(0, thread_local_options.total_stack_size());
+    const auto [min_lb, max_ub] = (lb | ub).bound(0, total_stack_size());
     if (min_lb > max_ub) {
         return false;
     }
@@ -378,7 +379,7 @@ bool ArrayDomain::all_num_lb_ub(const Interval& lb, const Interval& ub) const {
 }
 
 bool ArrayDomain::all_num_width(const Interval& index, const Interval& width) const {
-    const auto [min_lb, max_ub] = as_numbytes_range(index, width);
+    const auto [min_lb, max_ub] = as_numbytes_range(index, width, total_stack_size());
     assert(min_lb <= max_ub);
     return this->num_bytes.all_num(min_lb, max_ub);
 }
@@ -396,7 +397,8 @@ int ArrayDomain::min_all_num_size(const NumAbsDomain& inv, const Variable offset
 }
 
 // Get one byte of a value.
-std::optional<uint8_t> get_value_byte(const NumAbsDomain& inv, const offset_t o, const int width) {
+std::optional<uint8_t> get_value_byte(const NumAbsDomain& inv, const offset_t o, const int width,
+                                      const bool big_endian) {
     const Variable v = variable_registry.cell_var(DataKind::svalues, (o / width) * width, width);
     const std::optional<Number> t = inv.eval_interval(v).singleton();
     if (!t) {
@@ -408,21 +410,21 @@ std::optional<uint8_t> get_value_byte(const NumAbsDomain& inv, const offset_t o,
     switch (width) {
     case sizeof(uint8_t): break;
     case sizeof(uint16_t):
-        if (thread_local_options.big_endian) {
+        if (big_endian) {
             n = boost::endian::native_to_big<uint16_t>(n);
         } else {
             n = boost::endian::native_to_little<uint16_t>(n);
         }
         break;
     case sizeof(uint32_t):
-        if (thread_local_options.big_endian) {
+        if (big_endian) {
             n = boost::endian::native_to_big<uint32_t>(n);
         } else {
             n = boost::endian::native_to_little<uint32_t>(n);
         }
         break;
     case sizeof(Index):
-        if (thread_local_options.big_endian) {
+        if (big_endian) {
             n = boost::endian::native_to_big<Index>(n);
         } else {
             n = boost::endian::native_to_little<Index>(n);
@@ -435,7 +437,7 @@ std::optional<uint8_t> get_value_byte(const NumAbsDomain& inv, const offset_t o,
 }
 
 std::optional<LinearExpression> ArrayDomain::load(const NumAbsDomain& inv, const DataKind kind, const Interval& i,
-                                                  const int width) const {
+                                                  const int width, const bool big_endian) const {
     if (const std::optional<Number> n = i.singleton()) {
         offset_map_t& offset_map = lookup_array_map(kind);
         const int64_t k = n->narrow<int64_t>();
@@ -451,13 +453,13 @@ std::optional<LinearExpression> ArrayDomain::load(const NumAbsDomain& inv, const
             bool found = true;
             for (unsigned int index = 0; index < size; index++) {
                 const offset_t byte_offset{o + index};
-                std::optional<uint8_t> b = get_value_byte(inv, byte_offset, 8);
+                std::optional<uint8_t> b = get_value_byte(inv, byte_offset, 8, big_endian);
                 if (!b) {
-                    b = get_value_byte(inv, byte_offset, 4);
+                    b = get_value_byte(inv, byte_offset, 4, big_endian);
                     if (!b) {
-                        b = get_value_byte(inv, byte_offset, 2);
+                        b = get_value_byte(inv, byte_offset, 2, big_endian);
                         if (!b) {
-                            b = get_value_byte(inv, byte_offset, 1);
+                            b = get_value_byte(inv, byte_offset, 1, big_endian);
                         }
                     }
                 }
@@ -476,7 +478,7 @@ std::optional<LinearExpression> ArrayDomain::load(const NumAbsDomain& inv, const
                 }
                 if (size == 2) {
                     uint16_t b = *reinterpret_cast<uint16_t*>(result_buffer);
-                    if (thread_local_options.big_endian) {
+                    if (big_endian) {
                         b = boost::endian::native_to_big<uint16_t>(b);
                     } else {
                         b = boost::endian::native_to_little<uint16_t>(b);
@@ -485,7 +487,7 @@ std::optional<LinearExpression> ArrayDomain::load(const NumAbsDomain& inv, const
                 }
                 if (size == 4) {
                     uint32_t b = *reinterpret_cast<uint32_t*>(result_buffer);
-                    if (thread_local_options.big_endian) {
+                    if (big_endian) {
                         b = boost::endian::native_to_big<uint32_t>(b);
                     } else {
                         b = boost::endian::native_to_little<uint32_t>(b);
@@ -494,7 +496,7 @@ std::optional<LinearExpression> ArrayDomain::load(const NumAbsDomain& inv, const
                 }
                 if (size == 8) {
                     Index b = *reinterpret_cast<Index*>(result_buffer);
-                    if (thread_local_options.big_endian) {
+                    if (big_endian) {
                         b = boost::endian::native_to_big<Index>(b);
                     } else {
                         b = boost::endian::native_to_little<Index>(b);
@@ -578,16 +580,17 @@ std::optional<LinearExpression> ArrayDomain::load_type(const Interval& i, int wi
 // partially cover that range can be split such that any non-covered portions become new cells.
 static std::optional<std::pair<offset_t, unsigned>> split_and_find_var(const ArrayDomain& array_domain,
                                                                        NumAbsDomain& inv, const DataKind kind,
-                                                                       const Interval& idx, const Interval& elem_size) {
+                                                                       const Interval& idx, const Interval& elem_size,
+                                                                       const bool big_endian) {
     if (kind == DataKind::svalues || kind == DataKind::uvalues) {
-        array_domain.split_number_var(inv, kind, idx, elem_size);
+        array_domain.split_number_var(inv, kind, idx, elem_size, big_endian);
     }
     return kill_and_find_var([&inv](Variable v) { inv.havoc(v); }, kind, idx, elem_size);
 }
 
 std::optional<Variable> ArrayDomain::store(NumAbsDomain& inv, const DataKind kind, const Interval& idx,
-                                           const Interval& elem_size) {
-    if (auto maybe_cell = split_and_find_var(*this, inv, kind, idx, elem_size)) {
+                                           const Interval& elem_size, const bool big_endian) {
+    if (auto maybe_cell = split_and_find_var(*this, inv, kind, idx, elem_size, big_endian)) {
         // perform strong update
         auto [offset, size] = *maybe_cell;
         const Cell c = lookup_array_map(kind).mk_cell(offset, size);
@@ -615,7 +618,7 @@ std::optional<Variable> ArrayDomain::store_type(TypeDomain& inv, const Interval&
         using namespace dsl_syntax;
         // Weak update: cannot perform a strong update because the index is
         // not a singleton. Havoc the type cells in the range.
-        const auto [lb, ub] = as_numbytes_range(idx, width);
+        const auto [lb, ub] = as_numbytes_range(idx, width, total_stack_size());
         if (!is_num) {
             // A non-numeric value may overwrite previously numeric bytes,
             // so conservatively mark the range as non-numeric.
@@ -628,8 +631,9 @@ std::optional<Variable> ArrayDomain::store_type(TypeDomain& inv, const Interval&
     return {};
 }
 
-void ArrayDomain::havoc(NumAbsDomain& inv, const DataKind kind, const Interval& idx, const Interval& elem_size) {
-    split_and_find_var(*this, inv, kind, idx, elem_size);
+void ArrayDomain::havoc(NumAbsDomain& inv, const DataKind kind, const Interval& idx, const Interval& elem_size,
+                        const bool big_endian) {
+    split_and_find_var(*this, inv, kind, idx, elem_size, big_endian);
 }
 
 void ArrayDomain::havoc_type(TypeDomain& inv, const Interval& idx, const Interval& elem_size) {
@@ -653,9 +657,9 @@ void ArrayDomain::store_numbers(const Interval& _idx, const Interval& _width) {
         return;
     }
 
-    if (*idx_n + *width > thread_local_options.total_stack_size()) {
+    if (*idx_n + *width > total_stack_size()) {
         CRAB_WARN("array expansion store range ignored because ", "the number of elements is larger than limit of ",
-                  thread_local_options.total_stack_size());
+                  total_stack_size());
         return;
     }
     num_bytes.reset(idx_n->narrow<int>(), width->narrow<int>());

--- a/src/crab/array_domain.hpp
+++ b/src/crab/array_domain.hpp
@@ -41,6 +41,11 @@ class ArrayDomain final {
     // Top at the requested size.
     explicit ArrayDomain(const size_t stack_size) : num_bytes(BitsetDomain{stack_size}) {}
 
+    [[nodiscard]]
+    int total_stack_size() const {
+        return gsl::narrow<int>(num_bytes.size());
+    }
+
     // no move constructor to BitsetDomain, and therefore no copy-then-move for ArrayDomain
     explicit ArrayDomain(const BitsetDomain& num_bytes) : num_bytes(num_bytes) {}
     ArrayDomain(const ArrayDomain& arr) = default;
@@ -74,18 +79,21 @@ class ArrayDomain final {
     int min_all_num_size(const NumAbsDomain& inv, Variable offset) const;
 
     [[nodiscard]]
-    std::optional<LinearExpression> load(const NumAbsDomain& inv, DataKind kind, const Interval& i, int width) const;
+    std::optional<LinearExpression> load(const NumAbsDomain& inv, DataKind kind, const Interval& i, int width,
+                                         bool big_endian) const;
     std::optional<LinearExpression> load_type(const Interval& i, int width) const;
-    std::optional<Variable> store(NumAbsDomain& inv, DataKind kind, const Interval& idx, const Interval& elem_size);
+    std::optional<Variable> store(NumAbsDomain& inv, DataKind kind, const Interval& idx, const Interval& elem_size,
+                                  bool big_endian);
     std::optional<Variable> store_type(TypeDomain& inv, const Interval& idx, const Interval& width, bool is_num);
-    void havoc(NumAbsDomain& inv, DataKind kind, const Interval& idx, const Interval& elem_size);
+    void havoc(NumAbsDomain& inv, DataKind kind, const Interval& idx, const Interval& elem_size, bool big_endian);
     void havoc_type(TypeDomain& inv, const Interval& idx, const Interval& elem_size);
 
     // Perform array stores over an array segment
     void store_numbers(const Interval& _idx, const Interval& _width);
 
-    void split_number_var(NumAbsDomain& inv, DataKind kind, const Interval& ii, const Interval& elem_size) const;
-    void split_cell(NumAbsDomain& inv, DataKind kind, int cell_start_index, unsigned int len) const;
+    void split_number_var(NumAbsDomain& inv, DataKind kind, const Interval& ii, const Interval& elem_size,
+                          bool big_endian) const;
+    void split_cell(NumAbsDomain& inv, DataKind kind, int cell_start_index, unsigned int len, bool big_endian) const;
 
     void initialize_numbers(int lb, int width);
 };

--- a/src/crab/bitset_domain.hpp
+++ b/src/crab/bitset_domain.hpp
@@ -28,6 +28,11 @@ class BitsetDomain final {
     // BitsetDomain has no bottom of its own; bottom for a container that
     // needs one is represented externally (e.g. wrapping the stack in
     // std::optional inside EbpfDomain).
+    [[nodiscard]]
+    size_t size() const noexcept {
+        return non_numerical_bytes.size();
+    }
+
     void set_to_top() noexcept { non_numerical_bytes.set(); }
 
     [[nodiscard]]

--- a/src/crab/ebpf_transformer.cpp
+++ b/src/crab/ebpf_transformer.cpp
@@ -202,7 +202,7 @@ void EbpfTransformer::havoc_subprogram_stack(const std::string& prefix) {
     const int64_t stack_start = intv.singleton()->cast_to<int64_t>() - frame_size;
     stack.havoc_type(dom.state.types, Interval{stack_start}, Interval{frame_size});
     for (const DataKind kind : iterate_kinds()) {
-        stack.havoc(dom.state.values, kind, Interval{stack_start}, Interval{frame_size});
+        stack.havoc(dom.state.values, kind, Interval{stack_start}, Interval{frame_size}, context.options.big_endian);
     }
 }
 
@@ -463,15 +463,18 @@ void EbpfTransformer::do_load_stack(TypeToNumDomain& state, const Reg& target_re
     if (width == 1 || width == 2 || width == 4 || width == 8) {
         // Use the addr before we havoc the destination register since we might be getting the
         // addr from that same register.
-        const std::optional<LinearExpression> sresult = stack.load(state.values, DataKind::svalues, addr, width);
-        const std::optional<LinearExpression> uresult = stack.load(state.values, DataKind::uvalues, addr, width);
+        const bool big_endian = context.options.big_endian;
+        const std::optional<LinearExpression> sresult =
+            stack.load(state.values, DataKind::svalues, addr, width, big_endian);
+        const std::optional<LinearExpression> uresult =
+            stack.load(state.values, DataKind::uvalues, addr, width, big_endian);
         state.havoc_register_except_type(target_reg);
         state.values.assign(target.svalue, sresult);
         state.values.assign(target.uvalue, uresult);
         for (const TypeEncoding type : state.iterate_types(target_reg)) {
             for (const auto& kind : type_to_kinds.at(type)) {
                 const Variable dst_var = variable_registry.reg(kind, target_reg.v);
-                state.values.assign(dst_var, stack.load(state.values, kind, addr, width));
+                state.values.assign(dst_var, stack.load(state.values, kind, addr, width, big_endian));
             }
         }
     } else {
@@ -627,18 +630,19 @@ void EbpfTransformer::do_store_stack(TypeToNumDomain& state, const LinearExpress
                                      const std::optional<Reg>& opt_val_reg) {
     const Interval addr = state.values.eval_interval(symb_addr);
     const Interval width{exact_width};
+    const bool big_endian = context.options.big_endian;
     // no aliasing of val - we don't move from stack to stack, so we can just havoc first
     stack.havoc_type(state.types, addr, width);
     for (const DataKind kind : iterate_kinds()) {
         if (kind == DataKind::svalues || kind == DataKind::uvalues) {
             continue;
         }
-        stack.havoc(state.values, kind, addr, width);
+        stack.havoc(state.values, kind, addr, width, context.options.big_endian);
     }
     bool must_be_num = false;
     if (opt_val_reg && !state.is_initialized(*opt_val_reg)) {
-        stack.havoc(state.values, DataKind::svalues, addr, width);
-        stack.havoc(state.values, DataKind::uvalues, addr, width);
+        stack.havoc(state.values, DataKind::svalues, addr, width, big_endian);
+        stack.havoc(state.values, DataKind::uvalues, addr, width, big_endian);
     } else {
         // opt_val_reg is unset when storing an immediate value.
         must_be_num = !opt_val_reg || state.is_in_group(*opt_val_reg, TS_NUM);
@@ -647,36 +651,36 @@ void EbpfTransformer::do_store_stack(TypeToNumDomain& state, const LinearExpress
         state.assign_type(stack.store_type(state.types, addr, width, must_be_num), val_type);
 
         if (exact_width == 8) {
-            stack.havoc(state.values, DataKind::svalues, addr, width);
-            stack.havoc(state.values, DataKind::uvalues, addr, width);
-            state.values.assign(stack.store(state.values, DataKind::svalues, addr, width), val_svalue);
-            state.values.assign(stack.store(state.values, DataKind::uvalues, addr, width), val_uvalue);
+            stack.havoc(state.values, DataKind::svalues, addr, width, big_endian);
+            stack.havoc(state.values, DataKind::uvalues, addr, width, big_endian);
+            state.values.assign(stack.store(state.values, DataKind::svalues, addr, width, big_endian), val_svalue);
+            state.values.assign(stack.store(state.values, DataKind::uvalues, addr, width, big_endian), val_uvalue);
 
             if (!must_be_num) {
                 for (TypeEncoding type : state.iterate_types(*opt_val_reg)) {
                     for (const DataKind kind : type_to_kinds.at(type)) {
                         const Variable src_var = variable_registry.reg(kind, opt_val_reg->v);
-                        state.values.assign(stack.store(state.values, kind, addr, width), src_var);
+                        state.values.assign(stack.store(state.values, kind, addr, width, big_endian), src_var);
                     }
                 }
             }
         } else if ((exact_width == 1 || exact_width == 2 || exact_width == 4) && must_be_num) {
             // Keep track of numbers on the stack that might be used as array indices.
-            if (const auto stack_svalue = stack.store(state.values, DataKind::svalues, addr, width)) {
+            if (const auto stack_svalue = stack.store(state.values, DataKind::svalues, addr, width, big_endian)) {
                 state.values.assign(stack_svalue, val_svalue);
                 state.values->overflow_bounds(*stack_svalue, exact_width * 8, true);
             } else {
-                stack.havoc(state.values, DataKind::svalues, addr, width);
+                stack.havoc(state.values, DataKind::svalues, addr, width, big_endian);
             }
-            if (const auto stack_uvalue = stack.store(state.values, DataKind::uvalues, addr, width)) {
+            if (const auto stack_uvalue = stack.store(state.values, DataKind::uvalues, addr, width, big_endian)) {
                 state.values.assign(stack_uvalue, val_uvalue);
                 state.values->overflow_bounds(*stack_uvalue, exact_width * 8, false);
             } else {
-                stack.havoc(state.values, DataKind::uvalues, addr, width);
+                stack.havoc(state.values, DataKind::uvalues, addr, width, big_endian);
             }
         } else {
-            stack.havoc(state.values, DataKind::svalues, addr, width);
-            stack.havoc(state.values, DataKind::uvalues, addr, width);
+            stack.havoc(state.values, DataKind::svalues, addr, width, big_endian);
+            stack.havoc(state.values, DataKind::uvalues, addr, width, big_endian);
         }
     }
 
@@ -863,7 +867,7 @@ void EbpfTransformer::operator()(const Call& call) {
                     }
                     const Interval addr = state.values.eval_interval(*offset);
                     for (const DataKind kind : iterate_kinds()) {
-                        stack.havoc(state.values, kind, addr, w);
+                        stack.havoc(state.values, kind, addr, w, context.options.big_endian);
                     }
                     // Keep this scoped to stack-typed pointers only.
                     stack.store_numbers(addr, w);
@@ -894,7 +898,7 @@ void EbpfTransformer::operator()(const Call& call) {
                     // Pointer to a memory region that the called function may change,
                     // so we must havoc.
                     for (const DataKind kind : iterate_kinds()) {
-                        stack.havoc(state.values, kind, addr, width);
+                        stack.havoc(state.values, kind, addr, width, context.options.big_endian);
                     }
                 } else {
                     store_numbers = false;

--- a/src/fwd_analyzer.cpp
+++ b/src/fwd_analyzer.cpp
@@ -16,8 +16,6 @@
 
 namespace prevail {
 
-thread_local ebpf_verifier_options_t thread_local_options;
-
 static void clear_analysis_thread_local_state() { clear_thread_local_state(); }
 
 void ebpf_verifier_clear_thread_local_state() {
@@ -173,12 +171,6 @@ AnalysisResult analyze(const Program& prog, const ebpf_verifier_options_t& optio
 AnalysisResult analyze(const Program& prog, const StringInvariant& entry_invariant,
                        const ebpf_verifier_options_t& options) {
     return analyze(prog, entry_invariant, make_context(prog, options));
-}
-
-AnalysisResult analyze(const Program& prog) { return analyze(prog, thread_local_options); }
-
-AnalysisResult analyze(const Program& prog, const StringInvariant& entry_invariant) {
-    return analyze(prog, entry_invariant, thread_local_options);
 }
 
 AnalysisResult analyze(const Program& prog, const AnalysisContext& context) {

--- a/src/ir/cfg_builder.cpp
+++ b/src/ir/cfg_builder.cpp
@@ -648,7 +648,6 @@ Program Program::from_sequence(const InstructionSeq& inst_seq, const ProgramInfo
                                const ebpf_verifier_options_t& options) {
     ProgramInfo mutable_info = info;
     options.validate();
-    thread_local_options = options;
     assert(info.platform != nullptr && "platform must be set before instruction feature validation");
     ResolvedKfuncCalls resolved_kfunc_calls;
     validate_instruction_feature_support(inst_seq, info, &resolved_kfunc_calls);

--- a/src/ir/program.hpp
+++ b/src/ir/program.hpp
@@ -67,6 +67,6 @@ class InvalidControlFlow final : public std::runtime_error {
 std::vector<Assertion> get_assertions(const Instruction& ins, const ProgramInfo& info,
                                       const ebpf_verifier_options_t& options, const std::optional<Label>& label);
 
-void print_program(const Program& prog, std::ostream& os, bool simplify);
+void print_program(const Program& prog, std::ostream& os, bool simplify, bool print_line_info = false);
 void print_dot(const Program& prog, const std::string& outfile);
 } // namespace prevail

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -233,18 +233,18 @@ int main(int argc, char** argv) {
         }
 
         if (print_cfg) {
-            print_program(prog, std::cout, verbosity.simplify);
+            print_program(prog, std::cout, verbosity.simplify, verbosity.print_line_info);
             return 0;
         }
 
-        auto result = analyze(prog);
+        auto result = analyze(prog, ebpf_verifier_options);
         if (!quiet) {
             if (verbosity.print_invariants) {
-                print_invariants(std::cout, prog, verbosity.simplify, result);
+                print_invariants(std::cout, prog, verbosity.simplify, result, verbosity.print_line_info);
             }
             if (verbosity.print_failures) {
                 if (auto verification_error = result.find_first_error()) {
-                    print_error(std::cout, *verification_error, prog);
+                    print_error(std::cout, *verification_error, prog, verbosity.print_line_info);
                 }
             }
             if (failure_slice && result.failed) {
@@ -254,7 +254,8 @@ int main(int argc, char** argv) {
                 slice_params.max_slices = 1;
                 const AnalysisContext context{prog.info(), ebpf_verifier_options, *prog.info().platform};
                 auto slices = result.compute_failure_slices(prog, slice_params, context);
-                print_failure_slices(std::cout, prog, verbosity.simplify, result, slices);
+                print_failure_slices(std::cout, prog, verbosity.simplify, result, slices, false,
+                                     verbosity.print_line_info);
             } else if (failure_slice && !result.failed) {
                 std::cout << "Program passed verification; no failure slices to display.\n";
             }
@@ -275,7 +276,7 @@ int main(int argc, char** argv) {
                 // Print the first error if not already printed by -v or -f.
                 if (!verbosity.print_invariants && !verbosity.print_failures && !failure_slice) {
                     if (auto verification_error = result.find_first_error()) {
-                        print_error(std::cout, *verification_error, prog);
+                        print_error(std::cout, *verification_error, prog, verbosity.print_line_info);
                     }
                     std::cout << "Hint: run with --failure-slice for a causal trace, or -v for full invariants.\n";
                 }

--- a/src/printing.cpp
+++ b/src/printing.cpp
@@ -123,8 +123,8 @@ struct LineInfoPrinter {
 struct DetailedPrinter : LineInfoPrinter {
     const Program& prog;
 
-    DetailedPrinter(std::ostream& os, const Program& prog)
-        : LineInfoPrinter{os, prog.info().line_info, thread_local_options.verbosity_opts.print_line_info}, prog(prog) {}
+    DetailedPrinter(std::ostream& os, const Program& prog, const bool print_line_info = false)
+        : LineInfoPrinter{os, prog.info().line_info, print_line_info}, prog(prog) {}
 
     void print_labels(const std::string& direction, const std::set<Label>& labels) {
         auto [it, et] = std::pair{labels.begin(), labels.end()};
@@ -155,8 +155,8 @@ struct DetailedPrinter : LineInfoPrinter {
     }
 };
 
-void print_program(const Program& prog, std::ostream& os, const bool simplify) {
-    DetailedPrinter printer{os, prog};
+void print_program(const Program& prog, std::ostream& os, const bool simplify, const bool print_line_info) {
+    DetailedPrinter printer{os, prog, print_line_info};
     for (const BasicBlock& bb : BasicBlock::collect_basic_blocks(prog.cfg(), simplify)) {
         printer.print_jump("from", bb.first_label());
         os << bb.first_label() << ":\n";
@@ -169,8 +169,9 @@ void print_program(const Program& prog, std::ostream& os, const bool simplify) {
     os << "\n";
 }
 
-void print_invariants(std::ostream& os, const Program& prog, const bool simplify, const AnalysisResult& result) {
-    DetailedPrinter printer{os, prog};
+void print_invariants(std::ostream& os, const Program& prog, const bool simplify, const AnalysisResult& result,
+                      const bool print_line_info) {
+    DetailedPrinter printer{os, prog, print_line_info};
     for (const BasicBlock& bb : BasicBlock::collect_basic_blocks(prog.cfg(), simplify)) {
         if (result.invariants.at(bb.first_label()).pre.is_bottom()) {
             continue;
@@ -190,7 +191,7 @@ void print_invariants(std::ostream& os, const Program& prog, const bool simplify
                 if (label != bb.last_label()) {
                     os << "After " << current.pre << "\n";
                 }
-                print_error(os, *current.error, prog);
+                print_error(os, *current.error, prog, print_line_info);
                 os << "\n";
                 return;
             }
@@ -250,8 +251,8 @@ std::string to_string(const VerificationError& error) {
     return ss.str();
 }
 
-void print_error(std::ostream& os, const VerificationError& error, const Program& prog) {
-    LineInfoPrinter printer{os, prog.info().line_info, thread_local_options.verbosity_opts.print_line_info};
+void print_error(std::ostream& os, const VerificationError& error, const Program& prog, const bool print_line_info) {
+    LineInfoPrinter printer{os, prog.info().line_info, print_line_info};
     if (const auto& label = error.where) {
         printer.print_line_info(*label);
         os << *label << ": ";
@@ -723,8 +724,8 @@ std::ostream& operator<<(std::ostream& os, const btf_line_info_t& line_info) {
 
 void print_invariants_filtered(std::ostream& os, const Program& prog, const bool simplify, const AnalysisResult& result,
                                const std::set<Label>& filter, const bool compact,
-                               const std::map<Label, RelevantState>* relevance) {
-    DetailedPrinter printer{os, prog};
+                               const std::map<Label, RelevantState>* relevance, const bool print_line_info) {
+    DetailedPrinter printer{os, prog, print_line_info};
     const auto basic_blocks = BasicBlock::collect_basic_blocks(prog.cfg(), simplify);
 
     // Build a mapping from each label in a basic block to the block's first label.
@@ -929,7 +930,7 @@ void print_invariants_filtered(std::ostream& os, const Program& prog, const bool
             const auto& current = result.invariants.at(label);
             if (current.error) {
                 os << "\nVerification error:\n";
-                print_error(os, *current.error, prog);
+                print_error(os, *current.error, prog, print_line_info);
                 os << "\n";
             }
         }
@@ -952,7 +953,7 @@ void print_invariants_filtered(std::ostream& os, const Program& prog, const bool
 }
 
 void print_failure_slices(std::ostream& os, const Program& prog, const bool simplify, const AnalysisResult& result,
-                          const std::vector<FailureSlice>& slices, const bool compact) {
+                          const std::vector<FailureSlice>& slices, const bool compact, const bool print_line_info) {
     if (slices.empty()) {
         os << "No verification failures found.\n";
         return;
@@ -1078,7 +1079,8 @@ void print_failure_slices(std::ostream& os, const Program& prog, const bool simp
 
         // Print the filtered CFG with assertion filtering based on relevance
         os << "[CAUSAL TRACE]\n";
-        print_invariants_filtered(os, prog, simplify, result, slice.impacted_labels(), compact, &slice.relevance);
+        print_invariants_filtered(os, prog, simplify, result, slice.impacted_labels(), compact, &slice.relevance,
+                                  print_line_info);
 
         if (i + 1 < slices.size()) {
             os << "\n";

--- a/src/result.hpp
+++ b/src/result.hpp
@@ -174,21 +174,18 @@ struct AnalysisResult {
                                           size_t max_steps = 200) const;
 };
 
-void print_error(std::ostream& os, const VerificationError& error, const Program& prog);
-void print_invariants(std::ostream& os, const Program& prog, bool simplify, const AnalysisResult& result);
+void print_error(std::ostream& os, const VerificationError& error, const Program& prog, bool print_line_info = false);
+void print_invariants(std::ostream& os, const Program& prog, bool simplify, const AnalysisResult& result,
+                      bool print_line_info = false);
 void print_unreachable(std::ostream& os, const Program& prog, const AnalysisResult& result);
 
-/// Print invariants filtered to only show labels in the given set.
-/// Used to print a failure slice in context.
-/// @param compact If true, skip invariant output and only show instructions.
-/// @param relevance If provided, only show assertions involving relevant registers.
 void print_invariants_filtered(std::ostream& os, const Program& prog, bool simplify, const AnalysisResult& result,
                                const std::set<Label>& filter, bool compact = false,
-                               const std::map<Label, RelevantState>* relevance = nullptr);
+                               const std::map<Label, RelevantState>* relevance = nullptr, bool print_line_info = false);
 
 /// Print all failure slices in a structured diagnostic format.
 /// @param compact If true, skip detailed invariants for smaller output.
 void print_failure_slices(std::ostream& os, const Program& prog, bool simplify, const AnalysisResult& result,
-                          const std::vector<FailureSlice>& slices, bool compact = false);
+                          const std::vector<FailureSlice>& slices, bool compact = false, bool print_line_info = false);
 
 } // namespace prevail

--- a/src/test/ebpf_yaml.cpp
+++ b/src/test/ebpf_yaml.cpp
@@ -403,7 +403,6 @@ std::optional<Failure> run_yaml_test_case(TestCase test_case, bool debug) {
         };
     }
 
-    thread_local_options = {};
     ThreadLocalGuard clear_thread_local_state;
     test_case.options.verbosity_opts.print_failures = true;
     if (debug) {
@@ -414,7 +413,6 @@ std::optional<Failure> run_yaml_test_case(TestCase test_case, bool debug) {
     EbpfProgramType program_type = make_program_type(test_case.name, &context_descriptor);
 
     ProgramInfo info{&g_platform_test, {test_map_descriptor}, program_type};
-    thread_local_options = test_case.options;
     try {
         const Program prog = Program::from_sequence(test_case.instruction_seq, info, test_case.options);
         const AnalysisContext context{prog.info(), test_case.options, *prog.info().platform};
@@ -474,11 +472,12 @@ std::optional<Failure> run_yaml_test_case(TestCase test_case, bool debug) {
 }
 
 template <std::signed_integral TS>
-void add_stack_variable(std::set<std::string>& more, int& offset, const std::vector<std::byte>& memory_bytes) {
+void add_stack_variable(std::set<std::string>& more, int& offset, const std::vector<std::byte>& memory_bytes,
+                        const int total_stack_size) {
     using TU = std::make_unsigned_t<TS>;
     constexpr size_t size = sizeof(TS);
     static_assert(sizeof(TU) == size);
-    const auto src = memory_bytes.data() + offset + memory_bytes.size() - thread_local_options.total_stack_size();
+    const auto src = memory_bytes.data() + offset + memory_bytes.size() - total_stack_size;
     TS svalue;
     std::memcpy(&svalue, src, size);
     TU uvalue;
@@ -489,59 +488,57 @@ void add_stack_variable(std::set<std::string>& more, int& offset, const std::vec
     offset += size;
 }
 
-StringInvariant stack_contents_invariant(const std::vector<std::byte>& memory_bytes) {
-    std::set<std::string> more = {
-        "r1.type=stack",
-        "r1.stack_offset=" + std::to_string(thread_local_options.total_stack_size() - memory_bytes.size()),
-        "r1.stack_numeric_size=" + std::to_string(memory_bytes.size()),
-        "r10.type=stack",
-        "r10.stack_offset=" + std::to_string(thread_local_options.total_stack_size()),
-        "s[" + std::to_string(thread_local_options.total_stack_size() - memory_bytes.size()) + "..." +
-            std::to_string(thread_local_options.total_stack_size() - 1) + "].type=number"};
+StringInvariant stack_contents_invariant(const std::vector<std::byte>& memory_bytes, const int total_stack_size) {
+    std::set<std::string> more = {"r1.type=stack",
+                                  "r1.stack_offset=" + std::to_string(total_stack_size - memory_bytes.size()),
+                                  "r1.stack_numeric_size=" + std::to_string(memory_bytes.size()),
+                                  "r10.type=stack",
+                                  "r10.stack_offset=" + std::to_string(total_stack_size),
+                                  "s[" + std::to_string(total_stack_size - memory_bytes.size()) + "..." +
+                                      std::to_string(total_stack_size - 1) + "].type=number"};
 
-    int offset = thread_local_options.total_stack_size() - gsl::narrow<int>(memory_bytes.size());
+    int offset = total_stack_size - gsl::narrow<int>(memory_bytes.size());
     if (offset % 2 != 0) {
-        add_stack_variable<int8_t>(more, offset, memory_bytes);
+        add_stack_variable<int8_t>(more, offset, memory_bytes, total_stack_size);
     }
     if (offset % 4 != 0) {
-        add_stack_variable<int16_t>(more, offset, memory_bytes);
+        add_stack_variable<int16_t>(more, offset, memory_bytes, total_stack_size);
     }
     if (offset % 8 != 0) {
-        add_stack_variable<int32_t>(more, offset, memory_bytes);
+        add_stack_variable<int32_t>(more, offset, memory_bytes, total_stack_size);
     }
-    while (offset < thread_local_options.total_stack_size()) {
-        add_stack_variable<int64_t>(more, offset, memory_bytes);
+    while (offset < total_stack_size) {
+        add_stack_variable<int64_t>(more, offset, memory_bytes, total_stack_size);
     }
 
     return StringInvariant(std::move(more));
 }
 
 // Helper to convert uint8_t memory to stack invariant
-static StringInvariant stack_contents_invariant(const std::vector<uint8_t>& memory_bytes) {
+static StringInvariant stack_contents_invariant(const std::vector<uint8_t>& memory_bytes, const int total_stack_size) {
     std::vector<std::byte> bytes(memory_bytes.size());
     std::ranges::transform(memory_bytes, bytes.begin(), [](uint8_t b) { return static_cast<std::byte>(b); });
-    return stack_contents_invariant(bytes);
+    return stack_contents_invariant(bytes, total_stack_size);
 }
 
 ConformanceTestResult run_conformance_test_case(const std::vector<uint8_t>& memory_bytes,
                                                 std::span<const EbpfInst> instructions, bool debug) {
-    thread_local_options = {};
+    ebpf_verifier_options_t options{};
     ebpf_context_descriptor_t context_descriptor{64, -1, -1, -1};
     EbpfProgramType program_type = make_program_type("conformance_check", &context_descriptor);
 
     ProgramInfo info{&g_platform_test, {}, program_type};
 
-    // Copy instructions into a local vector for RawProgram.
     std::vector<EbpfInst> insts(instructions.begin(), instructions.end());
 
     StringInvariant pre_invariant = StringInvariant::top();
 
     if (!memory_bytes.empty()) {
-        if (memory_bytes.size() > thread_local_options.total_stack_size()) {
+        if (memory_bytes.size() > to_unsigned(options.total_stack_size())) {
             std::cerr << "memory size overflow\n";
             return {};
         }
-        pre_invariant = pre_invariant + stack_contents_invariant(memory_bytes);
+        pre_invariant = pre_invariant + stack_contents_invariant(memory_bytes, options.total_stack_size());
     }
     RawProgram raw_prog{.prog = insts};
     ebpf_platform_t platform = g_ebpf_platform_linux;
@@ -557,7 +554,6 @@ ConformanceTestResult run_conformance_test_case(const std::vector<uint8_t>& memo
 
     const InstructionSeq& inst_seq = std::get<InstructionSeq>(prog_or_error);
 
-    ebpf_verifier_options_t options{};
     if (debug) {
         print(inst_seq, std::cout, {});
         options.verbosity_opts.print_failures = true;

--- a/src/test/test_elf_loader.cpp
+++ b/src/test/test_elf_loader.cpp
@@ -333,7 +333,6 @@ void patch_first_relocation_type(const std::filesystem::path& path, const std::s
 
 #define FAIL_LOAD_ELF_BASE(test_name, dirname, filename, sectionname)                                                  \
     TEST_CASE(test_name, "[elf]") {                                                                                    \
-        thread_local_options = {};                                                                                     \
         REQUIRE_THROWS_AS(                                                                                             \
             ([&]() {                                                                                                   \
                 ElfObject{"ebpf-samples/" dirname "/" filename, {}, &g_ebpf_platform_linux}.get_programs(sectionname); \
@@ -351,7 +350,6 @@ void patch_first_relocation_type(const std::filesystem::path& path, const std::s
 
 #define LOAD_ELF_SECTION(dirname, filename, sectionname)                                                           \
     TEST_CASE("Try loading section: " dirname "/" filename " " sectionname, "[elf]") {                             \
-        thread_local_options = {};                                                                                 \
         const auto progs =                                                                                         \
             ElfObject{"ebpf-samples/" dirname "/" filename, {}, &g_ebpf_platform_linux}.get_programs(sectionname); \
         REQUIRE_FALSE(progs.empty());                                                                              \
@@ -389,7 +387,6 @@ LOAD_ELF_SECTION("cilium-ebpf", "loader-clang-20-el.elf", "socket/2")
 LOAD_ELF_SECTION("cilium-ebpf", "loader_nobtf-el.elf", "socket/2")
 
 TEST_CASE("CO-RE relocations are parsed from .BTF.ext core_relo subsection", "[elf][core]") {
-    thread_local_options = {};
 
     constexpr auto fentry_path = "ebpf-samples/cilium-examples/tcprtt_bpf_bpfel.o";
     constexpr auto fentry_section = "fentry/tcp_close";
@@ -407,7 +404,6 @@ TEST_CASE("CO-RE relocations are parsed from .BTF.ext core_relo subsection", "[e
 }
 
 TEST_CASE("ELF loader rejects non-BPF e_machine", "[elf][hardening]") {
-    thread_local_options = {};
 
     TempElfFile elf{"ebpf-samples/build/twomaps.o", "bad-machine"};
     patch_machine(elf.path(), ELFIO::EM_X86_64);
@@ -417,7 +413,6 @@ TEST_CASE("ELF loader rejects non-BPF e_machine", "[elf][hardening]") {
 }
 
 TEST_CASE("ELF loader rejects relocation sections with out-of-bounds file offsets", "[elf][hardening]") {
-    thread_local_options = {};
 
     TempElfFile elf{"ebpf-samples/build/twomaps.o", "bad-reloc-offset"};
     const auto file_size = std::filesystem::file_size(elf.path());
@@ -428,7 +423,6 @@ TEST_CASE("ELF loader rejects relocation sections with out-of-bounds file offset
 }
 
 TEST_CASE("ELF loader rejects malformed legacy maps section record size", "[elf][hardening]") {
-    thread_local_options = {};
 
     TempElfFile elf{"ebpf-samples/bpf_cilium_test/bpf_lb-DLB_L3.o", "bad-maps-size"};
     // Keep the section in-bounds but make each inferred map record too small.
@@ -439,7 +433,6 @@ TEST_CASE("ELF loader rejects malformed legacy maps section record size", "[elf]
 }
 
 TEST_CASE("CO-RE access string offset out-of-bounds fails cleanly", "[elf][core][hardening]") {
-    thread_local_options = {};
 
     TempElfFile elf{"ebpf-samples/cilium-examples/tcprtt_bpf_bpfel.o", "bad-core-access"};
     patch_first_core_access_string_offset(elf.path(), 0xfffffff0U);
@@ -449,7 +442,6 @@ TEST_CASE("CO-RE access string offset out-of-bounds fails cleanly", "[elf][core]
 }
 
 TEST_CASE("ELF loader rejects relocation entries with invalid symbol index", "[elf][hardening]") {
-    thread_local_options = {};
 
     TempElfFile elf{"ebpf-samples/build/twomaps.o", "bad-reloc-symbol-index"};
     patch_first_relocation_symbol_index(elf.path(), ".rel.text", 0x00ffffffU);
@@ -459,7 +451,6 @@ TEST_CASE("ELF loader rejects relocation entries with invalid symbol index", "[e
 }
 
 TEST_CASE("ELF loader rejects unsupported relocation types", "[elf][hardening]") {
-    thread_local_options = {};
 
     TempElfFile elf{"ebpf-samples/build/twomaps.o", "bad-reloc-type"};
     patch_first_relocation_type(elf.path(), ".rel.text", 0xffU);
@@ -469,7 +460,6 @@ TEST_CASE("ELF loader rejects unsupported relocation types", "[elf][hardening]")
 }
 
 TEST_CASE("ELF loader rewrites .ksyms function calls to call_btf", "[elf]") {
-    thread_local_options = {};
 
     ElfObject elf{"ebpf-samples/cilium-ebpf/kfunc-kmod-el.elf", {}, &g_ebpf_platform_linux};
     const auto& progs = elf.get_programs("tc", "call_kfunc");
@@ -490,7 +480,6 @@ TEST_CASE("ELF loader rewrites .ksyms function calls to call_btf", "[elf]") {
 }
 
 TEST_CASE("ELF loader fails unresolved .ksyms function calls before builtin fallback", "[elf]") {
-    thread_local_options = {};
 
     ebpf_platform_t platform = g_ebpf_platform_linux;
     platform.resolve_ksym_btf_id = resolve_no_ksym_symbols;
@@ -500,7 +489,6 @@ TEST_CASE("ELF loader fails unresolved .ksyms function calls before builtin fall
 }
 
 TEST_CASE("ELF loader ignores non-function .ksyms entries", "[elf]") {
-    thread_local_options = {};
 
     ebpf_platform_t platform = g_ebpf_platform_linux;
     platform.resolve_ksym_btf_id = resolve_no_ksym_symbols;
@@ -578,7 +566,6 @@ TEST_CASE("rewrite_extern_constant_load bails out on values exceeding int32 rang
 // The load_elf function uses file_size(path) for section-bounds validation, which
 // fails for non-file paths like "memory". The fix falls back to stream size.
 TEST_CASE("read_elf succeeds with istream and non-file path", "[elf]") {
-    thread_local_options = {};
 
     // Read a valid ELF file into memory.
     const auto bytes = read_file_bytes("ebpf-samples/build/twomaps.o");

--- a/src/test/test_marshal.cpp
+++ b/src/test/test_marshal.cpp
@@ -214,8 +214,8 @@ static const EbpfInstructionTemplate instruction_template[] = {
 static void check_unmarshal_succeed(const EbpfInst& ins, const ebpf_platform_t& platform = g_ebpf_platform_linux) {
     const ProgramInfo info{.platform = &platform, .type = platform.get_program_type("unspec", "unspec")};
     constexpr EbpfInst exit{.opcode = INST_OP_EXIT};
-    const InstructionSeq parsed =
-        std::get<InstructionSeq>(unmarshal(RawProgram{"", "", 0, "", {ins, exit, exit}, info}, thread_local_options));
+    const InstructionSeq parsed = std::get<InstructionSeq>(
+        unmarshal(RawProgram{"", "", 0, "", {ins, exit, exit}, info}, ebpf_verifier_options_t{}));
     REQUIRE(parsed.size() == 3);
 }
 
@@ -225,7 +225,7 @@ static void check_unmarshal_succeed(EbpfInst inst1, EbpfInst inst2,
     const ProgramInfo info{.platform = &platform, .type = platform.get_program_type("unspec", "unspec")};
     constexpr EbpfInst exit{.opcode = INST_OP_EXIT};
     const InstructionSeq parsed = std::get<InstructionSeq>(
-        unmarshal(RawProgram{"", "", 0, "", {inst1, inst2, exit, exit}, info}, thread_local_options));
+        unmarshal(RawProgram{"", "", 0, "", {inst1, inst2, exit, exit}, info}, ebpf_verifier_options_t{}));
     REQUIRE(parsed.size() == 3);
 }
 
@@ -235,8 +235,8 @@ static void compare_unmarshal_marshal(const EbpfInst& ins, const EbpfInst& expec
                                       const ebpf_platform_t& platform = g_ebpf_platform_linux) {
     ProgramInfo info{.platform = &platform, .type = platform.get_program_type("unspec", "unspec")};
     constexpr EbpfInst exit{.opcode = INST_OP_EXIT};
-    const InstructionSeq inst_seq =
-        std::get<InstructionSeq>(unmarshal(RawProgram{"", "", 0, "", {ins, exit, exit}, info}, thread_local_options));
+    const InstructionSeq inst_seq = std::get<InstructionSeq>(
+        unmarshal(RawProgram{"", "", 0, "", {ins, exit, exit}, info}, ebpf_verifier_options_t{}));
     REQUIRE(inst_seq.size() == 3);
     auto [_, single, _2] = inst_seq.front();
     (void)_;  // unused
@@ -254,7 +254,7 @@ static void compare_unmarshal_marshal(const EbpfInst& ins1, const EbpfInst& ins2
                      .type = g_ebpf_platform_linux.get_program_type("unspec", "unspec")};
     constexpr EbpfInst exit{.opcode = INST_OP_EXIT};
     InstructionSeq parsed = std::get<InstructionSeq>(
-        unmarshal(RawProgram{"", "", 0, "", {ins1, ins2, exit, exit}, info}, thread_local_options));
+        unmarshal(RawProgram{"", "", 0, "", {ins1, ins2, exit, exit}, info}, ebpf_verifier_options_t{}));
     REQUIRE(parsed.size() == 3);
     auto [_, single, _2] = parsed.front();
     (void)_;  // unused
@@ -273,7 +273,7 @@ static void compare_unmarshal_marshal(const EbpfInst& ins1, const EbpfInst& ins2
                      .type = g_ebpf_platform_linux.get_program_type("unspec", "unspec")};
     constexpr EbpfInst exit{.opcode = INST_OP_EXIT};
     const InstructionSeq inst_seq = std::get<InstructionSeq>(
-        unmarshal(RawProgram{"", "", 0, "", {ins1, ins2, exit, exit}, info}, thread_local_options));
+        unmarshal(RawProgram{"", "", 0, "", {ins1, ins2, exit, exit}, info}, ebpf_verifier_options_t{}));
     REQUIRE(inst_seq.size() == 3);
     auto [_, single, _2] = inst_seq.front();
     (void)_;  // unused
@@ -291,8 +291,8 @@ static void compare_unmarshal_marshal(const EbpfInst& ins1, const EbpfInst& ins2
 static void compare_marshal_unmarshal(const Instruction& ins, bool double_cmd = false,
                                       const ebpf_platform_t& platform = g_ebpf_platform_linux) {
     ProgramInfo info{.platform = &platform, .type = platform.get_program_type("unspec", "unspec")};
-    const InstructionSeq inst_seq =
-        std::get<InstructionSeq>(unmarshal(RawProgram{"", "", 0, "", marshal(ins, 0), info}, thread_local_options));
+    const InstructionSeq inst_seq = std::get<InstructionSeq>(
+        unmarshal(RawProgram{"", "", 0, "", marshal(ins, 0), info}, ebpf_verifier_options_t{}));
     REQUIRE(inst_seq.size() == 1);
     auto [_, single, _2] = inst_seq.back();
     (void)_;  // unused
@@ -303,7 +303,7 @@ static void compare_marshal_unmarshal(const Instruction& ins, bool double_cmd = 
 static void check_marshal_unmarshal_fail(const Instruction& ins, const std::string& expected_error_message,
                                          const ebpf_platform_t& platform = g_ebpf_platform_linux) {
     const ProgramInfo info{.platform = &platform, .type = platform.get_program_type("unspec", "unspec")};
-    auto result = unmarshal(RawProgram{"", "", 0, "", marshal(ins, 0), info}, thread_local_options);
+    auto result = unmarshal(RawProgram{"", "", 0, "", marshal(ins, 0), info}, ebpf_verifier_options_t{});
     auto* error_message = std::get_if<std::string>(&result);
     REQUIRE(error_message != nullptr);
     REQUIRE(*error_message == expected_error_message);
@@ -313,7 +313,7 @@ static void check_unmarshal_fail(EbpfInst inst, const std::string& expected_erro
                                  const ebpf_platform_t& platform = g_ebpf_platform_linux) {
     ProgramInfo info{.platform = &platform, .type = platform.get_program_type("unspec", "unspec")};
     std::vector insns = {inst};
-    auto result = unmarshal(RawProgram{"", "", 0, "", insns, info}, thread_local_options);
+    auto result = unmarshal(RawProgram{"", "", 0, "", insns, info}, ebpf_verifier_options_t{});
     auto* error_message = std::get_if<std::string>(&result);
     REQUIRE(error_message != nullptr);
     REQUIRE(*error_message == expected_error_message);
@@ -324,7 +324,7 @@ static void check_unmarshal_fail_goto(EbpfInst inst, const std::string& expected
     ProgramInfo info{.platform = &platform, .type = platform.get_program_type("unspec", "unspec")};
     constexpr EbpfInst exit{.opcode = INST_OP_EXIT};
     std::vector insns{inst, exit, exit};
-    auto result = unmarshal(RawProgram{"", "", 0, "", insns, info}, thread_local_options);
+    auto result = unmarshal(RawProgram{"", "", 0, "", insns, info}, ebpf_verifier_options_t{});
     auto* error_message = std::get_if<std::string>(&result);
     REQUIRE(error_message != nullptr);
     REQUIRE(*error_message == expected_error_message);
@@ -335,7 +335,7 @@ static void check_unmarshal_fail(EbpfInst inst1, EbpfInst inst2, const std::stri
                                  const ebpf_platform_t& platform = g_ebpf_platform_linux) {
     ProgramInfo info{.platform = &platform, .type = platform.get_program_type("unspec", "unspec")};
     std::vector insns{inst1, inst2};
-    auto result = unmarshal(RawProgram{"", "", 0, "", insns, info}, thread_local_options);
+    auto result = unmarshal(RawProgram{"", "", 0, "", insns, info}, ebpf_verifier_options_t{});
     auto* error_message = std::get_if<std::string>(&result);
     REQUIRE(error_message != nullptr);
     REQUIRE(*error_message == expected_error_message);
@@ -343,7 +343,7 @@ static void check_unmarshal_fail(EbpfInst inst1, EbpfInst inst2, const std::stri
 
 static Call unmarshal_single_call(const EbpfInst& call_inst, const ProgramInfo& info) {
     constexpr EbpfInst exit{.opcode = INST_OP_EXIT};
-    const auto parsed = unmarshal(RawProgram{"", "", 0, "", {call_inst, exit, exit}, info}, thread_local_options);
+    const auto parsed = unmarshal(RawProgram{"", "", 0, "", {call_inst, exit, exit}, info}, ebpf_verifier_options_t{});
     auto* inst_seq = std::get_if<InstructionSeq>(&parsed);
     REQUIRE(inst_seq != nullptr);
     REQUIRE(inst_seq->size() == 3);
@@ -940,15 +940,14 @@ TEST_CASE("unmarshal builtin calls only when relocation-gated", "[disasm][marsha
     REQUIRE(has_assertion(assertions, ValidSize{Reg{3}, false}));
     REQUIRE(has_assertion(assertions, ValidAccess{1, Reg{1}, 0, Value{Reg{3}}, false, AccessType::write}));
 }
-#define FAIL_UNMARSHAL(dirname, filename, sectionname)                                                       \
-    TEST_CASE("Try unmarshalling bad program: " dirname "/" filename " " sectionname, "[unmarshal]") {       \
-        thread_local_options = {};                                                                           \
-        ElfObject elf{"ebpf-samples/" dirname "/" filename, {}, &g_ebpf_platform_linux};                     \
-        const auto& raw_progs = elf.get_programs(sectionname);                                               \
-        REQUIRE(raw_progs.size() == 1);                                                                      \
-        const RawProgram& raw_prog = raw_progs.back();                                                       \
-        std::variant<InstructionSeq, std::string> prog_or_error = unmarshal(raw_prog, thread_local_options); \
-        REQUIRE(std::holds_alternative<std::string>(prog_or_error));                                         \
+#define FAIL_UNMARSHAL(dirname, filename, sectionname)                                                 \
+    TEST_CASE("Try unmarshalling bad program: " dirname "/" filename " " sectionname, "[unmarshal]") { \
+        ElfObject elf{"ebpf-samples/" dirname "/" filename, {}, &g_ebpf_platform_linux};               \
+        const auto& raw_progs = elf.get_programs(sectionname);                                         \
+        REQUIRE(raw_progs.size() == 1);                                                                \
+        const RawProgram& raw_prog = raw_progs.back();                                                 \
+        std::variant<InstructionSeq, std::string> prog_or_error = unmarshal(raw_prog, {});             \
+        REQUIRE(std::holds_alternative<std::string>(prog_or_error));                                   \
     }
 
 // Some intentional unmarshal failures
@@ -976,7 +975,7 @@ TEST_CASE("instruction feature handling after unmarshal", "[unmarshal]") {
         auto prog_or_error = unmarshal(raw_prog, {});
         REQUIRE(std::holds_alternative<InstructionSeq>(prog_or_error));
         const Program prog = Program::from_sequence(std::get<InstructionSeq>(prog_or_error), info, {});
-        REQUIRE(verify(prog));
+        REQUIRE(verify(prog, {}));
     }
 
     SECTION("kfunc call in local subprogram does not use helper prototype lookup") {
@@ -990,7 +989,7 @@ TEST_CASE("instruction feature handling after unmarshal", "[unmarshal]") {
         auto prog_or_error = unmarshal(raw_prog, {});
         REQUIRE(std::holds_alternative<InstructionSeq>(prog_or_error));
         const Program prog = Program::from_sequence(std::get<InstructionSeq>(prog_or_error), info, {});
-        REQUIRE(verify(prog));
+        REQUIRE(verify(prog, {}));
     }
 
     SECTION("kfunc in subprogram is not misclassified when BTF id overlaps helper id") {
@@ -1004,7 +1003,7 @@ TEST_CASE("instruction feature handling after unmarshal", "[unmarshal]") {
         auto prog_or_error = unmarshal(raw_prog, {});
         REQUIRE(std::holds_alternative<InstructionSeq>(prog_or_error));
         const Program prog = Program::from_sequence(std::get<InstructionSeq>(prog_or_error), info, {});
-        REQUIRE(verify(prog));
+        REQUIRE(verify(prog, {}));
     }
 
     SECTION("kfunc map-value return is lowered to map-lookup call contract") {
@@ -1022,7 +1021,7 @@ TEST_CASE("instruction feature handling after unmarshal", "[unmarshal]") {
         const auto* call = std::get_if<Call>(&prog.instruction_at(Label{0}));
         REQUIRE(call != nullptr);
         REQUIRE(call->is_map_lookup);
-        REQUIRE(verify(prog));
+        REQUIRE(verify(prog, {}));
     }
 
     SECTION("kfunc with acquire flag is accepted") {
@@ -1063,7 +1062,7 @@ TEST_CASE("instruction feature handling after unmarshal", "[unmarshal]") {
         auto xdp_prog_or_error = unmarshal(xdp_raw_prog, {});
         REQUIRE(std::holds_alternative<InstructionSeq>(xdp_prog_or_error));
         const Program xdp_prog = Program::from_sequence(std::get<InstructionSeq>(xdp_prog_or_error), xdp_info, {});
-        REQUIRE(verify(xdp_prog));
+        REQUIRE(verify(xdp_prog, {}));
     }
 
     SECTION("kfunc privileged gating is enforced") {
@@ -1087,7 +1086,7 @@ TEST_CASE("instruction feature handling after unmarshal", "[unmarshal]") {
         REQUIRE(std::holds_alternative<InstructionSeq>(kprobe_prog_or_error));
         const Program kprobe_prog =
             Program::from_sequence(std::get<InstructionSeq>(kprobe_prog_or_error), kprobe_info, {});
-        REQUIRE(verify(kprobe_prog));
+        REQUIRE(verify(kprobe_prog, {}));
     }
 
     SECTION("kfunc argument typing is enforced from prototype table") {
@@ -1098,7 +1097,7 @@ TEST_CASE("instruction feature handling after unmarshal", "[unmarshal]") {
         auto good_prog_or_error = unmarshal(good_raw_prog, {});
         REQUIRE(std::holds_alternative<InstructionSeq>(good_prog_or_error));
         const Program good_prog = Program::from_sequence(std::get<InstructionSeq>(good_prog_or_error), info, {});
-        REQUIRE(verify(good_prog));
+        REQUIRE(verify(good_prog, {}));
 
         RawProgram bad_raw_prog{"",
                                 "",
@@ -1110,7 +1109,7 @@ TEST_CASE("instruction feature handling after unmarshal", "[unmarshal]") {
         auto bad_prog_or_error = unmarshal(bad_raw_prog, {});
         REQUIRE(std::holds_alternative<InstructionSeq>(bad_prog_or_error));
         const Program bad_prog = Program::from_sequence(std::get<InstructionSeq>(bad_prog_or_error), info, {});
-        REQUIRE_FALSE(verify(bad_prog));
+        REQUIRE_FALSE(verify(bad_prog, {}));
     }
 
     SECTION("kfunc pointer-size argument pairs enforce null and size constraints") {
@@ -1127,7 +1126,7 @@ TEST_CASE("instruction feature handling after unmarshal", "[unmarshal]") {
         auto good_prog_or_error = unmarshal(good_raw_prog, {});
         REQUIRE(std::holds_alternative<InstructionSeq>(good_prog_or_error));
         const Program good_prog = Program::from_sequence(std::get<InstructionSeq>(good_prog_or_error), info, {});
-        REQUIRE(verify(good_prog));
+        REQUIRE(verify(good_prog, {}));
 
         RawProgram bad_size_raw_prog{"",
                                      "",
@@ -1141,7 +1140,7 @@ TEST_CASE("instruction feature handling after unmarshal", "[unmarshal]") {
         REQUIRE(std::holds_alternative<InstructionSeq>(bad_size_prog_or_error));
         const Program bad_size_prog =
             Program::from_sequence(std::get<InstructionSeq>(bad_size_prog_or_error), info, {});
-        REQUIRE_FALSE(verify(bad_size_prog));
+        REQUIRE_FALSE(verify(bad_size_prog, {}));
 
         RawProgram bad_nullability_raw_prog{
             "",
@@ -1155,7 +1154,7 @@ TEST_CASE("instruction feature handling after unmarshal", "[unmarshal]") {
         REQUIRE(std::holds_alternative<InstructionSeq>(bad_nullability_prog_or_error));
         const Program bad_nullability_prog =
             Program::from_sequence(std::get<InstructionSeq>(bad_nullability_prog_or_error), info, {});
-        REQUIRE_FALSE(verify(bad_nullability_prog));
+        REQUIRE_FALSE(verify(bad_nullability_prog, {}));
     }
 
     SECTION("kfunc writable-memory argument pairs enforce writeability and strict size") {
@@ -1175,7 +1174,7 @@ TEST_CASE("instruction feature handling after unmarshal", "[unmarshal]") {
         auto good_prog_or_error = unmarshal(good_raw_prog, {});
         REQUIRE(std::holds_alternative<InstructionSeq>(good_prog_or_error));
         const Program good_prog = Program::from_sequence(std::get<InstructionSeq>(good_prog_or_error), info, {});
-        REQUIRE(verify(good_prog));
+        REQUIRE(verify(good_prog, {}));
 
         RawProgram bad_nullability_raw_prog{
             "",
@@ -1189,7 +1188,7 @@ TEST_CASE("instruction feature handling after unmarshal", "[unmarshal]") {
         REQUIRE(std::holds_alternative<InstructionSeq>(bad_nullability_prog_or_error));
         const Program bad_nullability_prog =
             Program::from_sequence(std::get<InstructionSeq>(bad_nullability_prog_or_error), info, {});
-        REQUIRE_FALSE(verify(bad_nullability_prog));
+        REQUIRE_FALSE(verify(bad_nullability_prog, {}));
 
         RawProgram bad_size_raw_prog{"",
                                      "",
@@ -1204,7 +1203,7 @@ TEST_CASE("instruction feature handling after unmarshal", "[unmarshal]") {
         REQUIRE(std::holds_alternative<InstructionSeq>(bad_size_prog_or_error));
         const Program bad_size_prog =
             Program::from_sequence(std::get<InstructionSeq>(bad_size_prog_or_error), info, {});
-        REQUIRE_FALSE(verify(bad_size_prog));
+        REQUIRE_FALSE(verify(bad_size_prog, {}));
     }
 
     SECTION("lddw variable_addr pseudo") {
@@ -1336,7 +1335,7 @@ TEST_CASE("instruction feature handling after unmarshal", "[unmarshal]") {
         auto good_prog_or_error = unmarshal(good_raw_prog, {});
         REQUIRE(std::holds_alternative<InstructionSeq>(good_prog_or_error));
         const Program good_prog = Program::from_sequence(std::get<InstructionSeq>(good_prog_or_error), info, {});
-        REQUIRE(verify(good_prog));
+        REQUIRE(verify(good_prog, {}));
 
         RawProgram bad_raw_prog{
             "",
@@ -1350,7 +1349,7 @@ TEST_CASE("instruction feature handling after unmarshal", "[unmarshal]") {
         auto bad_prog_or_error = unmarshal(bad_raw_prog, {});
         REQUIRE(std::holds_alternative<InstructionSeq>(bad_prog_or_error));
         const Program bad_prog = Program::from_sequence(std::get<InstructionSeq>(bad_prog_or_error), info, {});
-        REQUIRE_FALSE(verify(bad_prog));
+        REQUIRE_FALSE(verify(bad_prog, {}));
     }
 
     SECTION("ptr_to_func callback target must be a valid instruction label") {
@@ -1368,7 +1367,7 @@ TEST_CASE("instruction feature handling after unmarshal", "[unmarshal]") {
         auto good_prog_or_error = unmarshal(good_raw_prog, {});
         REQUIRE(std::holds_alternative<InstructionSeq>(good_prog_or_error));
         const Program good_prog = Program::from_sequence(std::get<InstructionSeq>(good_prog_or_error), info, {});
-        REQUIRE(verify(good_prog));
+        REQUIRE(verify(good_prog, {}));
 
         RawProgram bad_raw_prog{
             "",
@@ -1383,7 +1382,7 @@ TEST_CASE("instruction feature handling after unmarshal", "[unmarshal]") {
         auto bad_prog_or_error = unmarshal(bad_raw_prog, {});
         REQUIRE(std::holds_alternative<InstructionSeq>(bad_prog_or_error));
         const Program bad_prog = Program::from_sequence(std::get<InstructionSeq>(bad_prog_or_error), info, {});
-        REQUIRE_FALSE(verify(bad_prog));
+        REQUIRE_FALSE(verify(bad_prog, {}));
     }
 
     SECTION("ptr_to_func callback target must have reachable exit") {
@@ -1401,7 +1400,7 @@ TEST_CASE("instruction feature handling after unmarshal", "[unmarshal]") {
         auto bad_prog_or_error = unmarshal(bad_raw_prog, {});
         REQUIRE(std::holds_alternative<InstructionSeq>(bad_prog_or_error));
         const Program bad_prog = Program::from_sequence(std::get<InstructionSeq>(bad_prog_or_error), info, {});
-        REQUIRE_FALSE(verify(bad_prog));
+        REQUIRE_FALSE(verify(bad_prog, {}));
     }
 
     SECTION("helper id not usable on platform") {

--- a/src/test/test_print.cpp
+++ b/src/test/test_print.cpp
@@ -35,7 +35,7 @@ void verify_printed_string(const std::string& file) {
     ElfObject elf{std::string(TEST_OBJECT_FILE_DIRECTORY) + file + ".o", {}, &g_ebpf_platform_linux};
     const auto& raw_progs = elf.get_programs();
     const RawProgram& raw_prog = raw_progs.back();
-    std::variant<InstructionSeq, std::string> prog_or_error = unmarshal(raw_prog, thread_local_options);
+    std::variant<InstructionSeq, std::string> prog_or_error = unmarshal(raw_prog, {});
     auto program = std::get_if<InstructionSeq>(&prog_or_error);
     REQUIRE(program != nullptr);
     print(*program, generated_output, {});

--- a/src/test/test_verify.hpp
+++ b/src/test/test_verify.hpp
@@ -162,45 +162,45 @@ struct BoundedTestName {
     TEST_CASE(PREVAIL_BOUNDED_NAME.data, tags)
 
 // Verify a program in a section that may have multiple programs in it.
-#define VERIFY_PROGRAM(dirname, filename, section_name, program_name, _options, platform, should_pass, count)     \
-    do {                                                                                                          \
-        prevail::thread_local_options = _options;                                                                 \
-        auto raw_progs = verify_test::read_elf_cached("ebpf-samples/" dirname "/" filename, section_name, "",     \
-                                                      prevail::thread_local_options, platform);                   \
-        REQUIRE(raw_progs.size() == count);                                                                       \
-        bool matched_program = false;                                                                             \
-        for (auto& raw_prog : raw_progs) {                                                                        \
-            if (count == 1 || raw_prog.function_name == program_name) {                                           \
-                matched_program = true;                                                                           \
-                INFO("function_name=" << raw_prog.function_name);                                                 \
-                if (should_pass) {                                                                                \
-                    const auto prog_or_error = prevail::unmarshal(raw_prog, prevail::thread_local_options);       \
-                    const auto inst_seq = std::get_if<prevail::InstructionSeq>(&prog_or_error);                   \
-                    REQUIRE(inst_seq);                                                                            \
-                    const prevail::Program prog =                                                                 \
-                        prevail::Program::from_sequence(*inst_seq, raw_prog.info, prevail::thread_local_options); \
-                    REQUIRE(prevail::verify(prog) == true);                                                       \
-                } else {                                                                                          \
-                    bool rejected = false;                                                                        \
-                    try {                                                                                         \
-                        const auto prog_or_error = prevail::unmarshal(raw_prog, prevail::thread_local_options);   \
-                        const auto inst_seq = std::get_if<prevail::InstructionSeq>(&prog_or_error);               \
-                        if (!inst_seq) {                                                                          \
-                            rejected = true;                                                                      \
-                        } else {                                                                                  \
-                            const prevail::Program prog = prevail::Program::from_sequence(                        \
-                                *inst_seq, raw_prog.info, prevail::thread_local_options);                         \
-                            rejected = (prevail::verify(prog) == false);                                          \
-                        }                                                                                         \
-                    } catch (const std::runtime_error& ex) {                                                      \
-                        INFO("rejected_by_exception=" << ex.what());                                              \
-                        rejected = true;                                                                          \
-                    }                                                                                             \
-                    REQUIRE(rejected);                                                                            \
-                }                                                                                                 \
-            }                                                                                                     \
-        }                                                                                                         \
-        REQUIRE(matched_program);                                                                                 \
+#define VERIFY_PROGRAM(dirname, filename, section_name, program_name, _options, platform, should_pass, count) \
+    do {                                                                                                      \
+        const prevail::ebpf_verifier_options_t _prevail_opts = _options;                                      \
+        auto raw_progs = verify_test::read_elf_cached("ebpf-samples/" dirname "/" filename, section_name, "", \
+                                                      _prevail_opts, platform);                               \
+        REQUIRE(raw_progs.size() == count);                                                                   \
+        bool matched_program = false;                                                                         \
+        for (auto& raw_prog : raw_progs) {                                                                    \
+            if (count == 1 || raw_prog.function_name == program_name) {                                       \
+                matched_program = true;                                                                       \
+                INFO("function_name=" << raw_prog.function_name);                                             \
+                if (should_pass) {                                                                            \
+                    const auto prog_or_error = prevail::unmarshal(raw_prog, _prevail_opts);                   \
+                    const auto inst_seq = std::get_if<prevail::InstructionSeq>(&prog_or_error);               \
+                    REQUIRE(inst_seq);                                                                        \
+                    const prevail::Program prog =                                                             \
+                        prevail::Program::from_sequence(*inst_seq, raw_prog.info, _prevail_opts);             \
+                    REQUIRE(prevail::verify(prog, _prevail_opts) == true);                                    \
+                } else {                                                                                      \
+                    bool rejected = false;                                                                    \
+                    try {                                                                                     \
+                        const auto prog_or_error = prevail::unmarshal(raw_prog, _prevail_opts);               \
+                        const auto inst_seq = std::get_if<prevail::InstructionSeq>(&prog_or_error);           \
+                        if (!inst_seq) {                                                                      \
+                            rejected = true;                                                                  \
+                        } else {                                                                              \
+                            const prevail::Program prog =                                                     \
+                                prevail::Program::from_sequence(*inst_seq, raw_prog.info, _prevail_opts);     \
+                            rejected = (prevail::verify(prog, _prevail_opts) == false);                       \
+                        }                                                                                     \
+                    } catch (const std::runtime_error& ex) {                                                  \
+                        INFO("rejected_by_exception=" << ex.what());                                          \
+                        rejected = true;                                                                      \
+                    }                                                                                         \
+                    REQUIRE(rejected);                                                                        \
+                }                                                                                             \
+            }                                                                                                 \
+        }                                                                                                     \
+        REQUIRE(matched_program);                                                                             \
     } while (0)
 
 // Verify a section with only one program in it.

--- a/src/test/test_verify_multithreading.cpp
+++ b/src/test/test_verify_multithreading.cpp
@@ -5,7 +5,7 @@
 
 static void test_analyze_thread(const prevail::Program* prog, bool* res) {
     try {
-        *res = prevail::verify(*prog);
+        *res = prevail::verify(*prog, {});
     } catch (...) {
         *res = false;
     }

--- a/src/verifier.hpp
+++ b/src/verifier.hpp
@@ -13,22 +13,12 @@ namespace prevail {
 AnalysisResult analyze(const Program& prog, const ebpf_verifier_options_t& options);
 AnalysisResult analyze(const Program& prog, const StringInvariant& entry_invariant,
                        const ebpf_verifier_options_t& options);
-AnalysisResult analyze(const Program& prog);
-AnalysisResult analyze(const Program& prog, const StringInvariant& entry_invariant);
 AnalysisResult analyze(const Program& prog, const AnalysisContext& context);
 AnalysisResult analyze(const Program& prog, const StringInvariant& entry_invariant, const AnalysisContext& context);
 void ebpf_verifier_clear_thread_local_state();
 inline bool verify(const Program& prog, const ebpf_verifier_options_t& options) {
     try {
         return !analyze(prog, options).failed;
-    } catch (const std::exception&) {
-        ebpf_verifier_clear_thread_local_state();
-        return false;
-    }
-}
-inline bool verify(const Program& prog) {
-    try {
-        return !analyze(prog).failed;
     } catch (const std::exception&) {
         ebpf_verifier_clear_thread_local_state();
         return false;


### PR DESCRIPTION
## Summary

- Thread `big_endian` and `total_stack_size` through ArrayDomain methods (`load`, `store`, `havoc`, `split_cell`, `split_number_var`) instead of reading `thread_local_options`. Derive `total_stack_size` from ArrayDomain's own `BitsetDomain::size()`
- Add `analyze(prog, options)` and `verify(prog, options)` overloads; remove the no-options shims that read `thread_local_options`
- Pass `print_line_info` explicitly through all print functions (`print_program`, `print_invariants`, `print_error`, `print_invariants_filtered`, `print_failure_slices`)
- Remove `thread_local_options` variable, extern declaration, and all test harness assignments
- Replace test macro `thread_local_options` usage with local variables or default `{}`

Continues #1091. Together with that PR, this eliminates all semantic thread-local state from the verifier. The only remaining thread-locals are domain-internal caches (`thread_local_array_map`, `SplitDBM::scratch_`) that are per-analysis scratch space, not semantic inputs.

Closes #1077.

## Test plan

- [x] Full test suite passes with seed 2276513626
- [x] Codex review clean (one finding about `print_failure_slices` not forwarding `print_line_info` — fixed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)