### PR TITLE
Share helper/kfunc arg resolution; compact kfunc prototype table

### DIFF
--- a/src/ir/arg_kind.hpp
+++ b/src/ir/arg_kind.hpp
@@ -1,0 +1,144 @@
+// Copyright (c) Prevail Verifier contributors.
+// SPDX-License-Identifier: MIT
+#pragma once
+
+#include <array>
+#include <optional>
+
+#include <gsl/narrow>
+
+#include "ir/syntax.hpp"
+#include "spec/ebpf_base.h"
+
+namespace prevail {
+
+/// Map an ABI argument-type tag to the resolved single-arg kind it implies,
+/// or std::nullopt for tags that are not single-arg (pair members, sizes,
+/// DONTCARE/UNSUPPORTED sentinels, etc.). Shared by helper and kfunc
+/// resolution; each caller decides how to handle nullopt (silent fallback
+/// vs. set-unsupported).
+[[nodiscard]]
+inline std::optional<ArgSingle::Kind> to_arg_single_kind(const ebpf_argument_type_t t) {
+    switch (t) {
+    case EBPF_ARGUMENT_TYPE_ANYTHING: return ArgSingle::Kind::ANYTHING;
+    case EBPF_ARGUMENT_TYPE_PTR_TO_STACK:
+    case EBPF_ARGUMENT_TYPE_PTR_TO_STACK_OR_NULL: return ArgSingle::Kind::PTR_TO_STACK;
+    case EBPF_ARGUMENT_TYPE_PTR_TO_MAP:
+    case EBPF_ARGUMENT_TYPE_CONST_PTR_TO_MAP: return ArgSingle::Kind::MAP_FD;
+    case EBPF_ARGUMENT_TYPE_PTR_TO_MAP_OF_PROGRAMS: return ArgSingle::Kind::MAP_FD_PROGRAMS;
+    case EBPF_ARGUMENT_TYPE_PTR_TO_MAP_KEY: return ArgSingle::Kind::PTR_TO_MAP_KEY;
+    case EBPF_ARGUMENT_TYPE_PTR_TO_MAP_VALUE:
+    case EBPF_ARGUMENT_TYPE_PTR_TO_UNINIT_MAP_VALUE: return ArgSingle::Kind::PTR_TO_MAP_VALUE;
+    case EBPF_ARGUMENT_TYPE_PTR_TO_CTX:
+    case EBPF_ARGUMENT_TYPE_PTR_TO_CTX_OR_NULL: return ArgSingle::Kind::PTR_TO_CTX;
+    case EBPF_ARGUMENT_TYPE_PTR_TO_FUNC: return ArgSingle::Kind::PTR_TO_FUNC;
+    default: return std::nullopt;
+    }
+}
+
+/// Map an ABI argument-type tag to the resolved pair kind for the pointer
+/// half of a (ptr, size) pair, or std::nullopt for tags that do not
+/// participate as a pair pointer. The size half is conveyed separately via
+/// EBPF_ARGUMENT_TYPE_CONST_SIZE / EBPF_ARGUMENT_TYPE_CONST_SIZE_OR_ZERO.
+[[nodiscard]]
+inline std::optional<ArgPair::Kind> to_arg_pair_kind(const ebpf_argument_type_t t) {
+    switch (t) {
+    case EBPF_ARGUMENT_TYPE_PTR_TO_READABLE_MEM:
+    case EBPF_ARGUMENT_TYPE_PTR_TO_READABLE_MEM_OR_NULL:
+    case EBPF_ARGUMENT_TYPE_PTR_TO_READONLY_MEM:
+    case EBPF_ARGUMENT_TYPE_PTR_TO_READONLY_MEM_OR_NULL: return ArgPair::Kind::PTR_TO_READABLE_MEM;
+    case EBPF_ARGUMENT_TYPE_PTR_TO_WRITABLE_MEM:
+    case EBPF_ARGUMENT_TYPE_PTR_TO_WRITABLE_MEM_OR_NULL: return ArgPair::Kind::PTR_TO_WRITABLE_MEM;
+    default: return std::nullopt;
+    }
+}
+
+/// Outcome of consuming one position in the helper/kfunc argument list.
+/// Callers use it to advance the loop index and to format their own
+/// "unsupported" diagnostic so error wording (helper vs. kfunc) stays
+/// caller-controlled.
+enum class ArgOutcome {
+    Single,         ///< Single-arg consumed; caller advances i by 1.
+    Pair,           ///< (ptr, size) pair consumed; caller advances i by 2.
+    Stop,           ///< DONTCARE reached; remaining positions are unused.
+    Unavailable,    ///< Argument type is not supported on this platform.
+    MismatchedSize, ///< Pointer arg not followed by CONST_SIZE/CONST_SIZE_OR_ZERO.
+};
+
+/// Process a single position in the argument array, populating
+/// `contract` with whatever single or pair entry it implies. The args
+/// span has DONTCARE sentinels at index 0 and the last index, so
+/// `args[i + 1]` is always in bounds for `i` in the caller's loop range.
+[[nodiscard]]
+inline ArgOutcome process_arg(CallContract& contract, const std::array<ebpf_argument_type_t, 7>& args, const size_t i) {
+    const Reg reg{gsl::narrow<uint8_t>(i)};
+    switch (args[i]) {
+    case EBPF_ARGUMENT_TYPE_DONTCARE: return ArgOutcome::Stop;
+    case EBPF_ARGUMENT_TYPE_UNSUPPORTED: return ArgOutcome::Unavailable;
+    case EBPF_ARGUMENT_TYPE_CONST_SIZE:
+    case EBPF_ARGUMENT_TYPE_CONST_SIZE_OR_ZERO: return ArgOutcome::MismatchedSize;
+    case EBPF_ARGUMENT_TYPE_PTR_TO_CONST_STR: return ArgOutcome::Unavailable;
+    case EBPF_ARGUMENT_TYPE_PTR_TO_BTF_ID_SOCK_COMMON:
+    case EBPF_ARGUMENT_TYPE_PTR_TO_SOCK_COMMON:
+        contract.singles.push_back({ArgSingle::Kind::PTR_TO_SOCKET, false, reg});
+        return ArgOutcome::Single;
+    case EBPF_ARGUMENT_TYPE_PTR_TO_BTF_ID:
+    case EBPF_ARGUMENT_TYPE_PTR_TO_PERCPU_BTF_ID:
+        contract.singles.push_back({ArgSingle::Kind::PTR_TO_BTF_ID, false, reg});
+        return ArgOutcome::Single;
+    case EBPF_ARGUMENT_TYPE_PTR_TO_ALLOC_MEM:
+        contract.singles.push_back({ArgSingle::Kind::PTR_TO_ALLOC_MEM, false, reg});
+        return ArgOutcome::Single;
+    case EBPF_ARGUMENT_TYPE_PTR_TO_SPIN_LOCK:
+        contract.singles.push_back({ArgSingle::Kind::PTR_TO_SPIN_LOCK, false, reg});
+        return ArgOutcome::Single;
+    case EBPF_ARGUMENT_TYPE_PTR_TO_TIMER:
+        contract.singles.push_back({ArgSingle::Kind::PTR_TO_TIMER, false, reg});
+        return ArgOutcome::Single;
+    case EBPF_ARGUMENT_TYPE_CONST_ALLOC_SIZE_OR_ZERO:
+        contract.singles.push_back({ArgSingle::Kind::CONST_SIZE_OR_ZERO, false, reg});
+        contract.alloc_size_reg = reg;
+        return ArgOutcome::Single;
+    case EBPF_ARGUMENT_TYPE_PTR_TO_LONG:
+        contract.singles.push_back({ArgSingle::Kind::PTR_TO_WRITABLE_LONG, false, reg});
+        return ArgOutcome::Single;
+    case EBPF_ARGUMENT_TYPE_PTR_TO_INT:
+        contract.singles.push_back({ArgSingle::Kind::PTR_TO_WRITABLE_INT, false, reg});
+        return ArgOutcome::Single;
+    case EBPF_ARGUMENT_TYPE_PTR_TO_STACK_OR_NULL:
+    case EBPF_ARGUMENT_TYPE_PTR_TO_CTX_OR_NULL:
+        if (const auto kind = to_arg_single_kind(args[i])) {
+            contract.singles.push_back({*kind, true, reg});
+            return ArgOutcome::Single;
+        }
+        return ArgOutcome::Unavailable;
+    case EBPF_ARGUMENT_TYPE_PTR_TO_READABLE_MEM:
+    case EBPF_ARGUMENT_TYPE_PTR_TO_READABLE_MEM_OR_NULL:
+    case EBPF_ARGUMENT_TYPE_PTR_TO_READONLY_MEM:
+    case EBPF_ARGUMENT_TYPE_PTR_TO_READONLY_MEM_OR_NULL:
+    case EBPF_ARGUMENT_TYPE_PTR_TO_WRITABLE_MEM:
+    case EBPF_ARGUMENT_TYPE_PTR_TO_WRITABLE_MEM_OR_NULL: {
+        if (args[i + 1] != EBPF_ARGUMENT_TYPE_CONST_SIZE && args[i + 1] != EBPF_ARGUMENT_TYPE_CONST_SIZE_OR_ZERO) {
+            return ArgOutcome::MismatchedSize;
+        }
+        const auto pair_kind = to_arg_pair_kind(args[i]);
+        if (!pair_kind) {
+            return ArgOutcome::Unavailable;
+        }
+        const bool can_be_zero = (args[i + 1] == EBPF_ARGUMENT_TYPE_CONST_SIZE_OR_ZERO);
+        const bool or_null = args[i] == EBPF_ARGUMENT_TYPE_PTR_TO_READABLE_MEM_OR_NULL ||
+                             args[i] == EBPF_ARGUMENT_TYPE_PTR_TO_READONLY_MEM_OR_NULL ||
+                             args[i] == EBPF_ARGUMENT_TYPE_PTR_TO_WRITABLE_MEM_OR_NULL;
+        contract.pairs.push_back({*pair_kind, or_null, reg, Reg{gsl::narrow<uint8_t>(i + 1)}, can_be_zero});
+        return ArgOutcome::Pair;
+    }
+    default:
+        if (const auto kind = to_arg_single_kind(args[i])) {
+            contract.singles.push_back({*kind, false, reg});
+            return ArgOutcome::Single;
+        }
+        return ArgOutcome::Unavailable;
+    }
+}
+
+} // namespace prevail

--- a/src/ir/call_resolver.cpp
+++ b/src/ir/call_resolver.cpp
@@ -3,46 +3,13 @@
 #include <array>
 #include <string>
 
-#include <gsl/narrow>
-
+#include "ir/arg_kind.hpp"
 #include "ir/call_resolver.hpp"
 #include "spec/function_prototypes.hpp"
 
 namespace prevail {
 
 namespace {
-
-ArgSingle::Kind to_arg_single_kind(const ebpf_argument_type_t t) {
-    switch (t) {
-    case EBPF_ARGUMENT_TYPE_ANYTHING: return ArgSingle::Kind::ANYTHING;
-    case EBPF_ARGUMENT_TYPE_PTR_TO_STACK: return ArgSingle::Kind::PTR_TO_STACK;
-    case EBPF_ARGUMENT_TYPE_PTR_TO_STACK_OR_NULL: return ArgSingle::Kind::PTR_TO_STACK;
-    case EBPF_ARGUMENT_TYPE_PTR_TO_MAP: return ArgSingle::Kind::MAP_FD;
-    case EBPF_ARGUMENT_TYPE_CONST_PTR_TO_MAP: return ArgSingle::Kind::MAP_FD;
-    case EBPF_ARGUMENT_TYPE_PTR_TO_MAP_OF_PROGRAMS: return ArgSingle::Kind::MAP_FD_PROGRAMS;
-    case EBPF_ARGUMENT_TYPE_PTR_TO_MAP_KEY: return ArgSingle::Kind::PTR_TO_MAP_KEY;
-    case EBPF_ARGUMENT_TYPE_PTR_TO_MAP_VALUE: return ArgSingle::Kind::PTR_TO_MAP_VALUE;
-    case EBPF_ARGUMENT_TYPE_PTR_TO_UNINIT_MAP_VALUE: return ArgSingle::Kind::PTR_TO_MAP_VALUE;
-    case EBPF_ARGUMENT_TYPE_PTR_TO_CTX: return ArgSingle::Kind::PTR_TO_CTX;
-    case EBPF_ARGUMENT_TYPE_PTR_TO_CTX_OR_NULL: return ArgSingle::Kind::PTR_TO_CTX;
-    case EBPF_ARGUMENT_TYPE_PTR_TO_FUNC: return ArgSingle::Kind::PTR_TO_FUNC;
-    default: break;
-    }
-    return {};
-}
-
-ArgPair::Kind to_arg_pair_kind(const ebpf_argument_type_t t) {
-    switch (t) {
-    case EBPF_ARGUMENT_TYPE_PTR_TO_READABLE_MEM_OR_NULL:
-    case EBPF_ARGUMENT_TYPE_PTR_TO_READABLE_MEM: return ArgPair::Kind::PTR_TO_READABLE_MEM;
-    case EBPF_ARGUMENT_TYPE_PTR_TO_READONLY_MEM_OR_NULL:
-    case EBPF_ARGUMENT_TYPE_PTR_TO_READONLY_MEM: return ArgPair::Kind::PTR_TO_READABLE_MEM;
-    case EBPF_ARGUMENT_TYPE_PTR_TO_WRITABLE_MEM_OR_NULL:
-    case EBPF_ARGUMENT_TYPE_PTR_TO_WRITABLE_MEM: return ArgPair::Kind::PTR_TO_WRITABLE_MEM;
-    default: break;
-    }
-    return {};
-}
 
 ResolvedCall make_unsupported(const Call& call, std::string name, std::string reason) {
     return ResolvedCall{.call = call,
@@ -86,91 +53,19 @@ ResolvedCall resolve_helper(const Call& call, const ProgramInfo& info) {
     const std::array<ebpf_argument_type_t, 7> args = {
         {EBPF_ARGUMENT_TYPE_DONTCARE, proto.argument_type[0], proto.argument_type[1], proto.argument_type[2],
          proto.argument_type[3], proto.argument_type[4], EBPF_ARGUMENT_TYPE_DONTCARE}};
-    for (size_t i = 1; i < args.size() - 1; i++) {
-        switch (args[i]) {
-        case EBPF_ARGUMENT_TYPE_UNSUPPORTED:
+    for (size_t i = 1; i < args.size() - 1;) {
+        switch (process_arg(res.contract, args, i)) {
+        case ArgOutcome::Single: i += 1; break;
+        case ArgOutcome::Pair: i += 2; break;
+        case ArgOutcome::Stop: return res;
+        case ArgOutcome::Unavailable:
             return make_unsupported(call, helper_prototype_name,
                                     "helper argument type is unavailable on this platform: " + helper_prototype_name);
-        case EBPF_ARGUMENT_TYPE_DONTCARE: return res;
-        case EBPF_ARGUMENT_TYPE_ANYTHING:
-        case EBPF_ARGUMENT_TYPE_PTR_TO_MAP:
-        case EBPF_ARGUMENT_TYPE_CONST_PTR_TO_MAP:
-        case EBPF_ARGUMENT_TYPE_PTR_TO_MAP_OF_PROGRAMS:
-        case EBPF_ARGUMENT_TYPE_PTR_TO_MAP_KEY:
-        case EBPF_ARGUMENT_TYPE_PTR_TO_MAP_VALUE:
-        case EBPF_ARGUMENT_TYPE_PTR_TO_UNINIT_MAP_VALUE:
-        case EBPF_ARGUMENT_TYPE_PTR_TO_STACK:
-        case EBPF_ARGUMENT_TYPE_PTR_TO_CTX:
-        case EBPF_ARGUMENT_TYPE_PTR_TO_FUNC:
-            res.contract.singles.push_back({to_arg_single_kind(args[i]), false, Reg{gsl::narrow<uint8_t>(i)}});
-            break;
-        case EBPF_ARGUMENT_TYPE_PTR_TO_STACK_OR_NULL:
-        case EBPF_ARGUMENT_TYPE_PTR_TO_CTX_OR_NULL:
-            res.contract.singles.push_back({to_arg_single_kind(args[i]), true, Reg{gsl::narrow<uint8_t>(i)}});
-            break;
-        case EBPF_ARGUMENT_TYPE_PTR_TO_BTF_ID_SOCK_COMMON:
-        case EBPF_ARGUMENT_TYPE_PTR_TO_SOCK_COMMON:
-            res.contract.singles.push_back({ArgSingle::Kind::PTR_TO_SOCKET, false, Reg{gsl::narrow<uint8_t>(i)}});
-            break;
-        case EBPF_ARGUMENT_TYPE_PTR_TO_BTF_ID:
-        case EBPF_ARGUMENT_TYPE_PTR_TO_PERCPU_BTF_ID:
-            res.contract.singles.push_back({ArgSingle::Kind::PTR_TO_BTF_ID, false, Reg{gsl::narrow<uint8_t>(i)}});
-            break;
-        case EBPF_ARGUMENT_TYPE_PTR_TO_ALLOC_MEM:
-            res.contract.singles.push_back({ArgSingle::Kind::PTR_TO_ALLOC_MEM, false, Reg{gsl::narrow<uint8_t>(i)}});
-            break;
-        case EBPF_ARGUMENT_TYPE_PTR_TO_SPIN_LOCK:
-            res.contract.singles.push_back({ArgSingle::Kind::PTR_TO_SPIN_LOCK, false, Reg{gsl::narrow<uint8_t>(i)}});
-            break;
-        case EBPF_ARGUMENT_TYPE_PTR_TO_TIMER:
-            res.contract.singles.push_back({ArgSingle::Kind::PTR_TO_TIMER, false, Reg{gsl::narrow<uint8_t>(i)}});
-            break;
-        case EBPF_ARGUMENT_TYPE_CONST_ALLOC_SIZE_OR_ZERO:
-            res.contract.singles.push_back({ArgSingle::Kind::CONST_SIZE_OR_ZERO, false, Reg{gsl::narrow<uint8_t>(i)}});
-            res.contract.alloc_size_reg = Reg{gsl::narrow<uint8_t>(i)};
-            break;
-        case EBPF_ARGUMENT_TYPE_PTR_TO_LONG:
-            res.contract.singles.push_back(
-                {ArgSingle::Kind::PTR_TO_WRITABLE_LONG, false, Reg{gsl::narrow<uint8_t>(i)}});
-            break;
-        case EBPF_ARGUMENT_TYPE_PTR_TO_INT:
-            res.contract.singles.push_back({ArgSingle::Kind::PTR_TO_WRITABLE_INT, false, Reg{gsl::narrow<uint8_t>(i)}});
-            break;
-        case EBPF_ARGUMENT_TYPE_PTR_TO_CONST_STR:
+        case ArgOutcome::MismatchedSize:
             return make_unsupported(call, helper_prototype_name,
-                                    "helper argument type is unavailable on this platform: " + helper_prototype_name);
-        case EBPF_ARGUMENT_TYPE_CONST_SIZE:
-            return make_unsupported(call, helper_prototype_name,
-                                    "mismatched EBPF_ARGUMENT_TYPE_PTR_TO* and EBPF_ARGUMENT_TYPE_CONST_SIZE: " +
+                                    "Pointer argument not followed by EBPF_ARGUMENT_TYPE_CONST_SIZE or "
+                                    "EBPF_ARGUMENT_TYPE_CONST_SIZE_OR_ZERO: " +
                                         helper_prototype_name);
-        case EBPF_ARGUMENT_TYPE_CONST_SIZE_OR_ZERO:
-            return make_unsupported(
-                call, helper_prototype_name,
-                "mismatched EBPF_ARGUMENT_TYPE_PTR_TO* and EBPF_ARGUMENT_TYPE_CONST_SIZE_OR_ZERO: " +
-                    helper_prototype_name);
-        case EBPF_ARGUMENT_TYPE_PTR_TO_READABLE_MEM_OR_NULL:
-        case EBPF_ARGUMENT_TYPE_PTR_TO_READABLE_MEM:
-        case EBPF_ARGUMENT_TYPE_PTR_TO_READONLY_MEM_OR_NULL:
-        case EBPF_ARGUMENT_TYPE_PTR_TO_READONLY_MEM:
-        case EBPF_ARGUMENT_TYPE_PTR_TO_WRITABLE_MEM_OR_NULL:
-        case EBPF_ARGUMENT_TYPE_PTR_TO_WRITABLE_MEM: {
-            // `args[i + 1]` is always in bounds: `args` has 7 entries with a
-            // DONTCARE sentinel at index 6, and the loop runs while i < 6.
-            if (args[i + 1] != EBPF_ARGUMENT_TYPE_CONST_SIZE && args[i + 1] != EBPF_ARGUMENT_TYPE_CONST_SIZE_OR_ZERO) {
-                return make_unsupported(call, helper_prototype_name,
-                                        "Pointer argument not followed by EBPF_ARGUMENT_TYPE_CONST_SIZE or "
-                                        "EBPF_ARGUMENT_TYPE_CONST_SIZE_OR_ZERO: " +
-                                            helper_prototype_name);
-            }
-            const bool can_be_zero = (args[i + 1] == EBPF_ARGUMENT_TYPE_CONST_SIZE_OR_ZERO);
-            const bool or_null = args[i] == EBPF_ARGUMENT_TYPE_PTR_TO_READABLE_MEM_OR_NULL ||
-                                 args[i] == EBPF_ARGUMENT_TYPE_PTR_TO_READONLY_MEM_OR_NULL ||
-                                 args[i] == EBPF_ARGUMENT_TYPE_PTR_TO_WRITABLE_MEM_OR_NULL;
-            res.contract.pairs.push_back({to_arg_pair_kind(args[i]), or_null, Reg{gsl::narrow<uint8_t>(i)},
-                                          Reg{gsl::narrow<uint8_t>(i + 1)}, can_be_zero});
-            i++;
-            break;
-        }
         }
     }
     return res;

--- a/src/linux/kfunc.cpp
+++ b/src/linux/kfunc.cpp
@@ -5,9 +5,9 @@
 
 #include <algorithm>
 #include <array>
-#include <stdexcept>
 #include <string_view>
 
+#include "ir/arg_kind.hpp"
 #include "spec/function_prototypes.hpp"
 
 namespace prevail {
@@ -15,196 +15,49 @@ namespace prevail {
 namespace {
 
 struct KfuncPrototypeEntry {
-    int32_t btf_id;
-    EbpfHelperPrototype proto;
-    KfuncFlags flags;
+    int32_t btf_id{};
+    EbpfHelperPrototype proto{};
+    KfuncFlags flags = KfuncFlags::none;
     std::string_view required_program_type;
-    bool requires_privileged;
+    bool requires_privileged = false;
 };
 
 constexpr std::array<KfuncPrototypeEntry, 12> kfunc_prototypes{{
-    {
-        12,
-        EbpfHelperPrototype{
-            .name = "kfunc_test_id_overlap_tail_call",
-            .return_type = EBPF_RETURN_TYPE_INTEGER,
-            .argument_type = {EBPF_ARGUMENT_TYPE_DONTCARE, EBPF_ARGUMENT_TYPE_DONTCARE, EBPF_ARGUMENT_TYPE_DONTCARE,
-                              EBPF_ARGUMENT_TYPE_DONTCARE, EBPF_ARGUMENT_TYPE_DONTCARE},
-            .reallocate_packet = false,
-            .ctx_descriptor = nullptr,
-            .unsupported = false,
-        },
-        KfuncFlags::none,
-        "",
-        false,
-    },
-    {
-        1000,
-        EbpfHelperPrototype{
-            .name = "kfunc_test_ret_int",
-            .return_type = EBPF_RETURN_TYPE_INTEGER,
-            .argument_type = {EBPF_ARGUMENT_TYPE_DONTCARE, EBPF_ARGUMENT_TYPE_DONTCARE, EBPF_ARGUMENT_TYPE_DONTCARE,
-                              EBPF_ARGUMENT_TYPE_DONTCARE, EBPF_ARGUMENT_TYPE_DONTCARE},
-            .reallocate_packet = false,
-            .ctx_descriptor = nullptr,
-            .unsupported = false,
-        },
-        KfuncFlags::none,
-        "",
-        false,
-    },
-    {
-        1001,
-        EbpfHelperPrototype{
-            .name = "kfunc_test_ctx_arg",
-            .return_type = EBPF_RETURN_TYPE_INTEGER,
-            .argument_type = {EBPF_ARGUMENT_TYPE_PTR_TO_CTX, EBPF_ARGUMENT_TYPE_DONTCARE, EBPF_ARGUMENT_TYPE_DONTCARE,
-                              EBPF_ARGUMENT_TYPE_DONTCARE, EBPF_ARGUMENT_TYPE_DONTCARE},
-            .reallocate_packet = false,
-            .ctx_descriptor = nullptr,
-            .unsupported = false,
-        },
-        KfuncFlags::none,
-        "",
-        false,
-    },
-    {
-        1002,
-        EbpfHelperPrototype{
-            .name = "kfunc_test_acquire_flag",
-            .return_type = EBPF_RETURN_TYPE_INTEGER,
-            .argument_type = {EBPF_ARGUMENT_TYPE_DONTCARE, EBPF_ARGUMENT_TYPE_DONTCARE, EBPF_ARGUMENT_TYPE_DONTCARE,
-                              EBPF_ARGUMENT_TYPE_DONTCARE, EBPF_ARGUMENT_TYPE_DONTCARE},
-            .reallocate_packet = false,
-            .ctx_descriptor = nullptr,
-            .unsupported = false,
-        },
-        KfuncFlags::acquire,
-        "",
-        false,
-    },
-    {
-        1003,
-        EbpfHelperPrototype{
-            .name = "kfunc_test_xdp_only",
-            .return_type = EBPF_RETURN_TYPE_INTEGER,
-            .argument_type = {EBPF_ARGUMENT_TYPE_DONTCARE, EBPF_ARGUMENT_TYPE_DONTCARE, EBPF_ARGUMENT_TYPE_DONTCARE,
-                              EBPF_ARGUMENT_TYPE_DONTCARE, EBPF_ARGUMENT_TYPE_DONTCARE},
-            .reallocate_packet = false,
-            .ctx_descriptor = nullptr,
-            .unsupported = false,
-        },
-        KfuncFlags::none,
-        "xdp",
-        false,
-    },
-    {
-        1004,
-        EbpfHelperPrototype{
-            .name = "kfunc_test_privileged_only",
-            .return_type = EBPF_RETURN_TYPE_INTEGER,
-            .argument_type = {EBPF_ARGUMENT_TYPE_DONTCARE, EBPF_ARGUMENT_TYPE_DONTCARE, EBPF_ARGUMENT_TYPE_DONTCARE,
-                              EBPF_ARGUMENT_TYPE_DONTCARE, EBPF_ARGUMENT_TYPE_DONTCARE},
-            .reallocate_packet = false,
-            .ctx_descriptor = nullptr,
-            .unsupported = false,
-        },
-        KfuncFlags::none,
-        "",
-        true,
-    },
-    {
-        1005,
-        EbpfHelperPrototype{
-            .name = "kfunc_test_ret_map_value_or_null",
-            .return_type = EBPF_RETURN_TYPE_PTR_TO_MAP_VALUE_OR_NULL,
-            .argument_type = {EBPF_ARGUMENT_TYPE_DONTCARE, EBPF_ARGUMENT_TYPE_DONTCARE, EBPF_ARGUMENT_TYPE_DONTCARE,
-                              EBPF_ARGUMENT_TYPE_DONTCARE, EBPF_ARGUMENT_TYPE_DONTCARE},
-            .reallocate_packet = false,
-            .ctx_descriptor = nullptr,
-            .unsupported = false,
-        },
-        KfuncFlags::none,
-        "",
-        false,
-    },
-    {
-        1006,
-        EbpfHelperPrototype{
-            .name = "kfunc_test_readable_mem_or_null_size",
-            .return_type = EBPF_RETURN_TYPE_INTEGER,
-            .argument_type = {EBPF_ARGUMENT_TYPE_PTR_TO_READABLE_MEM_OR_NULL, EBPF_ARGUMENT_TYPE_CONST_SIZE_OR_ZERO,
-                              EBPF_ARGUMENT_TYPE_DONTCARE, EBPF_ARGUMENT_TYPE_DONTCARE, EBPF_ARGUMENT_TYPE_DONTCARE},
-            .reallocate_packet = false,
-            .ctx_descriptor = nullptr,
-            .unsupported = false,
-        },
-        KfuncFlags::none,
-        "",
-        false,
-    },
-    {
-        1007,
-        EbpfHelperPrototype{
-            .name = "kfunc_test_writable_mem_size",
-            .return_type = EBPF_RETURN_TYPE_INTEGER,
-            .argument_type = {EBPF_ARGUMENT_TYPE_PTR_TO_WRITABLE_MEM, EBPF_ARGUMENT_TYPE_CONST_SIZE,
-                              EBPF_ARGUMENT_TYPE_DONTCARE, EBPF_ARGUMENT_TYPE_DONTCARE, EBPF_ARGUMENT_TYPE_DONTCARE},
-            .reallocate_packet = false,
-            .ctx_descriptor = nullptr,
-            .unsupported = false,
-        },
-        KfuncFlags::none,
-        "",
-        false,
-    },
-    {
-        1008,
-        EbpfHelperPrototype{
-            .name = "kfunc_test_release_flag",
-            .return_type = EBPF_RETURN_TYPE_INTEGER,
-            .argument_type = {EBPF_ARGUMENT_TYPE_DONTCARE, EBPF_ARGUMENT_TYPE_DONTCARE, EBPF_ARGUMENT_TYPE_DONTCARE,
-                              EBPF_ARGUMENT_TYPE_DONTCARE, EBPF_ARGUMENT_TYPE_DONTCARE},
-            .reallocate_packet = false,
-            .ctx_descriptor = nullptr,
-            .unsupported = false,
-        },
-        KfuncFlags::release,
-        "",
-        false,
-    },
+    {.btf_id = 12, .proto = {.name = "kfunc_test_id_overlap_tail_call", .return_type = EBPF_RETURN_TYPE_INTEGER}},
+    {.btf_id = 1000, .proto = {.name = "kfunc_test_ret_int", .return_type = EBPF_RETURN_TYPE_INTEGER}},
+    {.btf_id = 1001,
+     .proto = {.name = "kfunc_test_ctx_arg",
+               .return_type = EBPF_RETURN_TYPE_INTEGER,
+               .argument_type = {EBPF_ARGUMENT_TYPE_PTR_TO_CTX}}},
+    {.btf_id = 1002,
+     .proto = {.name = "kfunc_test_acquire_flag", .return_type = EBPF_RETURN_TYPE_INTEGER},
+     .flags = KfuncFlags::acquire},
+    {.btf_id = 1003,
+     .proto = {.name = "kfunc_test_xdp_only", .return_type = EBPF_RETURN_TYPE_INTEGER},
+     .required_program_type = "xdp"},
+    {.btf_id = 1004,
+     .proto = {.name = "kfunc_test_privileged_only", .return_type = EBPF_RETURN_TYPE_INTEGER},
+     .requires_privileged = true},
+    {.btf_id = 1005,
+     .proto = {.name = "kfunc_test_ret_map_value_or_null", .return_type = EBPF_RETURN_TYPE_PTR_TO_MAP_VALUE_OR_NULL}},
+    {.btf_id = 1006,
+     .proto = {.name = "kfunc_test_readable_mem_or_null_size",
+               .return_type = EBPF_RETURN_TYPE_INTEGER,
+               .argument_type = {EBPF_ARGUMENT_TYPE_PTR_TO_READABLE_MEM_OR_NULL,
+                                 EBPF_ARGUMENT_TYPE_CONST_SIZE_OR_ZERO}}},
+    {.btf_id = 1007,
+     .proto = {.name = "kfunc_test_writable_mem_size",
+               .return_type = EBPF_RETURN_TYPE_INTEGER,
+               .argument_type = {EBPF_ARGUMENT_TYPE_PTR_TO_WRITABLE_MEM, EBPF_ARGUMENT_TYPE_CONST_SIZE}}},
+    {.btf_id = 1008,
+     .proto = {.name = "kfunc_test_release_flag", .return_type = EBPF_RETURN_TYPE_INTEGER},
+     .flags = KfuncFlags::release},
     // bpf_cpumask_create/bpf_cpumask_release form an acquire/release pair.
     // Acquire without enforced release — verifier does not yet track release obligations (see ID 1010).
-    {
-        1009,
-        EbpfHelperPrototype{
-            .name = "bpf_cpumask_create",
-            .return_type = EBPF_RETURN_TYPE_INTEGER,
-            .argument_type = {EBPF_ARGUMENT_TYPE_DONTCARE, EBPF_ARGUMENT_TYPE_DONTCARE, EBPF_ARGUMENT_TYPE_DONTCARE,
-                              EBPF_ARGUMENT_TYPE_DONTCARE, EBPF_ARGUMENT_TYPE_DONTCARE},
-            .reallocate_packet = false,
-            .ctx_descriptor = nullptr,
-            .unsupported = false,
-        },
-        KfuncFlags::acquire,
-        "",
-        false,
-    },
-    {
-        1010,
-        EbpfHelperPrototype{
-            .name = "bpf_cpumask_release",
-            .return_type = EBPF_RETURN_TYPE_INTEGER,
-            .argument_type = {EBPF_ARGUMENT_TYPE_DONTCARE, EBPF_ARGUMENT_TYPE_DONTCARE, EBPF_ARGUMENT_TYPE_DONTCARE,
-                              EBPF_ARGUMENT_TYPE_DONTCARE, EBPF_ARGUMENT_TYPE_DONTCARE},
-            .reallocate_packet = false,
-            .ctx_descriptor = nullptr,
-            .unsupported = false,
-        },
-        KfuncFlags::none, // release semantics not yet enforced by verifier
-        "",
-        false,
-    },
+    {.btf_id = 1009,
+     .proto = {.name = "bpf_cpumask_create", .return_type = EBPF_RETURN_TYPE_INTEGER},
+     .flags = KfuncFlags::acquire},
+    {.btf_id = 1010, .proto = {.name = "bpf_cpumask_release", .return_type = EBPF_RETURN_TYPE_INTEGER}},
 }};
 
 constexpr bool kfunc_prototypes_are_sorted_by_btf_id() {
@@ -226,33 +79,6 @@ std::optional<KfuncPrototypeEntry> lookup_kfunc_prototype(const int32_t btf_id) 
         return *it;
     }
     return std::nullopt;
-}
-
-ArgSingle::Kind to_arg_single_kind(const ebpf_argument_type_t t) {
-    switch (t) {
-    case EBPF_ARGUMENT_TYPE_ANYTHING: return ArgSingle::Kind::ANYTHING;
-    case EBPF_ARGUMENT_TYPE_PTR_TO_STACK:
-    case EBPF_ARGUMENT_TYPE_PTR_TO_STACK_OR_NULL: return ArgSingle::Kind::PTR_TO_STACK;
-    case EBPF_ARGUMENT_TYPE_PTR_TO_MAP: return ArgSingle::Kind::MAP_FD;
-    case EBPF_ARGUMENT_TYPE_PTR_TO_MAP_OF_PROGRAMS: return ArgSingle::Kind::MAP_FD_PROGRAMS;
-    case EBPF_ARGUMENT_TYPE_PTR_TO_MAP_KEY: return ArgSingle::Kind::PTR_TO_MAP_KEY;
-    case EBPF_ARGUMENT_TYPE_PTR_TO_MAP_VALUE: return ArgSingle::Kind::PTR_TO_MAP_VALUE;
-    case EBPF_ARGUMENT_TYPE_PTR_TO_CTX:
-    case EBPF_ARGUMENT_TYPE_PTR_TO_CTX_OR_NULL: return ArgSingle::Kind::PTR_TO_CTX;
-    default: break;
-    }
-    throw std::runtime_error("internal error: unmapped kfunc single-arg type " + std::to_string(static_cast<int>(t)));
-}
-
-ArgPair::Kind to_arg_pair_kind(const ebpf_argument_type_t t) {
-    switch (t) {
-    case EBPF_ARGUMENT_TYPE_PTR_TO_READABLE_MEM_OR_NULL:
-    case EBPF_ARGUMENT_TYPE_PTR_TO_READABLE_MEM: return ArgPair::Kind::PTR_TO_READABLE_MEM;
-    case EBPF_ARGUMENT_TYPE_PTR_TO_WRITABLE_MEM_OR_NULL:
-    case EBPF_ARGUMENT_TYPE_PTR_TO_WRITABLE_MEM: return ArgPair::Kind::PTR_TO_WRITABLE_MEM;
-    default: break;
-    }
-    throw std::runtime_error("internal error: unmapped kfunc pair-arg type " + std::to_string(static_cast<int>(t)));
 }
 
 void set_unsupported(std::string* why_not, const std::string& reason) {
@@ -317,87 +143,19 @@ std::optional<ResolvedCall> make_kfunc_call(const int32_t btf_id, const EbpfProg
     const std::array<ebpf_argument_type_t, 7> args = {
         {EBPF_ARGUMENT_TYPE_DONTCARE, proto.argument_type[0], proto.argument_type[1], proto.argument_type[2],
          proto.argument_type[3], proto.argument_type[4], EBPF_ARGUMENT_TYPE_DONTCARE}};
-    for (size_t i = 1; i < args.size() - 1; i++) {
-        switch (args[i]) {
-        case EBPF_ARGUMENT_TYPE_DONTCARE: return res;
-        case EBPF_ARGUMENT_TYPE_UNSUPPORTED:
-            set_unsupported(why_not, std::string("kfunc argument type is unavailable on this platform: ") + proto.name);
-            return std::nullopt;
-        case EBPF_ARGUMENT_TYPE_ANYTHING:
-        case EBPF_ARGUMENT_TYPE_PTR_TO_MAP:
-        case EBPF_ARGUMENT_TYPE_PTR_TO_MAP_OF_PROGRAMS:
-        case EBPF_ARGUMENT_TYPE_PTR_TO_MAP_KEY:
-        case EBPF_ARGUMENT_TYPE_PTR_TO_MAP_VALUE:
-        case EBPF_ARGUMENT_TYPE_PTR_TO_STACK:
-        case EBPF_ARGUMENT_TYPE_PTR_TO_CTX:
-            res.contract.singles.push_back({to_arg_single_kind(args[i]), false, Reg{gsl::narrow<uint8_t>(i)}});
-            break;
-        case EBPF_ARGUMENT_TYPE_PTR_TO_STACK_OR_NULL:
-        case EBPF_ARGUMENT_TYPE_PTR_TO_CTX_OR_NULL:
-            res.contract.singles.push_back({to_arg_single_kind(args[i]), true, Reg{gsl::narrow<uint8_t>(i)}});
-            break;
-        case EBPF_ARGUMENT_TYPE_CONST_SIZE:
-            set_unsupported(
-                why_not,
-                std::string("mismatched kfunc EBPF_ARGUMENT_TYPE_PTR_TO* and EBPF_ARGUMENT_TYPE_CONST_SIZE: ") +
-                    proto.name);
-            return std::nullopt;
-        case EBPF_ARGUMENT_TYPE_CONST_SIZE_OR_ZERO:
-            set_unsupported(why_not, std::string("mismatched kfunc EBPF_ARGUMENT_TYPE_PTR_TO* and "
-                                                 "EBPF_ARGUMENT_TYPE_CONST_SIZE_OR_ZERO: ") +
-                                         proto.name);
-            return std::nullopt;
-        case EBPF_ARGUMENT_TYPE_PTR_TO_READABLE_MEM_OR_NULL:
-        case EBPF_ARGUMENT_TYPE_PTR_TO_READABLE_MEM:
-        case EBPF_ARGUMENT_TYPE_PTR_TO_WRITABLE_MEM_OR_NULL:
-        case EBPF_ARGUMENT_TYPE_PTR_TO_WRITABLE_MEM: {
-            // args[i+1] is always in bounds: args has a DONTCARE sentinel at index 6.
-            if (args[i + 1] != EBPF_ARGUMENT_TYPE_CONST_SIZE && args[i + 1] != EBPF_ARGUMENT_TYPE_CONST_SIZE_OR_ZERO) {
-                set_unsupported(why_not,
-                                std::string("kfunc pointer argument not followed by EBPF_ARGUMENT_TYPE_CONST_SIZE or "
-                                            "EBPF_ARGUMENT_TYPE_CONST_SIZE_OR_ZERO: ") +
-                                    proto.name);
-                return std::nullopt;
-            }
-            const bool can_be_zero = (args[i + 1] == EBPF_ARGUMENT_TYPE_CONST_SIZE_OR_ZERO);
-            const bool or_null = args[i] == EBPF_ARGUMENT_TYPE_PTR_TO_READABLE_MEM_OR_NULL ||
-                                 args[i] == EBPF_ARGUMENT_TYPE_PTR_TO_WRITABLE_MEM_OR_NULL;
-            res.contract.pairs.push_back({to_arg_pair_kind(args[i]), or_null, Reg{gsl::narrow<uint8_t>(i)},
-                                          Reg{gsl::narrow<uint8_t>(i + 1)}, can_be_zero});
-            i++;
-            break;
-        }
-        case EBPF_ARGUMENT_TYPE_PTR_TO_BTF_ID_SOCK_COMMON:
-        case EBPF_ARGUMENT_TYPE_PTR_TO_SOCK_COMMON:
-            res.contract.singles.push_back({ArgSingle::Kind::PTR_TO_SOCKET, false, Reg{gsl::narrow<uint8_t>(i)}});
-            break;
-        case EBPF_ARGUMENT_TYPE_PTR_TO_BTF_ID:
-        case EBPF_ARGUMENT_TYPE_PTR_TO_PERCPU_BTF_ID:
-            res.contract.singles.push_back({ArgSingle::Kind::PTR_TO_BTF_ID, false, Reg{gsl::narrow<uint8_t>(i)}});
-            break;
-        case EBPF_ARGUMENT_TYPE_PTR_TO_ALLOC_MEM:
-            res.contract.singles.push_back({ArgSingle::Kind::PTR_TO_ALLOC_MEM, false, Reg{gsl::narrow<uint8_t>(i)}});
-            break;
-        case EBPF_ARGUMENT_TYPE_PTR_TO_SPIN_LOCK:
-            res.contract.singles.push_back({ArgSingle::Kind::PTR_TO_SPIN_LOCK, false, Reg{gsl::narrow<uint8_t>(i)}});
-            break;
-        case EBPF_ARGUMENT_TYPE_PTR_TO_TIMER:
-            res.contract.singles.push_back({ArgSingle::Kind::PTR_TO_TIMER, false, Reg{gsl::narrow<uint8_t>(i)}});
-            break;
-        case EBPF_ARGUMENT_TYPE_CONST_ALLOC_SIZE_OR_ZERO:
-            res.contract.singles.push_back({ArgSingle::Kind::CONST_SIZE_OR_ZERO, false, Reg{gsl::narrow<uint8_t>(i)}});
-            res.contract.alloc_size_reg = Reg{gsl::narrow<uint8_t>(i)};
-            break;
-        case EBPF_ARGUMENT_TYPE_PTR_TO_LONG:
-            res.contract.singles.push_back(
-                {ArgSingle::Kind::PTR_TO_WRITABLE_LONG, false, Reg{gsl::narrow<uint8_t>(i)}});
-            break;
-        case EBPF_ARGUMENT_TYPE_PTR_TO_INT:
-            res.contract.singles.push_back({ArgSingle::Kind::PTR_TO_WRITABLE_INT, false, Reg{gsl::narrow<uint8_t>(i)}});
-            break;
-        case EBPF_ARGUMENT_TYPE_PTR_TO_CONST_STR:
-        default:
+    for (size_t i = 1; i < args.size() - 1;) {
+        switch (process_arg(res.contract, args, i)) {
+        case ArgOutcome::Single: i += 1; break;
+        case ArgOutcome::Pair: i += 2; break;
+        case ArgOutcome::Stop: return res;
+        case ArgOutcome::Unavailable:
             set_unsupported(why_not, std::string("kfunc argument type is unsupported on this platform: ") + proto.name);
+            return std::nullopt;
+        case ArgOutcome::MismatchedSize:
+            set_unsupported(why_not,
+                            std::string("kfunc pointer argument not followed by EBPF_ARGUMENT_TYPE_CONST_SIZE or "
+                                        "EBPF_ARGUMENT_TYPE_CONST_SIZE_OR_ZERO: ") +
+                                proto.name);
             return std::nullopt;
         }
     }

--- a/src/linux/kfunc.cpp
+++ b/src/linux/kfunc.cpp
@@ -69,7 +69,17 @@ constexpr bool kfunc_prototypes_are_sorted_by_btf_id() {
     return true;
 }
 
+constexpr bool kfunc_prototypes_have_names() {
+    for (const auto& entry : kfunc_prototypes) {
+        if (entry.proto.name == nullptr) {
+            return false;
+        }
+    }
+    return true;
+}
+
 static_assert(kfunc_prototypes_are_sorted_by_btf_id(), "kfunc_prototypes must be strictly sorted by btf_id");
+static_assert(kfunc_prototypes_have_names(), "kfunc_prototypes entries must define proto.name");
 
 std::optional<KfuncPrototypeEntry> lookup_kfunc_prototype(const int32_t btf_id) {
     const auto it =


### PR DESCRIPTION
## Summary
- Extract duplicated `to_arg_single_kind` / `to_arg_pair_kind` and the ~85-line args-walk switch from `call_resolver.cpp` and `kfunc.cpp` into a shared `src/ir/arg_kind.hpp`. Each caller dispatches on an `ArgOutcome` enum and formats its own diagnostic, so helper vs. kfunc wording stays caller-controlled while structural parity is enforced rather than maintained by convention.
- Compact the 12-entry kfunc prototype table by giving `KfuncPrototypeEntry` member-default initializers and rewriting entries with designated initializers — each entry shrinks from ~14 lines to 1–3 lines.
- Adopt unified arg-type behavior on both paths: `PTR_TO_FUNC`, `PTR_TO_READONLY_MEM[_OR_NULL]`, `CONST_PTR_TO_MAP`, and `PTR_TO_UNINIT_MAP_VALUE` are now accepted by `make_kfunc_call` (previously rejected by fall-through). No current kfunc entry exercises these tags, so the change is dormant in practice; this resolves the documented helper/kfunc asymmetry.

Net diff: +204 / -407 across the touched files. No intended behavior change.

## Test plan
- [x] `cmake --build build --parallel` — clean
- [x] `./bin/tests` — 1320 passed + 236 failed-as-expected + 1 skipped, 0 actual failures
- [x] `clang-format --dry-run --Werror` on touched files — clean
- [ ] CI green