### PR TITLE
Fix EbpfDomain::to_set() returning top instead of bottom

### DIFF
--- a/src/crab/ebpf_domain.cpp
+++ b/src/crab/ebpf_domain.cpp
@@ -20,11 +20,7 @@ namespace prevail {
 
 StringInvariant EbpfDomain::to_set() const {
     if (!stack) {
-        // BUG: bottom should serialize as bottom ("_|_"), but several YAML
-        // tests encode the wrong answer (top) in their `post: []` expectations.
-        // Returning top here matches those expectations. Fix by returning
-        // bottom and updating the YAML tests in the same change.
-        return StringInvariant::top();
+        return StringInvariant::bottom();
     }
     return state.to_set() + stack->to_set();
 }

--- a/test-data/assign.yaml
+++ b/test-data/assign.yaml
@@ -181,7 +181,8 @@ code:
   <start>: |
     w2 = r10
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "0: Invalid type (r10.type == number)"
@@ -212,7 +213,8 @@ code:
   <start>: |
     w2 = r1
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "0: Invalid type (r1.type == number)"
@@ -309,7 +311,8 @@ code:
   <start>: |
     w1 = r2
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "0: Invalid type (r2.type == number)"
@@ -340,7 +343,8 @@ code:
   <start>: |
     w2 = r1
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "0: Invalid type (r1.type == number)"
@@ -369,7 +373,8 @@ code:
   <start>: |
     w2 = r1
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "0: Invalid type (r1.type == number)"
@@ -398,7 +403,8 @@ code:
   <start>: |
     w2 = r1
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "0: Invalid type (r1.type == number)"

--- a/test-data/atomic.yaml
+++ b/test-data/atomic.yaml
@@ -254,7 +254,8 @@ code:
   <start>: |
     lock *(u32 *)(r2 + 4) += r1
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "0: Upper bound must be at most r2.shared_region_size (valid_access(r2.offset+4, width=4) for write)"
@@ -592,7 +593,8 @@ code:
   <start>: |
     lock *(u32 *)(r2 + 4) += r1
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "0: Invalid type (r2.type in {ctx, stack, packet, shared})"
@@ -607,7 +609,8 @@ code:
   <start>: |
     lock *(u64 *)(r2 + 4) cx= r1
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "0: Invalid type (r1.type == number)"

--- a/test-data/call.yaml
+++ b/test-data/call.yaml
@@ -63,7 +63,8 @@ code:
   <start>: |
     call 1; bpf_map_lookup_elem
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "0: Possible null access (within(r2:key_size(r1)))"
@@ -78,7 +79,8 @@ code:
   <start>: |
     call 1; bpf_map_lookup_elem
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "0: Upper bound must be at most r2.shared_region_size (within(r2:key_size(r1)))"
@@ -92,7 +94,8 @@ code:
   <start>: |
     call 1; bpf_map_lookup_elem
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "0: Lower bound must be at least 0 (within(r2:key_size(r1)))"
@@ -106,7 +109,8 @@ code:
   <start>: |
     call 1; bpf_map_lookup_elem
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "0: Illegal map update with a non-numerical value [-oo-oo) (within(r2:key_size(r1)))"
@@ -157,7 +161,8 @@ code:
   <start>: |
     call 2; bpf_map_update_elem
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "0: Upper bound must be at most r3.shared_region_size (within(r3:value_size(r1)))"
@@ -192,7 +197,8 @@ code:
   <start>: |
     call 2; bpf_map_update_elem
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "0: Possible null access (within(r3:value_size(r1)))"
@@ -230,7 +236,8 @@ code:
   <start>: |
     call 2; bpf_map_update_elem
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "0: Illegal map update with a non-numerical value [496-500) (within(r3:value_size(r1)))"
@@ -247,7 +254,8 @@ code:
   <start>: |
     call 2; bpf_map_update_elem
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "0: Invalid type (r3.type in {stack, packet, shared})"
@@ -283,7 +291,8 @@ code:
   <start>: |
     call 130; bpf_ringbuf_output
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "0: Stack content is not numeric (valid_access(r2.offset, width=r3) for read)"
@@ -300,7 +309,8 @@ code:
   <start>: |
     call 130; bpf_ringbuf_output
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "0: Invalid type (r2.type in {stack, packet, shared})"
@@ -334,7 +344,8 @@ code:
   <start>: |
     call 67; bpf_get_stack
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "0: Invalid type (r2.type in {stack, packet, shared})"
@@ -363,7 +374,8 @@ code:
   <start>: |
     call 6; bpf_trace_printk
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "0: Invalid size (r2.value > 0)"

--- a/test-data/callx.yaml
+++ b/test-data/callx.yaml
@@ -76,7 +76,8 @@ code:
   <start>: |
     callx r8; bpf_map_lookup_elem
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "0: Possible null access (within(r2:key_size(r1)))"
@@ -92,7 +93,8 @@ code:
     callx r8; bpf_map_lookup_elem
 
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "0: Upper bound must be at most r2.shared_region_size (within(r2:key_size(r1)))"
@@ -108,7 +110,8 @@ code:
     callx r8; bpf_map_lookup_elem
 
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "0: Lower bound must be at least 0 (within(r2:key_size(r1)))"
@@ -122,7 +125,8 @@ code:
     callx r8
 
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "0: invalid helper function id 1000 (r8.type is helper)"
@@ -136,7 +140,8 @@ code:
     callx r8
 
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "0: invalid helper function id 1000 (r8.type is helper)"
@@ -149,7 +154,8 @@ code:
   <start>: |
     callx r8; bpf_map_lookup_elem
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "0: callx helper function id is not a valid singleton (r8.type is helper)"
@@ -165,7 +171,8 @@ code:
     callx r8; bpf_map_lookup_elem
 
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "0: Illegal map update with a non-numerical value [-oo-oo) (within(r2:key_size(r1)))"
@@ -229,7 +236,8 @@ code:
     callx r8; bpf_map_update_elem
 
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "0: Upper bound must be at most r3.shared_region_size (within(r3:value_size(r1)))"
@@ -270,7 +278,8 @@ code:
     callx r8; bpf_map_update_elem
 
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "0: Possible null access (within(r3:value_size(r1)))"
@@ -313,7 +322,8 @@ code:
     callx r8; bpf_map_update_elem
 
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "0: Illegal map update with a non-numerical value [496-500) (within(r3:value_size(r1)))"
@@ -332,7 +342,8 @@ code:
     callx r8; bpf_map_update_elem
 
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "0: Invalid type (r3.type in {stack, packet, shared})"
@@ -374,7 +385,8 @@ code:
     callx r8; bpf_ringbuf_output
 
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "0: Stack content is not numeric (valid_access(r2.offset, width=r3) for read)"
@@ -392,7 +404,8 @@ code:
   <start>: |
     callx r8; bpf_ringbuf_output
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "0: Invalid type (r2.type in {stack, packet, shared})"
@@ -432,7 +445,8 @@ code:
     callx r8; bpf_get_stack
 
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "0: Invalid type (r2.type in {stack, packet, shared})"

--- a/test-data/jump.yaml
+++ b/test-data/jump.yaml
@@ -116,7 +116,8 @@ code:
   <start>: |
     assume w1 == 13
 
-post: []
+post:
+  - "_|_"
 messages:
   - "0: Code becomes unreachable (assume r1 w== 13)"
 ---
@@ -330,7 +331,8 @@ code:
     r3 -= r1; trigger same_type(r2, r1)
 
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "8: Cannot subtract pointers to different regions (r1.type == number or r3.type == r1.type in {ctx, stack, packet})"
@@ -397,7 +399,8 @@ code:
     r3 = r1
     r3 += r2; the domain does not currently store inequalities so we can't yet tell that this is safe
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "8: Only numbers can be added to pointers (r2.type in {ctx, stack, packet, shared} -> r3.type == number)"
@@ -576,7 +579,8 @@ code:
   <start>: |
     assume r1 != r1
 
-post: []
+post:
+  - "_|_"
 messages:
   - "0: Code becomes unreachable (assume r1 != r1)"
 ---
@@ -614,7 +618,8 @@ code:
   <start>: |
     assume r1 < r2
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "0: Invalid type (r1.type in {number, ctx, stack, packet, shared})"
@@ -660,7 +665,8 @@ code:
   <exit>: |
     exit
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "0:1: Code becomes unreachable (assume r1 == 0)"
@@ -681,7 +687,8 @@ code:
   <exit>: |
     exit
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "2: Invalid type (r0.type == number)"
@@ -701,7 +708,8 @@ code:
   <exit>: |
     exit
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "2: Invalid type (r0.type == number)"
@@ -775,7 +783,8 @@ code:
   <exit>: |
     exit
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "0:1: Code becomes unreachable (assume r1 <= 0)"
@@ -796,7 +805,8 @@ code:
   <exit>: |
     exit
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "0:1: Code becomes unreachable (assume r1 < 0)"
@@ -817,7 +827,8 @@ code:
   <exit>: |
     exit
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "0: Invalid type (r1.type == number)"
@@ -837,7 +848,8 @@ code:
   <exit>: |
     exit
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "0: Invalid type (r1.type == number)"
@@ -857,7 +869,8 @@ code:
   <exit>: |
     exit
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "0: Invalid type (r1.type == number)"
@@ -877,7 +890,8 @@ code:
   <exit>: |
     exit
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "0: Invalid type (r1.type == number)"
@@ -897,7 +911,8 @@ code:
   <exit>: |
     exit
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "0: Invalid type (r1.type == number)"
@@ -917,7 +932,8 @@ code:
   <exit>: |
     exit
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "0: Invalid type (r1.type == number)"
@@ -937,7 +953,8 @@ code:
   <exit>: |
     exit
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "0: Invalid type (r1.type == number)"
@@ -957,7 +974,8 @@ code:
   <exit>: |
     exit
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "0: Invalid type (r1.type == number)"
@@ -977,7 +995,8 @@ code:
   <exit>: |
     exit
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "0: Invalid type (r1.type == number)"
@@ -997,7 +1016,8 @@ code:
   <exit>: |
     exit
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "0: Invalid type (r1.type == number)"
@@ -1017,7 +1037,8 @@ code:
   <exit>: |
     exit
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "0: Invalid type (r1.type == number)"
@@ -1037,7 +1058,8 @@ code:
   <exit>: |
     exit
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "0: Invalid type (r1.type == number)"
@@ -1057,7 +1079,8 @@ code:
   <exit>: |
     exit
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "0: Invalid type (r1.type == number)"
@@ -1077,7 +1100,8 @@ code:
   <exit>: |
     exit
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "0: Invalid type (r1.type == number)"
@@ -1097,7 +1121,8 @@ code:
   <exit>: |
     exit
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "0: Invalid type (r1.type == number)"
@@ -1117,7 +1142,8 @@ code:
   <exit>: |
     exit
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "0: Invalid type (r1.type == number)"
@@ -1150,7 +1176,8 @@ code:
   <start>: |
     assume r1 != r2
 
-post: []
+post:
+  - "_|_"
 messages:
   - "0: Lower bound must be at least meta_offset (valid_access(r1.offset) for comparison/subtraction)"
 ---
@@ -1162,6 +1189,7 @@ code:
   <start>: |
     assume r1 < r2
 
-post: []
+post:
+  - "_|_"
 messages:
   - "0: Lower bound must be at least r10.stack_offset - subprogram_stack_size (valid_access(r1.offset) for comparison/subtraction)"

--- a/test-data/loop.yaml
+++ b/test-data/loop.yaml
@@ -239,7 +239,8 @@ code:
     if r0 < 1 goto <start>
     exit
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "1:2: Code becomes unreachable (assume r0 >= 1)"
@@ -256,7 +257,8 @@ code:
     if r0 <= 1 goto <start>
     exit
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "1:2: Code becomes unreachable (assume r0 > 1)"
@@ -274,7 +276,8 @@ code:
     if r0 == 0 goto <start>
     exit
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "1:2: Code becomes unreachable (assume r0 != 0)"
@@ -292,7 +295,8 @@ code:
     if r0 > 0 goto <start>
     exit
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "1:2: Code becomes unreachable (assume r0 <= 0)"
@@ -310,7 +314,8 @@ code:
     if r0 >= 0 goto <start>
     exit
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "1:2: Code becomes unreachable (assume r0 < 0)"
@@ -327,7 +332,8 @@ code:
   <loop1>: |
     if r0 < 2 goto <start>
     exit
-post: []
+post:
+  - "_|_"
 messages:
   - "1:2: Code becomes unreachable (assume r0 <= 0)"
   - "3:4: Code becomes unreachable (assume r0 >= 2)"
@@ -414,7 +420,8 @@ code:
   <out>: |
     exit
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "1:3: Code becomes unreachable (assume r0 > 10)"

--- a/test-data/movsx.yaml
+++ b/test-data/movsx.yaml
@@ -89,7 +89,8 @@ code:
   <start>: |
     r2 s32= r1
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "0: Invalid type (r1.type == number)"

--- a/test-data/packet.yaml
+++ b/test-data/packet.yaml
@@ -41,7 +41,8 @@ code:
     r4 = 0
     *(u64 *)(r1 + 0) = r4
 
-post: []
+post:
+  - "_|_"
 messages:
   - "1: Upper bound must be at most packet_size (valid_access(r1.offset, width=8) for write)"
 
@@ -56,7 +57,8 @@ code:
   <start>: |
     r4 = *(u64 *)(r1 + 0)
 
-post: []
+post:
+  - "_|_"
 messages:
   - "0: Upper bound must be at most packet_size (valid_access(r1.offset, width=8) for read)"
 
@@ -222,7 +224,8 @@ code:
   <start>: |
     r2 = *(u64 *)(r1 - 8)
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "0: Lower bound must be at least meta_offset (valid_access(r1.offset-8, width=8) for read)"
@@ -236,7 +239,8 @@ code:
   <start>: |
     r2 = *(u64 *)(r1 + 8)
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "0: Upper bound must be at most packet_size (valid_access(r1.offset+8, width=8) for read)"
@@ -269,6 +273,7 @@ code:
     assume r3 s<= r1;
     r0 = *(u8 *)(r2 + 100);
 
-post: []
+post:
+  - "_|_"
 messages:
   - "3: Upper bound must be at most packet_size (valid_access(r2.offset+100, width=1) for read)"

--- a/test-data/pointer.yaml
+++ b/test-data/pointer.yaml
@@ -16,7 +16,8 @@ code:
     w1 += 0
     r2 = *(u32 *)(r1 + 0)
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "1: Invalid type (r1.type in {ctx, stack, packet, shared})"
@@ -37,7 +38,8 @@ code:
     w1 -= 0
     r2 = *(u32 *)(r1 + 0)
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "1: Invalid type (r1.type in {ctx, stack, packet, shared})"
@@ -58,7 +60,8 @@ code:
     w1 *= 1
     r2 = *(u32 *)(r1 + 0)
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "0: Invalid type (r1.type == number)"
@@ -79,7 +82,8 @@ code:
     w1 /= 1
     r2 = *(u32 *)(r1 + 0)
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "0: Invalid type (r1.type == number)"
@@ -100,7 +104,8 @@ code:
     w1 %= 0
     r2 = *(u32 *)(r1 + 0)
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "0: Invalid type (r1.type == number)"
@@ -120,7 +125,8 @@ code:
     w1 s/= 1
     r2 = *(u32 *)(r1 + 0)
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "0: Invalid type (r1.type == number)"
@@ -141,7 +147,8 @@ code:
     w1 s%= 0
     r2 = *(u32 *)(r1 + 0)
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "0: Invalid type (r1.type == number)"
@@ -162,7 +169,8 @@ code:
     w1 &= -1
     r2 = *(u32 *)(r1 + 0)
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "0: Invalid type (r1.type == number)"
@@ -183,7 +191,8 @@ code:
     w1 |= 0
     r2 = *(u32 *)(r1 + 0)
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "0: Invalid type (r1.type == number)"
@@ -204,7 +213,8 @@ code:
     w1 ^= 0
     r2 = *(u32 *)(r1 + 0)
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "0: Invalid type (r1.type == number)"
@@ -225,7 +235,8 @@ code:
     w1 <<= 0
     r2 = *(u32 *)(r1 + 0)
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "0: Invalid type (r1.type == number)"
@@ -246,7 +257,8 @@ code:
     w1 >>= 0
     r2 = *(u32 *)(r1 + 0)
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "0: Invalid type (r1.type == number)"
@@ -267,7 +279,8 @@ code:
     w1 s>>= 0
     r2 = *(u32 *)(r1 + 0)
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "0: Invalid type (r1.type == number)"
@@ -289,7 +302,8 @@ code:
     w1 = - w1
     r2 = *(u32 *)(r1 + 0)
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "0: Invalid type (r1.type == number)"
@@ -312,7 +326,8 @@ code:
     r0 = r1
     exit
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "1: Invalid type (r0.type == number)"
@@ -335,7 +350,8 @@ code:
   <start>: |
     w0 = w1
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "0: Invalid type (r1.type == number)"

--- a/test-data/sdivmod.yaml
+++ b/test-data/sdivmod.yaml
@@ -10,7 +10,8 @@ code:
   <start>: |
     r1 s/= r2
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "0: Only numbers can be used as divisors (r2 != 0)"
@@ -52,7 +53,8 @@ code:
   <start>: |
     r1 s/= r2
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "0: Possible division by zero (r2 != 0)"
@@ -85,7 +87,8 @@ code:
   <start>: |
     r1 s/= r2
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "0: Possible division by zero (r2 != 0)"
@@ -101,7 +104,8 @@ code:
   <start>: |
     r1 s/= r2  ; this could divide by 0
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "0: Possible division by zero (r2 != 0)"
@@ -117,7 +121,8 @@ code:
   <start>: |
     r1 s/= r2 ; this could divide by 0 but ok to set to 0
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "0: Possible division by zero (r2 != 0)"
@@ -133,7 +138,8 @@ code:
   <start>: |
     r1 s/= r2  ; this could divide by 0
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "0: Possible division by zero (r2 != 0)"
@@ -149,7 +155,8 @@ code:
   <start>: |
     r1 s/= r2 ; this could divide by 0 but ok to set to 0
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "0: Possible division by zero (r2 != 0)"
@@ -165,7 +172,8 @@ code:
   <start>: |
     r1 s/= r2  ; this could divide by 0
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "0: Possible division by zero (r2 != 0)"
@@ -181,7 +189,8 @@ code:
   <start>: |
     r1 s/= r2  ; this could divide by 0
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "0: Possible division by zero (r2 != 0)"
@@ -237,7 +246,8 @@ code:
   <start>: |
     r1 s%= r2
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "0: Possible division by zero (r2 != 0)"
@@ -270,7 +280,8 @@ code:
   <start>: |
     r1 s%= r2
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "0: Possible division by zero (r2 != 0)"
@@ -286,7 +297,8 @@ code:
   <start>: |
     r1 s%= r2 ; this could do modulo 0 so could set r1 = r2
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "0: Possible division by zero (r2 != 0)"
@@ -302,7 +314,8 @@ code:
   <start>: |
     r1 s%= r2 ; this could do modulo 0 so could set r1 = r2
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "0: Possible division by zero (r2 != 0)"
@@ -318,7 +331,8 @@ code:
   <start>: |
     r1 s%= r2 ; this could do modulo 0 so could set r1 = r2
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "0: Possible division by zero (r2 != 0)"
@@ -334,7 +348,8 @@ code:
   <start>: |
     r1 s%= r2 ; this could do modulo 0 so could set r1 = r2
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "0: Possible division by zero (r2 != 0)"
@@ -350,7 +365,8 @@ code:
   <start>: |
     r1 s%= r2  ; this could be modulo 0
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "0: Possible division by zero (r2 != 0)"
@@ -366,7 +382,8 @@ code:
   <start>: |
     r1 s%= r2  ; this could be modulo 0
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "0: Possible division by zero (r2 != 0)"

--- a/test-data/stack.yaml
+++ b/test-data/stack.yaml
@@ -636,7 +636,8 @@ code:
     r0 = 0
     exit
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "0: Lower bound must be at least r10.stack_offset - subprogram_stack_size (valid_access(r10.offset-513, width=1) for write)"
@@ -836,7 +837,8 @@ code:
     r3 = *(u64 *)(r2 + 0)      ; read 8 bytes - should FAIL (only 4 guaranteed)
     exit
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "4: Stack content is not numeric (valid_access(r2.offset, width=8) for read)"

--- a/test-data/subtract.yaml
+++ b/test-data/subtract.yaml
@@ -67,7 +67,8 @@ code:
   <start>: |
     r3 -= r2
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "0: Cannot subtract pointers to non-singleton regions (r2.type == number or r3.type == r2.type in {ctx, stack, packet})"
@@ -81,7 +82,8 @@ code:
   <start>: |
     r3 -= r2
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "0: Cannot subtract pointers to different regions (r2.type == number or r3.type == r2.type in {ctx, stack, packet})"
@@ -138,7 +140,8 @@ code:
   <start>: |
     r1 -= r2
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "0: Upper bound must be at most total_stack_size (r2.type == number or r1.type == r2.type in {ctx, stack, packet})"

--- a/test-data/udivmod.yaml
+++ b/test-data/udivmod.yaml
@@ -10,7 +10,8 @@ code:
   <start>: |
     r1 /= r2
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "0: Only numbers can be used as divisors (r2 != 0)"
@@ -52,7 +53,8 @@ code:
   <start>: |
     r1 /= r2
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "0: Possible division by zero (r2 != 0)"
@@ -85,7 +87,8 @@ code:
   <start>: |
     r1 /= r2
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "0: Possible division by zero (r2 != 0)"
@@ -101,7 +104,8 @@ code:
   <start>: |
     r1 /= r2  ; this could divide by 0
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "0: Possible division by zero (r2 != 0)"
@@ -117,7 +121,8 @@ code:
   <start>: |
     r1 /= r2 ; this could divide by 0 but ok to set to 0
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "0: Possible division by zero (r2 != 0)"
@@ -133,7 +138,8 @@ code:
   <start>: |
     r1 /= r2  ; this could divide by 0
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "0: Possible division by zero (r2 != 0)"
@@ -149,7 +155,8 @@ code:
   <start>: |
     r1 /= r2 ; this could divide by 0 but ok to set to 0
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "0: Possible division by zero (r2 != 0)"
@@ -165,7 +172,8 @@ code:
   <start>: |
     r1 /= r2  ; this could divide by 0
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "0: Possible division by zero (r2 != 0)"
@@ -181,7 +189,8 @@ code:
   <start>: |
     r1 /= r2  ; this could divide by 0
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "0: Possible division by zero (r2 != 0)"
@@ -237,7 +246,8 @@ code:
   <start>: |
     r1 %= r2
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "0: Possible division by zero (r2 != 0)"
@@ -270,7 +280,8 @@ code:
   <start>: |
     r1 %= r2
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "0: Possible division by zero (r2 != 0)"
@@ -286,7 +297,8 @@ code:
   <start>: |
     r1 %= r2 ; this could do modulo 0 so could set r1 = r2
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "0: Possible division by zero (r2 != 0)"
@@ -302,7 +314,8 @@ code:
   <start>: |
     r1 %= r2 ; this could do modulo 0 so could set r1 = r2
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "0: Possible division by zero (r2 != 0)"
@@ -318,7 +331,8 @@ code:
   <start>: |
     r1 %= r2 ; this could do modulo 0 so could set r1 = r2
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "0: Possible division by zero (r2 != 0)"
@@ -334,7 +348,8 @@ code:
   <start>: |
     r1 %= r2 ; this could do modulo 0 so could set r1 = r2
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "0: Possible division by zero (r2 != 0)"
@@ -350,7 +365,8 @@ code:
   <start>: |
     r1 %= r2  ; this could be modulo 0
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "0: Possible division by zero (r2 != 0)"
@@ -366,7 +382,8 @@ code:
   <start>: |
     r1 %= r2  ; this could be modulo 0
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "0: Possible division by zero (r2 != 0)"

--- a/test-data/uninit.yaml
+++ b/test-data/uninit.yaml
@@ -12,7 +12,8 @@ code:
   <start>: |
     r0 += r3
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "0: Invalid type (r3.type in {number, ctx, stack, packet, shared})"
@@ -29,7 +30,8 @@ code:
   <start>: |
     r0 -= r3
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "0: Cannot subtract pointers to different regions (r3.type == number or r0.type == r3.type in {ctx, stack, packet})"
@@ -46,7 +48,8 @@ code:
   <start>: |
     r0 *= r3
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "0: Invalid type (r3.type == number)"
@@ -63,7 +66,8 @@ code:
   <start>: |
     r0 /= r3
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "0: Only numbers can be used as divisors (r3 != 0)"
@@ -80,7 +84,8 @@ code:
   <start>: |
     r0 s/= r3
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "0: Only numbers can be used as divisors (r3 != 0)"
@@ -97,7 +102,8 @@ code:
   <start>: |
     r0 %= r3
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "0: Only numbers can be used as divisors (r3 != 0)"
@@ -114,7 +120,8 @@ code:
   <start>: |
     r0 s%= r3
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "0: Only numbers can be used as divisors (r3 != 0)"
@@ -131,7 +138,8 @@ code:
   <start>: |
     r0 &= r3
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "0: Invalid type (r3.type == number)"
@@ -148,7 +156,8 @@ code:
   <start>: |
     r0 |= r3
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "0: Invalid type (r3.type == number)"
@@ -165,7 +174,8 @@ code:
   <start>: |
     r0 ^= r3
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "0: Invalid type (r3.type == number)"
@@ -182,7 +192,8 @@ code:
   <start>: |
     r0 <<= r3
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "0: Invalid type (r3.type == number)"
@@ -199,7 +210,8 @@ code:
   <start>: |
     r0 >>= r3
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "0: Invalid type (r3.type == number)"
@@ -216,7 +228,8 @@ code:
   <start>: |
     r0 s>>= r3
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "0: Invalid type (r3.type == number)"
@@ -233,7 +246,8 @@ code:
   <start>: |
     r0 s8= r3
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "0: Invalid type (r3.type == number)"
@@ -250,7 +264,8 @@ code:
   <start>: |
     r0 s16= r3
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "0: Invalid type (r3.type == number)"
@@ -267,7 +282,8 @@ code:
   <start>: |
     r0 s32= r3
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "0: Invalid type (r3.type == number)"
@@ -297,7 +313,8 @@ code:
   <start>: |
     *(u64 *)(r1 + 0) = r0
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "0: Only numbers can be stored to externally-visible regions (r1.type != stack -> r0.type == number)"
@@ -313,7 +330,8 @@ code:
   <start>: |
     *(u32 *)(r1 + 0) = r0
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "0: Invalid type (r0.type == number)"
@@ -329,7 +347,8 @@ code:
   <start>: |
     *(u16 *)(r1 + 0) = r0
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "0: Invalid type (r0.type == number)"
@@ -345,7 +364,8 @@ code:
   <start>: |
     *(u8 *)(r1 + 0) = r0
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "0: Invalid type (r0.type == number)"
@@ -361,7 +381,8 @@ code:
   <start>: |
     lock *(u64 *)(r1 + 0) += r5
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "0: Invalid type (r5.type == number)"
@@ -377,7 +398,8 @@ code:
   <start>: |
     lock *(u64 *)(r1 + 0) &= r5
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "0: Invalid type (r5.type == number)"
@@ -393,7 +415,8 @@ code:
   <start>: |
     lock *(u64 *)(r1 + 0) |= r5
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "0: Invalid type (r5.type == number)"
@@ -409,7 +432,8 @@ code:
   <start>: |
     lock *(u64 *)(r1 + 0) |= r5
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "0: Invalid type (r5.type == number)"
@@ -425,7 +449,8 @@ code:
   <start>: |
     lock *(u64 *)(r1 + 0) x= r5
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "0: Invalid type (r5.type == number)"
@@ -441,7 +466,8 @@ code:
   <start>: |
     lock *(u64 *)(r1 + 0) x= r5
 
-post: []
+post:
+  - "_|_"
 
 messages:
   - "0: Invalid type (r5.type == number)"

--- a/test-data/unsigned.yaml
+++ b/test-data/unsigned.yaml
@@ -5,7 +5,8 @@ test-case: "assume 0 < 0 implies bottom"
 pre: ["r1.type=number", "r1.svalue=0", "r1.uvalue=0"]
 code:
   <start>: assume r1 < 0
-post: []
+post:
+  - "_|_"
 messages:
   - "0: Code becomes unreachable (assume r1 < 0)"
 ---
@@ -13,7 +14,8 @@ test-case: "assume 0 w< 0 implies bottom"
 pre: ["r1.type=number", "r1.svalue=0", "r1.uvalue=0"]
 code:
   <start>: assume w1 < 0
-post: []
+post:
+  - "_|_"
 messages:
   - "0: Code becomes unreachable (assume r1 w< 0)"
 ---
@@ -21,7 +23,8 @@ test-case: "assume -1 < 0 implies bottom"
 pre: ["r1.type=number", "r1.svalue=-1", "r1.uvalue=18446744073709551615"]
 code:
   <start>: assume r1 < 0
-post: []
+post:
+  - "_|_"
 messages:
   - "0: Code becomes unreachable (assume r1 < 0)"
 ---
@@ -29,7 +32,8 @@ test-case: "assume -1 w< 0 implies bottom"
 pre: ["r1.type=number", "r1.svalue=-1", "r1.uvalue=18446744073709551615"]
 code:
   <start>: assume w1 < 0
-post: []
+post:
+  - "_|_"
 messages:
   - "0: Code becomes unreachable (assume r1 w< 0)"
 ---
@@ -37,7 +41,8 @@ test-case: "assume -1 < 1 implies bottom"
 pre: ["r1.type=number", "r1.svalue=-1", "r1.uvalue=18446744073709551615"]
 code:
   <start>: assume r1 < 1
-post: []
+post:
+  - "_|_"
 messages:
   - "0: Code becomes unreachable (assume r1 < 1)"
 ---
@@ -45,7 +50,8 @@ test-case: "assume -1 w< 1 implies bottom"
 pre: ["r1.type=number", "r1.svalue=-1", "r1.uvalue=18446744073709551615"]
 code:
   <start>: assume w1 < 1
-post: []
+post:
+  - "_|_"
 messages:
   - "0: Code becomes unreachable (assume r1 w< 1)"
 ---
@@ -53,7 +59,8 @@ test-case: "assume 1 < 0 implies bottom"
 pre: ["r1.type=number", "r1.svalue=1", "r1.uvalue=1"]
 code:
   <start>: assume r1 < 0
-post: []
+post:
+  - "_|_"
 messages:
   - "0: Code becomes unreachable (assume r1 < 0)"
 ---
@@ -61,7 +68,8 @@ test-case: "assume 1 w< 0 implies bottom"
 pre: ["r1.type=number", "r1.svalue=1", "r1.uvalue=1"]
 code:
   <start>: assume w1 < 0
-post: []
+post:
+  - "_|_"
 messages:
   - "0: Code becomes unreachable (assume r1 w< 0)"
 ---
@@ -69,7 +77,8 @@ test-case: "assume 1 < 1 implies bottom"
 pre: ["r1.type=number", "r1.svalue=1", "r1.uvalue=1"]
 code:
   <start>: assume r1 < 1
-post: []
+post:
+  - "_|_"
 messages:
   - "0: Code becomes unreachable (assume r1 < 1)"
 ---
@@ -77,7 +86,8 @@ test-case: "assume 1 w< 1 implies bottom"
 pre: ["r1.type=number", "r1.svalue=1", "r1.uvalue=1"]
 code:
   <start>: assume w1 < 1
-post: []
+post:
+  - "_|_"
 messages:
   - "0: Code becomes unreachable (assume r1 w< 1)"
 ---
@@ -85,7 +95,8 @@ test-case: "assume 2 < 1 implies bottom"
 pre: ["r1.type=number", "r1.svalue=2", "r1.uvalue=2"]
 code:
   <start>: assume r1 < 1
-post: []
+post:
+  - "_|_"
 messages:
   - "0: Code becomes unreachable (assume r1 < 1)"
 ---
@@ -93,7 +104,8 @@ test-case: "assume 2 w< 1 implies bottom"
 pre: ["r1.type=number", "r1.svalue=2", "r1.uvalue=2"]
 code:
   <start>: assume w1 < 1
-post: []
+post:
+  - "_|_"
 messages:
   - "0: Code becomes unreachable (assume r1 w< 1)"
 ---
@@ -101,7 +113,8 @@ test-case: "assume [0, 1] < 0 implies bottom"
 pre: ["r1.type=number", "r1.svalue=[0, 1]", "r1.uvalue=[0, 1]", "r1.uvalue=r1.svalue"]
 code:
   <start>: assume r1 < 0
-post: []
+post:
+  - "_|_"
 messages:
   - "0: Code becomes unreachable (assume r1 < 0)"
 ---
@@ -109,7 +122,8 @@ test-case: "assume [0, 1] w< 0 implies bottom"
 pre: ["r1.type=number", "r1.svalue=[0, 1]", "r1.uvalue=[0, 1]", "r1.uvalue=r1.svalue"]
 code:
   <start>: assume w1 < 0
-post: []
+post:
+  - "_|_"
 messages:
   - "0: Code becomes unreachable (assume r1 w< 0)"
 ---
@@ -117,7 +131,8 @@ test-case: "assume [2, 3] < 1 implies bottom"
 pre: ["r1.type=number", "r1.svalue=[2, 3]", "r1.uvalue=[2, 3]", "r1.uvalue=r1.svalue"]
 code:
   <start>: assume r1 < 1
-post: []
+post:
+  - "_|_"
 messages:
   - "0: Code becomes unreachable (assume r1 < 1)"
 ---
@@ -125,7 +140,8 @@ test-case: "assume [2, 3] w< 1 implies bottom"
 pre: ["r1.type=number", "r1.svalue=[2, 3]", "r1.uvalue=[2, 3]", "r1.uvalue=r1.svalue"]
 code:
   <start>: assume w1 < 1
-post: []
+post:
+  - "_|_"
 messages:
   - "0: Code becomes unreachable (assume r1 w< 1)"
 ---
@@ -133,7 +149,8 @@ test-case: "assume [-2, -1] < 0 implies bottom"
 pre: ["r1.type=number", "r1.svalue=[-2, -1]", "r1.uvalue=[18446744073709551614, 18446744073709551615]"]
 code:
   <start>: assume r1 < 1
-post: []
+post:
+  - "_|_"
 messages:
   - "0: Code becomes unreachable (assume r1 < 1)"
 ---
@@ -141,7 +158,8 @@ test-case: "assume [-2, -1] w< 0 implies bottom"
 pre: ["r1.type=number", "r1.svalue=[-2, -1]", "r1.uvalue=[18446744073709551614, 18446744073709551615]"]
 code:
   <start>: assume w1 < 1
-post: []
+post:
+  - "_|_"
 messages:
   - "0: Code becomes unreachable (assume r1 w< 1)"
 ---
@@ -149,7 +167,8 @@ test-case: "assume [-3, -2] < -3 implies bottom"
 pre: ["r1.type=number", "r1.svalue=[-3, -2]", "r1.uvalue=[18446744073709551613, 18446744073709551614]"]
 code:
   <start>: assume r1 < -3
-post: []
+post:
+  - "_|_"
 messages:
   - "0: Code becomes unreachable (assume r1 < -3)"
 ---
@@ -157,7 +176,8 @@ test-case: "assume [-3, -2] w< -3 implies bottom"
 pre: ["r1.type=number", "r1.svalue=[-3, -2]", "r1.uvalue=[18446744073709551613, 18446744073709551614]"]
 code:
   <start>: assume w1 < -3
-post: []
+post:
+  - "_|_"
 messages:
   - "0: Code becomes unreachable (assume r1 w< -3)"
 ---
@@ -165,7 +185,8 @@ test-case: "assume [-3, -2] < -4 implies bottom"
 pre: ["r1.type=number", "r1.svalue=[-3, -2]", "r1.uvalue=[18446744073709551613, 18446744073709551614]"]
 code:
   <start>: assume r1 < -4
-post: []
+post:
+  - "_|_"
 messages:
   - "0: Code becomes unreachable (assume r1 < -4)"
 ---
@@ -173,7 +194,8 @@ test-case: "assume [-3, -2] w< -4 implies bottom"
 pre: ["r1.type=number", "r1.svalue=[-3, -2]", "r1.uvalue=[18446744073709551613, 18446744073709551614]"]
 code:
   <start>: assume w1 < -4
-post: []
+post:
+  - "_|_"
 messages:
   - "0: Code becomes unreachable (assume r1 w< -4)"
 ---
@@ -182,7 +204,8 @@ pre: ["r1.type=number", "r1.svalue=1", "r1.uvalue=1",
       "r2.type=number", "r2.svalue=[0, 1]", "r2.uvalue=[0, 1]", "r2.uvalue=r2.svalue"]
 code:
   <start>: assume r1 < r2
-post: []
+post:
+  - "_|_"
 messages:
   - "0: Code becomes unreachable (assume r1 < r2)"
 ---
@@ -191,7 +214,8 @@ pre: ["r1.type=number", "r1.svalue=1", "r1.uvalue=1",
       "r2.type=number", "r2.svalue=[0, 1]", "r2.uvalue=[0, 1]", "r2.uvalue=r2.svalue"]
 code:
   <start>: assume w1 < r2
-post: []
+post:
+  - "_|_"
 messages:
   - "0: Code becomes unreachable (assume r1 w< r2)"
 ---
@@ -200,7 +224,8 @@ pre: ["r1.type=number", "r1.svalue=-1", "r1.uvalue=18446744073709551615",
       "r2.type=number", "r2.svalue=[0, 1]", "r2.uvalue=[0, 1]", "r2.uvalue=r2.svalue"]
 code:
   <start>: assume r1 < r2
-post: []
+post:
+  - "_|_"
 messages:
   - "0: Code becomes unreachable (assume r1 < r2)"
 ---
@@ -209,7 +234,8 @@ pre: ["r1.type=number", "r1.svalue=-1", "r1.uvalue=18446744073709551615",
       "r2.type=number", "r2.svalue=[0, 1]", "r2.uvalue=[0, 1]", "r2.uvalue=r2.svalue"]
 code:
   <start>: assume w1 < r2
-post: []
+post:
+  - "_|_"
 messages:
   - "0: Code becomes unreachable (assume r1 w< r2)"
 ---
@@ -218,7 +244,8 @@ pre: ["r1.type=number", "r1.svalue=-1", "r1.uvalue=18446744073709551615",
       "r2.type=number", "r2.svalue=[1, 2]", "r2.uvalue=[1, 2]", "r2.uvalue=r2.svalue"]
 code:
   <start>: assume r1 < r2
-post: []
+post:
+  - "_|_"
 messages:
   - "0: Code becomes unreachable (assume r1 < r2)"
 ---
@@ -227,7 +254,8 @@ pre: ["r1.type=number", "r1.svalue=-1", "r1.uvalue=18446744073709551615",
       "r2.type=number", "r2.svalue=[1, 2]", "r2.uvalue=[1, 2]", "r2.uvalue=r2.svalue"]
 code:
   <start>: assume w1 < r2
-post: []
+post:
+  - "_|_"
 messages:
   - "0: Code becomes unreachable (assume r1 w< r2)"
 ---
@@ -236,7 +264,8 @@ pre: ["r1.type=number", "r1.svalue=2", "r1.uvalue=2",
       "r2.type=number", "r2.svalue=[0, 1]", "r2.uvalue=[0, 1]", "r2.uvalue=r2.svalue"]
 code:
   <start>: assume r1 < r2
-post: []
+post:
+  - "_|_"
 messages:
   - "0: Code becomes unreachable (assume r1 < r2)"
 ---
@@ -245,7 +274,8 @@ pre: ["r1.type=number", "r1.svalue=2", "r1.uvalue=2",
       "r2.type=number", "r2.svalue=[0, 1]", "r2.uvalue=[0, 1]", "r2.uvalue=r2.svalue"]
 code:
   <start>: assume w1 < r2
-post: []
+post:
+  - "_|_"
 messages:
   - "0: Code becomes unreachable (assume r1 w< r2)"
 ---
@@ -254,7 +284,8 @@ pre: ["r1.type=number", "r1.svalue=1", "r1.uvalue=1",
       "r2.type=number", "r2.svalue=[0, 1]", "r2.uvalue=[0, 1]", "r2.uvalue=r2.svalue"]
 code:
   <start>: assume r1 < r2
-post: []
+post:
+  - "_|_"
 messages:
   - "0: Code becomes unreachable (assume r1 < r2)"
 ---
@@ -263,7 +294,8 @@ pre: ["r1.type=number", "r1.svalue=1", "r1.uvalue=1",
       "r2.type=number", "r2.svalue=[0, 1]", "r2.uvalue=[0, 1]", "r2.uvalue=r2.svalue"]
 code:
   <start>: assume w1 < r2
-post: []
+post:
+  - "_|_"
 messages:
   - "0: Code becomes unreachable (assume r1 w< r2)"
 ---
@@ -272,7 +304,8 @@ pre: ["r1.type=number", "r1.svalue=1", "r1.uvalue=1",
       "r2.type=number", "r2.svalue=[0, 1]", "r2.uvalue=[0, 1]", "r2.uvalue=r2.svalue"]
 code:
   <start>: assume r1 < r2
-post: []
+post:
+  - "_|_"
 messages:
   - "0: Code becomes unreachable (assume r1 < r2)"
 ---
@@ -281,7 +314,8 @@ pre: ["r1.type=number", "r1.svalue=1", "r1.uvalue=1",
       "r2.type=number", "r2.svalue=[0, 1]", "r2.uvalue=[0, 1]", "r2.uvalue=r2.svalue"]
 code:
   <start>: assume w1 < r2
-post: []
+post:
+  - "_|_"
 messages:
   - "0: Code becomes unreachable (assume r1 w< r2)"
 ---
@@ -290,7 +324,8 @@ pre: ["r1.type=number", "r1.svalue=[2, 3]", "r1.uvalue=[2, 3]", "r1.uvalue=r1.sv
       "r2.type=number", "r2.svalue=[1, 2]", "r2.uvalue=[1, 2]", "r2.uvalue=r2.svalue"]
 code:
   <start>: assume r1 < r2
-post: []
+post:
+  - "_|_"
 messages:
   - "0: Code becomes unreachable (assume r1 < r2)"
 ---
@@ -299,7 +334,8 @@ pre: ["r1.type=number", "r1.svalue=[2, 3]", "r1.uvalue=[2, 3]", "r1.uvalue=r1.sv
       "r2.type=number", "r2.svalue=[1, 2]", "r2.uvalue=[1, 2]", "r2.uvalue=r2.svalue"]
 code:
   <start>: assume w1 < r2
-post: []
+post:
+  - "_|_"
 messages:
   - "0: Code becomes unreachable (assume r1 w< r2)"
 ---
@@ -308,7 +344,8 @@ pre: ["r1.type=number", "r1.svalue=[-2, -1]", "r1.uvalue=[18446744073709551614, 
       "r2.type=number", "r2.svalue=[0, 1]", "r2.uvalue=[0, 1]", "r2.uvalue=r2.svalue"]
 code:
   <start>: assume r1 < r2
-post: []
+post:
+  - "_|_"
 messages:
   - "0: Code becomes unreachable (assume r1 < r2)"
 ---
@@ -317,7 +354,8 @@ pre: ["r1.type=number", "r1.svalue=[-2, -1]", "r1.uvalue=[18446744073709551614, 
       "r2.type=number", "r2.svalue=[0, 1]", "r2.uvalue=[0, 1]", "r2.uvalue=r2.svalue"]
 code:
   <start>: assume w1 < r2
-post: []
+post:
+  - "_|_"
 messages:
   - "0: Code becomes unreachable (assume r1 w< r2)"
 ---
@@ -326,7 +364,8 @@ pre: ["r1.type=number", "r1.svalue=[-3, -2]", "r1.uvalue=[18446744073709551613, 
       "r2.type=number", "r2.svalue=[-4, -3]", "r2.uvalue=[18446744073709551612, 18446744073709551613]"]
 code:
   <start>: assume r1 < r2
-post: []
+post:
+  - "_|_"
 messages:
   - "0: Code becomes unreachable (assume r1 < r2)"
 ---
@@ -335,7 +374,8 @@ pre: ["r1.type=number", "r1.svalue=[-3, -2]", "r1.uvalue=[18446744073709551613, 
       "r2.type=number", "r2.svalue=[-4, -3]", "r2.uvalue=[18446744073709551612, 18446744073709551613]"]
 code:
   <start>: assume w1 < r2
-post: []
+post:
+  - "_|_"
 messages:
   - "0: Code becomes unreachable (assume r1 w< r2)"
 ---
@@ -344,7 +384,8 @@ pre: ["r1.type=number", "r1.svalue=[-3, -2]", "r1.uvalue=[18446744073709551613, 
       "r2.type=number", "r2.svalue=[-5, -4]", "r2.uvalue=[18446744073709551611, 18446744073709551612]"]
 code:
   <start>: assume r1 < r2
-post: []
+post:
+  - "_|_"
 messages:
   - "0: Code becomes unreachable (assume r1 < r2)"
 ---
@@ -353,7 +394,8 @@ pre: ["r1.type=number", "r1.svalue=[-3, -2]", "r1.uvalue=[18446744073709551613, 
       "r2.type=number", "r2.svalue=[-5, -4]", "r2.uvalue=[18446744073709551611, 18446744073709551612]"]
 code:
   <start>: assume w1 < r2
-post: []
+post:
+  - "_|_"
 messages:
   - "0: Code becomes unreachable (assume r1 w< r2)"
 ---
@@ -363,7 +405,8 @@ code:
   <start>: |
     r1 = -9223372036854775807ll
     assume r1 < 0
-post: []
+post:
+  - "_|_"
 messages:
   - "1: Code becomes unreachable (assume r1 < 0)"
 ---
@@ -373,7 +416,8 @@ code:
   <start>: |
     r1 = -9223372036854775807ll
     assume w1 < 0
-post: []
+post:
+  - "_|_"
 messages:
   - "1: Code becomes unreachable (assume r1 w< 0)"
 ---
@@ -389,7 +433,8 @@ test-case: "assume [INT_MIN+1, -1] < 0 implies bottom"
 pre: ["r1.type=number", "r1.svalue=[-9223372036854775807, -1]", "r1.uvalue=[9223372036854775809, 18446744073709551615]"]
 code:
   <start>: assume r1 < 0
-post: []
+post:
+  - "_|_"
 messages:
   - "0: Code becomes unreachable (assume r1 < 0)"
 ---
@@ -398,7 +443,8 @@ pre: ["r1.type=number", "r1.svalue=[-2147483648, -1]", "r1.uvalue=[1844674407156
 code:
   <start>: |
     assume w1 < 0
-post: []
+post:
+  - "_|_"
 messages:
   - "0: Code becomes unreachable (assume r1 w< 0)"
 ---
@@ -407,7 +453,8 @@ pre: ["r1.type=number", "r1.svalue=-4294967298", "r1.uvalue=18446744069414584318
 code:
   <start>: |
     assume w1 < 0
-post: []
+post:
+  - "_|_"
 messages:
   - "0: Code becomes unreachable (assume r1 w< 0)"
 ---
@@ -417,7 +464,8 @@ code:
   <start>: |
     r1 = -9223372036854775807ll
     assume r1 < 1
-post: []
+post:
+  - "_|_"
 messages:
   - "1: Code becomes unreachable (assume r1 < 1)"
 ---
@@ -427,7 +475,8 @@ code:
   <start>: |
     r1 = -2147483648
     assume w1 < 1
-post: []
+post:
+  - "_|_"
 messages:
   - "1: Code becomes unreachable (assume r1 w< 1)"
 ---
@@ -438,7 +487,8 @@ code:
     r1 = -9223372036854775807ll
     r2 = -9223372036854775807ll
     assume r1 < r2
-post: []
+post:
+  - "_|_"
 messages:
   - "2: Code becomes unreachable (assume r1 < r2)"
 ---
@@ -449,7 +499,8 @@ code:
     r1 = -2147483648
     r2 = -2147483648
     assume w1 < r2
-post: []
+post:
+  - "_|_"
 messages:
   - "2: Code becomes unreachable (assume r1 w< r2)"
 ---
@@ -460,7 +511,8 @@ code:
     r1 = -9223372036854775806ll
     r2 = -9223372036854775807ll
     assume r1 < r2
-post: []
+post:
+  - "_|_"
 messages:
   - "2: Code becomes unreachable (assume r1 < r2)"
 ---
@@ -471,7 +523,8 @@ code:
     r1 = -1
     r2 = -9223372036854775807ll
     assume r1 < r2
-post: []
+post:
+  - "_|_"
 messages:
   - "2: Code becomes unreachable (assume r1 < r2)"
 ---
@@ -482,7 +535,8 @@ code:
     r1 = -1
     r2 = -2147483648
     assume w1 < r2
-post: []
+post:
+  - "_|_"
 messages:
   - "2: Code becomes unreachable (assume r1 w< r2)"
 ---
@@ -493,7 +547,8 @@ code:
     r1 = -2147483648
     r2 = 2147483647
     assume w1 < r2
-post: []
+post:
+  - "_|_"
 messages:
   - "2: Code becomes unreachable (assume r1 w< r2)"
 ---
@@ -503,7 +558,8 @@ code:
   <start>: |
     r1 += 1
     assume r1 < 1
-post: []
+post:
+  - "_|_"
 messages:
   - "1: Code becomes unreachable (assume r1 < 1)"
 ---
@@ -512,7 +568,8 @@ pre: ["r1.type=number", "r1.svalue=[1, 2147483647]", "r1.uvalue=[1, 2147483647]"
 code:
   <start>: |
     assume w1 < 1
-post: []
+post:
+  - "_|_"
 messages:
   - "0: Code becomes unreachable (assume r1 w< 1)"
 ---
@@ -522,7 +579,8 @@ code:
   <start>: |
     r1 += 3
     assume r1 < 1
-post: []
+post:
+  - "_|_"
 messages:
   - "1: Code becomes unreachable (assume r1 < 1)"
 ---
@@ -531,7 +589,8 @@ pre: ["r1.type=number", "r1.svalue=[2147483646, 2147483647]", "r1.uvalue=[214748
 code:
   <start>: |
     assume w1 < 1
-post: []
+post:
+  - "_|_"
 messages:
   - "0: Code becomes unreachable (assume r1 w< 1)"
 ---
@@ -541,7 +600,8 @@ code:
   <start>: |
     r1 += 4
     assume r1 < 1
-post: []
+post:
+  - "_|_"
 messages:
   - "1: Code becomes unreachable (assume r1 < 1)"
 ---
@@ -594,7 +654,8 @@ pre: ["r1.type=number", "r1.svalue=[0, 1]", "r1.uvalue=[0, 1]", "r1.uvalue=r1.sv
 code:
   <start>: |
     assume r1 > 1
-post: []
+post:
+  - "_|_"
 messages:
   - "0: Code becomes unreachable (assume r1 > 1)"
 ---
@@ -603,7 +664,8 @@ pre: ["r1.type=number", "r1.svalue=[0, 1]", "r1.uvalue=[0, 1]", "r1.uvalue=r1.sv
 code:
   <start>: |
     assume w1 > 1
-post: []
+post:
+  - "_|_"
 messages:
   - "0: Code becomes unreachable (assume r1 w> 1)"
 ---
@@ -683,7 +745,8 @@ code:
   <start>: |
     r2 = 9223372036854775807ll
     assume r1 > r2
-post: []
+post:
+  - "_|_"
 messages:
   - "1: Code becomes unreachable (assume r1 > r2)"
 ---
@@ -692,7 +755,8 @@ pre: ["r1.type=number", "r1.svalue=[0, 2147483647]", "r1.uvalue=[0, 2147483647]"
 code:
   <start>: |
     assume w1 > 2147483647
-post: []
+post:
+  - "_|_"
 messages:
   - "0: Code becomes unreachable (assume r1 w> 2147483647)"
 ---
@@ -1058,7 +1122,8 @@ test-case: "assume 11 != 11 implies bottom"
 pre: ["r1.type=number", "r1.svalue=11", "r1.uvalue=11"]
 code:
   <start>: assume r1 != 11
-post: []
+post:
+  - "_|_"
 messages:
   - "0: Code becomes unreachable (assume r1 != 11)"
 ---
@@ -1084,7 +1149,8 @@ test-case: "assume 4294967307 w!= 11 implies bottom"
 pre: ["r1.type=number", "r1.svalue=4294967307", "r1.uvalue=4294967307"]
 code:
   <start>: assume w1 != 11
-post: []
+post:
+  - "_|_"
 messages:
   - "0: Code becomes unreachable (assume r1 w!= 11)"
 ---
@@ -1092,7 +1158,8 @@ test-case: "assume [3, 4] w< 2 implies bottom"
 pre: ["r1.type=number", "r1.svalue=[3, 4]", "r1.uvalue=[3, 4]"]
 code:
   <start>: assume w1 < 2
-post: []
+post:
+  - "_|_"
 messages:
   - "0: Code becomes unreachable (assume r1 w< 2)"
 ---
@@ -1218,7 +1285,8 @@ test-case: "assume 32-bit 0xFFFFFFFE s> 0 implies bottom"
 pre: ["r1.type=number", "r1.svalue=4294967294", "r1.uvalue=4294967294"]
 code:
   <start>: assume w1 s> 0
-post: []
+post:
+  - "_|_"
 messages:
   - "0: Code becomes unreachable (assume r1 ws> 0)"
 ---


### PR DESCRIPTION
## Summary
- `EbpfDomain::to_set()` returned `StringInvariant::top()` when the domain is bottom (unreachable), instead of `StringInvariant::bottom()`.
- Updated 225 YAML test expectations across 15 test-data files that encoded the wrong answer (`post: []` = top) to the correct `post: ["_|_"]` (bottom).

Fixes the last item in #1077

## Test plan
- [x] All YAML tests pass
- [x] Full test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)