### PR TITLE
Add --version flag (#1108)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -182,7 +182,10 @@ set(prevail_binary_dir "${prevail_source_dir}/bin" CACHE INTERNAL "")
 # Prefer `git describe` so non-release builds are unambiguous; fall back to the
 # project version when building outside a git checkout (e.g. tarball or install).
 set(prevail_VERSION_STRING "")
-if (IS_DIRECTORY "${prevail_source_dir}/.git" AND NOT CMAKE_CROSSCOMPILING)
+# Accept both a `.git` directory (normal clone) and a `.git` file (linked
+# worktrees, submodules) — both are valid Git layouts that resolve under
+# `git -C`.
+if (EXISTS "${prevail_source_dir}/.git" AND NOT CMAKE_CROSSCOMPILING)
   find_package(Git QUIET)
   if (GIT_FOUND)
     execute_process(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -178,10 +178,30 @@ set_target_properties(prevail PROPERTIES
 
 set(prevail_binary_dir "${prevail_source_dir}/bin" CACHE INTERNAL "")
 
+# Version string baked into the CLI (`prevail --version`).
+# Prefer `git describe` so non-release builds are unambiguous; fall back to the
+# project version when building outside a git checkout (e.g. tarball or install).
+set(prevail_VERSION_STRING "")
+if (IS_DIRECTORY "${prevail_source_dir}/.git" AND NOT CMAKE_CROSSCOMPILING)
+  find_package(Git QUIET)
+  if (GIT_FOUND)
+    execute_process(
+      COMMAND "${GIT_EXECUTABLE}" -C "${prevail_source_dir}" describe --tags --always --dirty
+      OUTPUT_VARIABLE prevail_VERSION_STRING
+      OUTPUT_STRIP_TRAILING_WHITESPACE
+      ERROR_QUIET
+    )
+  endif ()
+endif ()
+if (prevail_VERSION_STRING STREQUAL "")
+  set(prevail_VERSION_STRING "v${PROJECT_VERSION}")
+endif ()
+
 # Main executable: bin/prevail
 add_executable(prevail-cli "${prevail_source_dir}/src/main.cpp")
 set_target_properties(prevail-cli PROPERTIES OUTPUT_NAME "prevail")
 target_link_libraries(prevail-cli PRIVATE prevail ${CMAKE_DL_LIBS})
+target_compile_definitions(prevail-cli PRIVATE PREVAIL_VERSION_STRING="${prevail_VERSION_STRING}")
 if (CMAKE_CONFIGURATION_TYPES)
   set_target_properties(prevail-cli PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY_DEBUG "${prevail_binary_dir}"

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -56,6 +56,7 @@ int main(int argc, char** argv) {
 
     CLI::App app{"PREVAIL is a new eBPF verifier based on abstract interpretation."};
     app.option_defaults()->delimiter(',');
+    app.set_version_flag("--version", PREVAIL_VERSION_STRING);
 
     std::string filename;
     app.add_option("path", filename, "Elf file to analyze")->required()->check(CLI::ExistingFile);


### PR DESCRIPTION
## Summary

- CMake derives the version string from `git describe --tags --always --dirty` at configure time, falling back to `v\${PROJECT_VERSION}` outside a git checkout.
- `prevail-cli` is built with `-DPREVAIL_VERSION_STRING="..."` and exposes it via CLI11's `set_version_flag`.

Closes #1108.

Example:

```
$ bin/prevail --version
v0.2.2-19-gf39732c5
```

`meson`'s `find_program(...).version()` previously hit CLI11's RequiredError (exit 106) because `path` is a required positional; `set_version_flag` short-circuits parsing before required-arg checks.

## Test plan
- [x] `bin/prevail --version` prints the git-describe string and exits 0
- [x] Build via `cmake -B build && cmake --build build --target prevail-cli`
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)