### PR TITLE
Fix #1099: tighten ValidMapKeyValue packet bound; inline bounds checks

### DIFF
--- a/src/crab/ebpf_checker.cpp
+++ b/src/crab/ebpf_checker.cpp
@@ -52,38 +52,45 @@ class EbpfChecker final {
         throw VerificationError(msg + " (" + to_string(assertion) + ")");
     }
 
-    // In-region access bounds: requires `access_lb >= floor` and
-    // `access_ub <= ceiling`. The overload set mirrors region_bounds(): each
-    // call site selects the per-type ceiling shape via the explicit T template
-    // argument, so the wrong combination is a compile error rather than a
-    // silently-ignored argument.
-    template <TypeEncoding T>
-        requires CtxDerivedCeiling<T>
-    void require_region_bounds(const LinearExpression& access_lb, const LinearExpression& access_ub) const {
-        const auto bounds = region_bounds<T>(context);
-        require_in_bounds(bounds, access_lb, access_ub);
-    }
-    template <TypeEncoding T>
-        requires RegDerivedCeiling<T>
-    void require_region_bounds(const RegPack& reg, const LinearExpression& access_lb,
-                               const LinearExpression& access_ub) const {
-        const auto bounds = region_bounds<T>(reg);
-        require_in_bounds(bounds, access_lb, access_ub);
-    }
-    template <TypeEncoding T>
-        requires(T == T_PACKET)
-    void require_region_bounds(Variable packet_size, const LinearExpression& access_lb,
-                               const LinearExpression& access_ub) const {
-        const auto bounds = region_bounds<T>(packet_size);
-        require_in_bounds(bounds, access_lb, access_ub);
-    }
+    // Bounds checks for in-region accesses are split by *what determines the
+    // region's ceiling*:
+    //
+    //  - "static" regions have a ceiling that is a property of the program
+    //    invocation as a whole, not of the specific allocation that produced
+    //    the pointer. T_STACK and T_CTX read fixed ceilings from
+    //    AnalysisContext (total_stack_size, ctx_descriptor->size). T_PACKET
+    //    fits here, *not* under "dynamic", because there is exactly one
+    //    packet per program invocation: its bounds (packet_size, set once at
+    //    entry; or the loose max_packet_size constant) do not vary with the
+    //    allocation site of the pointer. The two T_PACKET ceilings split
+    //    further by access shape -- see the (Variable) overload below.
+    //
+    //  - "dynamic" regions have a ceiling that *does* depend on the
+    //    allocation site: T_SHARED's shared_region_size and T_ALLOC_MEM's
+    //    alloc_mem_size are kind variables on the RegPack, set when the
+    //    pointer was produced (map lookup, ringbuf_reserve, ...). The
+    //    TypeEncoding adds nothing the size variable does not already
+    //    carry, so the dynamic-region check takes the size directly.
 
-    void require_in_bounds(const RegionBounds& bounds, const LinearExpression& access_lb,
-                           const LinearExpression& access_ub) const {
-        using namespace dsl_syntax;
-        require_value(dom.state, access_lb >= bounds.lb_floor, bounds.lb_message);
-        require_value(dom.state, access_ub <= bounds.ub_ceiling, bounds.ub_message);
-    }
+    // Static-region bounds, ceiling chosen by `type`:
+    //   T_STACK / T_CTX -> their AnalysisContext-derived ceilings;
+    //   T_PACKET        -> the loose max_packet_size constant. Use this
+    //                      T_PACKET form *only* for pointer-comparison
+    //                      checks (width == 0) where the pointer may
+    //                      legitimately be past the runtime packet_size
+    //                      until the comparison gates the actual access.
+    void check_access_to_static_region(TypeEncoding type, const LinearExpression& access_lb,
+                                       const LinearExpression& access_ub) const;
+    // T_PACKET dereference: bound by the runtime packet_size variable. Pass
+    // `variable_registry.packet_size()`. The TypeEncoding is implicit here
+    // (only T_PACKET has a runtime-Variable ceiling).
+    void check_access_to_static_region(Variable packet_size, const LinearExpression& access_lb,
+                                       const LinearExpression& access_ub) const;
+    // Dynamic-region bounds: pass the per-allocation size variable
+    // (RegPack::shared_region_size for T_SHARED,
+    // RegPack::alloc_mem_size for T_ALLOC_MEM).
+    void check_access_to_dynamic_region(Variable region_size, const LinearExpression& access_lb,
+                                        const LinearExpression& access_ub) const;
 
     const Assertion assertion;
 
@@ -103,6 +110,52 @@ std::optional<VerificationError> ebpf_domain_check(const EbpfDomain& dom, const 
         return {error};
     }
     return {};
+}
+
+void EbpfChecker::check_access_to_static_region(const TypeEncoding type, const LinearExpression& access_lb,
+                                                const LinearExpression& access_ub) const {
+    using namespace dsl_syntax;
+    switch (type) {
+    case T_STACK: {
+        const auto floor = reg_pack(R10_STACK_POINTER).stack_offset - context.options.subprogram_stack_size;
+        require_value(dom.state, access_lb >= floor,
+                      "Lower bound must be at least r10.stack_offset - subprogram_stack_size");
+        require_value(dom.state, access_ub <= LinearExpression{context.options.total_stack_size()},
+                      "Upper bound must be at most total_stack_size");
+        return;
+    }
+    case T_CTX: {
+        const auto ctx_size = context.program_info().type.ctx_descriptor->size;
+        require_value(dom.state, access_lb >= LinearExpression{0}, "Lower bound must be at least 0");
+        require_value(dom.state, access_ub <= LinearExpression{ctx_size},
+                      std::string("Upper bound must be at most ") + std::to_string(ctx_size));
+        return;
+    }
+    case T_PACKET: {
+        const auto max = context.options.max_packet_size;
+        require_value(dom.state, access_lb >= variable_registry.meta_offset(),
+                      "Lower bound must be at least meta_offset");
+        require_value(dom.state, access_ub <= LinearExpression{max},
+                      std::string("Upper bound must be at most ") + std::to_string(max));
+        return;
+    }
+    default: throw_fail("internal error: check_access_to_static_region called on non-static region type");
+    }
+}
+
+void EbpfChecker::check_access_to_static_region(const Variable packet_size, const LinearExpression& access_lb,
+                                                const LinearExpression& access_ub) const {
+    using namespace dsl_syntax;
+    require_value(dom.state, access_lb >= variable_registry.meta_offset(), "Lower bound must be at least meta_offset");
+    require_value(dom.state, access_ub <= packet_size, "Upper bound must be at most packet_size");
+}
+
+void EbpfChecker::check_access_to_dynamic_region(const Variable region_size, const LinearExpression& access_lb,
+                                                 const LinearExpression& access_ub) const {
+    using namespace dsl_syntax;
+    require_value(dom.state, access_lb >= LinearExpression{0}, "Lower bound must be at least 0");
+    require_value(dom.state, access_ub <= region_size,
+                  std::string("Upper bound must be at most ") + variable_registry.name(region_size));
 }
 
 void EbpfChecker::operator()(const Comparable& s) const {
@@ -271,14 +324,14 @@ void EbpfChecker::operator()(const ValidMapKeyValue& s) const {
         case T_PACKET: {
             Variable lb = access_reg.packet_offset;
             LinearExpression ub = lb + width;
-            require_region_bounds<T_PACKET>(variable_registry.packet_size(), lb, ub);
+            check_access_to_static_region(variable_registry.packet_size(), lb, ub);
             // Packet memory is both readable and writable.
             break;
         }
         case T_SHARED: {
             Variable lb = access_reg.shared_offset;
             LinearExpression ub = lb + width;
-            require_region_bounds<T_SHARED>(access_reg, lb, ub);
+            check_access_to_dynamic_region(access_reg.shared_region_size, lb, ub);
             require_value(dom.state, access_reg.svalue > 0, "Possible null access");
             // Shared memory is zero-initialized when created so is safe to read and write.
             break;
@@ -307,7 +360,7 @@ void EbpfChecker::operator()(const ValidAccess& s) const {
         switch (type) {
         case T_STACK: {
             const auto [lb, ub] = lb_ub_access_pair(s, reg.stack_offset);
-            require_region_bounds<T_STACK>(lb, ub);
+            check_access_to_static_region(T_STACK, lb, ub);
             // Stack reads must hit known-numeric bytes.
             if (s.access_type == AccessType::read &&
                 !dom.stack->all_num_lb_ub(dom.state.values.eval_interval(lb), dom.state.values.eval_interval(ub))) {
@@ -324,7 +377,7 @@ void EbpfChecker::operator()(const ValidAccess& s) const {
         }
         case T_CTX: {
             const auto [lb, ub] = lb_ub_access_pair(s, reg.ctx_offset);
-            require_region_bounds<T_CTX>(lb, ub);
+            check_access_to_static_region(T_CTX, lb, ub);
             // T_CTX: bounds suffice; non-null when in bounds.
             break;
         }
@@ -332,18 +385,19 @@ void EbpfChecker::operator()(const ValidAccess& s) const {
             const auto [lb, ub] = lb_ub_access_pair(s, reg.packet_offset);
             // Pointer-comparison checks (width == 0) may legitimately reach
             // past the runtime packet_size, so they use the looser
-            // max_packet_size ceiling. Real dereferences must be bounded by
-            // the runtime packet_size variable.
+            // max_packet_size ceiling (the TypeEncoding overload). Real
+            // dereferences must be bounded by the runtime packet_size
+            // variable (the Variable overload).
             if (is_comparison_check) {
-                require_region_bounds<T_PACKET>(lb, ub);
+                check_access_to_static_region(T_PACKET, lb, ub);
             } else {
-                require_region_bounds<T_PACKET>(variable_registry.packet_size(), lb, ub);
+                check_access_to_static_region(variable_registry.packet_size(), lb, ub);
             }
             break;
         }
         case T_SHARED: {
             const auto [lb, ub] = lb_ub_access_pair(s, reg.shared_offset);
-            require_region_bounds<T_SHARED>(reg, lb, ub);
+            check_access_to_dynamic_region(reg.shared_region_size, lb, ub);
             if (!is_comparison_check && !s.or_null) {
                 require_value(dom.state, reg.svalue > 0, "Possible null access");
             }
@@ -351,7 +405,7 @@ void EbpfChecker::operator()(const ValidAccess& s) const {
         }
         case T_ALLOC_MEM: {
             const auto [lb, ub] = lb_ub_access_pair(s, reg.alloc_mem_offset);
-            require_region_bounds<T_ALLOC_MEM>(reg, lb, ub);
+            check_access_to_dynamic_region(reg.alloc_mem_size, lb, ub);
             if (!is_comparison_check && !s.or_null) {
                 require_value(dom.state, reg.svalue > 0, "Possible null access");
             }

--- a/src/crab/ebpf_checker.cpp
+++ b/src/crab/ebpf_checker.cpp
@@ -255,7 +255,7 @@ void EbpfChecker::operator()(const ValidMapKeyValue& s) const {
         case T_PACKET: {
             Variable lb = access_reg.packet_offset;
             LinearExpression ub = lb + width;
-            require_region_bounds(T_PACKET, access_reg, lb, ub);
+            require_region_bounds(T_PACKET, access_reg, lb, ub, variable_registry.packet_size());
             // Packet memory is both readable and writable.
             break;
         }

--- a/src/crab/ebpf_checker.cpp
+++ b/src/crab/ebpf_checker.cpp
@@ -52,14 +52,39 @@ class EbpfChecker final {
         throw VerificationError(msg + " (" + to_string(assertion) + ")");
     }
 
-    // Single driver for in-region access bounds: requires `access_lb >= floor`
-    // and `access_ub <= ceiling` for the region. `packet_size` overrides the
-    // T_PACKET upper bound; see region_bounds().
-    void require_region_bounds(TypeEncoding type, const RegPack& reg, const LinearExpression& access_lb,
-                               const LinearExpression& access_ub,
-                               std::optional<Variable> packet_size = std::nullopt) const;
+    // In-region access bounds: requires `access_lb >= floor` and
+    // `access_ub <= ceiling`. The overload set mirrors region_bounds(): each
+    // call site selects the per-type ceiling shape via the explicit T template
+    // argument, so the wrong combination is a compile error rather than a
+    // silently-ignored argument.
+    template <TypeEncoding T>
+        requires CtxDerivedCeiling<T>
+    void require_region_bounds(const LinearExpression& access_lb, const LinearExpression& access_ub) const {
+        const auto bounds = region_bounds<T>(context);
+        require_in_bounds(bounds, access_lb, access_ub);
+    }
+    template <TypeEncoding T>
+        requires RegDerivedCeiling<T>
+    void require_region_bounds(const RegPack& reg, const LinearExpression& access_lb,
+                               const LinearExpression& access_ub) const {
+        const auto bounds = region_bounds<T>(reg);
+        require_in_bounds(bounds, access_lb, access_ub);
+    }
+    template <TypeEncoding T>
+        requires(T == T_PACKET)
+    void require_region_bounds(Variable packet_size, const LinearExpression& access_lb,
+                               const LinearExpression& access_ub) const {
+        const auto bounds = region_bounds<T>(packet_size);
+        require_in_bounds(bounds, access_lb, access_ub);
+    }
 
-  private:
+    void require_in_bounds(const RegionBounds& bounds, const LinearExpression& access_lb,
+                           const LinearExpression& access_ub) const {
+        using namespace dsl_syntax;
+        require_value(dom.state, access_lb >= bounds.lb_floor, bounds.lb_message);
+        require_value(dom.state, access_ub <= bounds.ub_ceiling, bounds.ub_message);
+    }
+
     const Assertion assertion;
 
     const EbpfDomain& dom;
@@ -78,15 +103,6 @@ std::optional<VerificationError> ebpf_domain_check(const EbpfDomain& dom, const 
         return {error};
     }
     return {};
-}
-
-void EbpfChecker::require_region_bounds(const TypeEncoding type, const RegPack& reg, const LinearExpression& access_lb,
-                                        const LinearExpression& access_ub,
-                                        const std::optional<Variable> packet_size) const {
-    using namespace dsl_syntax;
-    const auto bounds = region_bounds(type, reg, context, packet_size);
-    require_value(dom.state, access_lb >= bounds.lb_floor, bounds.lb_message);
-    require_value(dom.state, access_ub <= bounds.ub_ceiling, bounds.ub_message);
 }
 
 void EbpfChecker::operator()(const Comparable& s) const {
@@ -255,14 +271,14 @@ void EbpfChecker::operator()(const ValidMapKeyValue& s) const {
         case T_PACKET: {
             Variable lb = access_reg.packet_offset;
             LinearExpression ub = lb + width;
-            require_region_bounds(T_PACKET, access_reg, lb, ub, variable_registry.packet_size());
+            require_region_bounds<T_PACKET>(variable_registry.packet_size(), lb, ub);
             // Packet memory is both readable and writable.
             break;
         }
         case T_SHARED: {
             Variable lb = access_reg.shared_offset;
             LinearExpression ub = lb + width;
-            require_region_bounds(T_SHARED, access_reg, lb, ub);
+            require_region_bounds<T_SHARED>(access_reg, lb, ub);
             require_value(dom.state, access_reg.svalue > 0, "Possible null access");
             // Shared memory is zero-initialized when created so is safe to read and write.
             break;
@@ -288,50 +304,59 @@ void EbpfChecker::operator()(const ValidAccess& s) const {
 
     const auto reg = reg_pack(s.reg);
     for (const auto type : dom.state.enumerate_types(s.reg)) {
-        if (is_region_access_type(type)) {
-            // Bounds-checked region access. The region's offset variable, the
-            // bounds rule, and per-region nuance live here together.
-            const auto offset_var = primary_kind_variable_for_type(s.reg, type);
-            if (!offset_var.has_value()) {
-                // is_region_access_type and primary_kind_variable_for_type should agree;
-                // if they ever drift, fail closed in release builds rather than UB-dereference.
-                throw_fail("internal error: region access type has no primary kind variable");
-            }
-            auto [lb, ub] = lb_ub_access_pair(s, *offset_var);
-            const std::optional<Variable> packet_size = (type == T_PACKET && !is_comparison_check)
-                                                            ? std::optional{variable_registry.packet_size()}
-                                                            : std::nullopt;
-            require_region_bounds(type, reg, lb, ub, packet_size);
-            switch (type) {
-            case T_STACK:
-                // Stack reads must hit known-numeric bytes.
-                if (s.access_type == AccessType::read &&
-                    !dom.stack->all_num_lb_ub(dom.state.values.eval_interval(lb), dom.state.values.eval_interval(ub))) {
-                    if (s.offset < 0) {
-                        throw_fail("Stack content is not numeric");
-                    } else {
-                        LinearExpression w = std::holds_alternative<Imm>(s.width)
-                                                 ? LinearExpression{std::get<Imm>(s.width).v}
-                                                 : reg_pack(std::get<Reg>(s.width)).svalue;
-                        require_value(dom.state, w <= reg.stack_numeric_size - s.offset,
-                                      "Stack content is not numeric");
-                    }
-                }
-                break;
-            case T_SHARED:
-            case T_ALLOC_MEM:
-                // Both are nullable; constrain non-null when the access is a real dereference.
-                if (!is_comparison_check && !s.or_null) {
-                    require_value(dom.state, reg.svalue > 0, "Possible null access");
-                }
-                break;
-            default:
-                // T_PACKET, T_CTX: bounds suffice; both are non-null when in bounds.
-                break;
-            }
-            continue;
-        }
         switch (type) {
+        case T_STACK: {
+            const auto [lb, ub] = lb_ub_access_pair(s, reg.stack_offset);
+            require_region_bounds<T_STACK>(lb, ub);
+            // Stack reads must hit known-numeric bytes.
+            if (s.access_type == AccessType::read &&
+                !dom.stack->all_num_lb_ub(dom.state.values.eval_interval(lb), dom.state.values.eval_interval(ub))) {
+                if (s.offset < 0) {
+                    throw_fail("Stack content is not numeric");
+                } else {
+                    LinearExpression w = std::holds_alternative<Imm>(s.width)
+                                             ? LinearExpression{std::get<Imm>(s.width).v}
+                                             : reg_pack(std::get<Reg>(s.width)).svalue;
+                    require_value(dom.state, w <= reg.stack_numeric_size - s.offset, "Stack content is not numeric");
+                }
+            }
+            break;
+        }
+        case T_CTX: {
+            const auto [lb, ub] = lb_ub_access_pair(s, reg.ctx_offset);
+            require_region_bounds<T_CTX>(lb, ub);
+            // T_CTX: bounds suffice; non-null when in bounds.
+            break;
+        }
+        case T_PACKET: {
+            const auto [lb, ub] = lb_ub_access_pair(s, reg.packet_offset);
+            // Pointer-comparison checks (width == 0) may legitimately reach
+            // past the runtime packet_size, so they use the looser
+            // max_packet_size ceiling. Real dereferences must be bounded by
+            // the runtime packet_size variable.
+            if (is_comparison_check) {
+                require_region_bounds<T_PACKET>(lb, ub);
+            } else {
+                require_region_bounds<T_PACKET>(variable_registry.packet_size(), lb, ub);
+            }
+            break;
+        }
+        case T_SHARED: {
+            const auto [lb, ub] = lb_ub_access_pair(s, reg.shared_offset);
+            require_region_bounds<T_SHARED>(reg, lb, ub);
+            if (!is_comparison_check && !s.or_null) {
+                require_value(dom.state, reg.svalue > 0, "Possible null access");
+            }
+            break;
+        }
+        case T_ALLOC_MEM: {
+            const auto [lb, ub] = lb_ub_access_pair(s, reg.alloc_mem_offset);
+            require_region_bounds<T_ALLOC_MEM>(reg, lb, ub);
+            if (!is_comparison_check && !s.or_null) {
+                require_value(dom.state, reg.svalue > 0, "Possible null access");
+            }
+            break;
+        }
         case T_NUM:
             if (!is_comparison_check) {
                 if (s.or_null) {

--- a/src/crab/ebpf_checker.cpp
+++ b/src/crab/ebpf_checker.cpp
@@ -52,45 +52,19 @@ class EbpfChecker final {
         throw VerificationError(msg + " (" + to_string(assertion) + ")");
     }
 
-    // Bounds checks for in-region accesses are split by *what determines the
-    // region's ceiling*:
-    //
-    //  - "static" regions have a ceiling that is a property of the program
-    //    invocation as a whole, not of the specific allocation that produced
-    //    the pointer. T_STACK and T_CTX read fixed ceilings from
-    //    AnalysisContext (total_stack_size, ctx_descriptor->size). T_PACKET
-    //    fits here, *not* under "dynamic", because there is exactly one
-    //    packet per program invocation: its bounds (packet_size, set once at
-    //    entry; or the loose max_packet_size constant) do not vary with the
-    //    allocation site of the pointer. The two T_PACKET ceilings split
-    //    further by access shape -- see the (Variable) overload below.
-    //
-    //  - "dynamic" regions have a ceiling that *does* depend on the
-    //    allocation site: T_SHARED's shared_region_size and T_ALLOC_MEM's
-    //    alloc_mem_size are kind variables on the RegPack, set when the
-    //    pointer was produced (map lookup, ringbuf_reserve, ...). The
-    //    TypeEncoding adds nothing the size variable does not already
-    //    carry, so the dynamic-region check takes the size directly.
-
-    // Static-region bounds, ceiling chosen by `type`:
-    //   T_STACK / T_CTX -> their AnalysisContext-derived ceilings;
-    //   T_PACKET        -> the loose max_packet_size constant. Use this
-    //                      T_PACKET form *only* for pointer-comparison
-    //                      checks (width == 0) where the pointer may
-    //                      legitimately be past the runtime packet_size
-    //                      until the comparison gates the actual access.
-    void check_access_to_static_region(TypeEncoding type, const LinearExpression& access_lb,
-                                       const LinearExpression& access_ub) const;
-    // T_PACKET dereference: bound by the runtime packet_size variable. Pass
-    // `variable_registry.packet_size()`. The TypeEncoding is implicit here
-    // (only T_PACKET has a runtime-Variable ceiling).
-    void check_access_to_static_region(Variable packet_size, const LinearExpression& access_lb,
-                                       const LinearExpression& access_ub) const;
-    // Dynamic-region bounds: pass the per-allocation size variable
-    // (RegPack::shared_region_size for T_SHARED,
-    // RegPack::alloc_mem_size for T_ALLOC_MEM).
-    void check_access_to_dynamic_region(Variable region_size, const LinearExpression& access_lb,
-                                        const LinearExpression& access_ub) const;
+    // Per-region bounds checks compose two primitives at each call site, so
+    // the floor and ceiling for a given access are spelled out where they
+    // are checked rather than picked by a dispatcher.
+    void require_lower_bound(const LinearExpression& access_lb, const LinearExpression& floor,
+                             const std::string& msg) const {
+        using namespace dsl_syntax;
+        require_value(dom.state, access_lb >= floor, msg);
+    }
+    void require_upper_bound(const LinearExpression& access_ub, const LinearExpression& ceiling,
+                             const std::string& msg) const {
+        using namespace dsl_syntax;
+        require_value(dom.state, access_ub <= ceiling, msg);
+    }
 
     const Assertion assertion;
 
@@ -110,52 +84,6 @@ std::optional<VerificationError> ebpf_domain_check(const EbpfDomain& dom, const 
         return {error};
     }
     return {};
-}
-
-void EbpfChecker::check_access_to_static_region(const TypeEncoding type, const LinearExpression& access_lb,
-                                                const LinearExpression& access_ub) const {
-    using namespace dsl_syntax;
-    switch (type) {
-    case T_STACK: {
-        const auto floor = reg_pack(R10_STACK_POINTER).stack_offset - context.options.subprogram_stack_size;
-        require_value(dom.state, access_lb >= floor,
-                      "Lower bound must be at least r10.stack_offset - subprogram_stack_size");
-        require_value(dom.state, access_ub <= LinearExpression{context.options.total_stack_size()},
-                      "Upper bound must be at most total_stack_size");
-        return;
-    }
-    case T_CTX: {
-        const auto ctx_size = context.program_info().type.ctx_descriptor->size;
-        require_value(dom.state, access_lb >= LinearExpression{0}, "Lower bound must be at least 0");
-        require_value(dom.state, access_ub <= LinearExpression{ctx_size},
-                      std::string("Upper bound must be at most ") + std::to_string(ctx_size));
-        return;
-    }
-    case T_PACKET: {
-        const auto max = context.options.max_packet_size;
-        require_value(dom.state, access_lb >= variable_registry.meta_offset(),
-                      "Lower bound must be at least meta_offset");
-        require_value(dom.state, access_ub <= LinearExpression{max},
-                      std::string("Upper bound must be at most ") + std::to_string(max));
-        return;
-    }
-    default: throw_fail("internal error: check_access_to_static_region called on non-static region type");
-    }
-}
-
-void EbpfChecker::check_access_to_static_region(const Variable packet_size, const LinearExpression& access_lb,
-                                                const LinearExpression& access_ub) const {
-    using namespace dsl_syntax;
-    require_value(dom.state, access_lb >= variable_registry.meta_offset(), "Lower bound must be at least meta_offset");
-    require_value(dom.state, access_ub <= packet_size, "Upper bound must be at most packet_size");
-}
-
-void EbpfChecker::check_access_to_dynamic_region(const Variable region_size, const LinearExpression& access_lb,
-                                                 const LinearExpression& access_ub) const {
-    using namespace dsl_syntax;
-    require_value(dom.state, access_lb >= LinearExpression{0}, "Lower bound must be at least 0");
-    require_value(dom.state, access_ub <= region_size,
-                  std::string("Upper bound must be at most ") + variable_registry.name(region_size));
 }
 
 void EbpfChecker::operator()(const Comparable& s) const {
@@ -324,14 +252,17 @@ void EbpfChecker::operator()(const ValidMapKeyValue& s) const {
         case T_PACKET: {
             Variable lb = access_reg.packet_offset;
             LinearExpression ub = lb + width;
-            check_access_to_static_region(variable_registry.packet_size(), lb, ub);
+            require_lower_bound(lb, variable_registry.meta_offset(), "Lower bound must be at least meta_offset");
+            require_upper_bound(ub, variable_registry.packet_size(), "Upper bound must be at most packet_size");
             // Packet memory is both readable and writable.
             break;
         }
         case T_SHARED: {
             Variable lb = access_reg.shared_offset;
             LinearExpression ub = lb + width;
-            check_access_to_dynamic_region(access_reg.shared_region_size, lb, ub);
+            require_lower_bound(lb, LinearExpression{0}, "Lower bound must be at least 0");
+            require_upper_bound(ub, access_reg.shared_region_size,
+                                "Upper bound must be at most " + variable_registry.name(access_reg.shared_region_size));
             require_value(dom.state, access_reg.svalue > 0, "Possible null access");
             // Shared memory is zero-initialized when created so is safe to read and write.
             break;
@@ -360,7 +291,10 @@ void EbpfChecker::operator()(const ValidAccess& s) const {
         switch (type) {
         case T_STACK: {
             const auto [lb, ub] = lb_ub_access_pair(s, reg.stack_offset);
-            check_access_to_static_region(T_STACK, lb, ub);
+            require_lower_bound(lb, reg_pack(R10_STACK_POINTER).stack_offset - context.options.subprogram_stack_size,
+                                "Lower bound must be at least r10.stack_offset - subprogram_stack_size");
+            require_upper_bound(ub, LinearExpression{context.options.total_stack_size()},
+                                "Upper bound must be at most total_stack_size");
             // Stack reads must hit known-numeric bytes.
             if (s.access_type == AccessType::read &&
                 !dom.stack->all_num_lb_ub(dom.state.values.eval_interval(lb), dom.state.values.eval_interval(ub))) {
@@ -376,28 +310,34 @@ void EbpfChecker::operator()(const ValidAccess& s) const {
             break;
         }
         case T_CTX: {
+            const auto ctx_size = context.program_info().type.ctx_descriptor->size;
             const auto [lb, ub] = lb_ub_access_pair(s, reg.ctx_offset);
-            check_access_to_static_region(T_CTX, lb, ub);
+            require_lower_bound(lb, LinearExpression{0}, "Lower bound must be at least 0");
+            require_upper_bound(ub, LinearExpression{ctx_size},
+                                "Upper bound must be at most " + std::to_string(ctx_size));
             // T_CTX: bounds suffice; non-null when in bounds.
             break;
         }
         case T_PACKET: {
             const auto [lb, ub] = lb_ub_access_pair(s, reg.packet_offset);
+            require_lower_bound(lb, variable_registry.meta_offset(), "Lower bound must be at least meta_offset");
             // Pointer-comparison checks (width == 0) may legitimately reach
             // past the runtime packet_size, so they use the looser
-            // max_packet_size ceiling (the TypeEncoding overload). Real
-            // dereferences must be bounded by the runtime packet_size
-            // variable (the Variable overload).
+            // max_packet_size ceiling. Real dereferences must be bounded by
+            // the runtime packet_size variable.
             if (is_comparison_check) {
-                check_access_to_static_region(T_PACKET, lb, ub);
+                const auto max = context.options.max_packet_size;
+                require_upper_bound(ub, LinearExpression{max}, "Upper bound must be at most " + std::to_string(max));
             } else {
-                check_access_to_static_region(variable_registry.packet_size(), lb, ub);
+                require_upper_bound(ub, variable_registry.packet_size(), "Upper bound must be at most packet_size");
             }
             break;
         }
         case T_SHARED: {
             const auto [lb, ub] = lb_ub_access_pair(s, reg.shared_offset);
-            check_access_to_dynamic_region(reg.shared_region_size, lb, ub);
+            require_lower_bound(lb, LinearExpression{0}, "Lower bound must be at least 0");
+            require_upper_bound(ub, reg.shared_region_size,
+                                "Upper bound must be at most " + variable_registry.name(reg.shared_region_size));
             if (!is_comparison_check && !s.or_null) {
                 require_value(dom.state, reg.svalue > 0, "Possible null access");
             }
@@ -405,7 +345,9 @@ void EbpfChecker::operator()(const ValidAccess& s) const {
         }
         case T_ALLOC_MEM: {
             const auto [lb, ub] = lb_ub_access_pair(s, reg.alloc_mem_offset);
-            check_access_to_dynamic_region(reg.alloc_mem_size, lb, ub);
+            require_lower_bound(lb, LinearExpression{0}, "Lower bound must be at least 0");
+            require_upper_bound(ub, reg.alloc_mem_size,
+                                "Upper bound must be at most " + variable_registry.name(reg.alloc_mem_size));
             if (!is_comparison_check && !s.or_null) {
                 require_value(dom.state, reg.svalue > 0, "Possible null access");
             }

--- a/src/crab/region_semantics.cpp
+++ b/src/crab/region_semantics.cpp
@@ -1,13 +1,7 @@
 // Copyright (c) Prevail Verifier contributors.
 // SPDX-License-Identifier: MIT
-#include <cassert>
-#include <stdexcept>
-#include <string>
-
-#include "arith/dsl_syntax.hpp"
 #include "crab/region_semantics.hpp"
 #include "crab/type_to_num.hpp"
-#include "crab/var_registry.hpp"
 
 namespace prevail {
 
@@ -24,57 +18,6 @@ std::optional<Variable> primary_kind_variable_for_type(const Reg& reg, const Typ
     case T_BTF_ID: return r.btf_id_offset;
     case T_ALLOC_MEM: return r.alloc_mem_offset;
     default: return {};
-    }
-}
-
-RegionBounds region_bounds(const TypeEncoding type, const RegPack& reg, const AnalysisContext& ctx,
-                           const std::optional<Variable> packet_size) {
-    using namespace dsl_syntax;
-    // packet_size only refines the T_PACKET upper bound; passing it for other
-    // region types is silently ignored downstream and indicates a caller bug.
-    assert(!packet_size || type == T_PACKET);
-    switch (type) {
-    case T_STACK:
-        return {.lb_floor = reg_pack(R10_STACK_POINTER).stack_offset - ctx.options.subprogram_stack_size,
-                .lb_message = "Lower bound must be at least r10.stack_offset - subprogram_stack_size",
-                .ub_ceiling = LinearExpression{ctx.options.total_stack_size()},
-                .ub_message = "Upper bound must be at most total_stack_size"};
-    case T_CTX: {
-        const auto ctx_size = ctx.program_info().type.ctx_descriptor->size;
-        return {.lb_floor = LinearExpression{0},
-                .lb_message = "Lower bound must be at least 0",
-                .ub_ceiling = LinearExpression{ctx_size},
-                .ub_message = std::string("Upper bound must be at most ") + std::to_string(ctx_size)};
-    }
-    case T_PACKET:
-        if (packet_size) {
-            return {.lb_floor = variable_registry.meta_offset(),
-                    .lb_message = "Lower bound must be at least meta_offset",
-                    .ub_ceiling = *packet_size,
-                    .ub_message = "Upper bound must be at most packet_size"};
-        }
-        return {.lb_floor = variable_registry.meta_offset(),
-                .lb_message = "Lower bound must be at least meta_offset",
-                .ub_ceiling = LinearExpression{ctx.options.max_packet_size},
-                .ub_message =
-                    std::string("Upper bound must be at most ") + std::to_string(ctx.options.max_packet_size)};
-    case T_SHARED:
-        return {.lb_floor = LinearExpression{0},
-                .lb_message = "Lower bound must be at least 0",
-                .ub_ceiling = reg.shared_region_size,
-                .ub_message =
-                    std::string("Upper bound must be at most ") + variable_registry.name(reg.shared_region_size)};
-    case T_ALLOC_MEM:
-        return {.lb_floor = LinearExpression{0},
-                .lb_message = "Lower bound must be at least 0",
-                .ub_ceiling = reg.alloc_mem_size,
-                .ub_message = std::string("Upper bound must be at most ") + variable_registry.name(reg.alloc_mem_size)};
-    default:
-        // The caller is expected to gate by region type (e.g., the checker's
-        // ValidAccess switch). Reaching this point is a programming error -
-        // throw unconditionally so the contract is enforced in release builds
-        // too (assert would be stripped under NDEBUG).
-        throw std::logic_error("region_bounds called on non-region type");
     }
 }
 

--- a/src/crab/region_semantics.cpp
+++ b/src/crab/region_semantics.cpp
@@ -1,5 +1,6 @@
 // Copyright (c) Prevail Verifier contributors.
 // SPDX-License-Identifier: MIT
+#include <cassert>
 #include <stdexcept>
 #include <string>
 
@@ -29,6 +30,9 @@ std::optional<Variable> primary_kind_variable_for_type(const Reg& reg, const Typ
 RegionBounds region_bounds(const TypeEncoding type, const RegPack& reg, const AnalysisContext& ctx,
                            const std::optional<Variable> packet_size) {
     using namespace dsl_syntax;
+    // packet_size only refines the T_PACKET upper bound; passing it for other
+    // region types is silently ignored downstream and indicates a caller bug.
+    assert(!packet_size || type == T_PACKET);
     switch (type) {
     case T_STACK:
         return {.lb_floor = reg_pack(R10_STACK_POINTER).stack_offset - ctx.options.subprogram_stack_size,

--- a/src/crab/region_semantics.hpp
+++ b/src/crab/region_semantics.hpp
@@ -3,22 +3,16 @@
 #pragma once
 
 #include <optional>
-#include <string>
 
-#include "analysis_context.hpp"
-#include "arith/dsl_syntax.hpp"
-#include "arith/linear_expression.hpp"
 #include "arith/variable.hpp"
 #include "crab/type_encoding.hpp"
-#include "crab/type_to_num.hpp"
-#include "crab/var_registry.hpp"
 #include "ir/syntax.hpp"
 
 namespace prevail {
 
-/// True for pointer types whose in-region accesses are bounds-checked by
-/// `region_bounds`. Other pointer types (T_SOCKET, T_BTF_ID, T_MAP,
-/// T_MAP_PROGRAMS, T_FUNC) are not directly dereferenceable in this verifier.
+/// True for pointer types whose in-region accesses are bounds-checked. Other
+/// pointer types (T_SOCKET, T_BTF_ID, T_MAP, T_MAP_PROGRAMS, T_FUNC) are not
+/// directly dereferenceable in this verifier.
 inline constexpr bool is_region_access_type(const TypeEncoding type) {
     switch (type) {
     case T_STACK:
@@ -41,84 +35,5 @@ inline constexpr bool is_region_access_type(const TypeEncoding type) {
 /// T_ALLOC_MEM owns alloc_mem_size. Those are accessed via RegPack directly,
 /// not through this function.
 std::optional<Variable> primary_kind_variable_for_type(const Reg& reg, TypeEncoding type);
-
-/// Address-range bounds an in-region access must satisfy. Used by checker
-/// callers as: `require access_lb >= lb_floor; require access_ub <= ub_ceiling`.
-/// Messages are diagnostic-only and resolved at the bounds-construction site so
-/// they can mention concrete numbers (e.g. ctx_descriptor->size).
-struct RegionBounds {
-    LinearExpression lb_floor;
-    std::string lb_message;
-    LinearExpression ub_ceiling;
-    std::string ub_message;
-};
-
-/// Bounds are partitioned by the *shape* of context the ceiling is read from:
-/// - context-derived: T_STACK, T_CTX, and T_PACKET *when no runtime override
-///   is supplied* (ceiling comes from `AnalysisContext::options`).
-/// - reg-derived: T_SHARED, T_ALLOC_MEM (ceiling is a kind variable on `RegPack`).
-/// - T_PACKET *with* a runtime override: a separate overload that takes the
-///   `packet_size` Variable directly. This is the dereference path; sites that
-///   actually read or write packet bytes must use it. The context-derived
-///   T_PACKET overload uses the looser `max_packet_size` ceiling and is only
-///   correct for pointer-comparison checks (no actual access).
-template <TypeEncoding T>
-concept CtxDerivedCeiling = (T == T_STACK || T == T_CTX || T == T_PACKET);
-
-template <TypeEncoding T>
-concept RegDerivedCeiling = (T == T_SHARED || T == T_ALLOC_MEM);
-
-template <TypeEncoding T>
-    requires CtxDerivedCeiling<T>
-RegionBounds region_bounds(const AnalysisContext& ctx) {
-    using namespace dsl_syntax;
-    if constexpr (T == T_STACK) {
-        return {.lb_floor = reg_pack(R10_STACK_POINTER).stack_offset - ctx.options.subprogram_stack_size,
-                .lb_message = "Lower bound must be at least r10.stack_offset - subprogram_stack_size",
-                .ub_ceiling = LinearExpression{ctx.options.total_stack_size()},
-                .ub_message = "Upper bound must be at most total_stack_size"};
-    } else if constexpr (T == T_CTX) {
-        const auto ctx_size = ctx.program_info().type.ctx_descriptor->size;
-        return {.lb_floor = LinearExpression{0},
-                .lb_message = "Lower bound must be at least 0",
-                .ub_ceiling = LinearExpression{ctx_size},
-                .ub_message = std::string("Upper bound must be at most ") + std::to_string(ctx_size)};
-    } else { // T_PACKET, static ceiling: pointer-comparison checks only.
-        return {.lb_floor = variable_registry.meta_offset(),
-                .lb_message = "Lower bound must be at least meta_offset",
-                .ub_ceiling = LinearExpression{ctx.options.max_packet_size},
-                .ub_message =
-                    std::string("Upper bound must be at most ") + std::to_string(ctx.options.max_packet_size)};
-    }
-}
-
-template <TypeEncoding T>
-    requires RegDerivedCeiling<T>
-RegionBounds region_bounds(const RegPack& reg) {
-    if constexpr (T == T_SHARED) {
-        return {.lb_floor = LinearExpression{0},
-                .lb_message = "Lower bound must be at least 0",
-                .ub_ceiling = reg.shared_region_size,
-                .ub_message =
-                    std::string("Upper bound must be at most ") + variable_registry.name(reg.shared_region_size)};
-    } else { // T_ALLOC_MEM
-        return {.lb_floor = LinearExpression{0},
-                .lb_message = "Lower bound must be at least 0",
-                .ub_ceiling = reg.alloc_mem_size,
-                .ub_message = std::string("Upper bound must be at most ") + variable_registry.name(reg.alloc_mem_size)};
-    }
-}
-
-/// T_PACKET with a runtime ceiling. Use at every site that actually reads or
-/// writes packet bytes (direct ValidAccess dereferences, helper key/value
-/// buffers via ValidMapKeyValue). Pass `variable_registry.packet_size()`.
-template <TypeEncoding T>
-    requires(T == T_PACKET)
-RegionBounds region_bounds(Variable packet_size) {
-    return {.lb_floor = variable_registry.meta_offset(),
-            .lb_message = "Lower bound must be at least meta_offset",
-            .ub_ceiling = packet_size,
-            .ub_message = "Upper bound must be at most packet_size"};
-}
 
 } // namespace prevail

--- a/src/crab/region_semantics.hpp
+++ b/src/crab/region_semantics.hpp
@@ -6,9 +6,11 @@
 #include <string>
 
 #include "analysis_context.hpp"
+#include "arith/dsl_syntax.hpp"
 #include "arith/linear_expression.hpp"
 #include "arith/variable.hpp"
 #include "crab/type_encoding.hpp"
+#include "crab/type_to_num.hpp"
 #include "crab/var_registry.hpp"
 #include "ir/syntax.hpp"
 
@@ -51,13 +53,72 @@ struct RegionBounds {
     std::string ub_message;
 };
 
-/// Bounds for a region-typed access. Defined for T_STACK, T_CTX, T_PACKET,
-/// T_SHARED, T_ALLOC_MEM. For other types the caller should not invoke this.
-///
-/// `packet_size` overrides the T_PACKET upper bound. When nullopt, the
-/// upper bound is options.max_packet_size; pass `variable_registry.packet_size()`
-/// to bound by the runtime packet size variable.
-RegionBounds region_bounds(TypeEncoding type, const RegPack& reg, const AnalysisContext& ctx,
-                           std::optional<Variable> packet_size = std::nullopt);
+/// Bounds are partitioned by the *shape* of context the ceiling is read from:
+/// - context-derived: T_STACK, T_CTX, and T_PACKET *when no runtime override
+///   is supplied* (ceiling comes from `AnalysisContext::options`).
+/// - reg-derived: T_SHARED, T_ALLOC_MEM (ceiling is a kind variable on `RegPack`).
+/// - T_PACKET *with* a runtime override: a separate overload that takes the
+///   `packet_size` Variable directly. This is the dereference path; sites that
+///   actually read or write packet bytes must use it. The context-derived
+///   T_PACKET overload uses the looser `max_packet_size` ceiling and is only
+///   correct for pointer-comparison checks (no actual access).
+template <TypeEncoding T>
+concept CtxDerivedCeiling = (T == T_STACK || T == T_CTX || T == T_PACKET);
+
+template <TypeEncoding T>
+concept RegDerivedCeiling = (T == T_SHARED || T == T_ALLOC_MEM);
+
+template <TypeEncoding T>
+    requires CtxDerivedCeiling<T>
+RegionBounds region_bounds(const AnalysisContext& ctx) {
+    using namespace dsl_syntax;
+    if constexpr (T == T_STACK) {
+        return {.lb_floor = reg_pack(R10_STACK_POINTER).stack_offset - ctx.options.subprogram_stack_size,
+                .lb_message = "Lower bound must be at least r10.stack_offset - subprogram_stack_size",
+                .ub_ceiling = LinearExpression{ctx.options.total_stack_size()},
+                .ub_message = "Upper bound must be at most total_stack_size"};
+    } else if constexpr (T == T_CTX) {
+        const auto ctx_size = ctx.program_info().type.ctx_descriptor->size;
+        return {.lb_floor = LinearExpression{0},
+                .lb_message = "Lower bound must be at least 0",
+                .ub_ceiling = LinearExpression{ctx_size},
+                .ub_message = std::string("Upper bound must be at most ") + std::to_string(ctx_size)};
+    } else { // T_PACKET, static ceiling: pointer-comparison checks only.
+        return {.lb_floor = variable_registry.meta_offset(),
+                .lb_message = "Lower bound must be at least meta_offset",
+                .ub_ceiling = LinearExpression{ctx.options.max_packet_size},
+                .ub_message =
+                    std::string("Upper bound must be at most ") + std::to_string(ctx.options.max_packet_size)};
+    }
+}
+
+template <TypeEncoding T>
+    requires RegDerivedCeiling<T>
+RegionBounds region_bounds(const RegPack& reg) {
+    if constexpr (T == T_SHARED) {
+        return {.lb_floor = LinearExpression{0},
+                .lb_message = "Lower bound must be at least 0",
+                .ub_ceiling = reg.shared_region_size,
+                .ub_message =
+                    std::string("Upper bound must be at most ") + variable_registry.name(reg.shared_region_size)};
+    } else { // T_ALLOC_MEM
+        return {.lb_floor = LinearExpression{0},
+                .lb_message = "Lower bound must be at least 0",
+                .ub_ceiling = reg.alloc_mem_size,
+                .ub_message = std::string("Upper bound must be at most ") + variable_registry.name(reg.alloc_mem_size)};
+    }
+}
+
+/// T_PACKET with a runtime ceiling. Use at every site that actually reads or
+/// writes packet bytes (direct ValidAccess dereferences, helper key/value
+/// buffers via ValidMapKeyValue). Pass `variable_registry.packet_size()`.
+template <TypeEncoding T>
+    requires(T == T_PACKET)
+RegionBounds region_bounds(Variable packet_size) {
+    return {.lb_floor = variable_registry.meta_offset(),
+            .lb_message = "Lower bound must be at least meta_offset",
+            .ub_ceiling = packet_size,
+            .ub_message = "Upper bound must be at most packet_size"};
+}
 
 } // namespace prevail


### PR DESCRIPTION
## Summary

Fixes #1099 and reshapes the bounds-check helpers around it into two primitives that each per-region case composes directly.

## The bug

`ValidMapKeyValue`'s T_PACKET branch checked the upper bound against the loose `max_packet_size` constant, while `ValidAccess`'s T_PACKET dereference path used the runtime `variable_registry.packet_size()` for a tighter check. Helper map key/value pointers are real reads/writes through the pointer (the helper copies `key_size` / `value_size` bytes), so they need the same runtime ceiling as direct dereferences. Using `max_packet_size` was unsoundly loose: a program could pass verification while accessing past the actual runtime `packet_size`.

The fix at the call site now reads as one line:

```cpp
require_upper_bound(ub, variable_registry.packet_size(), "Upper bound must be at most packet_size");
```

## The refactor

Replaced the previous `region_bounds` / `RegionBounds` / `require_region_bounds` apparatus (and a brief detour through templated overloads and a `static`/`dynamic` taxonomy) with two trivial member primitives on `EbpfChecker`:

```cpp
void require_lower_bound(const LinearExpression& access_lb,
                         const LinearExpression& floor,   const std::string& msg) const;
void require_upper_bound(const LinearExpression& access_ub,
                         const LinearExpression& ceiling, const std::string& msg) const;
```

Each per-type case (`T_STACK`, `T_CTX`, `T_PACKET`, `T_SHARED`, `T_ALLOC_MEM`) in `EbpfChecker::operator()(const ValidAccess&)` and `operator()(const ValidMapKeyValue&)` now spells out its floor and ceiling directly at the line where the access is checked, rather than routing through a per-region helper whose contract had to be carried in comments.

`ValidAccess`'s outer loop also folds its inner `is_region_access_type` switch into the per-type switch — every bounds check is now in a case with a compile-time-constant region type. The runtime `primary_kind_variable_for_type` lookup is no longer needed at the call sites (each case names the offset variable directly).

The `region_bounds` free function and `RegionBounds` struct are removed; `region_semantics.{hpp,cpp}` shrinks to just `is_region_access_type` and `primary_kind_variable_for_type` (still used elsewhere).

## Why this shape

The bug class behind #1099 was that the per-region helper had two T_PACKET ceilings (loose `max_packet_size` for pointer-comparison checks, runtime `packet_size` for dereferences) and the choice was hidden behind a `std::optional<Variable>` argument. "I forgot to pass it" looked identical to "I deliberately chose not to" — which is exactly how the asymmetry between `ValidMapKeyValue` and `ValidAccess` stayed invisible.

After the refactor the choice is *the literal ceiling expression* on the `require_upper_bound` line. The diff that fixes a #1099-class bug is the diff readers see at the call site.

## Soundness

- `packet_size <= max_packet_size` is an invariant of the abstract domain, so tightening the T_PACKET ceiling at this site can only reject programs that the previous version also could have caught at the analogous `ValidAccess` site — no previously-verified program becomes rejected for a reason that wasn't already there.
- Pointer-comparison checks (`width == 0`) in `ValidAccess::T_PACKET` continue to use `max_packet_size`, preserving the legitimate `end = ptr + N; if (end <= data_end)` pattern.
- All other per-region bounds (T_STACK, T_CTX, T_SHARED, T_ALLOC_MEM) preserve their floor/ceiling expressions exactly as in the previous code.

## Test plan

- [x] `cmake --build build --parallel` — clean build
- [x] `./bin/tests` — 1314 passed, 1 skipped, 236 failed-as-expected (unchanged from main)

## References

- Closes #1099
- Origin discussion: PR #1097 ([thread](https://github.com/vbpf/prevail/pull/1097#discussion_r3138435056))