### PR TITLE
Split runtime semantics from presentation/orchestration (#1085)

### DIFF
--- a/src/analysis_context.hpp
+++ b/src/analysis_context.hpp
@@ -28,9 +28,11 @@ namespace prevail {
 /// directly.
 struct AnalysisContext {
     Program program;
-    ebpf_verifier_options_t options;
+    VerifierOptions options;
 
-    AnalysisContext(Program p, ebpf_verifier_options_t o) : program(std::move(p)), options(std::move(o)) {}
+    AnalysisContext(Program p, VerifierOptions o) : program(std::move(p)), options(std::move(o)) {}
+
+    const RuntimeConfig& runtime() const { return options.runtime; }
 
     const ProgramInfo& program_info() const { return program.info(); }
     const ebpf_platform_t& platform() const {
@@ -39,12 +41,12 @@ struct AnalysisContext {
     }
 
     // Look up `map_fd` in this program's descriptor table.
-    const EbpfMapDescriptor& map_descriptor(int map_fd) const {
+    const EbpfMapDescriptor& map_descriptor(const int map_fd) const {
         return platform().get_map_descriptor(map_fd, program_info().map_descriptors);
     }
 
     // Whether `helper_id` is callable from this program's type.
-    bool is_helper_usable(int32_t helper_id) const {
+    bool is_helper_usable(const int32_t helper_id) const {
         return platform().is_helper_usable(helper_id, program_info().type);
     }
 };

--- a/src/arith/dsl_syntax.hpp
+++ b/src/arith/dsl_syntax.hpp
@@ -8,7 +8,7 @@ namespace prevail::dsl_syntax {
 
 inline LinearExpression operator-(const LinearExpression& e) { return e.negate(); }
 
-inline LinearExpression operator*(Variable x, const Number& n) { return LinearExpression(n, x); }
+inline LinearExpression operator*(const Variable x, const Number& n) { return LinearExpression(n, x); }
 
 inline LinearExpression operator*(const Number& n, const LinearExpression& e) { return e.multiply(n); }
 

--- a/src/arith/linear_constraint.hpp
+++ b/src/arith/linear_constraint.hpp
@@ -18,7 +18,7 @@ class LinearConstraint final {
     ConstraintKind _constraint_kind;
 
   public:
-    LinearConstraint(LinearExpression expression, ConstraintKind constraint_kind)
+    LinearConstraint(LinearExpression expression, const ConstraintKind constraint_kind)
         : _expression(std::move(expression)), _constraint_kind(constraint_kind) {}
 
     [[nodiscard]]

--- a/src/arith/linear_expression.hpp
+++ b/src/arith/linear_expression.hpp
@@ -38,7 +38,7 @@ class LinearExpression final {
 
     LinearExpression(std::integral auto coefficient) : _constant_term(coefficient) {}
     LinearExpression(is_enum auto coefficient) : _constant_term(coefficient) {}
-    LinearExpression(Variable variable) { _variable_terms[variable] = 1; }
+    LinearExpression(const Variable variable) { _variable_terms[variable] = 1; }
 
     LinearExpression(const Number& coefficient, const Variable& variable) {
         if (coefficient != 0) {

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -6,14 +6,10 @@
 #include <string>
 
 namespace prevail {
-struct prepare_cfg_options {
-    /// When true, verifies that the program terminates.
-    bool check_for_termination = false;
-    /// When true, ensures the program has a valid exit block.
-    bool must_have_exit = true;
-};
 
-struct verbosity_options_t {
+/// Display and diagnostics knobs. Reading or writing any of these never
+/// affects which programs the verifier accepts.
+struct VerbosityOptions {
     /// When true, prints simplified control flow graph by merging chains into basic blocks.
     bool simplify = true;
 
@@ -41,13 +37,9 @@ struct verbosity_options_t {
     bool compact_slice = false;
 };
 
-struct ebpf_verifier_options_t {
-    // Options that control how the control flow graph is built.
-    prepare_cfg_options cfg_opts;
-
-    // False to use actual map fd's, true to use mock fd's.
-    bool mock_map_fds = true;
-
+/// Runtime/semantic configuration: knobs read by the analyzer, checker,
+/// and abstract domain whose values affect which programs are accepted.
+struct RuntimeConfig {
     // True to do additional checks for some things that would fail at runtime.
     bool strict = false;
 
@@ -59,6 +51,10 @@ struct ebpf_verifier_options_t {
 
     // True if the ELF file is built on a big endian system.
     bool big_endian = false;
+
+    // When true, instrument loop heads with bounded-loop-count counters and
+    // require the analysis to prove they remain within the loop bound.
+    bool check_for_termination = false;
 
     // Per-subprogram stack frame size in bytes.
     int subprogram_stack_size = 512;
@@ -94,11 +90,20 @@ struct ebpf_verifier_options_t {
                                         "], got " + std::to_string(max_packet_size));
         }
     }
-
-    verbosity_options_t verbosity_opts;
 };
 
-struct ebpf_verifier_stats_t {
+struct VerifierOptions {
+    RuntimeConfig runtime;
+    VerbosityOptions verbosity_opts;
+
+    /// When true, ensures the program has a valid exit block.
+    bool must_have_exit = true;
+
+    // False to use actual map fd's, true to use mock fd's.
+    bool mock_map_fds = true;
+};
+
+struct VerifierStats {
     int total_errors{};
     int max_loop_count{};
 };

--- a/src/crab/add_bottom.hpp
+++ b/src/crab/add_bottom.hpp
@@ -180,7 +180,7 @@ class AddBottom final {
         return Interval::bottom();
     }
 
-    void set(Variable x, const Interval& intv) {
+    void set(const Variable x, const Interval& intv) {
         if (intv.is_bottom()) {
             dom = {};
         } else if (dom) {

--- a/src/crab/array_domain.cpp
+++ b/src/crab/array_domain.cpp
@@ -69,7 +69,6 @@ static Variable cell_var(const DataKind kind, const Cell& c) {
 // At these sizes, specialized data structures (patricia tries, flat sorted vectors) show no
 // macro-level improvement while adding complexity or external dependencies.
 class offset_map_t final {
-  private:
     friend class ArrayDomain;
 
     using cell_set_t = std::set<Cell>;
@@ -91,11 +90,6 @@ class offset_map_t final {
     offset_map_t() = default;
 
     [[nodiscard]]
-    bool empty() const {
-        return _map.empty();
-    }
-
-    [[nodiscard]]
     std::size_t size() const {
         return _map.size();
     }
@@ -115,25 +109,6 @@ class offset_map_t final {
     std::vector<Cell> get_overlap_cells_symbolic_offset(const Interval& range);
 
     friend std::ostream& operator<<(std::ostream& o, offset_map_t& m);
-
-    /* Operations needed if used as value in a separate_domain */
-    [[nodiscard]]
-    bool is_top() const {
-        return empty();
-    }
-
-    [[nodiscard]]
-    // ReSharper disable once CppMemberFunctionMayBeStatic
-    bool is_bottom() const {
-        return false;
-    }
-    /*
-       We don't distinguish between bottom and top.
-       This is fine because separate_domain only calls bottom if operator[] is called over a bottom state.
-       Thus, we will make sure that we don't call operator[] in that case.
-    */
-    static offset_map_t bottom() { return offset_map_t(); }
-    static offset_map_t top() { return offset_map_t(); }
 };
 
 void offset_map_t::remove_cell(const Cell& c) {
@@ -266,7 +241,7 @@ std::ostream& operator<<(std::ostream& o, offset_map_t& m) {
 
 // Create a new cell that is a subset of an existing cell.
 void ArrayDomain::split_cell(NumAbsDomain& inv, const DataKind kind, const int cell_start_index, const unsigned int len,
-                             const bool big_endian) const {
+                             const bool big_endian) {
     assert(kind == DataKind::svalues || kind == DataKind::uvalues);
 
     // Get the values from the indicated stack range.
@@ -284,8 +259,8 @@ void ArrayDomain::split_cell(NumAbsDomain& inv, const DataKind kind, const int c
 
 // Prepare to havoc bytes in the middle of a cell by potentially splitting the cell if it is numeric,
 // into the part to the left of the havoced portion, and the part to the right of the havoced portion.
-void ArrayDomain::split_number_var(NumAbsDomain& inv, DataKind kind, const Interval& ii, const Interval& elem_size,
-                                   const bool big_endian) const {
+void ArrayDomain::split_number_var(NumAbsDomain& inv, const DataKind kind, const Interval& ii,
+                                   const Interval& elem_size, const bool big_endian) const {
     assert(kind == DataKind::svalues || kind == DataKind::uvalues);
     offset_map_t& offset_map = lookup_array_map(kind);
     const std::optional<Number> n = ii.singleton();
@@ -330,7 +305,7 @@ void ArrayDomain::split_number_var(NumAbsDomain& inv, DataKind kind, const Inter
 // Find overlapping cells for the given index range and kill (havoc + remove) them.
 // Returns the exact offset and size if the index and element size are both constant.
 template <typename HavocFn>
-static std::optional<std::pair<offset_t, unsigned>> kill_and_find_var(const HavocFn& havoc_var, DataKind kind,
+static std::optional<std::pair<offset_t, unsigned>> kill_and_find_var(const HavocFn& havoc_var, const DataKind kind,
                                                                       const Interval& ii, const Interval& elem_size) {
     std::optional<std::pair<offset_t, unsigned>> res;
 
@@ -437,7 +412,7 @@ std::optional<uint8_t> get_value_byte(const NumAbsDomain& inv, const offset_t o,
 }
 
 std::optional<LinearExpression> ArrayDomain::load(const NumAbsDomain& inv, const DataKind kind, const Interval& i,
-                                                  const int width, const bool big_endian) const {
+                                                  const int width, const bool big_endian) {
     if (const std::optional<Number> n = i.singleton()) {
         offset_map_t& offset_map = lookup_array_map(kind);
         const int64_t k = n->narrow<int64_t>();
@@ -527,7 +502,7 @@ std::optional<LinearExpression> ArrayDomain::load(const NumAbsDomain& inv, const
     return {};
 }
 
-std::optional<LinearExpression> ArrayDomain::load_type(const Interval& i, int width) const {
+std::optional<LinearExpression> ArrayDomain::load_type(const Interval& i, const int width) const {
     if (const std::optional<Number> n = i.singleton()) {
         offset_map_t& offset_map = lookup_array_map(DataKind::types);
         const int64_t k = n->narrow<int64_t>();
@@ -585,11 +560,11 @@ static std::optional<std::pair<offset_t, unsigned>> split_and_find_var(const Arr
     if (kind == DataKind::svalues || kind == DataKind::uvalues) {
         array_domain.split_number_var(inv, kind, idx, elem_size, big_endian);
     }
-    return kill_and_find_var([&inv](Variable v) { inv.havoc(v); }, kind, idx, elem_size);
+    return kill_and_find_var([&inv](const Variable v) { inv.havoc(v); }, kind, idx, elem_size);
 }
 
 std::optional<Variable> ArrayDomain::store(NumAbsDomain& inv, const DataKind kind, const Interval& idx,
-                                           const Interval& elem_size, const bool big_endian) {
+                                           const Interval& elem_size, const bool big_endian) const {
     if (auto maybe_cell = split_and_find_var(*this, inv, kind, idx, elem_size, big_endian)) {
         // perform strong update
         auto [offset, size] = *maybe_cell;
@@ -603,7 +578,7 @@ std::optional<Variable> ArrayDomain::store(NumAbsDomain& inv, const DataKind kin
 std::optional<Variable> ArrayDomain::store_type(TypeDomain& inv, const Interval& idx, const Interval& width,
                                                 const bool is_num) {
     constexpr auto kind = DataKind::types;
-    if (auto maybe_cell = kill_and_find_var([&inv](Variable v) { inv.havoc_type(v); }, kind, idx, width)) {
+    if (auto maybe_cell = kill_and_find_var([&inv](const Variable v) { inv.havoc_type(v); }, kind, idx, width)) {
         // perform strong update
         auto [offset, size] = *maybe_cell;
         if (is_num) {
@@ -632,13 +607,13 @@ std::optional<Variable> ArrayDomain::store_type(TypeDomain& inv, const Interval&
 }
 
 void ArrayDomain::havoc(NumAbsDomain& inv, const DataKind kind, const Interval& idx, const Interval& elem_size,
-                        const bool big_endian) {
+                        const bool big_endian) const {
     split_and_find_var(*this, inv, kind, idx, elem_size, big_endian);
 }
 
 void ArrayDomain::havoc_type(TypeDomain& inv, const Interval& idx, const Interval& elem_size) {
     constexpr auto kind = DataKind::types;
-    if (auto maybe_cell = kill_and_find_var([&inv](Variable v) { inv.havoc_type(v); }, kind, idx, elem_size)) {
+    if (auto maybe_cell = kill_and_find_var([&inv](const Variable v) { inv.havoc_type(v); }, kind, idx, elem_size)) {
         auto [offset, size] = *maybe_cell;
         num_bytes.havoc(offset, size);
     }

--- a/src/crab/array_domain.hpp
+++ b/src/crab/array_domain.hpp
@@ -79,13 +79,13 @@ class ArrayDomain final {
     int min_all_num_size(const NumAbsDomain& inv, Variable offset) const;
 
     [[nodiscard]]
-    std::optional<LinearExpression> load(const NumAbsDomain& inv, DataKind kind, const Interval& i, int width,
-                                         bool big_endian) const;
+    static std::optional<LinearExpression> load(const NumAbsDomain& inv, DataKind kind, const Interval& i, int width,
+                                                bool big_endian);
     std::optional<LinearExpression> load_type(const Interval& i, int width) const;
     std::optional<Variable> store(NumAbsDomain& inv, DataKind kind, const Interval& idx, const Interval& elem_size,
-                                  bool big_endian);
+                                  bool big_endian) const;
     std::optional<Variable> store_type(TypeDomain& inv, const Interval& idx, const Interval& width, bool is_num);
-    void havoc(NumAbsDomain& inv, DataKind kind, const Interval& idx, const Interval& elem_size, bool big_endian);
+    void havoc(NumAbsDomain& inv, DataKind kind, const Interval& idx, const Interval& elem_size, bool big_endian) const;
     void havoc_type(TypeDomain& inv, const Interval& idx, const Interval& elem_size);
 
     // Perform array stores over an array segment
@@ -93,7 +93,7 @@ class ArrayDomain final {
 
     void split_number_var(NumAbsDomain& inv, DataKind kind, const Interval& ii, const Interval& elem_size,
                           bool big_endian) const;
-    void split_cell(NumAbsDomain& inv, DataKind kind, int cell_start_index, unsigned int len, bool big_endian) const;
+    static void split_cell(NumAbsDomain& inv, DataKind kind, int cell_start_index, unsigned int len, bool big_endian);
 
     void initialize_numbers(int lb, int width);
 };

--- a/src/crab/ebpf_checker.cpp
+++ b/src/crab/ebpf_checker.cpp
@@ -97,8 +97,8 @@ void EbpfChecker::operator()(const Comparable& s) const {
             throw_fail("Cannot subtract pointers to non-singleton regions");
         }
         // And, to avoid wraparound errors, they must be within bounds.
-        this->operator()(ValidAccess{context.options.max_call_stack_frames, s.r1, 0, Imm{0}, false});
-        this->operator()(ValidAccess{context.options.max_call_stack_frames, s.r2, 0, Imm{0}, false});
+        this->operator()(ValidAccess{context.runtime().max_call_stack_frames, s.r1, 0, Imm{0}, false});
+        this->operator()(ValidAccess{context.runtime().max_call_stack_frames, s.r2, 0, Imm{0}, false});
     } else {
         // _Maybe_ different types, so r2 must be a number.
         // We checked in a previous assertion that r1 is a pointer or a number.
@@ -119,7 +119,7 @@ void EbpfChecker::operator()(const ValidDivisor& s) const {
     if (!dom.state.implies_superset(s.reg, TS_POINTER, s.reg, TS_NUM)) {
         throw_fail("Only numbers can be used as divisors");
     }
-    if (!context.options.allow_division_by_zero) {
+    if (!context.runtime().allow_division_by_zero) {
         const auto reg = reg_pack(s.reg);
         const auto v = s.is_signed ? reg.svalue : reg.uvalue;
         require_value(dom.state, v != 0, "Possible division by zero");
@@ -160,7 +160,7 @@ void EbpfChecker::operator()(const FuncConstraint& s) const {
                 throw_fail("invalid helper function id " + std::to_string(imm));
             }
             const Call call{.func = imm, .kind = CallKind::helper};
-            for (const Assertion& sub_assertion : get_assertions(call, context.program_info(), context.options, {})) {
+            for (const Assertion& sub_assertion : get_assertions(call, context.program_info(), context.runtime(), {})) {
                 // TODO: create explicit sub assertions elsewhere
                 EbpfChecker{dom, sub_assertion, context}.visit();
             }
@@ -225,7 +225,7 @@ void EbpfChecker::operator()(const ValidMapKeyValue& s) const {
                 std::string ub_s = ub_is && ub_is->fits<int32_t>() ? std::to_string(ub_is->narrow<int32_t>()) : "oo";
                 require_value(dom.state, LinearConstraint::false_const(),
                               "Illegal map update with a non-numerical value [" + lb_s + "-" + ub_s + ")");
-            } else if (context.options.strict && fd_type.has_value()) {
+            } else if (context.runtime().strict && fd_type.has_value()) {
                 EbpfMapType map_type = context.platform().get_map_type(*fd_type);
                 if (map_type.is_array) {
                     // Get offset value.
@@ -291,9 +291,9 @@ void EbpfChecker::operator()(const ValidAccess& s) const {
         switch (type) {
         case T_STACK: {
             const auto [lb, ub] = lb_ub_access_pair(s, reg.stack_offset);
-            require_lower_bound(lb, reg_pack(R10_STACK_POINTER).stack_offset - context.options.subprogram_stack_size,
+            require_lower_bound(lb, reg_pack(R10_STACK_POINTER).stack_offset - context.runtime().subprogram_stack_size,
                                 "Lower bound must be at least r10.stack_offset - subprogram_stack_size");
-            require_upper_bound(ub, LinearExpression{context.options.total_stack_size()},
+            require_upper_bound(ub, LinearExpression{context.runtime().total_stack_size()},
                                 "Upper bound must be at most total_stack_size");
             // Stack reads must hit known-numeric bytes.
             if (s.access_type == AccessType::read &&
@@ -326,7 +326,7 @@ void EbpfChecker::operator()(const ValidAccess& s) const {
             // max_packet_size ceiling. Real dereferences must be bounded by
             // the runtime packet_size variable.
             if (is_comparison_check) {
-                const auto max = context.options.max_packet_size;
+                const auto max = context.runtime().max_packet_size;
                 require_upper_bound(ub, LinearExpression{max}, "Upper bound must be at most " + std::to_string(max));
             } else {
                 require_upper_bound(ub, variable_registry.packet_size(), "Upper bound must be at most packet_size");

--- a/src/crab/ebpf_domain.cpp
+++ b/src/crab/ebpf_domain.cpp
@@ -39,7 +39,7 @@ std::optional<int64_t> EbpfDomain::get_stack_offset(const Reg& reg) const {
 }
 
 EbpfDomain EbpfDomain::top(const AnalysisContext& context) {
-    return top(static_cast<size_t>(context.options.total_stack_size()));
+    return top(static_cast<size_t>(context.runtime().total_stack_size()));
 }
 
 EbpfDomain EbpfDomain::top(const size_t total_stack_size) {
@@ -170,7 +170,7 @@ EbpfDomain EbpfDomain::calculate_constant_limits(const AnalysisContext& context,
         inv.add_value_constraint(r.svalue >= std::numeric_limits<int32_t>::min());
         inv.add_value_constraint(r.uvalue <= std::numeric_limits<uint32_t>::max());
         inv.add_value_constraint(r.uvalue >= 0);
-        inv.add_value_constraint(r.stack_offset <= context.options.total_stack_size());
+        inv.add_value_constraint(r.stack_offset <= context.runtime().total_stack_size());
         inv.add_value_constraint(r.stack_offset >= 0);
         inv.add_value_constraint(r.shared_offset <= r.shared_region_size);
         inv.add_value_constraint(r.shared_offset >= 0);
@@ -372,7 +372,7 @@ void EbpfDomain::initialize_packet(const AnalysisContext& context) {
     inv.havoc(variable_registry.meta_offset());
 
     inv.add_value_constraint(0 <= variable_registry.packet_size());
-    inv.add_value_constraint(variable_registry.packet_size() < context.options.max_packet_size);
+    inv.add_value_constraint(variable_registry.packet_size() < context.runtime().max_packet_size);
     if (context.program_info().type.ctx_descriptor->meta >= 0) {
         inv.add_value_constraint(variable_registry.meta_offset() <= 0);
         inv.add_value_constraint(variable_registry.meta_offset() >= -4098);
@@ -397,10 +397,10 @@ EbpfDomain EbpfDomain::from_constraints(const std::vector<std::pair<Variable, Ty
 
 EbpfDomain EbpfDomain::from_constraints(const std::set<std::string>& constraints, const bool setup_constraints,
                                         const AnalysisContext& context) {
-    EbpfDomain inv =
-        setup_constraints
-            ? setup_entry(false, context)
-            : EbpfDomain{TypeToNumDomain::top(), ArrayDomain{static_cast<size_t>(context.options.total_stack_size())}};
+    EbpfDomain inv = setup_constraints
+                         ? setup_entry(false, context)
+                         : EbpfDomain{TypeToNumDomain::top(),
+                                      ArrayDomain{static_cast<size_t>(context.runtime().total_stack_size())}};
     auto numeric_ranges = std::vector<Interval>();
     auto [type_equalities, type_restrictions, value_constraints] =
         parse_linear_constraints(constraints, numeric_ranges);
@@ -432,9 +432,9 @@ EbpfDomain EbpfDomain::setup_entry(const bool init_r1, const AnalysisContext& co
 
     const auto r10 = variable_registry.reg_pack(R10_STACK_POINTER);
     constexpr Reg r10_reg{R10_STACK_POINTER};
-    const auto total_stack = context.options.total_stack_size();
+    const auto total_stack = context.runtime().total_stack_size();
     inv.state.values.add_constraint(total_stack <= r10.svalue);
-    inv.state.values.add_constraint(r10.svalue <= ptr_max(context.options.max_packet_size));
+    inv.state.values.add_constraint(r10.svalue <= ptr_max(context.runtime().max_packet_size));
     inv.state.values.assign(r10.stack_offset, total_stack);
     // stack_numeric_size would be 0, but TOP has the same result
     // so no need to assign it.
@@ -444,7 +444,7 @@ EbpfDomain EbpfDomain::setup_entry(const bool init_r1, const AnalysisContext& co
         const auto r1 = variable_registry.reg_pack(R1_ARG);
         constexpr Reg r1_reg{R1_ARG};
         inv.state.values.add_constraint(1 <= r1.svalue);
-        inv.state.values.add_constraint(r1.svalue <= ptr_max(context.options.max_packet_size));
+        inv.state.values.add_constraint(r1.svalue <= ptr_max(context.runtime().max_packet_size));
         inv.state.values.assign(r1.ctx_offset, 0);
         inv.state.assign_type(r1_reg, T_CTX);
     }

--- a/src/crab/ebpf_domain.cpp
+++ b/src/crab/ebpf_domain.cpp
@@ -14,6 +14,7 @@
 #include "crab/array_domain.hpp"
 #include "crab/ebpf_domain.hpp"
 #include "crab/var_registry.hpp"
+#include "crab_utils/num_safety.hpp"
 #include "ir/unmarshal.hpp"
 
 namespace prevail {
@@ -39,7 +40,7 @@ std::optional<int64_t> EbpfDomain::get_stack_offset(const Reg& reg) const {
 }
 
 EbpfDomain EbpfDomain::top(const AnalysisContext& context) {
-    return top(static_cast<size_t>(context.runtime().total_stack_size()));
+    return top(to_unsigned(context.runtime().total_stack_size()));
 }
 
 EbpfDomain EbpfDomain::top(const size_t total_stack_size) {
@@ -397,10 +398,9 @@ EbpfDomain EbpfDomain::from_constraints(const std::vector<std::pair<Variable, Ty
 
 EbpfDomain EbpfDomain::from_constraints(const std::set<std::string>& constraints, const bool setup_constraints,
                                         const AnalysisContext& context) {
-    EbpfDomain inv = setup_constraints
-                         ? setup_entry(false, context)
-                         : EbpfDomain{TypeToNumDomain::top(),
-                                      ArrayDomain{static_cast<size_t>(context.runtime().total_stack_size())}};
+    EbpfDomain inv = setup_constraints ? setup_entry(false, context)
+                                       : EbpfDomain{TypeToNumDomain::top(),
+                                                    ArrayDomain{to_unsigned(context.runtime().total_stack_size())}};
     auto numeric_ranges = std::vector<Interval>();
     auto [type_equalities, type_restrictions, value_constraints] =
         parse_linear_constraints(constraints, numeric_ranges);

--- a/src/crab/ebpf_domain.hpp
+++ b/src/crab/ebpf_domain.hpp
@@ -97,7 +97,7 @@ class EbpfDomain final {
     /// default-options size.
     static EbpfDomain from_constraints(const std::vector<std::pair<Variable, TypeSet>>& type_restrictions,
                                        const std::vector<LinearConstraint>& value_constraints,
-                                       size_t total_stack_size = ebpf_verifier_options_t{}.total_stack_size());
+                                       size_t total_stack_size = RuntimeConfig{}.total_stack_size());
     void initialize_packet(const AnalysisContext& context);
 
     StringInvariant to_set() const;

--- a/src/crab/ebpf_transformer.cpp
+++ b/src/crab/ebpf_transformer.cpp
@@ -199,11 +199,11 @@ void EbpfTransformer::havoc_subprogram_stack(const std::string& prefix) {
     if (!intv.is_singleton()) {
         return;
     }
-    const auto frame_size = context.options.subprogram_stack_size;
+    const auto frame_size = context.runtime().subprogram_stack_size;
     const int64_t stack_start = intv.singleton()->cast_to<int64_t>() - frame_size;
     stack.havoc_type(dom.state.types, Interval{stack_start}, Interval{frame_size});
     for (const DataKind kind : iterate_kinds()) {
-        stack.havoc(dom.state.values, kind, Interval{stack_start}, Interval{frame_size}, context.options.big_endian);
+        stack.havoc(dom.state.values, kind, Interval{stack_start}, Interval{frame_size}, context.runtime().big_endian);
     }
 }
 
@@ -345,7 +345,7 @@ void EbpfTransformer::operator()(const Un& stmt) {
     // so we use unsigned which still fits in a signed int64.
     switch (stmt.op) {
     case Un::Op::BE16:
-        if (!context.options.big_endian) {
+        if (!context.runtime().big_endian) {
             swap_endianness(dst.svalue, boost::endian::endian_reverse<uint16_t>);
             swap_endianness(dst.uvalue, boost::endian::endian_reverse<uint16_t>);
         } else {
@@ -354,7 +354,7 @@ void EbpfTransformer::operator()(const Un& stmt) {
         }
         break;
     case Un::Op::BE32:
-        if (!context.options.big_endian) {
+        if (!context.runtime().big_endian) {
             swap_endianness(dst.svalue, boost::endian::endian_reverse<uint32_t>);
             swap_endianness(dst.uvalue, boost::endian::endian_reverse<uint32_t>);
         } else {
@@ -363,13 +363,13 @@ void EbpfTransformer::operator()(const Un& stmt) {
         }
         break;
     case Un::Op::BE64:
-        if (!context.options.big_endian) {
+        if (!context.runtime().big_endian) {
             swap_endianness(dst.svalue, boost::endian::endian_reverse<int64_t>);
             swap_endianness(dst.uvalue, boost::endian::endian_reverse<uint64_t>);
         }
         break;
     case Un::Op::LE16:
-        if (context.options.big_endian) {
+        if (context.runtime().big_endian) {
             swap_endianness(dst.svalue, boost::endian::endian_reverse<uint16_t>);
             swap_endianness(dst.uvalue, boost::endian::endian_reverse<uint16_t>);
         } else {
@@ -378,7 +378,7 @@ void EbpfTransformer::operator()(const Un& stmt) {
         }
         break;
     case Un::Op::LE32:
-        if (context.options.big_endian) {
+        if (context.runtime().big_endian) {
             swap_endianness(dst.svalue, boost::endian::endian_reverse<uint32_t>);
             swap_endianness(dst.uvalue, boost::endian::endian_reverse<uint32_t>);
         } else {
@@ -387,7 +387,7 @@ void EbpfTransformer::operator()(const Un& stmt) {
         }
         break;
     case Un::Op::LE64:
-        if (context.options.big_endian) {
+        if (context.runtime().big_endian) {
             swap_endianness(dst.svalue, boost::endian::endian_reverse<int64_t>);
             swap_endianness(dst.uvalue, boost::endian::endian_reverse<uint64_t>);
         }
@@ -425,7 +425,7 @@ void EbpfTransformer::operator()(const Exit& a) {
 
     // Restore r10.
     constexpr Reg r10_reg{R10_STACK_POINTER};
-    add(r10_reg, context.options.subprogram_stack_size, 64);
+    add(r10_reg, context.runtime().subprogram_stack_size, 64);
 
     // Scratch r1-r5: the callee may have clobbered them (caller-saved per BPF ABI).
     scratch_caller_saved_registers();
@@ -464,7 +464,7 @@ void EbpfTransformer::do_load_stack(TypeToNumDomain& state, const Reg& target_re
     if (width == 1 || width == 2 || width == 4 || width == 8) {
         // Use the addr before we havoc the destination register since we might be getting the
         // addr from that same register.
-        const bool big_endian = context.options.big_endian;
+        const bool big_endian = context.runtime().big_endian;
         const std::optional<LinearExpression> sresult =
             stack.load(state.values, DataKind::svalues, addr, width, big_endian);
         const std::optional<LinearExpression> uresult =
@@ -533,7 +533,7 @@ static void do_load_ctx(TypeToNumDomain& state, const AnalysisContext& context, 
             // EXPERIMENTAL: Explicit upper bound since packet_size is min_only.
             // This preserves the relational constraint (packet_offset <= packet_size)
             // while ensuring comparison checks have a concrete upper bound.
-            state.values.add_constraint(target.packet_offset < context.options.max_packet_size);
+            state.values.add_constraint(target.packet_offset < context.runtime().max_packet_size);
         }
     } else if (addr == desc->meta) {
         if (width == offset_width) {
@@ -550,7 +550,7 @@ static void do_load_ctx(TypeToNumDomain& state, const AnalysisContext& context, 
     if (width == offset_width) {
         state.assign_type(target_reg, T_PACKET);
         state.values.add_constraint(4098 <= target.svalue);
-        state.values.add_constraint(target.svalue <= ptr_max(context.options.max_packet_size));
+        state.values.add_constraint(target.svalue <= ptr_max(context.runtime().max_packet_size));
     }
 }
 
@@ -587,7 +587,7 @@ void EbpfTransformer::do_load(const Mem& b, const Reg& target_reg) {
         do_load_stack(dom.state, target_reg, addr, width, b.access.basereg);
         return;
     }
-    dom.state = dom.state.join_over_types(b.access.basereg, [&](TypeToNumDomain& state, TypeEncoding type) {
+    dom.state = dom.state.join_over_types(b.access.basereg, [&](TypeToNumDomain& state, const TypeEncoding type) {
         switch (type) {
         case T_CTX: do_load_ctx(state, context, target_reg, mem_reg.ctx_offset + offset, width); break;
         case T_STACK: do_load_stack(state, target_reg, mem_reg.stack_offset + offset, width, b.access.basereg); break;
@@ -626,14 +626,14 @@ void EbpfTransformer::do_store_stack(TypeToNumDomain& state, const LinearExpress
                                      const std::optional<Reg>& opt_val_reg) {
     const Interval addr = state.values.eval_interval(symb_addr);
     const Interval width{exact_width};
-    const bool big_endian = context.options.big_endian;
+    const bool big_endian = context.runtime().big_endian;
     // no aliasing of val - we don't move from stack to stack, so we can just havoc first
     stack.havoc_type(state.types, addr, width);
     for (const DataKind kind : iterate_kinds()) {
         if (kind == DataKind::svalues || kind == DataKind::uvalues) {
             continue;
         }
-        stack.havoc(state.values, kind, addr, width, context.options.big_endian);
+        stack.havoc(state.values, kind, addr, width, context.runtime().big_endian);
     }
     bool must_be_num = false;
     if (opt_val_reg && !state.is_initialized(*opt_val_reg)) {
@@ -869,7 +869,7 @@ void EbpfTransformer::operator()(const Call& call) {
                     }
                     const Interval addr = state.values.eval_interval(*offset);
                     for (const DataKind kind : iterate_kinds()) {
-                        stack.havoc(state.values, kind, addr, w, context.options.big_endian);
+                        stack.havoc(state.values, kind, addr, w, context.runtime().big_endian);
                     }
                     // Keep this scoped to stack-typed pointers only.
                     stack.store_numbers(addr, w);
@@ -900,7 +900,7 @@ void EbpfTransformer::operator()(const Call& call) {
                     // Pointer to a memory region that the called function may change,
                     // so we must havoc.
                     for (const DataKind kind : iterate_kinds()) {
-                        stack.havoc(state.values, kind, addr, width, context.options.big_endian);
+                        stack.havoc(state.values, kind, addr, width, context.runtime().big_endian);
                     }
                 } else {
                     store_numbers = false;
@@ -986,7 +986,7 @@ void EbpfTransformer::operator()(const CallLocal& call) {
 
     // Update r10.
     constexpr Reg r10_reg{R10_STACK_POINTER};
-    add(r10_reg, -context.options.subprogram_stack_size, 64);
+    add(r10_reg, -context.runtime().subprogram_stack_size, 64);
 }
 
 void EbpfTransformer::operator()(const Callx& callx) {
@@ -1065,7 +1065,7 @@ void EbpfTransformer::assign_valid_ptr(const Reg& dst_reg, const bool maybe_null
     } else {
         dom.state.values.add_constraint(0 < reg.svalue);
     }
-    dom.state.values.add_constraint(reg.svalue <= ptr_max(context.options.max_packet_size));
+    dom.state.values.add_constraint(reg.svalue <= ptr_max(context.runtime().max_packet_size));
     dom.state.values.assign(reg.uvalue, reg.svalue);
 }
 
@@ -1118,7 +1118,7 @@ void EbpfTransformer::shl(const Reg& dst_reg, int imm, const int finite_width) {
     }
 }
 
-void EbpfTransformer::lshr(const Reg& dst_reg, int imm, int finite_width) {
+void EbpfTransformer::lshr(const Reg& dst_reg, int imm, const int finite_width) {
     dom.state.havoc_offsets(dst_reg);
 
     // The BPF ISA requires masking the imm.

--- a/src/crab/finite_domain.hpp
+++ b/src/crab/finite_domain.hpp
@@ -160,7 +160,7 @@ class FiniteDomain {
     void set(const Variable x, const Interval& intv) { dom.set(x, intv); }
 
     /// Forget everything we know about the value of a variable.
-    void havoc(Variable v) { dom.havoc(v); }
+    void havoc(const Variable v) { dom.havoc(v); }
 
     [[nodiscard]]
     std::pair<std::size_t, std::size_t> size() const {

--- a/src/crab/type_encoding.hpp
+++ b/src/crab/type_encoding.hpp
@@ -73,7 +73,7 @@ constexpr unsigned type_to_bit(const TypeEncoding te) { return static_cast<unsig
 class TypeSet {
     std::bitset<NUM_TYPE_ENCODINGS> bits_;
 
-    explicit TypeSet(std::bitset<NUM_TYPE_ENCODINGS> bits) : bits_{bits} {}
+    explicit TypeSet(const std::bitset<NUM_TYPE_ENCODINGS> bits) : bits_{bits} {}
 
   public:
     TypeSet() = default;

--- a/src/crab/zone_domain.cpp
+++ b/src/crab/zone_domain.cpp
@@ -111,7 +111,7 @@ void ZoneDomain::diffcsts_of_assign(const LinearExpression& exp, std::vector<std
 void ZoneDomain::diffcsts_of_assign(const LinearExpression& exp,
                                     /* if true then process the upper
                                        bounds, else the lower bounds */
-                                    bool extract_upper_bounds,
+                                    const bool extract_upper_bounds,
                                     /* foreach {v, k} \in diff_csts we have
                                        the difference constraint v - k <= k */
                                     std::vector<std::pair<Variable, Weight>>& diff_csts) const {
@@ -298,7 +298,7 @@ static Interval trim_interval(const Interval& i, const Number& n) {
     return i;
 }
 
-bool ZoneDomain::add_univar_disequation(Variable x, const Number& n) {
+bool ZoneDomain::add_univar_disequation(const Variable x, const Number& n) {
     const Interval i = get_interval(x);
     const Interval new_i = trim_interval(i, n);
     if (new_i.is_bottom()) {

--- a/src/fwd_analyzer.cpp
+++ b/src/fwd_analyzer.cpp
@@ -109,7 +109,7 @@ class InterleavedFwdFixpointIterator final {
         for (const auto& label : _cfg.labels()) {
             result.invariants.emplace(label, InvariantMapPair{EbpfDomain::bottom(), {}, EbpfDomain::bottom()});
         }
-        if (context.options.runtime.check_for_termination) {
+        if (context.runtime().check_for_termination) {
             _wto.for_each_loop_head([&](const Label& label) {
                 _loop_counters.push_back(variable_registry.loop_counter(to_string(label)));
             });
@@ -290,7 +290,7 @@ AnalysisResult InterleavedFwdFixpointIterator::run(const AnalysisContext& contex
     const Program& prog = context.program;
     AnalysisResult result;
     InterleavedFwdFixpointIterator analyzer(context, result);
-    if (context.options.runtime.check_for_termination) {
+    if (context.runtime().check_for_termination) {
         // Initialize loop counters for potential loop headers.
         // This enables enforcement of upper bounds on loop iterations
         // during program verification.
@@ -302,7 +302,7 @@ AnalysisResult InterleavedFwdFixpointIterator::run(const AnalysisContext& contex
     for (const auto& component : analyzer._wto) {
         std::visit(analyzer, component);
     }
-    if (!result.failed && context.options.runtime.check_for_termination) {
+    if (!result.failed && context.runtime().check_for_termination) {
         analyzer.find_termination_errors(prog);
         if (!result.failed) {
             result.max_loop_count = analyzer.max_loop_count();

--- a/src/fwd_analyzer.cpp
+++ b/src/fwd_analyzer.cpp
@@ -72,7 +72,7 @@ class InterleavedFwdFixpointIterator final {
         // checks so that failing instructions still have deps recorded —
         // compute_failure_slices seeds its backward worklist from them.
         if (context.options.verbosity_opts.collect_instruction_deps) {
-            result.invariants.at(label).deps = extract_instruction_deps(ins, pre, context.options.total_stack_size());
+            result.invariants.at(label).deps = extract_instruction_deps(ins, pre, context.runtime().total_stack_size());
         }
 
         if (!std::holds_alternative<IncrementLoopCounter>(ins)) {
@@ -109,7 +109,7 @@ class InterleavedFwdFixpointIterator final {
         for (const auto& label : _cfg.labels()) {
             result.invariants.emplace(label, InvariantMapPair{EbpfDomain::bottom(), {}, EbpfDomain::bottom()});
         }
-        if (context.options.cfg_opts.check_for_termination) {
+        if (context.options.runtime.check_for_termination) {
             _wto.for_each_loop_head([&](const Label& label) {
                 _loop_counters.push_back(variable_registry.loop_counter(to_string(label)));
             });
@@ -160,25 +160,24 @@ class InterleavedFwdFixpointIterator final {
     static AnalysisResult run(const AnalysisContext& context, EbpfDomain entry_inv);
 };
 
-AnalysisResult analyze(const Program& prog, const ebpf_verifier_options_t& options) {
+AnalysisResult analyze(const Program& prog, const VerifierOptions& options) {
     return analyze(AnalysisContext{prog, options});
 }
 
-AnalysisResult analyze(const Program& prog, const StringInvariant& entry_invariant,
-                       const ebpf_verifier_options_t& options) {
+AnalysisResult analyze(const Program& prog, const StringInvariant& entry_invariant, const VerifierOptions& options) {
     return analyze(entry_invariant, AnalysisContext{prog, options});
 }
 
 AnalysisResult analyze(const AnalysisContext& context) {
     clear_analysis_thread_local_state();
     return InterleavedFwdFixpointIterator::run(context,
-                                               EbpfDomain::setup_entry(context.options.setup_constraints, context));
+                                               EbpfDomain::setup_entry(context.runtime().setup_constraints, context));
 }
 
 AnalysisResult analyze(const StringInvariant& entry_invariant, const AnalysisContext& context) {
     clear_analysis_thread_local_state();
     return InterleavedFwdFixpointIterator::run(
-        context, EbpfDomain::from_constraints(entry_invariant.value(), context.options.setup_constraints, context));
+        context, EbpfDomain::from_constraints(entry_invariant.value(), context.runtime().setup_constraints, context));
 }
 
 static EbpfDomain extrapolate(const EbpfDomain& before, const EbpfDomain& after, const unsigned int iteration,
@@ -291,7 +290,7 @@ AnalysisResult InterleavedFwdFixpointIterator::run(const AnalysisContext& contex
     const Program& prog = context.program;
     AnalysisResult result;
     InterleavedFwdFixpointIterator analyzer(context, result);
-    if (context.options.cfg_opts.check_for_termination) {
+    if (context.options.runtime.check_for_termination) {
         // Initialize loop counters for potential loop headers.
         // This enables enforcement of upper bounds on loop iterations
         // during program verification.
@@ -303,7 +302,7 @@ AnalysisResult InterleavedFwdFixpointIterator::run(const AnalysisContext& contex
     for (const auto& component : analyzer._wto) {
         std::visit(analyzer, component);
     }
-    if (!result.failed && context.options.cfg_opts.check_for_termination) {
+    if (!result.failed && context.options.runtime.check_for_termination) {
         analyzer.find_termination_errors(prog);
         if (!result.failed) {
             result.max_loop_count = analyzer.max_loop_count();

--- a/src/io/elf_loader.cpp
+++ b/src/io/elf_loader.cpp
@@ -43,7 +43,7 @@ struct SectionCacheEntry {
 
 struct ElfObject::ElfObjectState {
     std::string path;
-    ebpf_verifier_options_t options;
+    VerifierOptions options;
     const ebpf_platform_t* platform;
 
     bool catalog_loaded{};
@@ -58,7 +58,7 @@ struct ElfObject::ElfObjectState {
     std::optional<ELFIO::elfio> reader;
     std::optional<ELFIO::const_symbol_section_accessor> symbols;
 
-    ElfObjectState(std::string p, ebpf_verifier_options_t opts, const ebpf_platform_t* plat)
+    ElfObjectState(std::string p, VerifierOptions opts, const ebpf_platform_t* plat)
         : path(std::move(p)), options(std::move(opts)), platform(plat) {}
 
     void discover_programs();
@@ -177,7 +177,7 @@ std::vector<RawProgram> filter_section_programs(const std::vector<RawProgram>& p
 // ElfObject facade (delegates to ElfObjectState)
 // ---------------------------------------------------------------------------
 
-ElfObject::ElfObject(std::string path, ebpf_verifier_options_t options, const ebpf_platform_t* platform)
+ElfObject::ElfObject(std::string path, VerifierOptions options, const ebpf_platform_t* platform)
     : state_(std::make_unique<ElfObjectState>(std::move(path), std::move(options), platform)) {}
 
 ElfObject::~ElfObject() = default;

--- a/src/io/elf_loader.hpp
+++ b/src/io/elf_loader.hpp
@@ -33,7 +33,7 @@ struct ElfProgramInfo {
 /// @note Not thread-safe. Callers must synchronize externally.
 class ElfObject {
   public:
-    ElfObject(std::string path, ebpf_verifier_options_t options, const ebpf_platform_t* platform);
+    ElfObject(std::string path, VerifierOptions options, const ebpf_platform_t* platform);
     ~ElfObject();
     ElfObject(ElfObject&&) noexcept;
     ElfObject& operator=(ElfObject&&) noexcept;

--- a/src/io/elf_reader.cpp
+++ b/src/io/elf_reader.cpp
@@ -769,7 +769,7 @@ void ProgramReader::read_programs() {
 
 std::vector<RawProgram> read_elf(std::istream& input_stream, const std::string& path,
                                  const std::string& desired_section, const std::string& desired_program,
-                                 const ebpf_verifier_options_t& options, const ebpf_platform_t* platform) {
+                                 const VerifierOptions& options, const ebpf_platform_t* platform) {
     try {
         std::vector<RawProgram> res;
         parse_params_t params{path, options, platform, desired_section};
@@ -797,7 +797,7 @@ std::vector<RawProgram> read_elf(std::istream& input_stream, const std::string& 
 }
 
 std::vector<RawProgram> read_elf(const std::string& path, const std::string& desired_section,
-                                 const std::string& desired_program, const ebpf_verifier_options_t& options,
+                                 const std::string& desired_program, const VerifierOptions& options,
                                  const ebpf_platform_t* platform) {
     if (std::ifstream stream{path, std::ios::in | std::ios::binary}) {
         return read_elf(stream, path, desired_section, desired_program, options, platform);

--- a/src/io/elf_reader.hpp
+++ b/src/io/elf_reader.hpp
@@ -29,7 +29,7 @@ namespace prevail {
 
 struct parse_params_t {
     const std::string& path;
-    const ebpf_verifier_options_t& options;
+    const VerifierOptions& options;
     const ebpf_platform_t* platform;
     const std::string desired_section;
 };
@@ -211,10 +211,10 @@ class ProgramReader {
 
 std::vector<RawProgram> read_elf(std::istream& input_stream, const std::string& path,
                                  const std::string& desired_section, const std::string& desired_program,
-                                 const ebpf_verifier_options_t& options, const ebpf_platform_t* platform);
+                                 const VerifierOptions& options, const ebpf_platform_t* platform);
 
 std::vector<RawProgram> read_elf(const std::string& path, const std::string& desired_section,
-                                 const std::string& desired_program, const ebpf_verifier_options_t& options,
+                                 const std::string& desired_program, const VerifierOptions& options,
                                  const ebpf_platform_t* platform);
 
 } // namespace prevail

--- a/src/ir/assertions.cpp
+++ b/src/ir/assertions.cpp
@@ -17,7 +17,7 @@ using std::vector;
 namespace prevail {
 class AssertExtractor {
     const ProgramInfo& info;
-    const ebpf_verifier_options_t& options;
+    const RuntimeConfig& runtime;
     const std::optional<Label>& current_label; ///< Pre-simplification label this assert is part of.
 
     static Imm imm(const Value& v) { return std::get<Imm>(v); }
@@ -37,9 +37,8 @@ class AssertExtractor {
     }
 
   public:
-    explicit AssertExtractor(const ProgramInfo& info, const ebpf_verifier_options_t& options,
-                             const std::optional<Label>& label)
-        : info{info}, options{options}, current_label{label} {}
+    explicit AssertExtractor(const ProgramInfo& info, const RuntimeConfig& runtime, const std::optional<Label>& label)
+        : info{info}, runtime{runtime}, current_label{label} {}
 
     vector<Assertion> operator()(const Undefined&) const { return {}; }
 
@@ -239,7 +238,7 @@ class AssertExtractor {
         const int offset = ins.access.offset;
         if (basereg.v == R10_STACK_POINTER) {
             // We know we are accessing the stack.
-            if (offset < -options.subprogram_stack_size || offset + static_cast<int>(width.v) > 0) {
+            if (offset < -runtime.subprogram_stack_size || offset + static_cast<int>(width.v) > 0) {
                 // This assertion will fail
                 res.emplace_back(make_valid_access(basereg, offset, width, false,
                                                    ins.is_load ? AccessType::read : AccessType::write));
@@ -342,8 +341,8 @@ class AssertExtractor {
 /// compare numbers and pointers, or pointers to potentially distinct memory
 /// regions. The verifier will use these assertions to treat the program as
 /// unsafe unless it can prove that the assertions can never fail.
-vector<Assertion> get_assertions(const Instruction& ins, const ProgramInfo& info,
-                                 const ebpf_verifier_options_t& options, const std::optional<Label>& label) {
-    return std::visit(AssertExtractor{info, options, label}, ins);
+vector<Assertion> get_assertions(const Instruction& ins, const ProgramInfo& info, const RuntimeConfig& runtime,
+                                 const std::optional<Label>& label) {
+    return std::visit(AssertExtractor{info, runtime, label}, ins);
 }
 } // namespace prevail

--- a/src/ir/cfg_builder.cpp
+++ b/src/ir/cfg_builder.cpp
@@ -793,10 +793,9 @@ static void pass_insert_termination_counters(CfgBuilder& builder, const Wto& wto
 // Writes   : Populates builder.prog.m_assertions with the per-label precondition vector
 //            (memory bounds, type guards, etc.) produced by get_assertions.
 // Notes    : Runs for every label in the CFG, including synthetic ones (Assume / counters).
-static void pass_extract_assertions(CfgBuilder& builder, const ProgramInfo& info,
-                                    const ebpf_verifier_options_t& options) {
+static void pass_extract_assertions(CfgBuilder& builder, const ProgramInfo& info, const VerifierOptions& options) {
     for (const auto& label : builder.prog.labels()) {
-        builder.set_assertions(label, get_assertions(builder.prog.instruction_at(label), info, options, label));
+        builder.set_assertions(label, get_assertions(builder.prog.instruction_at(label), info, options.runtime, label));
     }
 }
 
@@ -804,9 +803,9 @@ static void pass_extract_assertions(CfgBuilder& builder, const ProgramInfo& info
 // pre/postcondition; this function's job is just to sequence them and hand the
 // result off as a finalised Program.
 Program Program::from_sequence(const InstructionSeq& inst_seq, const ProgramInfo& info,
-                               const ebpf_verifier_options_t& options) {
+                               const VerifierOptions& options) {
     // --- Pass: ValidateOptions --------------------------------------------
-    options.validate();
+    options.runtime.validate();
     // Preserves the platform-non-null invariant for every subsequent pass in this pipeline.
     assert(info.platform != nullptr && "info.platform must be set before Program::from_sequence");
 
@@ -825,10 +824,10 @@ Program Program::from_sequence(const InstructionSeq& inst_seq, const ProgramInfo
     // ProgramInfo rather than a default-constructed (null-platform) one.
     builder.prog.m_info = info;
     pass_populate_nodes(builder, inst_seq, info, resolved_kfunc_calls, lowered_pseudo_loads);
-    pass_connect_edges(builder, inst_seq, options.cfg_opts.must_have_exit);
+    pass_connect_edges(builder, inst_seq, options.must_have_exit);
 
     // --- Pass: InlineLocalCalls -------------------------------------------
-    pass_inline_local_calls(builder, inst_seq, options.max_call_stack_frames);
+    pass_inline_local_calls(builder, inst_seq, options.runtime.max_call_stack_frames);
 
     // --- Pass: ValidateTailCallDepth --------------------------------------
     const Wto wto{builder.prog.cfg()};
@@ -838,7 +837,7 @@ Program Program::from_sequence(const InstructionSeq& inst_seq, const ProgramInfo
     pass_compute_callback_metadata(builder);
 
     // --- Pass: InsertTerminationCounters ----------------------------------
-    if (options.cfg_opts.check_for_termination) {
+    if (options.runtime.check_for_termination) {
         pass_insert_termination_counters(builder, wto);
     }
 

--- a/src/ir/program.hpp
+++ b/src/ir/program.hpp
@@ -67,7 +67,7 @@ class Program {
     }
 
     static Program from_sequence(const InstructionSeq& inst_seq, const ProgramInfo& info,
-                                 const ebpf_verifier_options_t& options);
+                                 const VerifierOptions& options);
 };
 
 class InvalidControlFlow final : public std::runtime_error {
@@ -75,9 +75,9 @@ class InvalidControlFlow final : public std::runtime_error {
     explicit InvalidControlFlow(const std::string& what) : std::runtime_error(what) {}
 };
 
-std::vector<Assertion> get_assertions(const Instruction& ins, const ProgramInfo& info,
-                                      const ebpf_verifier_options_t& options, const std::optional<Label>& label);
+std::vector<Assertion> get_assertions(const Instruction& ins, const ProgramInfo& info, const RuntimeConfig& runtime,
+                                      const std::optional<Label>& label);
 
-void print_program(const Program& prog, std::ostream& os, const verbosity_options_t& verbosity);
+void print_program(const Program& prog, std::ostream& os, const VerbosityOptions& verbosity);
 void print_dot(const Program& prog, const std::string& outfile);
 } // namespace prevail

--- a/src/ir/unmarshal.cpp
+++ b/src/ir/unmarshal.cpp
@@ -612,11 +612,10 @@ struct Unmarshaller {
         }
     }
 
-    vector<LabeledInstruction> unmarshal(vector<EbpfInst> const& insts,
-                                         const prevail::ebpf_verifier_options_t& options) {
-        options.validate();
-        subprogram_stack_size = options.subprogram_stack_size;
-        allow_division_by_zero = options.allow_division_by_zero;
+    vector<LabeledInstruction> unmarshal(vector<EbpfInst> const& insts, const prevail::VerifierOptions& options) {
+        options.runtime.validate();
+        subprogram_stack_size = options.runtime.subprogram_stack_size;
+        allow_division_by_zero = options.runtime.allow_division_by_zero;
         vector<LabeledInstruction> prog;
         int exit_count = 0;
         if (insts.empty()) {
@@ -714,7 +713,7 @@ struct Unmarshaller {
 };
 
 std::variant<InstructionSeq, std::string> unmarshal(const RawProgram& raw_prog, vector<vector<string>>& notes,
-                                                    const prevail::ebpf_verifier_options_t& options) {
+                                                    const prevail::VerifierOptions& options) {
     try {
         return Unmarshaller{notes, raw_prog.info}.unmarshal(raw_prog.prog, options);
     } catch (InvalidInstruction& arg) {
@@ -725,7 +724,7 @@ std::variant<InstructionSeq, std::string> unmarshal(const RawProgram& raw_prog, 
 }
 
 std::variant<InstructionSeq, std::string> unmarshal(const RawProgram& raw_prog,
-                                                    const prevail::ebpf_verifier_options_t& options) {
+                                                    const prevail::VerifierOptions& options) {
     vector<vector<string>> notes;
     return unmarshal(raw_prog, notes, options);
 }

--- a/src/ir/unmarshal.hpp
+++ b/src/ir/unmarshal.hpp
@@ -21,8 +21,8 @@ namespace prevail {
  */
 std::variant<InstructionSeq, std::string> unmarshal(const RawProgram& raw_prog,
                                                     std::vector<std::vector<std::string>>& notes,
-                                                    const prevail::ebpf_verifier_options_t& options);
+                                                    const prevail::VerifierOptions& options);
 std::variant<InstructionSeq, std::string> unmarshal(const RawProgram& raw_prog,
-                                                    const prevail::ebpf_verifier_options_t& options);
+                                                    const prevail::VerifierOptions& options);
 
 } // namespace prevail

--- a/src/linux/linux_platform.cpp
+++ b/src/linux/linux_platform.cpp
@@ -112,8 +112,7 @@ struct BpfLoadMapDef {
     uint32_t numa_node;
 };
 
-static int create_map_linux(uint32_t map_type, uint32_t key_size, uint32_t value_size, uint32_t max_entries,
-                            VerifierOptions);
+static int create_map_linux(uint32_t map_type, uint32_t key_size, uint32_t value_size, uint32_t max_entries);
 
 // Allow for comma as a separator between multiple prefixes, to make
 // the preprocessor treat a prefix list as one macro argument.
@@ -272,7 +271,7 @@ static int allocate_mock_map_fd(const std::vector<EbpfMapDescriptor>& map_descri
 
 void parse_maps_section_linux(std::vector<EbpfMapDescriptor>& map_descriptors, const char* data,
                               const size_t map_def_size, const int map_count, const ebpf_platform_t* platform,
-                              const VerifierOptions options) {
+                              const VerifierOptions& options) {
     auto mapdefs = std::vector<BpfLoadMapDef>();
     for (int i = 0; i < map_count; i++) {
         BpfLoadMapDef def = {0};
@@ -281,10 +280,9 @@ void parse_maps_section_linux(std::vector<EbpfMapDescriptor>& map_descriptors, c
     }
 
     for (const auto& s : mapdefs) {
-        const int fd = options.mock_map_fds
-                           ? allocate_mock_map_fd(map_descriptors, get_map_type_linux(s.type), s.key_size, s.value_size,
-                                                  s.max_entries)
-                           : create_map_linux(s.type, s.key_size, s.value_size, s.max_entries, options);
+        const int fd = options.mock_map_fds ? allocate_mock_map_fd(map_descriptors, get_map_type_linux(s.type),
+                                                                   s.key_size, s.value_size, s.max_entries)
+                                            : create_map_linux(s.type, s.key_size, s.value_size, s.max_entries);
         map_descriptors.emplace_back(EbpfMapDescriptor{
             .original_fd = fd,
             .type = s.type,
@@ -316,7 +314,7 @@ static int do_bpf(const bpf_cmd cmd, bpf_attr& attr) { return syscall(321, cmd, 
  *  This function requires admin privileges.
  */
 static int create_map_linux(const uint32_t map_type, const uint32_t key_size, const uint32_t value_size,
-                            const uint32_t max_entries, const VerifierOptions) {
+                            const uint32_t max_entries) {
 #if __linux__
     bpf_attr attr{};
     memset(&attr, '\0', sizeof(attr));

--- a/src/linux/linux_platform.cpp
+++ b/src/linux/linux_platform.cpp
@@ -113,7 +113,7 @@ struct BpfLoadMapDef {
 };
 
 static int create_map_linux(uint32_t map_type, uint32_t key_size, uint32_t value_size, uint32_t max_entries,
-                            ebpf_verifier_options_t);
+                            VerifierOptions);
 
 // Allow for comma as a separator between multiple prefixes, to make
 // the preprocessor treat a prefix list as one macro argument.
@@ -239,7 +239,7 @@ static const EbpfMapType linux_map_types[] = {
     {BPF_MAP_TYPE(ARENA)},
 };
 
-EbpfMapType get_map_type_linux(uint32_t platform_specific_type) {
+EbpfMapType get_map_type_linux(const uint32_t platform_specific_type) {
     const uint32_t index = platform_specific_type;
     if (index == 0 || index >= std::size(linux_map_types)) {
         return linux_map_types[0];
@@ -272,7 +272,7 @@ static int allocate_mock_map_fd(const std::vector<EbpfMapDescriptor>& map_descri
 
 void parse_maps_section_linux(std::vector<EbpfMapDescriptor>& map_descriptors, const char* data,
                               const size_t map_def_size, const int map_count, const ebpf_platform_t* platform,
-                              const ebpf_verifier_options_t options) {
+                              const VerifierOptions options) {
     auto mapdefs = std::vector<BpfLoadMapDef>();
     for (int i = 0; i < map_count; i++) {
         BpfLoadMapDef def = {0};
@@ -316,7 +316,7 @@ static int do_bpf(const bpf_cmd cmd, bpf_attr& attr) { return syscall(321, cmd, 
  *  This function requires admin privileges.
  */
 static int create_map_linux(const uint32_t map_type, const uint32_t key_size, const uint32_t value_size,
-                            const uint32_t max_entries, const ebpf_verifier_options_t) {
+                            const uint32_t max_entries, const VerifierOptions) {
 #if __linux__
     bpf_attr attr{};
     memset(&attr, '\0', sizeof(attr));

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -48,7 +48,7 @@ int main(int argc, char** argv) {
     // Always call ebpf_verifier_clear_thread_local_state on scope exit.
     ThreadLocalGuard thread_local_state_guard;
 
-    ebpf_verifier_options_t ebpf_verifier_options;
+    VerifierOptions ebpf_verifier_options;
 
     CrabEnableWarningMsg(false);
 
@@ -75,32 +75,33 @@ int main(int argc, char** argv) {
     bool print_cfg = false;
     app.add_flag("--cfg", print_cfg, "Print control-flow graph and exit");
 
-    app.add_flag("--termination,!--no-verify-termination", ebpf_verifier_options.cfg_opts.check_for_termination,
+    app.add_flag("--termination,!--no-verify-termination", ebpf_verifier_options.runtime.check_for_termination,
                  "Verify termination. Default: ignore")
         ->group("Features");
 
-    app.add_flag("--allow-division-by-zero,!--no-division-by-zero", ebpf_verifier_options.allow_division_by_zero,
+    app.add_flag("--allow-division-by-zero,!--no-division-by-zero",
+                 ebpf_verifier_options.runtime.allow_division_by_zero,
                  "Handling potential division by zero. Default: allow")
         ->group("Features");
 
-    app.add_flag("--strict,-s", ebpf_verifier_options.strict,
+    app.add_flag("--strict,-s", ebpf_verifier_options.runtime.strict,
                  "Apply additional checks that would cause runtime failures")
         ->group("Features");
 
-    app.add_option("--stack-size", ebpf_verifier_options.subprogram_stack_size,
+    app.add_option("--stack-size", ebpf_verifier_options.runtime.subprogram_stack_size,
                    "Per-subprogram stack frame size in bytes (default: 512)")
         ->group("Features")
-        ->check(CLI::Range(1, ebpf_verifier_options_t::MAX_SUBPROGRAM_STACK_SIZE));
+        ->check(CLI::Range(1, RuntimeConfig::MAX_SUBPROGRAM_STACK_SIZE));
 
-    app.add_option("--max-call-stack-frames", ebpf_verifier_options.max_call_stack_frames,
+    app.add_option("--max-call-stack-frames", ebpf_verifier_options.runtime.max_call_stack_frames,
                    "Maximum number of nested function calls (default: 8)")
         ->group("Features")
-        ->check(CLI::Range(1, ebpf_verifier_options_t::MAX_CALL_STACK_FRAMES_LIMIT));
+        ->check(CLI::Range(1, RuntimeConfig::MAX_CALL_STACK_FRAMES_LIMIT));
 
-    app.add_option("--max-packet-size", ebpf_verifier_options.max_packet_size,
+    app.add_option("--max-packet-size", ebpf_verifier_options.runtime.max_packet_size,
                    "Maximum packet size in bytes (default: 65535)")
         ->group("Features")
-        ->check(CLI::Range(1, ebpf_verifier_options_t::MAX_PACKET_SIZE_LIMIT));
+        ->check(CLI::Range(1, RuntimeConfig::MAX_PACKET_SIZE_LIMIT));
 
     std::set<std::string> include_groups = get_conformance_group_names();
     app.add_option("--include_groups", include_groups, "Include conformance groups")
@@ -266,7 +267,7 @@ int main(int argc, char** argv) {
         if (!quiet) {
             if (pass) {
                 std::cout << "PASS: " << label;
-                if (ebpf_verifier_options.cfg_opts.check_for_termination) {
+                if (ebpf_verifier_options.runtime.check_for_termination) {
                     std::cout << " (terminates within " << result.max_loop_count << " loop iterations)";
                 }
                 std::cout << "\n";

--- a/src/platform.hpp
+++ b/src/platform.hpp
@@ -44,7 +44,7 @@ typedef std::optional<ResolvedCall> (*ebpf_resolve_kfunc_call_fn)(int32_t btf_id
 // In the future we may want to move map fd allocation after the verifier step.
 typedef void (*ebpf_parse_maps_section_fn)(std::vector<EbpfMapDescriptor>& map_descriptors, const char* data,
                                            size_t map_record_size, int map_count, const ebpf_platform_t* platform,
-                                           ebpf_verifier_options_t options);
+                                           VerifierOptions options);
 typedef void (*ebpf_resolve_inner_map_references_fn)(std::vector<EbpfMapDescriptor>& map_descriptors);
 
 typedef const EbpfMapDescriptor& (*ebpf_get_map_descriptor_fn)(int map_fd,

--- a/src/platform.hpp
+++ b/src/platform.hpp
@@ -44,7 +44,7 @@ typedef std::optional<ResolvedCall> (*ebpf_resolve_kfunc_call_fn)(int32_t btf_id
 // In the future we may want to move map fd allocation after the verifier step.
 typedef void (*ebpf_parse_maps_section_fn)(std::vector<EbpfMapDescriptor>& map_descriptors, const char* data,
                                            size_t map_record_size, int map_count, const ebpf_platform_t* platform,
-                                           VerifierOptions options);
+                                           const VerifierOptions& options);
 typedef void (*ebpf_resolve_inner_map_references_fn)(std::vector<EbpfMapDescriptor>& map_descriptors);
 
 typedef const EbpfMapDescriptor& (*ebpf_get_map_descriptor_fn)(int map_fd,

--- a/src/printing.cpp
+++ b/src/printing.cpp
@@ -165,7 +165,7 @@ struct DetailedPrinter : LineInfoPrinter {
     }
 };
 
-void print_program(const Program& prog, std::ostream& os, const verbosity_options_t& verbosity) {
+void print_program(const Program& prog, std::ostream& os, const VerbosityOptions& verbosity) {
     DetailedPrinter printer{os, prog, verbosity.print_line_info};
     for (const BasicBlock& bb : BasicBlock::collect_basic_blocks(prog.cfg(), verbosity.simplify)) {
         printer.print_jump("from", bb.first_label());
@@ -180,7 +180,7 @@ void print_program(const Program& prog, std::ostream& os, const verbosity_option
 }
 
 void print_invariants(std::ostream& os, const Program& prog, const AnalysisResult& result,
-                      const verbosity_options_t& verbosity) {
+                      const VerbosityOptions& verbosity) {
     DetailedPrinter printer{os, prog, verbosity.print_line_info};
     for (const BasicBlock& bb : BasicBlock::collect_basic_blocks(prog.cfg(), verbosity.simplify)) {
         if (result.invariants.at(bb.first_label()).pre.is_bottom()) {
@@ -263,7 +263,7 @@ std::string to_string(const VerificationError& error) {
 }
 
 void print_error(std::ostream& os, const VerificationError& error, const Program& prog,
-                 const verbosity_options_t& verbosity) {
+                 const VerbosityOptions& verbosity) {
     LineInfoPrinter printer{os, prog.info().line_info, verbosity.print_line_info};
     if (const auto& label = error.where) {
         printer.print_line_info(*label);
@@ -755,7 +755,7 @@ std::ostream& operator<<(std::ostream& os, const btf_line_info_t& line_info) {
 }
 
 void print_invariants_filtered(std::ostream& os, const Program& prog, const AnalysisResult& result,
-                               const std::set<Label>& filter, const verbosity_options_t& verbosity,
+                               const std::set<Label>& filter, const VerbosityOptions& verbosity,
                                const std::map<Label, RelevantState>* relevance) {
     DetailedPrinter printer{os, prog, verbosity.print_line_info};
     const bool compact = verbosity.compact_slice;
@@ -983,7 +983,7 @@ void print_invariants_filtered(std::ostream& os, const Program& prog, const Anal
 }
 
 void print_failure_slices(std::ostream& os, const Program& prog, const AnalysisResult& result,
-                          const std::vector<FailureSlice>& slices, const verbosity_options_t& verbosity) {
+                          const std::vector<FailureSlice>& slices, const VerbosityOptions& verbosity) {
     if (slices.empty()) {
         os << "No verification failures found.\n";
         return;

--- a/src/result.cpp
+++ b/src/result.cpp
@@ -117,7 +117,7 @@ bool RelevantState::is_relevant_constraint(const std::string& constraint) const 
 bool AnalysisResult::is_valid_after(const Label& label, const StringInvariant& state,
                                     const AnalysisContext& context) const {
     const EbpfDomain abstract_state =
-        EbpfDomain::from_constraints(state.value(), context.options.setup_constraints, context);
+        EbpfDomain::from_constraints(state.value(), context.runtime().setup_constraints, context);
     return abstract_state <= invariants.at(label).post;
 }
 
@@ -135,7 +135,7 @@ ObservationCheckResult AnalysisResult::check_observation_at_label(const Label& l
     const EbpfDomain observed_state =
         observation.is_bottom()
             ? EbpfDomain::bottom()
-            : EbpfDomain::from_constraints(observation.value(), context.options.setup_constraints, context);
+            : EbpfDomain::from_constraints(observation.value(), context.runtime().setup_constraints, context);
 
     if (observed_state.is_bottom()) {
         return {.ok = false, .message = "Observation constraints are unsatisfiable (domain is bottom)"};

--- a/src/result.hpp
+++ b/src/result.hpp
@@ -5,6 +5,7 @@
 #include <iosfwd>
 #include <map>
 #include <optional>
+#include <ranges>
 #include <set>
 #include <vector>
 

--- a/src/result.hpp
+++ b/src/result.hpp
@@ -68,7 +68,7 @@ struct RelevantState {
     std::set<Reg> registers;
     std::set<int64_t> stack_offsets; // Relative stack offsets (e.g., Mem.access.offset values like -8)
 
-    explicit RelevantState(const AnalysisContext& context) : total_stack_size(context.options.total_stack_size()) {}
+    explicit RelevantState(const AnalysisContext& context) : total_stack_size(context.runtime().total_stack_size()) {}
 
     /// Merge another relevance set into this one (union of registers and stack offsets).
     /// `total_stack_size` is invariant within one analysis and not touched.
@@ -132,7 +132,7 @@ struct FailureSlice {
     [[nodiscard]]
     std::set<Label> impacted_labels() const {
         std::set<Label> result;
-        for (const auto& [label, _] : relevance) {
+        for (const auto& label : relevance | std::views::keys) {
             result.insert(label);
         }
         return result;
@@ -200,18 +200,18 @@ struct AnalysisResult {
 };
 
 void print_error(std::ostream& os, const VerificationError& error, const Program& prog,
-                 const verbosity_options_t& verbosity);
+                 const VerbosityOptions& verbosity);
 void print_invariants(std::ostream& os, const Program& prog, const AnalysisResult& result,
-                      const verbosity_options_t& verbosity);
+                      const VerbosityOptions& verbosity);
 void print_unreachable(std::ostream& os, const Program& prog, const AnalysisResult& result);
 
 void print_invariants_filtered(std::ostream& os, const Program& prog, const AnalysisResult& result,
-                               const std::set<Label>& filter, const verbosity_options_t& verbosity,
+                               const std::set<Label>& filter, const VerbosityOptions& verbosity,
                                const std::map<Label, RelevantState>* relevance = nullptr);
 
 /// Print all failure slices in a structured diagnostic format.
 /// Use `verbosity.compact_slice = true` to skip detailed invariants.
 void print_failure_slices(std::ostream& os, const Program& prog, const AnalysisResult& result,
-                          const std::vector<FailureSlice>& slices, const verbosity_options_t& verbosity);
+                          const std::vector<FailureSlice>& slices, const VerbosityOptions& verbosity);
 
 } // namespace prevail

--- a/src/test/ebpf_yaml.cpp
+++ b/src/test/ebpf_yaml.cpp
@@ -78,7 +78,7 @@ static std::optional<ResolvedCall> ebpf_resolve_kfunc_call(const int32_t btf_id,
 }
 
 static void ebpf_parse_maps_section(vector<EbpfMapDescriptor>&, const char*, size_t, int, const ebpf_platform_t*,
-                                    VerifierOptions) {}
+                                    const VerifierOptions&) {}
 
 static EbpfMapDescriptor test_map_descriptor = {.original_fd = 0,
                                                 .type = 0,

--- a/src/test/ebpf_yaml.cpp
+++ b/src/test/ebpf_yaml.cpp
@@ -78,7 +78,7 @@ static std::optional<ResolvedCall> ebpf_resolve_kfunc_call(const int32_t btf_id,
 }
 
 static void ebpf_parse_maps_section(vector<EbpfMapDescriptor>&, const char*, size_t, int, const ebpf_platform_t*,
-                                    ebpf_verifier_options_t) {}
+                                    VerifierOptions) {}
 
 static EbpfMapDescriptor test_map_descriptor = {.original_fd = 0,
                                                 .type = 0,
@@ -313,34 +313,34 @@ static InstructionSeq raw_cfg_to_instruction_seq(const vector<std::tuple<string,
     return res;
 }
 
-static ebpf_verifier_options_t raw_options_to_options(const std::set<string>& raw_options) {
-    ebpf_verifier_options_t options{};
+static VerifierOptions raw_options_to_options(const std::set<string>& raw_options) {
+    VerifierOptions options{};
 
     // Use ~simplify for YAML tests unless otherwise specified.
     options.verbosity_opts.simplify = false;
 
     // All YAML tests use !setup_constraints.
-    options.setup_constraints = false;
+    options.runtime.setup_constraints = false;
 
     // Default to the machine's native endianness.
-    options.big_endian = std::endian::native == std::endian::big;
+    options.runtime.big_endian = std::endian::native == std::endian::big;
 
     // Permit test cases to not have an exit instruction.
-    options.cfg_opts.must_have_exit = false;
+    options.must_have_exit = false;
 
     for (const string& name : raw_options) {
         if (name == "!allow_division_by_zero") {
-            options.allow_division_by_zero = false;
+            options.runtime.allow_division_by_zero = false;
         } else if (name == "termination") {
-            options.cfg_opts.check_for_termination = true;
+            options.runtime.check_for_termination = true;
         } else if (name == "strict") {
-            options.strict = true;
+            options.runtime.strict = true;
         } else if (name == "simplify") {
             options.verbosity_opts.simplify = true;
         } else if (name == "big_endian") {
-            options.big_endian = true;
+            options.runtime.big_endian = true;
         } else if (name == "!big_endian") {
-            options.big_endian = false;
+            options.runtime.big_endian = false;
         } else {
             throw std::runtime_error("Unknown option: " + name);
         }
@@ -527,7 +527,7 @@ static StringInvariant stack_contents_invariant(const std::vector<uint8_t>& memo
 
 ConformanceTestResult run_conformance_test_case(const std::vector<uint8_t>& memory_bytes,
                                                 std::span<const EbpfInst> instructions, bool debug) {
-    ebpf_verifier_options_t options{};
+    VerifierOptions options{};
     ebpf_ctx_descriptor_t ctx_descriptor{64, -1, -1, -1};
     EbpfProgramType program_type = make_program_type("conformance_check", &ctx_descriptor);
 
@@ -538,11 +538,11 @@ ConformanceTestResult run_conformance_test_case(const std::vector<uint8_t>& memo
     StringInvariant pre_invariant = StringInvariant::top();
 
     if (!memory_bytes.empty()) {
-        if (memory_bytes.size() > to_unsigned(options.total_stack_size())) {
+        if (memory_bytes.size() > to_unsigned(options.runtime.total_stack_size())) {
             std::cerr << "memory size overflow\n";
             return {};
         }
-        pre_invariant = pre_invariant + stack_contents_invariant(memory_bytes, options.total_stack_size());
+        pre_invariant = pre_invariant + stack_contents_invariant(memory_bytes, options.runtime.total_stack_size());
     }
     RawProgram raw_prog{.prog = insts};
     ebpf_platform_t platform = g_ebpf_platform_linux;

--- a/src/test/ebpf_yaml.hpp
+++ b/src/test/ebpf_yaml.hpp
@@ -18,7 +18,7 @@ struct TestCase {
     // In that case, analysis is skipped and the exception message is compared.
     std::optional<std::string> expected_exception;
     std::optional<std::string> actual_exception;
-    ebpf_verifier_options_t options{};
+    VerifierOptions options{};
     StringInvariant assumed_pre_invariant;
     InstructionSeq instruction_seq;
     StringInvariant expected_post_invariant;

--- a/src/test/run_yaml.cpp
+++ b/src/test/run_yaml.cpp
@@ -10,7 +10,7 @@
 
 using namespace prevail;
 
-int main(int argc, char** argv) {
+int main(const int argc, char** argv) {
     CLI::App app{"Run YAML test cases"};
 
     std::string filename;

--- a/src/test/test_cfg_builder_passes.cpp
+++ b/src/test/test_cfg_builder_passes.cpp
@@ -32,7 +32,7 @@ Condition eq0_zero_is64() { return Condition{.op = Condition::Op::EQ, .left = Re
 
 TEST_CASE("pass_connect_edges rejects an empty instruction sequence", "[passes]") {
     const ProgramInfo info = default_info();
-    constexpr InstructionSeq empty;
+    const InstructionSeq empty;
     REQUIRE_THROWS_WITH(Program::from_sequence(empty, info, {}),
                         Catch::Matchers::ContainsSubstring("empty instruction sequence"));
 }

--- a/src/test/test_cfg_builder_passes.cpp
+++ b/src/test/test_cfg_builder_passes.cpp
@@ -32,12 +32,12 @@ Condition eq0_zero_is64() { return Condition{.op = Condition::Op::EQ, .left = Re
 
 TEST_CASE("pass_connect_edges rejects an empty instruction sequence", "[passes]") {
     const ProgramInfo info = default_info();
-    const InstructionSeq empty;
+    constexpr InstructionSeq empty;
     REQUIRE_THROWS_WITH(Program::from_sequence(empty, info, {}),
                         Catch::Matchers::ContainsSubstring("empty instruction sequence"));
 }
 
-TEST_CASE("pass_connect_edges short-circuits when a conditional target equals fallthrough", "[passes]") {
+TEST_CASE("pass_connect_edges short-circuits", "[passes]") {
     // The true-branch target is also the fallthrough label, so no synthetic Assume jump-labels
     // should be created -- just a plain add_child edge.
     const ProgramInfo info = default_info();
@@ -106,8 +106,8 @@ TEST_CASE("pass_lower_pseudo_loads rewrites VARIABLE_ADDR to an lddw Bin MOV", "
     REQUIRE(bin->lddw);
     const auto* imm = std::get_if<Imm>(&bin->v);
     REQUIRE(imm != nullptr);
-    const uint64_t expected = (static_cast<uint64_t>(static_cast<uint32_t>(0x5678)) << 32) |
-                              static_cast<uint64_t>(static_cast<uint32_t>(0x1234));
+    constexpr uint64_t expected = (static_cast<uint64_t>(static_cast<uint32_t>(0x5678)) << 32) |
+                                  static_cast<uint64_t>(static_cast<uint32_t>(0x1234));
     REQUIRE(imm->v == expected);
 }
 
@@ -176,9 +176,9 @@ TEST_CASE("pass_insert_termination_counters adds a counter at a WTO loop head", 
     seq.push_back(at(0, Bin{.op = Bin::Op::MOV, .dst = Reg{0}, .v = Imm{0}, .is64 = true}));
     seq.push_back(at(1, Jmp{.cond = std::nullopt, .target = Label{0}}));
 
-    ebpf_verifier_options_t options;
-    options.cfg_opts.check_for_termination = true;
-    options.cfg_opts.must_have_exit = false; // cycle without an exit is fine for this test
+    VerifierOptions options;
+    options.runtime.check_for_termination = true;
+    options.must_have_exit = false; // cycle without an exit is fine for this test
     const Program prog = Program::from_sequence(seq, info, options);
 
     bool found_counter = false;
@@ -197,8 +197,8 @@ TEST_CASE("pass_insert_termination_counters is off by default", "[passes]") {
     seq.push_back(at(0, Bin{.op = Bin::Op::MOV, .dst = Reg{0}, .v = Imm{0}, .is64 = true}));
     seq.push_back(at(1, Jmp{.cond = std::nullopt, .target = Label{0}}));
 
-    ebpf_verifier_options_t options;
-    options.cfg_opts.must_have_exit = false;
+    VerifierOptions options;
+    options.must_have_exit = false;
     // check_for_termination defaults to false.
     const Program prog = Program::from_sequence(seq, info, options);
 

--- a/src/test/test_elf_loader.cpp
+++ b/src/test/test_elf_loader.cpp
@@ -573,7 +573,7 @@ TEST_CASE("read_elf succeeds with istream and non-file path", "[elf]") {
     std::istringstream stream(data);
 
     // Use a non-file path — this is how ebpf-for-windows loads ELF from memory.
-    ebpf_verifier_options_t options{};
+    VerifierOptions options{};
     auto programs = read_elf(stream, "memory", ".text", "", options, &g_ebpf_platform_linux);
     REQUIRE(!programs.empty());
 }

--- a/src/test/test_failure_slice.cpp
+++ b/src/test/test_failure_slice.cpp
@@ -14,7 +14,7 @@ static bool sample_exists(const std::string& filename) { return std::filesystem:
 
 // Helper to load a program, run analysis with deps collection, and compute slices
 static std::vector<FailureSlice> get_failure_slices(const std::string& filename, const std::string& section) {
-    ebpf_verifier_options_t options{};
+    VerifierOptions options{};
     options.verbosity_opts.collect_instruction_deps = true;
 
     ElfObject elf{filename, options, &g_ebpf_platform_linux};
@@ -38,9 +38,9 @@ TEST_CASE("extract_instruction_deps for Bin instruction", "[failure_slice][deps]
     // r1 = r1 + r2 should read r1, r2 and write r1
     Bin bin_add{Bin::Op::ADD, Reg{1}, Reg{2}, true, false};
     Instruction ins = bin_add;
-    EbpfDomain dom = EbpfDomain::top(static_cast<size_t>(ebpf_verifier_options_t{}.total_stack_size()));
+    EbpfDomain dom = EbpfDomain::top(static_cast<size_t>(RuntimeConfig{}.total_stack_size()));
 
-    auto deps = extract_instruction_deps(ins, dom, ebpf_verifier_options_t{}.total_stack_size());
+    auto deps = extract_instruction_deps(ins, dom, RuntimeConfig{}.total_stack_size());
 
     REQUIRE(deps.regs_written.contains(Reg{1}));
     REQUIRE(deps.regs_read.contains(Reg{1})); // ADD also reads dst
@@ -51,9 +51,9 @@ TEST_CASE("extract_instruction_deps for MOV instruction", "[failure_slice][deps]
     // r1 = r2 should read r2 and write r1 (but not read r1)
     Bin bin_mov{Bin::Op::MOV, Reg{1}, Reg{2}, true, false};
     Instruction ins = bin_mov;
-    EbpfDomain dom = EbpfDomain::top(static_cast<size_t>(ebpf_verifier_options_t{}.total_stack_size()));
+    EbpfDomain dom = EbpfDomain::top(static_cast<size_t>(RuntimeConfig{}.total_stack_size()));
 
-    auto deps = extract_instruction_deps(ins, dom, ebpf_verifier_options_t{}.total_stack_size());
+    auto deps = extract_instruction_deps(ins, dom, RuntimeConfig{}.total_stack_size());
 
     REQUIRE(deps.regs_written.contains(Reg{1}));
     REQUIRE_FALSE(deps.regs_read.contains(Reg{1})); // MOV doesn't read dst
@@ -64,9 +64,9 @@ TEST_CASE("extract_instruction_deps for Mem load", "[failure_slice][deps]") {
     // r1 = *(r10 - 8) should read r10, write r1, and read stack[-8]
     Mem mem_load{Deref{8, Reg{10}, -8}, Reg{1}, true};
     Instruction ins = mem_load;
-    EbpfDomain dom = EbpfDomain::top(static_cast<size_t>(ebpf_verifier_options_t{}.total_stack_size()));
+    EbpfDomain dom = EbpfDomain::top(static_cast<size_t>(RuntimeConfig{}.total_stack_size()));
 
-    auto deps = extract_instruction_deps(ins, dom, ebpf_verifier_options_t{}.total_stack_size());
+    auto deps = extract_instruction_deps(ins, dom, RuntimeConfig{}.total_stack_size());
 
     REQUIRE(deps.regs_written.contains(Reg{1}));
     REQUIRE(deps.regs_read.contains(Reg{10}));
@@ -77,9 +77,9 @@ TEST_CASE("extract_instruction_deps for Mem store", "[failure_slice][deps]") {
     // *(r10 - 8) = r1 should read r10, r1 and write stack[-8]
     Mem mem_store{Deref{8, Reg{10}, -8}, Reg{1}, false};
     Instruction ins = mem_store;
-    EbpfDomain dom = EbpfDomain::top(static_cast<size_t>(ebpf_verifier_options_t{}.total_stack_size()));
+    EbpfDomain dom = EbpfDomain::top(static_cast<size_t>(RuntimeConfig{}.total_stack_size()));
 
-    auto deps = extract_instruction_deps(ins, dom, ebpf_verifier_options_t{}.total_stack_size());
+    auto deps = extract_instruction_deps(ins, dom, RuntimeConfig{}.total_stack_size());
 
     REQUIRE(deps.regs_read.contains(Reg{10}));
     REQUIRE(deps.regs_read.contains(Reg{1}));
@@ -176,7 +176,7 @@ TEST_CASE("print_failure_slices produces structured output", "[failure_slice][pr
     if (!sample_exists(sample)) {
         SKIP("Sample file not found: " << sample);
     }
-    ebpf_verifier_options_t options{};
+    VerifierOptions options{};
     options.verbosity_opts.collect_instruction_deps = true;
 
     ElfObject elf{sample, options, &g_ebpf_platform_linux};
@@ -194,7 +194,7 @@ TEST_CASE("print_failure_slices produces structured output", "[failure_slice][pr
     auto slices = result.compute_failure_slices(context);
 
     std::stringstream output;
-    verbosity_options_t verbosity{.simplify = false};
+    VerbosityOptions verbosity{.simplify = false};
     print_failure_slices(output, context.program, result, slices, verbosity);
 
     std::string output_str = output.str();
@@ -213,7 +213,7 @@ TEST_CASE("passing program produces no failure slices", "[failure_slice][integra
     if (!sample_exists(sample)) {
         SKIP("Sample file not found: " << sample);
     }
-    ebpf_verifier_options_t options{};
+    VerifierOptions options{};
     options.verbosity_opts.collect_instruction_deps = true;
 
     ElfObject elf{sample, options, &g_ebpf_platform_linux};
@@ -251,7 +251,7 @@ TEST_CASE("assume guard registers become relevant in slice", "[failure_slice][in
 
     // Check that at least one Assume label is in the slice
     // (the guard condition that determines reachability of the failing label)
-    ebpf_verifier_options_t options{};
+    VerifierOptions options{};
     options.verbosity_opts.collect_instruction_deps = true;
     ElfObject elf{sample, options, &g_ebpf_platform_linux};
     const auto& raw_progs = elf.get_programs("xdp");

--- a/src/test/test_failure_slice.cpp
+++ b/src/test/test_failure_slice.cpp
@@ -5,6 +5,7 @@
 #include <filesystem>
 #include <sstream>
 
+#include "crab_utils/num_safety.hpp"
 #include "ebpf_verifier.hpp"
 
 using namespace prevail;
@@ -38,7 +39,7 @@ TEST_CASE("extract_instruction_deps for Bin instruction", "[failure_slice][deps]
     // r1 = r1 + r2 should read r1, r2 and write r1
     Bin bin_add{Bin::Op::ADD, Reg{1}, Reg{2}, true, false};
     Instruction ins = bin_add;
-    EbpfDomain dom = EbpfDomain::top(static_cast<size_t>(RuntimeConfig{}.total_stack_size()));
+    EbpfDomain dom = EbpfDomain::top(to_unsigned(RuntimeConfig{}.total_stack_size()));
 
     auto deps = extract_instruction_deps(ins, dom, RuntimeConfig{}.total_stack_size());
 
@@ -51,7 +52,7 @@ TEST_CASE("extract_instruction_deps for MOV instruction", "[failure_slice][deps]
     // r1 = r2 should read r2 and write r1 (but not read r1)
     Bin bin_mov{Bin::Op::MOV, Reg{1}, Reg{2}, true, false};
     Instruction ins = bin_mov;
-    EbpfDomain dom = EbpfDomain::top(static_cast<size_t>(RuntimeConfig{}.total_stack_size()));
+    EbpfDomain dom = EbpfDomain::top(to_unsigned(RuntimeConfig{}.total_stack_size()));
 
     auto deps = extract_instruction_deps(ins, dom, RuntimeConfig{}.total_stack_size());
 
@@ -64,7 +65,7 @@ TEST_CASE("extract_instruction_deps for Mem load", "[failure_slice][deps]") {
     // r1 = *(r10 - 8) should read r10, write r1, and read stack[-8]
     Mem mem_load{Deref{8, Reg{10}, -8}, Reg{1}, true};
     Instruction ins = mem_load;
-    EbpfDomain dom = EbpfDomain::top(static_cast<size_t>(RuntimeConfig{}.total_stack_size()));
+    EbpfDomain dom = EbpfDomain::top(to_unsigned(RuntimeConfig{}.total_stack_size()));
 
     auto deps = extract_instruction_deps(ins, dom, RuntimeConfig{}.total_stack_size());
 
@@ -77,7 +78,7 @@ TEST_CASE("extract_instruction_deps for Mem store", "[failure_slice][deps]") {
     // *(r10 - 8) = r1 should read r10, r1 and write stack[-8]
     Mem mem_store{Deref{8, Reg{10}, -8}, Reg{1}, false};
     Instruction ins = mem_store;
-    EbpfDomain dom = EbpfDomain::top(static_cast<size_t>(RuntimeConfig{}.total_stack_size()));
+    EbpfDomain dom = EbpfDomain::top(to_unsigned(RuntimeConfig{}.total_stack_size()));
 
     auto deps = extract_instruction_deps(ins, dom, RuntimeConfig{}.total_stack_size());
 

--- a/src/test/test_join.cpp
+++ b/src/test/test_join.cpp
@@ -395,7 +395,7 @@ TEST_CASE("close_after_widen recovers transitive edge through unstable vertex", 
     // close_after_widen should run Dijkstra recovery from unstable vertex 1
     // and discover the transitive path 1->2->3 = 5+5 = 10, adding edge 1->3: 10.
 
-    auto make_graph = [](Weight w13) {
+    auto make_graph = [](const Weight w13) {
         Graph g;
         g.growTo(4);
         g.add_edge(0, Weight(100), 1);

--- a/src/test/test_marshal.cpp
+++ b/src/test/test_marshal.cpp
@@ -10,7 +10,6 @@
 #include "ir/marshal.hpp"
 #include "ir/program.hpp"
 #include "ir/unmarshal.hpp"
-#include "linux/gpl/spec_type_descriptors.hpp"
 
 using namespace prevail;
 
@@ -215,8 +214,8 @@ static const EbpfInstructionTemplate instruction_template[] = {
 static void check_unmarshal_succeed(const EbpfInst& ins, const ebpf_platform_t& platform = g_ebpf_platform_linux) {
     const ProgramInfo info{.platform = &platform, .type = platform.get_program_type("unspec", "unspec")};
     constexpr EbpfInst exit{.opcode = INST_OP_EXIT};
-    const InstructionSeq parsed = std::get<InstructionSeq>(
-        unmarshal(RawProgram{"", "", 0, "", {ins, exit, exit}, info}, ebpf_verifier_options_t{}));
+    const InstructionSeq parsed =
+        std::get<InstructionSeq>(unmarshal(RawProgram{"", "", 0, "", {ins, exit, exit}, info}, VerifierOptions{}));
     REQUIRE(parsed.size() == 3);
 }
 
@@ -226,7 +225,7 @@ static void check_unmarshal_succeed(EbpfInst inst1, EbpfInst inst2,
     const ProgramInfo info{.platform = &platform, .type = platform.get_program_type("unspec", "unspec")};
     constexpr EbpfInst exit{.opcode = INST_OP_EXIT};
     const InstructionSeq parsed = std::get<InstructionSeq>(
-        unmarshal(RawProgram{"", "", 0, "", {inst1, inst2, exit, exit}, info}, ebpf_verifier_options_t{}));
+        unmarshal(RawProgram{"", "", 0, "", {inst1, inst2, exit, exit}, info}, VerifierOptions{}));
     REQUIRE(parsed.size() == 3);
 }
 
@@ -236,8 +235,8 @@ static void compare_unmarshal_marshal(const EbpfInst& ins, const EbpfInst& expec
                                       const ebpf_platform_t& platform = g_ebpf_platform_linux) {
     ProgramInfo info{.platform = &platform, .type = platform.get_program_type("unspec", "unspec")};
     constexpr EbpfInst exit{.opcode = INST_OP_EXIT};
-    const InstructionSeq inst_seq = std::get<InstructionSeq>(
-        unmarshal(RawProgram{"", "", 0, "", {ins, exit, exit}, info}, ebpf_verifier_options_t{}));
+    const InstructionSeq inst_seq =
+        std::get<InstructionSeq>(unmarshal(RawProgram{"", "", 0, "", {ins, exit, exit}, info}, VerifierOptions{}));
     REQUIRE(inst_seq.size() == 3);
     auto [_, single, _2] = inst_seq.front();
     (void)_;  // unused
@@ -255,7 +254,7 @@ static void compare_unmarshal_marshal(const EbpfInst& ins1, const EbpfInst& ins2
                      .type = g_ebpf_platform_linux.get_program_type("unspec", "unspec")};
     constexpr EbpfInst exit{.opcode = INST_OP_EXIT};
     InstructionSeq parsed = std::get<InstructionSeq>(
-        unmarshal(RawProgram{"", "", 0, "", {ins1, ins2, exit, exit}, info}, ebpf_verifier_options_t{}));
+        unmarshal(RawProgram{"", "", 0, "", {ins1, ins2, exit, exit}, info}, VerifierOptions{}));
     REQUIRE(parsed.size() == 3);
     auto [_, single, _2] = parsed.front();
     (void)_;  // unused
@@ -274,7 +273,7 @@ static void compare_unmarshal_marshal(const EbpfInst& ins1, const EbpfInst& ins2
                      .type = g_ebpf_platform_linux.get_program_type("unspec", "unspec")};
     constexpr EbpfInst exit{.opcode = INST_OP_EXIT};
     const InstructionSeq inst_seq = std::get<InstructionSeq>(
-        unmarshal(RawProgram{"", "", 0, "", {ins1, ins2, exit, exit}, info}, ebpf_verifier_options_t{}));
+        unmarshal(RawProgram{"", "", 0, "", {ins1, ins2, exit, exit}, info}, VerifierOptions{}));
     REQUIRE(inst_seq.size() == 3);
     auto [_, single, _2] = inst_seq.front();
     (void)_;  // unused
@@ -292,8 +291,8 @@ static void compare_unmarshal_marshal(const EbpfInst& ins1, const EbpfInst& ins2
 static void compare_marshal_unmarshal(const Instruction& ins, bool double_cmd = false,
                                       const ebpf_platform_t& platform = g_ebpf_platform_linux) {
     ProgramInfo info{.platform = &platform, .type = platform.get_program_type("unspec", "unspec")};
-    const InstructionSeq inst_seq = std::get<InstructionSeq>(
-        unmarshal(RawProgram{"", "", 0, "", marshal(ins, 0), info}, ebpf_verifier_options_t{}));
+    const InstructionSeq inst_seq =
+        std::get<InstructionSeq>(unmarshal(RawProgram{"", "", 0, "", marshal(ins, 0), info}, VerifierOptions{}));
     REQUIRE(inst_seq.size() == 1);
     auto [_, single, _2] = inst_seq.back();
     (void)_;  // unused
@@ -304,7 +303,7 @@ static void compare_marshal_unmarshal(const Instruction& ins, bool double_cmd = 
 static void check_marshal_unmarshal_fail(const Instruction& ins, const std::string& expected_error_message,
                                          const ebpf_platform_t& platform = g_ebpf_platform_linux) {
     const ProgramInfo info{.platform = &platform, .type = platform.get_program_type("unspec", "unspec")};
-    auto result = unmarshal(RawProgram{"", "", 0, "", marshal(ins, 0), info}, ebpf_verifier_options_t{});
+    auto result = unmarshal(RawProgram{"", "", 0, "", marshal(ins, 0), info}, VerifierOptions{});
     auto* error_message = std::get_if<std::string>(&result);
     REQUIRE(error_message != nullptr);
     REQUIRE(*error_message == expected_error_message);
@@ -314,7 +313,7 @@ static void check_unmarshal_fail(EbpfInst inst, const std::string& expected_erro
                                  const ebpf_platform_t& platform = g_ebpf_platform_linux) {
     ProgramInfo info{.platform = &platform, .type = platform.get_program_type("unspec", "unspec")};
     std::vector insns = {inst};
-    auto result = unmarshal(RawProgram{"", "", 0, "", insns, info}, ebpf_verifier_options_t{});
+    auto result = unmarshal(RawProgram{"", "", 0, "", insns, info}, VerifierOptions{});
     auto* error_message = std::get_if<std::string>(&result);
     REQUIRE(error_message != nullptr);
     REQUIRE(*error_message == expected_error_message);
@@ -325,7 +324,7 @@ static void check_unmarshal_fail_goto(EbpfInst inst, const std::string& expected
     ProgramInfo info{.platform = &platform, .type = platform.get_program_type("unspec", "unspec")};
     constexpr EbpfInst exit{.opcode = INST_OP_EXIT};
     std::vector insns{inst, exit, exit};
-    auto result = unmarshal(RawProgram{"", "", 0, "", insns, info}, ebpf_verifier_options_t{});
+    auto result = unmarshal(RawProgram{"", "", 0, "", insns, info}, VerifierOptions{});
     auto* error_message = std::get_if<std::string>(&result);
     REQUIRE(error_message != nullptr);
     REQUIRE(*error_message == expected_error_message);
@@ -336,7 +335,7 @@ static void check_unmarshal_fail(EbpfInst inst1, EbpfInst inst2, const std::stri
                                  const ebpf_platform_t& platform = g_ebpf_platform_linux) {
     ProgramInfo info{.platform = &platform, .type = platform.get_program_type("unspec", "unspec")};
     std::vector insns{inst1, inst2};
-    auto result = unmarshal(RawProgram{"", "", 0, "", insns, info}, ebpf_verifier_options_t{});
+    auto result = unmarshal(RawProgram{"", "", 0, "", insns, info}, VerifierOptions{});
     auto* error_message = std::get_if<std::string>(&result);
     REQUIRE(error_message != nullptr);
     REQUIRE(*error_message == expected_error_message);
@@ -344,7 +343,7 @@ static void check_unmarshal_fail(EbpfInst inst1, EbpfInst inst2, const std::stri
 
 static Call unmarshal_single_call(const EbpfInst& call_inst, const ProgramInfo& info) {
     constexpr EbpfInst exit{.opcode = INST_OP_EXIT};
-    const auto parsed = unmarshal(RawProgram{"", "", 0, "", {call_inst, exit, exit}, info}, ebpf_verifier_options_t{});
+    const auto parsed = unmarshal(RawProgram{"", "", 0, "", {call_inst, exit, exit}, info}, VerifierOptions{});
     auto* inst_seq = std::get_if<InstructionSeq>(&parsed);
     REQUIRE(inst_seq != nullptr);
     REQUIRE(inst_seq->size() == 3);
@@ -939,7 +938,7 @@ TEST_CASE("unmarshal builtin calls only when relocation-gated", "[disasm][marsha
     REQUIRE(gated_resolved.contract.pairs[0] ==
             ArgPair{ArgPair::Kind::PTR_TO_WRITABLE_MEM, false, Reg{1}, Reg{3}, false});
 
-    const auto assertions = get_assertions(gated, info, ebpf_verifier_options_t{}, Label{0});
+    const auto assertions = get_assertions(gated, info, RuntimeConfig{}, Label{0});
     REQUIRE(has_assertion(assertions, TypeConstraint{Reg{1}, TypeGroup::mem}));
     REQUIRE(has_assertion(assertions, TypeConstraint{Reg{2}, TypeGroup::number}));
     REQUIRE(has_assertion(assertions, TypeConstraint{Reg{3}, TypeGroup::number}));

--- a/src/test/test_runtime_config.cpp
+++ b/src/test/test_runtime_config.cpp
@@ -1,0 +1,93 @@
+// Copyright (c) Prevail Verifier contributors.
+// SPDX-License-Identifier: MIT
+
+#include <catch2/catch_all.hpp>
+
+#include "config.hpp"
+
+using namespace prevail;
+
+TEST_CASE("RuntimeConfig defaults are accepted", "[config][runtime]") {
+    RuntimeConfig cfg{};
+    REQUIRE_NOTHROW(cfg.validate());
+    CHECK(cfg.subprogram_stack_size == 512);
+    CHECK(cfg.max_call_stack_frames == 8);
+    CHECK(cfg.max_packet_size == 0xffff);
+    CHECK(cfg.total_stack_size() == 512 * 8);
+}
+
+TEST_CASE("RuntimeConfig::total_stack_size is the product", "[config][runtime]") {
+    RuntimeConfig cfg{};
+    cfg.subprogram_stack_size = 1024;
+    cfg.max_call_stack_frames = 16;
+    CHECK(cfg.total_stack_size() == 1024 * 16);
+}
+
+TEST_CASE("RuntimeConfig::validate rejects out-of-range subprogram_stack_size", "[config][runtime]") {
+    RuntimeConfig cfg{};
+
+    cfg.subprogram_stack_size = 0;
+    CHECK_THROWS_AS(cfg.validate(), std::invalid_argument);
+
+    cfg.subprogram_stack_size = -1;
+    CHECK_THROWS_AS(cfg.validate(), std::invalid_argument);
+
+    cfg.subprogram_stack_size = RuntimeConfig::MAX_SUBPROGRAM_STACK_SIZE + 1;
+    CHECK_THROWS_AS(cfg.validate(), std::invalid_argument);
+
+    cfg.subprogram_stack_size = RuntimeConfig::MAX_SUBPROGRAM_STACK_SIZE;
+    CHECK_NOTHROW(cfg.validate());
+
+    cfg.subprogram_stack_size = 1;
+    CHECK_NOTHROW(cfg.validate());
+}
+
+TEST_CASE("RuntimeConfig::validate rejects out-of-range max_call_stack_frames", "[config][runtime]") {
+    RuntimeConfig cfg{};
+
+    cfg.max_call_stack_frames = 0;
+    CHECK_THROWS_AS(cfg.validate(), std::invalid_argument);
+
+    cfg.max_call_stack_frames = -1;
+    CHECK_THROWS_AS(cfg.validate(), std::invalid_argument);
+
+    cfg.max_call_stack_frames = RuntimeConfig::MAX_CALL_STACK_FRAMES_LIMIT + 1;
+    CHECK_THROWS_AS(cfg.validate(), std::invalid_argument);
+
+    cfg.max_call_stack_frames = RuntimeConfig::MAX_CALL_STACK_FRAMES_LIMIT;
+    CHECK_NOTHROW(cfg.validate());
+
+    cfg.max_call_stack_frames = 1;
+    CHECK_NOTHROW(cfg.validate());
+}
+
+TEST_CASE("RuntimeConfig::validate rejects out-of-range max_packet_size", "[config][runtime]") {
+    RuntimeConfig cfg{};
+
+    cfg.max_packet_size = 0;
+    CHECK_THROWS_AS(cfg.validate(), std::invalid_argument);
+
+    cfg.max_packet_size = -1;
+    CHECK_THROWS_AS(cfg.validate(), std::invalid_argument);
+
+    cfg.max_packet_size = RuntimeConfig::MAX_PACKET_SIZE_LIMIT + 1;
+    CHECK_THROWS_AS(cfg.validate(), std::invalid_argument);
+
+    cfg.max_packet_size = RuntimeConfig::MAX_PACKET_SIZE_LIMIT;
+    CHECK_NOTHROW(cfg.validate());
+
+    cfg.max_packet_size = 1;
+    CHECK_NOTHROW(cfg.validate());
+}
+
+TEST_CASE("VerifierOptions composes RuntimeConfig", "[config][runtime]") {
+    VerifierOptions options{};
+    static_assert(std::is_same_v<decltype(options.runtime), RuntimeConfig>);
+
+    options.runtime.strict = true;
+    options.runtime.allow_division_by_zero = false;
+    CHECK(options.runtime.strict);
+    CHECK_FALSE(options.runtime.allow_division_by_zero);
+
+    REQUIRE_NOTHROW(options.runtime.validate());
+}

--- a/src/test/test_verify.hpp
+++ b/src/test/test_verify.hpp
@@ -48,7 +48,7 @@ enum class VerifyIssueKind {
     LegacyBccBehavior,
 };
 
-inline const char* to_string(VerifyIssueKind kind) noexcept {
+inline const char* to_string(const VerifyIssueKind kind) noexcept {
     switch (kind) {
     case VerifyIssueKind::VerifierTypeTracking: return "VerifierTypeTracking";
     case VerifyIssueKind::VerifierBoundsTracking: return "VerifierBoundsTracking";
@@ -90,7 +90,7 @@ struct ElfObjectCacheKeyHash {
 
 inline std::vector<prevail::RawProgram> read_elf_cached(const std::string& path, const std::string& desired_section,
                                                         const std::string& desired_program,
-                                                        const prevail::ebpf_verifier_options_t& options,
+                                                        const prevail::VerifierOptions& options,
                                                         const prevail::ebpf_platform_t* platform) {
     static std::mutex cache_mutex;
     static std::unordered_map<ElfObjectCacheKey, prevail::ElfObject, ElfObjectCacheKeyHash> object_cache;
@@ -101,7 +101,7 @@ inline std::vector<prevail::RawProgram> read_elf_cached(const std::string& path,
         .verbosity_print_line_info = options.verbosity_opts.print_line_info,
         .verbosity_dump_btf_types_json = options.verbosity_opts.dump_btf_types_json,
     };
-    prevail::ebpf_verifier_options_t loader_options{};
+    prevail::VerifierOptions loader_options{};
     loader_options.verbosity_opts.print_line_info = options.verbosity_opts.print_line_info;
     loader_options.verbosity_opts.dump_btf_types_json = options.verbosity_opts.dump_btf_types_json;
 
@@ -164,7 +164,7 @@ struct BoundedTestName {
 // Verify a program in a section that may have multiple programs in it.
 #define VERIFY_PROGRAM(dirname, filename, section_name, program_name, _options, platform, should_pass, count) \
     do {                                                                                                      \
-        const prevail::ebpf_verifier_options_t _prevail_opts = _options;                                      \
+        const prevail::VerifierOptions _prevail_opts = _options;                                              \
         auto raw_progs = verify_test::read_elf_cached("ebpf-samples/" dirname "/" filename, section_name, "", \
                                                       _prevail_opts, platform);                               \
         REQUIRE(raw_progs.size() == count);                                                                   \
@@ -249,9 +249,9 @@ struct BoundedTestName {
 
 #define TEST_SECTION_REJECT_IF_STRICT(project, filename, section)                                    \
     BOUNDED_TEST_CASE(project "/" filename " " section, "[verify][samples][" project "]") {          \
-        prevail::ebpf_verifier_options_t options{};                                                  \
+        prevail::VerifierOptions options{};                                                          \
         VERIFY_SECTION(project, filename, section, options, &prevail::g_ebpf_platform_linux, true);  \
-        options.strict = true;                                                                       \
+        options.runtime.strict = true;                                                               \
         VERIFY_SECTION(project, filename, section, options, &prevail::g_ebpf_platform_linux, false); \
     }
 

--- a/src/verifier.hpp
+++ b/src/verifier.hpp
@@ -15,12 +15,11 @@ AnalysisResult analyze(const StringInvariant& entry_invariant, const AnalysisCon
 
 // Convenience overloads that copy `prog` into a fresh AnalysisContext.
 // For repeated analysis of the same program, build one AnalysisContext and reuse it.
-AnalysisResult analyze(const Program& prog, const ebpf_verifier_options_t& options);
-AnalysisResult analyze(const Program& prog, const StringInvariant& entry_invariant,
-                       const ebpf_verifier_options_t& options);
+AnalysisResult analyze(const Program& prog, const VerifierOptions& options);
+AnalysisResult analyze(const Program& prog, const StringInvariant& entry_invariant, const VerifierOptions& options);
 
 void ebpf_verifier_clear_thread_local_state();
-inline bool verify(const Program& prog, const ebpf_verifier_options_t& options) {
+inline bool verify(const Program& prog, const VerifierOptions& options) {
     try {
         return !analyze(prog, options).failed;
     } catch (const std::exception&) {


### PR DESCRIPTION
## Summary
Closes #1085. Introduces `RuntimeConfig` — the subset of verifier options that affects which programs are accepted — and reshapes `VerifierOptions` so a signature reveals whether a knob can change verification outcome.

- New `RuntimeConfig` groups the analysis-semantic fields: `strict`, `allow_division_by_zero`, `setup_constraints`, `big_endian`, `check_for_termination`, `subprogram_stack_size`, `max_call_stack_frames`, `max_packet_size`. `validate()` and `total_stack_size()` live here.
- `VerifierOptions` composes `RuntimeConfig` and `VerbosityOptions`; `mock_map_fds` and `must_have_exit` stay as top-level fields. The single-field `prepare_cfg_options` wrapper is gone.
- `check_for_termination` moved out of CFG-prep options into `RuntimeConfig` — it instruments loop heads and gates the post-analysis termination check, so it changes verification outcome.
- Functions that only consume runtime semantics (`get_assertions`, `AssertExtractor`, the abstract domain/checker/transformer) take `RuntimeConfig` directly. `AnalysisContext::runtime()` exposes the runtime subset.
- Legacy `_t`-suffixed structs renamed to PascalCase to match the rest of the codebase: `ebpf_verifier_options_t` → `VerifierOptions`, `verbosity_options_t` → `VerbosityOptions`, `ebpf_verifier_stats_t` → `VerifierStats`.
- Adds `src/test/test_runtime_config.cpp` covering `validate()` bounds and `total_stack_size()`.
- Includes incidental clang-tidy-style cleanups in unrelated files picked up by the formatter run.

## Test plan
- [x] \`cmake --build build --parallel --target tests\` succeeds in Release.
- [x] \`./bin/tests\` passes (1320 passed, 1 skipped, 236 failed-as-expected — matches baseline).
- [x] \`./bin/tests "[config]"\` covers the new \`RuntimeConfig\` validation tests.
- [x] CI green on the PR.