### PR TITLE
Fix heap-buffer-overflow from non-instruction-aligned FUNC symbols

### DIFF
--- a/src/io/elf_reader.cpp
+++ b/src/io/elf_reader.cpp
@@ -92,6 +92,11 @@ get_program_name_and_size(const ELFIO::section& sec, const ELFIO::Elf_Xword star
                 continue;
             }
             const auto relocation_offset = symbol_details.value;
+            if (relocation_offset % sizeof(EbpfInst) != 0) {
+                throw UnmarshalError("Non-instruction-aligned FUNC symbol '" + symbol_details.name +
+                                     "' at offset " + std::to_string(relocation_offset) + " in section " +
+                                     sec.get_name());
+            }
             if (relocation_offset == start) {
                 program_name = symbol_details.name;
             } else if (relocation_offset > start && relocation_offset < start + size) {
@@ -691,6 +696,9 @@ void ProgramReader::read_programs() {
             builtin_offsets_for_current_program.clear();
             auto [name, symbol_size] = get_program_name_and_size(*sec, offset, symbols);
             const auto extracted_size = compute_reachable_program_span(section_instructions, offset, symbol_size);
+            if (offset + extracted_size > sec->get_size()) {
+                throw UnmarshalError("Program span exceeds section bounds in section " + sec->get_name());
+            }
             auto instructions = vector_of<EbpfInst>(sec->get_data() + offset, extracted_size);
             if (const auto reloc_sec = get_relocation_section(sec_name)) {
                 process_relocations(instructions, ELFIO::const_relocation_section_accessor{reader, reloc_sec}, sec_name,

--- a/src/test/test_elf_loader.cpp
+++ b/src/test/test_elf_loader.cpp
@@ -577,3 +577,62 @@ TEST_CASE("read_elf succeeds with istream and non-file path", "[elf]") {
     auto programs = read_elf(stream, "memory", ".text", "", options, &g_ebpf_platform_linux);
     REQUIRE(!programs.empty());
 }
+
+// Verify that the ELF loader rejects FUNC symbols at non-instruction-aligned offsets.
+// Such a symbol would cause compute_reachable_program_span to inflate the extracted byte
+// span via truncating integer division, leading to a read past the section data buffer.
+TEST_CASE("ELF loader rejects non-instruction-aligned FUNC symbol", "[elf][hardening]") {
+
+    // Build a minimal ELF with an executable section and a FUNC symbol at an unaligned offset.
+    // We need enough instructions that the unaligned boundary causes the second iteration
+    // to enter read_programs' inner loop with a non-aligned offset.
+    ELFIO::elfio writer;
+    writer.create(ELFIO::ELFCLASS64, ELFIO::ELFDATA2LSB);
+    writer.set_os_abi(ELFIO::ELFOSABI_NONE);
+    writer.set_type(ELFIO::ET_REL);
+    writer.set_machine(ELFIO::EM_BPF);
+
+    // Create a .text section with 32 BPF "exit" instructions (256 bytes).
+    // This ensures the section is big enough that the second iteration's
+    // compute_reachable_program_span can return an aligned-but-overflowing span.
+    ELFIO::section* text_sec = writer.sections.add(".text");
+    text_sec->set_type(ELFIO::SHT_PROGBITS);
+    text_sec->set_flags(ELFIO::SHF_ALLOC | ELFIO::SHF_EXECINSTR);
+    text_sec->set_addr_align(8);
+    const uint8_t exit_inst[8] = {0x95, 0, 0, 0, 0, 0, 0, 0};
+    std::string inst_data;
+    for (int i = 0; i < 32; ++i) {
+        inst_data.append(reinterpret_cast<const char*>(exit_inst), sizeof(exit_inst));
+    }
+    text_sec->set_data(inst_data);
+
+    // Create a string table and symbol table.
+    ELFIO::section* str_sec = writer.sections.add(".strtab");
+    str_sec->set_type(ELFIO::SHT_STRTAB);
+    ELFIO::string_section_accessor str_writer(str_sec);
+
+    ELFIO::section* sym_sec = writer.sections.add(".symtab");
+    sym_sec->set_type(ELFIO::SHT_SYMTAB);
+    sym_sec->set_addr_align(8);
+    sym_sec->set_entry_size(writer.get_default_entry_size(ELFIO::SHT_SYMTAB));
+    sym_sec->set_link(str_sec->get_index());
+    sym_sec->set_info(1); // First global symbol index.
+    ELFIO::symbol_section_accessor sym_writer(writer, sym_sec);
+
+    // Add two FUNC symbols: one at offset 0 (the default) and one at UNALIGNED offset 7.
+    // The non-aligned FUNC symbol is rejected by get_program_name_and_size before
+    // it can produce a non-aligned program boundary.
+    sym_writer.add_symbol(str_writer, "prog_a", 0 /* aligned */, 7 /* size */,
+                          ELFIO::STB_GLOBAL, ELFIO::STT_FUNC, 0, text_sec->get_index());
+    sym_writer.add_symbol(str_writer, "prog_b", 7 /* NOT 8-aligned */, 256 - 7,
+                          ELFIO::STB_GLOBAL, ELFIO::STT_FUNC, 0, text_sec->get_index());
+
+    // Serialize to an in-memory stream.
+    std::ostringstream out_stream;
+    writer.save(out_stream);
+    std::istringstream in_stream(out_stream.str());
+
+    VerifierOptions options{};
+    REQUIRE_THROWS_WITH(read_elf(in_stream, "memory", ".text", "", options, &g_ebpf_platform_linux),
+                        Catch::Matchers::ContainsSubstring("Non-instruction-aligned FUNC symbol"));
+}

--- a/src/test/test_elf_loader.cpp
+++ b/src/test/test_elf_loader.cpp
@@ -636,3 +636,51 @@ TEST_CASE("ELF loader rejects non-instruction-aligned FUNC symbol", "[elf][harde
     REQUIRE_THROWS_WITH(read_elf(in_stream, "memory", ".text", "", options, &g_ebpf_platform_linux),
                         Catch::Matchers::ContainsSubstring("Non-instruction-aligned FUNC symbol"));
 }
+
+// Verify that the ELF loader accepts FUNC symbols at instruction-aligned offsets.
+// Companion to the rejection test above — ensures the alignment check does not
+// reject well-formed ELF files.
+TEST_CASE("ELF loader accepts instruction-aligned FUNC symbols", "[elf][hardening]") {
+
+    ELFIO::elfio writer;
+    writer.create(ELFIO::ELFCLASS64, ELFIO::ELFDATA2LSB);
+    writer.set_os_abi(ELFIO::ELFOSABI_NONE);
+    writer.set_type(ELFIO::ET_REL);
+    writer.set_machine(ELFIO::EM_BPF);
+
+    ELFIO::section* text_sec = writer.sections.add(".text");
+    text_sec->set_type(ELFIO::SHT_PROGBITS);
+    text_sec->set_flags(ELFIO::SHF_ALLOC | ELFIO::SHF_EXECINSTR);
+    text_sec->set_addr_align(8);
+    const uint8_t exit_inst[8] = {0x95, 0, 0, 0, 0, 0, 0, 0};
+    std::string inst_data;
+    for (int i = 0; i < 32; ++i) {
+        inst_data.append(reinterpret_cast<const char*>(exit_inst), sizeof(exit_inst));
+    }
+    text_sec->set_data(inst_data);
+
+    ELFIO::section* str_sec = writer.sections.add(".strtab");
+    str_sec->set_type(ELFIO::SHT_STRTAB);
+    ELFIO::string_section_accessor str_writer(str_sec);
+
+    ELFIO::section* sym_sec = writer.sections.add(".symtab");
+    sym_sec->set_type(ELFIO::SHT_SYMTAB);
+    sym_sec->set_addr_align(8);
+    sym_sec->set_entry_size(writer.get_default_entry_size(ELFIO::SHT_SYMTAB));
+    sym_sec->set_link(str_sec->get_index());
+    sym_sec->set_info(1);
+    ELFIO::symbol_section_accessor sym_writer(writer, sym_sec);
+
+    // Both FUNC symbols are at 8-byte-aligned offsets.
+    sym_writer.add_symbol(str_writer, "prog_a", 0, 8, ELFIO::STB_GLOBAL, ELFIO::STT_FUNC, 0, text_sec->get_index());
+    sym_writer.add_symbol(str_writer, "prog_b", 8, 256 - 8, ELFIO::STB_GLOBAL, ELFIO::STT_FUNC, 0,
+                          text_sec->get_index());
+
+    std::ostringstream out_stream;
+    writer.save(out_stream);
+    std::istringstream in_stream(out_stream.str());
+
+    VerifierOptions options{};
+    const auto programs = read_elf(in_stream, "memory", ".text", "", options, &g_ebpf_platform_linux);
+    REQUIRE_FALSE(programs.empty());
+}


### PR DESCRIPTION
## Summary

Reject STT_FUNC symbols in executable sections whose st_value is not a multiple of sizeof(EbpfInst) (8 bytes). Without this validation, a malformed ELF can cause a heap-buffer-overflow in vector_of<EbpfInst> during program loading.

Fixes #1105

## Changes

Root-cause fix — get_program_name_and_size() (elf_reader.cpp):

 - Validate that each FUNC symbol's st_value is instruction-aligned before using it as a program boundary. Throws UnmarshalError for non-aligned values. This protects both callers: ProgramReader::read_programs() and ElfObjectState::discover_programs().

Defense-in-depth — ProgramReader::read_programs() (elf_reader.cpp):

 - Bounds-check offset + extracted_size <= sec->get_size() before the vector_of call to guard against future regressions in span computation.

Test — test_elf_loader.cpp:

 - Add [elf][hardening] test that constructs a minimal ELF (via ELFIO) with a FUNC symbol at an unaligned offset and verifies it is cleanly rejected with UnmarshalError.

## get_program_name_and_size() Root cause analysis

The overflow originates from compute_reachable_program_span() performing truncating integer division (program_offset / sizeof(EbpfInst)) on a non-aligned byte offset. But the non-aligned offset enters the system through get_program_name_and_size(), which uses FUNC symbol values as program boundaries without alignment validation.

Fixing at this shared helper protects all downstream consumers, including the discover_programs() path in elf_loader.cpp which has the same offset += size loop.