### PR TITLE
Fix failure-slice filter losing total_stack_size; refactor printing API

### DIFF
--- a/src/config.hpp
+++ b/src/config.hpp
@@ -34,6 +34,11 @@ struct verbosity_options_t {
     /// the registers and stack offsets it reads/writes, enabling efficient
     /// backward slicing for failure diagnostics.
     bool collect_instruction_deps = false;
+
+    /// When printing failure slices, omit per-label pre/post invariants and
+    /// per-predecessor join-point detail — emit only the control-flow summary
+    /// and the instruction trace.
+    bool compact_slice = false;
 };
 
 struct ebpf_verifier_options_t {

--- a/src/ir/program.hpp
+++ b/src/ir/program.hpp
@@ -67,6 +67,6 @@ class InvalidControlFlow final : public std::runtime_error {
 std::vector<Assertion> get_assertions(const Instruction& ins, const ProgramInfo& info,
                                       const ebpf_verifier_options_t& options, const std::optional<Label>& label);
 
-void print_program(const Program& prog, std::ostream& os, bool simplify, bool print_line_info = false);
+void print_program(const Program& prog, std::ostream& os, const verbosity_options_t& verbosity);
 void print_dot(const Program& prog, const std::string& outfile);
 } // namespace prevail

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -233,18 +233,18 @@ int main(int argc, char** argv) {
         }
 
         if (print_cfg) {
-            print_program(prog, std::cout, verbosity.simplify, verbosity.print_line_info);
+            print_program(prog, std::cout, verbosity);
             return 0;
         }
 
         auto result = analyze(prog, ebpf_verifier_options);
         if (!quiet) {
             if (verbosity.print_invariants) {
-                print_invariants(std::cout, prog, verbosity.simplify, result, verbosity.print_line_info);
+                print_invariants(std::cout, prog, result, verbosity);
             }
             if (verbosity.print_failures) {
                 if (auto verification_error = result.find_first_error()) {
-                    print_error(std::cout, *verification_error, prog, verbosity.print_line_info);
+                    print_error(std::cout, *verification_error, prog, verbosity);
                 }
             }
             if (failure_slice && result.failed) {
@@ -254,8 +254,7 @@ int main(int argc, char** argv) {
                 slice_params.max_slices = 1;
                 const AnalysisContext context{prog.info(), ebpf_verifier_options, *prog.info().platform};
                 auto slices = result.compute_failure_slices(prog, slice_params, context);
-                print_failure_slices(std::cout, prog, verbosity.simplify, result, slices, false,
-                                     verbosity.print_line_info);
+                print_failure_slices(std::cout, prog, result, slices, verbosity);
             } else if (failure_slice && !result.failed) {
                 std::cout << "Program passed verification; no failure slices to display.\n";
             }
@@ -276,7 +275,7 @@ int main(int argc, char** argv) {
                 // Print the first error if not already printed by -v or -f.
                 if (!verbosity.print_invariants && !verbosity.print_failures && !failure_slice) {
                     if (auto verification_error = result.find_first_error()) {
-                        print_error(std::cout, *verification_error, prog, verbosity.print_line_info);
+                        print_error(std::cout, *verification_error, prog, verbosity);
                     }
                     std::cout << "Hint: run with --failure-slice for a causal trace, or -v for full invariants.\n";
                 }

--- a/src/printing.cpp
+++ b/src/printing.cpp
@@ -810,32 +810,40 @@ void print_invariants_filtered(std::ostream& os, const Program& prog, const bool
                 }
             }
             if (in_slice_parents.size() >= 2) {
-                // Build the union of relevant registers from this label and all in-slice parents
-                RelevantState join_relevance;
+                // Build the union of relevant registers from this label and all in-slice parents.
+                // Seed from an existing relevance entry so join_relevance inherits its context.
+                // Prefer the first filtered label; fall back to the first in-slice parent.
+                const RelevantState* seed = nullptr;
                 if (relevance->contains(first_filtered_label)) {
-                    const auto& fl = relevance->at(first_filtered_label);
-                    join_relevance.registers.insert(fl.registers.begin(), fl.registers.end());
-                    join_relevance.stack_offsets.insert(fl.stack_offsets.begin(), fl.stack_offsets.end());
-                    join_relevance.total_stack_size = fl.total_stack_size;
-                }
-                for (const auto& parent : in_slice_parents) {
-                    if (relevance->contains(parent)) {
-                        const auto& pr = relevance->at(parent);
-                        join_relevance.registers.insert(pr.registers.begin(), pr.registers.end());
-                        join_relevance.stack_offsets.insert(pr.stack_offsets.begin(), pr.stack_offsets.end());
+                    seed = &relevance->at(first_filtered_label);
+                } else {
+                    for (const auto& parent : in_slice_parents) {
+                        if (relevance->contains(parent)) {
+                            seed = &relevance->at(parent);
+                            break;
+                        }
                     }
                 }
+                if (seed) {
+                    RelevantState join_relevance = *seed; // copy-construct; carries context
+                    for (const auto& parent : in_slice_parents) {
+                        if (relevance->contains(parent)) {
+                            const auto& pr = relevance->at(parent);
+                            join_relevance.registers.insert(pr.registers.begin(), pr.registers.end());
+                            join_relevance.stack_offsets.insert(pr.stack_offsets.begin(), pr.stack_offsets.end());
+                        }
+                    }
 
-                os << "  --- join point: per-predecessor state ---\n";
-                for (const auto& parent : in_slice_parents) {
-                    const auto* post = get_parent_post_invariant(parent);
-                    if (post) {
-                        os << invariant_filter(&join_relevance);
-                        os << "  from " << parent << ": " << *post << "\n";
-                        os << invariant_filter(nullptr);
+                    os << "  --- join point: per-predecessor state ---\n";
+                    for (const auto& parent : in_slice_parents) {
+                        if (const auto* post = get_parent_post_invariant(parent)) {
+                            os << invariant_filter(&join_relevance);
+                            os << "  from " << parent << ": " << *post << "\n";
+                            os << invariant_filter(nullptr);
+                        }
                     }
+                    os << "  --- end join point ---\n";
                 }
-                os << "  --- end join point ---\n";
             }
         }
 
@@ -1021,7 +1029,7 @@ void print_failure_slices(std::ostream& os, const Program& prog, const bool simp
             // Labels consumed by a {..|..} group are skipped in linear output,
             // unless they are themselves join points (nested joins).
             std::set<Label> convergence_members;
-            for (const auto& [join_lbl, preds] : join_predecessors) {
+            for (const auto& preds : join_predecessors | std::views::values) {
                 for (const auto& p : preds) {
                     if (!join_predecessors.contains(p)) {
                         convergence_members.insert(p);

--- a/src/printing.cpp
+++ b/src/printing.cpp
@@ -832,9 +832,9 @@ void print_invariants_filtered(std::ostream& os, const Program& prog, const Anal
 
                 if (join_relevance) {
                     os << "  --- join point: per-predecessor state ---\n";
+                    invariant_filter guard(os, &*join_relevance);
                     for (const auto& parent : in_slice_parents) {
                         if (const auto* post = get_parent_post_invariant(parent)) {
-                            invariant_filter guard(os, &*join_relevance);
                             os << "  from " << parent << ": " << *post << "\n";
                         }
                     }

--- a/src/printing.cpp
+++ b/src/printing.cpp
@@ -155,9 +155,9 @@ struct DetailedPrinter : LineInfoPrinter {
     }
 };
 
-void print_program(const Program& prog, std::ostream& os, const bool simplify, const bool print_line_info) {
-    DetailedPrinter printer{os, prog, print_line_info};
-    for (const BasicBlock& bb : BasicBlock::collect_basic_blocks(prog.cfg(), simplify)) {
+void print_program(const Program& prog, std::ostream& os, const verbosity_options_t& verbosity) {
+    DetailedPrinter printer{os, prog, verbosity.print_line_info};
+    for (const BasicBlock& bb : BasicBlock::collect_basic_blocks(prog.cfg(), verbosity.simplify)) {
         printer.print_jump("from", bb.first_label());
         os << bb.first_label() << ":\n";
         for (const Label& label : bb) {
@@ -169,10 +169,10 @@ void print_program(const Program& prog, std::ostream& os, const bool simplify, c
     os << "\n";
 }
 
-void print_invariants(std::ostream& os, const Program& prog, const bool simplify, const AnalysisResult& result,
-                      const bool print_line_info) {
-    DetailedPrinter printer{os, prog, print_line_info};
-    for (const BasicBlock& bb : BasicBlock::collect_basic_blocks(prog.cfg(), simplify)) {
+void print_invariants(std::ostream& os, const Program& prog, const AnalysisResult& result,
+                      const verbosity_options_t& verbosity) {
+    DetailedPrinter printer{os, prog, verbosity.print_line_info};
+    for (const BasicBlock& bb : BasicBlock::collect_basic_blocks(prog.cfg(), verbosity.simplify)) {
         if (result.invariants.at(bb.first_label()).pre.is_bottom()) {
             continue;
         }
@@ -191,7 +191,7 @@ void print_invariants(std::ostream& os, const Program& prog, const bool simplify
                 if (label != bb.last_label()) {
                     os << "After " << current.pre << "\n";
                 }
-                print_error(os, *current.error, prog, print_line_info);
+                print_error(os, *current.error, prog, verbosity);
                 os << "\n";
                 return;
             }
@@ -251,8 +251,9 @@ std::string to_string(const VerificationError& error) {
     return ss.str();
 }
 
-void print_error(std::ostream& os, const VerificationError& error, const Program& prog, const bool print_line_info) {
-    LineInfoPrinter printer{os, prog.info().line_info, print_line_info};
+void print_error(std::ostream& os, const VerificationError& error, const Program& prog,
+                 const verbosity_options_t& verbosity) {
+    LineInfoPrinter printer{os, prog.info().line_info, verbosity.print_line_info};
     if (const auto& label = error.where) {
         printer.print_line_info(*label);
         os << *label << ": ";
@@ -722,11 +723,12 @@ std::ostream& operator<<(std::ostream& os, const btf_line_info_t& line_info) {
     return os;
 }
 
-void print_invariants_filtered(std::ostream& os, const Program& prog, const bool simplify, const AnalysisResult& result,
-                               const std::set<Label>& filter, const bool compact,
-                               const std::map<Label, RelevantState>* relevance, const bool print_line_info) {
-    DetailedPrinter printer{os, prog, print_line_info};
-    const auto basic_blocks = BasicBlock::collect_basic_blocks(prog.cfg(), simplify);
+void print_invariants_filtered(std::ostream& os, const Program& prog, const AnalysisResult& result,
+                               const std::set<Label>& filter, const verbosity_options_t& verbosity,
+                               const std::map<Label, RelevantState>* relevance) {
+    DetailedPrinter printer{os, prog, verbosity.print_line_info};
+    const bool compact = verbosity.compact_slice;
+    const auto basic_blocks = BasicBlock::collect_basic_blocks(prog.cfg(), verbosity.simplify);
 
     // Build a mapping from each label in a basic block to the block's first label.
     // Needed to look up post-invariants for mid-block predecessor labels at join points.
@@ -938,7 +940,7 @@ void print_invariants_filtered(std::ostream& os, const Program& prog, const bool
             const auto& current = result.invariants.at(label);
             if (current.error) {
                 os << "\nVerification error:\n";
-                print_error(os, *current.error, prog, print_line_info);
+                print_error(os, *current.error, prog, verbosity);
                 os << "\n";
             }
         }
@@ -960,8 +962,8 @@ void print_invariants_filtered(std::ostream& os, const Program& prog, const bool
     os << "\n";
 }
 
-void print_failure_slices(std::ostream& os, const Program& prog, const bool simplify, const AnalysisResult& result,
-                          const std::vector<FailureSlice>& slices, const bool compact, const bool print_line_info) {
+void print_failure_slices(std::ostream& os, const Program& prog, const AnalysisResult& result,
+                          const std::vector<FailureSlice>& slices, const verbosity_options_t& verbosity) {
     if (slices.empty()) {
         os << "No verification failures found.\n";
         return;
@@ -1087,8 +1089,7 @@ void print_failure_slices(std::ostream& os, const Program& prog, const bool simp
 
         // Print the filtered CFG with assertion filtering based on relevance
         os << "[CAUSAL TRACE]\n";
-        print_invariants_filtered(os, prog, simplify, result, slice.impacted_labels(), compact, &slice.relevance,
-                                  print_line_info);
+        print_invariants_filtered(os, prog, result, slice.impacted_labels(), verbosity, &slice.relevance);
 
         if (i + 1 < slices.size()) {
             os << "\n";

--- a/src/printing.cpp
+++ b/src/printing.cpp
@@ -4,6 +4,7 @@
 #include <fstream>
 #include <iomanip>
 #include <iostream>
+#include <optional>
 #include <variant>
 #include <vector>
 
@@ -811,35 +812,31 @@ void print_invariants_filtered(std::ostream& os, const Program& prog, const Anal
                     in_slice_parents.push_back(parent);
                 }
             }
-            if (in_slice_parents.size() >= 2) {
-                // Build the union of relevant registers from this label and all in-slice parents.
-                // Seed from an existing relevance entry so join_relevance inherits its context.
-                // Prefer the first filtered label; fall back to the first in-slice parent.
-                const RelevantState* seed = nullptr;
-                if (relevance->contains(first_filtered_label)) {
-                    seed = &relevance->at(first_filtered_label);
-                } else {
-                    for (const auto& parent : in_slice_parents) {
-                        if (relevance->contains(parent)) {
-                            seed = &relevance->at(parent);
-                            break;
-                        }
-                    }
-                }
-                if (seed) {
-                    RelevantState join_relevance = *seed; // copy-construct; carries context
-                    for (const auto& parent : in_slice_parents) {
-                        if (relevance->contains(parent)) {
-                            const auto& pr = relevance->at(parent);
-                            join_relevance.registers.insert(pr.registers.begin(), pr.registers.end());
-                            join_relevance.stack_offsets.insert(pr.stack_offsets.begin(), pr.stack_offsets.end());
-                        }
-                    }
 
+            if (in_slice_parents.size() >= 2) {
+                // Union of relevance from first_filtered_label and all in-slice parents.
+                // The first entry we find seeds the optional (supplying the filter context
+                // it carries); subsequent entries merge into it.
+                std::optional<RelevantState> join_relevance;
+                auto try_merge = [&](const Label& lbl) {
+                    if (const auto it = relevance->find(lbl); it != relevance->end()) {
+                        if (join_relevance) {
+                            join_relevance->merge(it->second);
+                        } else {
+                            join_relevance.emplace(it->second);
+                        }
+                    }
+                };
+                try_merge(first_filtered_label);
+                for (const auto& parent : in_slice_parents) {
+                    try_merge(parent);
+                }
+
+                if (join_relevance) {
                     os << "  --- join point: per-predecessor state ---\n";
                     for (const auto& parent : in_slice_parents) {
                         if (const auto* post = get_parent_post_invariant(parent)) {
-                            os << invariant_filter(&join_relevance);
+                            os << invariant_filter(&*join_relevance);
                             os << "  from " << parent << ": " << *post << "\n";
                             os << invariant_filter(nullptr);
                         }

--- a/src/printing.cpp
+++ b/src/printing.cpp
@@ -787,13 +787,11 @@ void print_invariants_filtered(std::ostream& os, const Program& prog, const Anal
 
         // Print pre-invariant for first filtered label in block (unless compact)
         if (!compact) {
-            // Set invariant filter if we have relevance info for this label
             const auto* label_relevance =
                 relevance ? (relevance->contains(first_filtered_label) ? &relevance->at(first_filtered_label) : nullptr)
                           : nullptr;
-            os << invariant_filter(label_relevance);
+            invariant_filter guard(os, label_relevance);
             os << "\nPre-invariant : " << result.invariants.at(first_filtered_label).pre << "\n";
-            os << invariant_filter(nullptr); // Clear filter
         }
 
         // Print the jump and block header anchored to the basic block entry label
@@ -836,9 +834,8 @@ void print_invariants_filtered(std::ostream& os, const Program& prog, const Anal
                     os << "  --- join point: per-predecessor state ---\n";
                     for (const auto& parent : in_slice_parents) {
                         if (const auto* post = get_parent_post_invariant(parent)) {
-                            os << invariant_filter(&*join_relevance);
+                            invariant_filter guard(os, &*join_relevance);
                             os << "  from " << parent << ": " << *post << "\n";
-                            os << invariant_filter(nullptr);
                         }
                     }
                     os << "  --- end join point ---\n";
@@ -870,10 +867,9 @@ void print_invariants_filtered(std::ostream& os, const Program& prog, const Anal
                             relevance ? (relevance->contains(prev_filtered_label) ? &relevance->at(prev_filtered_label)
                                                                                   : nullptr)
                                       : nullptr;
-                        os << invariant_filter(prev_label_relevance);
+                        invariant_filter guard(os, prev_label_relevance);
                         printer.print_jump("goto", prev_filtered_label);
                         os << "\nPost-invariant : " << prev_current.post << "\n";
-                        os << invariant_filter(nullptr);
                     }
                 }
                 // Check if there are skipped labels between prev and current
@@ -895,9 +891,8 @@ void print_invariants_filtered(std::ostream& os, const Program& prog, const Anal
                 if (!compact) {
                     const auto* label_rel =
                         relevance ? (relevance->contains(label) ? &relevance->at(label) : nullptr) : nullptr;
-                    os << invariant_filter(label_rel);
+                    invariant_filter guard(os, label_rel);
                     os << "\nPre-invariant : " << result.invariants.at(label).pre << "\n";
-                    os << invariant_filter(nullptr);
                     printer.print_jump("from", label);
                 }
             }
@@ -946,13 +941,11 @@ void print_invariants_filtered(std::ostream& os, const Program& prog, const Anal
         if (!compact) {
             const auto& current = result.invariants.at(last_label);
             if (!current.post.is_bottom()) {
-                // Set invariant filter for post-invariant
                 const auto* label_relevance =
                     relevance ? (relevance->contains(last_label) ? &relevance->at(last_label) : nullptr) : nullptr;
-                os << invariant_filter(label_relevance);
+                invariant_filter guard(os, label_relevance);
                 printer.print_jump("goto", last_label);
                 os << "\nPost-invariant : " << current.post << "\n";
-                os << invariant_filter(nullptr); // Clear filter
             }
         }
     }

--- a/src/result.cpp
+++ b/src/result.cpp
@@ -408,6 +408,14 @@ FailureSlice AnalysisResult::compute_slice_from_label(const Program& prog, const
     std::set<Label> conservative_visited; // Dedup for empty-relevance labels in conservative mode
     std::map<Label, RelevantState> slice_labels;
 
+    // Template for inserting new empty entries into `visited` / `slice_labels`.
+    // Copy-constructed from the seed so it carries the seed's filter data, then
+    // cleared. Used with try_emplace: the template is copied on insert, ignored
+    // when the key is already present.
+    RelevantState empty_template = seed_relevance;
+    empty_template.registers.clear();
+    empty_template.stack_offsets.clear();
+
     // Worklist: (label, relevant_state_after_this_label)
     std::vector<std::pair<Label, RelevantState>> worklist;
     worklist.emplace_back(label, seed_relevance);
@@ -434,8 +442,11 @@ FailureSlice AnalysisResult::compute_slice_from_label(const Program& prog, const
             continue;
         }
 
-        // Merge with existing relevance at this label (for deduplication)
-        auto& existing = visited[current_label];
+        // Merge with existing relevance at this label (for deduplication).
+        // try_emplace copy-constructs from empty_template on first visit;
+        // subsequent visits merge into the existing entry.
+        auto [visited_it, _visited_inserted] = visited.try_emplace(current_label, empty_template);
+        auto& existing = visited_it->second;
         const size_t prev_size = existing.registers.size() + existing.stack_offsets.size();
         existing.registers.insert(relevant_after.registers.begin(), relevant_after.registers.end());
         existing.stack_offsets.insert(relevant_after.stack_offsets.begin(), relevant_after.stack_offsets.end());
@@ -453,14 +464,13 @@ FailureSlice AnalysisResult::compute_slice_from_label(const Program& prog, const
             }
         }
 
-        // Compute what's relevant BEFORE this instruction using deps
-        RelevantState relevant_before;
+        // Compute what's relevant BEFORE this instruction using deps.
+        // Starts as a copy of relevant_after; the two branches below either
+        // modify it or leave it unchanged.
+        RelevantState relevant_before = relevant_after;
         const auto inv_it = invariants.find(current_label);
         if (inv_it != invariants.end() && inv_it->second.deps) {
             const auto& deps = *inv_it->second.deps;
-
-            // Start with what's relevant after
-            relevant_before = relevant_after;
 
             // Remove registers that are written by this instruction
             // (they weren't relevant before their definition)
@@ -549,18 +559,20 @@ FailureSlice AnalysisResult::compute_slice_from_label(const Program& prog, const
                 // Only include contributing labels in the output slice.
                 // Merge (not assign) because a label may be revisited from
                 // a different successor with additional relevance.
-                auto& existing = slice_labels[current_label];
-                existing.registers.insert(relevant_before.registers.begin(), relevant_before.registers.end());
-                existing.stack_offsets.insert(relevant_before.stack_offsets.begin(),
-                                              relevant_before.stack_offsets.end());
+                auto [it, _] = slice_labels.try_emplace(current_label, empty_template);
+                auto& slice_existing = it->second;
+                slice_existing.registers.insert(relevant_before.registers.begin(), relevant_before.registers.end());
+                slice_existing.stack_offsets.insert(relevant_before.stack_offsets.begin(),
+                                                    relevant_before.stack_offsets.end());
             }
         } else {
             // No deps available: conservatively treat this label as contributing
             // and propagate all current relevance to predecessors.
-            relevant_before = relevant_after;
-            auto& existing = slice_labels[current_label];
-            existing.registers.insert(relevant_before.registers.begin(), relevant_before.registers.end());
-            existing.stack_offsets.insert(relevant_before.stack_offsets.begin(), relevant_before.stack_offsets.end());
+            auto [it, _] = slice_labels.try_emplace(current_label, empty_template);
+            auto& slice_existing = it->second;
+            slice_existing.registers.insert(relevant_before.registers.begin(), relevant_before.registers.end());
+            slice_existing.stack_offsets.insert(relevant_before.stack_offsets.begin(),
+                                                relevant_before.stack_offsets.end());
         }
 
         // Add predecessors to worklist
@@ -597,7 +609,7 @@ FailureSlice AnalysisResult::compute_slice_from_label(const Program& prog, const
         // Include the join-point label itself so the printing code can display
         // per-predecessor state at this join.
         if (!slice_labels.contains(v_label)) {
-            join_expansion[v_label] = v_relevance;
+            join_expansion.emplace(v_label, v_relevance);
         }
         // Include all predecessors so the join display is complete.
         // Use visited relevance if available, otherwise use the join-point's relevance.
@@ -606,7 +618,7 @@ FailureSlice AnalysisResult::compute_slice_from_label(const Program& prog, const
                 continue;
             }
             const auto& rel = visited.contains(parent) ? visited.at(parent) : v_relevance;
-            join_expansion[parent] = rel;
+            join_expansion.emplace(parent, rel);
         }
     }
     slice_labels.insert(join_expansion.begin(), join_expansion.end());
@@ -636,7 +648,7 @@ std::vector<FailureSlice> AnalysisResult::compute_failure_slices(const Program& 
         // Forward analysis stops at the first failing assertion, which may not be
         // assertions[0]. Replay the checks against the pre-state to identify
         // the actual failing assertion and seed relevance from it.
-        RelevantState initial_relevance{.total_stack_size = context.options.total_stack_size()};
+        RelevantState initial_relevance(context);
         const auto& assertions = prog.assertions_at(label);
         bool found_failing = false;
         for (const auto& assertion : assertions) {

--- a/src/result.cpp
+++ b/src/result.cpp
@@ -19,7 +19,7 @@ namespace prevail {
 template <typename>
 inline constexpr bool always_false_v = false;
 
-// Stream-local storage index for invariant filter
+// Stream-local storage index for the invariant filter (per-stream pword slot).
 static int invariant_filter_index() {
     static const int index = std::ios_base::xalloc();
     return index;
@@ -29,9 +29,13 @@ const RelevantState* get_invariant_filter(std::ostream& os) {
     return static_cast<const RelevantState*>(os.pword(invariant_filter_index()));
 }
 
-std::ostream& operator<<(std::ostream& os, const invariant_filter& filter) {
-    os.pword(invariant_filter_index()) = const_cast<void*>(static_cast<const void*>(filter.state));
-    return os;
+invariant_filter::invariant_filter(std::ostream& os, const RelevantState* state)
+    : os_(os), previous_(get_invariant_filter(os)) {
+    os.pword(invariant_filter_index()) = const_cast<void*>(static_cast<const void*>(state));
+}
+
+invariant_filter::~invariant_filter() {
+    os_.pword(invariant_filter_index()) = const_cast<void*>(static_cast<const void*>(previous_));
 }
 
 bool RelevantState::is_relevant_constraint(const std::string& constraint) const {

--- a/src/result.cpp
+++ b/src/result.cpp
@@ -445,12 +445,11 @@ FailureSlice AnalysisResult::compute_slice_from_label(const Program& prog, const
         // Merge with existing relevance at this label (for deduplication).
         // try_emplace copy-constructs from empty_template on first visit;
         // subsequent visits merge into the existing entry.
-        auto [visited_it, _visited_inserted] = visited.try_emplace(current_label, empty_template);
+        auto [visited_it, _] = visited.try_emplace(current_label, empty_template);
         auto& existing = visited_it->second;
-        const size_t prev_size = existing.registers.size() + existing.stack_offsets.size();
-        existing.registers.insert(relevant_after.registers.begin(), relevant_after.registers.end());
-        existing.stack_offsets.insert(relevant_after.stack_offsets.begin(), relevant_after.stack_offsets.end());
-        const size_t new_size = existing.registers.size() + existing.stack_offsets.size();
+        const size_t prev_size = existing.size();
+        existing.merge(relevant_after);
+        const size_t new_size = existing.size();
 
         // If no new relevance was added, skip (already processed with same or broader relevance).
         // In conservative mode with empty relevance, use a separate visited set for dedup.
@@ -560,19 +559,13 @@ FailureSlice AnalysisResult::compute_slice_from_label(const Program& prog, const
                 // Merge (not assign) because a label may be revisited from
                 // a different successor with additional relevance.
                 auto [it, _] = slice_labels.try_emplace(current_label, empty_template);
-                auto& slice_existing = it->second;
-                slice_existing.registers.insert(relevant_before.registers.begin(), relevant_before.registers.end());
-                slice_existing.stack_offsets.insert(relevant_before.stack_offsets.begin(),
-                                                    relevant_before.stack_offsets.end());
+                it->second.merge(relevant_before);
             }
         } else {
             // No deps available: conservatively treat this label as contributing
             // and propagate all current relevance to predecessors.
             auto [it, _] = slice_labels.try_emplace(current_label, empty_template);
-            auto& slice_existing = it->second;
-            slice_existing.registers.insert(relevant_before.registers.begin(), relevant_before.registers.end());
-            slice_existing.stack_offsets.insert(relevant_before.stack_offsets.begin(),
-                                                relevant_before.stack_offsets.end());
+            it->second.merge(relevant_before);
         }
 
         // Add predecessors to worklist

--- a/src/result.hpp
+++ b/src/result.hpp
@@ -176,18 +176,19 @@ struct AnalysisResult {
                                           size_t max_steps = 200) const;
 };
 
-void print_error(std::ostream& os, const VerificationError& error, const Program& prog, bool print_line_info = false);
-void print_invariants(std::ostream& os, const Program& prog, bool simplify, const AnalysisResult& result,
-                      bool print_line_info = false);
+void print_error(std::ostream& os, const VerificationError& error, const Program& prog,
+                 const verbosity_options_t& verbosity);
+void print_invariants(std::ostream& os, const Program& prog, const AnalysisResult& result,
+                      const verbosity_options_t& verbosity);
 void print_unreachable(std::ostream& os, const Program& prog, const AnalysisResult& result);
 
-void print_invariants_filtered(std::ostream& os, const Program& prog, bool simplify, const AnalysisResult& result,
-                               const std::set<Label>& filter, bool compact = false,
-                               const std::map<Label, RelevantState>* relevance = nullptr, bool print_line_info = false);
+void print_invariants_filtered(std::ostream& os, const Program& prog, const AnalysisResult& result,
+                               const std::set<Label>& filter, const verbosity_options_t& verbosity,
+                               const std::map<Label, RelevantState>* relevance = nullptr);
 
 /// Print all failure slices in a structured diagnostic format.
-/// @param compact If true, skip detailed invariants for smaller output.
-void print_failure_slices(std::ostream& os, const Program& prog, bool simplify, const AnalysisResult& result,
-                          const std::vector<FailureSlice>& slices, bool compact = false, bool print_line_info = false);
+/// Use `verbosity.compact_slice = true` to skip detailed invariants.
+void print_failure_slices(std::ostream& os, const Program& prog, const AnalysisResult& result,
+                          const std::vector<FailureSlice>& slices, const verbosity_options_t& verbosity);
 
 } // namespace prevail

--- a/src/result.hpp
+++ b/src/result.hpp
@@ -88,19 +88,30 @@ struct RelevantState {
     bool is_relevant_constraint(const std::string& constraint) const;
 };
 
-/// Stream manipulator to filter invariant output to only relevant registers.
-/// Usage: os << invariant_filter(&relevant_state) << domain;
-/// To clear: os << invariant_filter(nullptr) << domain;
-struct invariant_filter {
-    const RelevantState* state;
-    explicit invariant_filter(const RelevantState* s) : state(s) {}
+/// Scoped guard that activates a `RelevantState` filter on an output stream.
+/// While the guard is alive, `operator<<(std::ostream&, const StringInvariant&)`
+/// consults the pointed-to state and skips items it considers irrelevant. The
+/// destructor restores whatever filter (if any) was active before — so guards
+/// nest cleanly and recover on exception.
+///
+/// Usage:
+///     {
+///         invariant_filter guard(os, &relevance);
+///         os << "\nPre-invariant : " << domain << "\n";
+///     }   // cleared automatically
+class invariant_filter {
+    std::ostream& os_;
+    const RelevantState* previous_;
+
+  public:
+    invariant_filter(std::ostream& os, const RelevantState* state);
+    ~invariant_filter();
+    invariant_filter(const invariant_filter&) = delete;
+    invariant_filter& operator=(const invariant_filter&) = delete;
 };
 
-/// Get the current invariant filter from a stream (nullptr if none).
+/// Get the current invariant filter from a stream (nullptr if none active).
 const RelevantState* get_invariant_filter(std::ostream& os);
-
-/// Set the invariant filter on a stream.
-std::ostream& operator<<(std::ostream& os, const invariant_filter& filter);
 
 /// A minimal diagnostic slice of a verification failure.
 /// Contains labels that contributed to the failure, with per-label

--- a/src/result.hpp
+++ b/src/result.hpp
@@ -61,12 +61,14 @@ struct InvariantMapPair {
     std::optional<InstructionDeps> deps; // Populated when collect_instruction_deps is set
 };
 
-/// State that is relevant at a specific program point.
-/// Used to filter what parts of the invariant to display.
+/// State that is relevant at a specific program point, used to filter
+/// what parts of the invariant to display.
 struct RelevantState {
+    int total_stack_size{};
     std::set<Reg> registers;
     std::set<int64_t> stack_offsets; // Relative stack offsets (e.g., Mem.access.offset values like -8)
-    int total_stack_size = 0;        // Used to translate relative stack offsets to absolute "s[...]" names.
+
+    explicit RelevantState(const AnalysisContext& context) : total_stack_size(context.options.total_stack_size()) {}
 
     /// Check if a constraint string (e.g., "r1.type=number") involves a relevant register.
     [[nodiscard]]

--- a/src/result.hpp
+++ b/src/result.hpp
@@ -70,6 +70,19 @@ struct RelevantState {
 
     explicit RelevantState(const AnalysisContext& context) : total_stack_size(context.options.total_stack_size()) {}
 
+    /// Merge another relevance set into this one (union of registers and stack offsets).
+    /// `total_stack_size` is invariant within one analysis and not touched.
+    void merge(const RelevantState& other) {
+        registers.insert(other.registers.begin(), other.registers.end());
+        stack_offsets.insert(other.stack_offsets.begin(), other.stack_offsets.end());
+    }
+
+    /// Number of tracked registers + stack offsets; used for dedup against a prior snapshot.
+    [[nodiscard]]
+    size_t size() const {
+        return registers.size() + stack_offsets.size();
+    }
+
     /// Check if a constraint string (e.g., "r1.type=number") involves a relevant register.
     [[nodiscard]]
     bool is_relevant_constraint(const std::string& constraint) const;

--- a/src/test/test_failure_slice.cpp
+++ b/src/test/test_failure_slice.cpp
@@ -194,7 +194,8 @@ TEST_CASE("print_failure_slices produces structured output", "[failure_slice][pr
     auto slices = result.compute_failure_slices(prog, context);
 
     std::stringstream output;
-    print_failure_slices(output, prog, false, result, slices);
+    verbosity_options_t verbosity{.simplify = false};
+    print_failure_slices(output, prog, result, slices, verbosity);
 
     std::string output_str = output.str();
 


### PR DESCRIPTION
## Summary

- **Bugfix**: `compute_slice_from_label` silently zeroed `RelevantState::total_stack_size` for every entry in `slice_labels` / `visited`. The field was added in #1088 to replace `thread_local_options`, but the `map[key]` + merge idiom produced default-constructed (`total=0`) entries that only had `registers` / `stack_offsets` copied into them. The filter then translated every relative stack offset against `total=0`, so `s[3912...3919]`-style constraints were filtered out of the printed slice unless a relevant register also appeared in them. Reproduces on `ebpf-samples/cilium-core/bpf_lxc.o tc/tail tail_handle_ipv6 --failure-slice`.
- **Fix by construction** rather than by patching propagation. `RelevantState` now:
  - owns just the analysis-wide data it needs (today: `int total_stack_size`),
  - has a single `explicit RelevantState(const AnalysisContext&)` constructor,
  - has no default constructor, so `map[key]` no longer compiles — the class of bug is closed.
  - Callers pass an `AnalysisContext`; nobody has to know which field the filter reads.
- **Refactors** along for the ride:
  - `RelevantState::merge()` / `size()` as methods, replacing four copies of `registers.insert + stack_offsets.insert` + size bookkeeping.
  - `print_program` / `print_invariants` / `print_error` / `print_invariants_filtered` / `print_failure_slices` now take a single `const verbosity_options_t&` instead of a variable tail of `bool simplify, bool compact, bool print_line_info`. `compact` moved to `verbosity_options_t::compact_slice`.
  - `invariant_filter` converted from a stream manipulator (`os << invariant_filter(&state); ... os << invariant_filter(nullptr);`) into a scoped RAII guard: `invariant_filter guard(os, &state);`. Five manual set/clear pairs collapse to five scoped locals, and the filter state is recovered on exception.

## Test plan

- [x] `ctest` / full catch2 suite: 1296/1533 passed, 236 failed as expected, 1 skipped (identical baseline to 4fda96bf).
- [x] Manual: `bin/prevail --failure-slice ebpf-samples/cilium-core/bpf_lxc.o tc/tail tail_handle_ipv6` now shows `s[3912...3919]` at label 28 (previously filtered out).
- [x] Output byte-identical between the first commit (pure fix, 15bbe81) and the HEAD of this branch (all four commits) — confirms the refactors are behavior-preserving.