### PR TITLE
README: spell out Ubuntu/compiler requirements (#630)

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,8 @@ cmake --build build --config Release
 brew install llvm cmake boost yaml-cpp
 ```
 
-The system llvm currently comes with Clang 15, which isn't enough to compile prevail, as it depends on C++23. Brew's
-llvm comes with Clang 17 (or newer), which has sufficient C++23 support.
+The system LLVM (shipped with Xcode Command Line Tools) provides Clang 15, which isn't enough to compile prevail since
+it depends on C++23. Brew's LLVM comes with Clang 17 (or newer), which has sufficient C++23 support.
 
 #### Make:
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,13 @@ cd prevail
 
 #### Dependencies (Ubuntu)
 
+Prevail is built as C++23, which requires GCC 13+ or Clang 17+. The
+default toolchain on Ubuntu 24.04 LTS (`build-essential` → GCC 13) is
+sufficient. On Ubuntu 22.04 install `g++-13` from the
+[ubuntu-toolchain-r PPA](https://launchpad.net/~ubuntu-toolchain-r/+archive/ubuntu/test);
+the default GCC 11 will not build the project. Earlier Ubuntu releases
+(e.g. 20.04) are not supported.
+
 ```bash
 sudo apt install build-essential git cmake libboost-dev libyaml-cpp-dev
 sudo apt install libboost-filesystem-dev libboost-program-options-dev
@@ -68,8 +75,8 @@ cmake --build build --config Release
 brew install llvm cmake boost yaml-cpp
 ```
 
-The system llvm currently comes with Clang 15, which isn't enough to compile prevail, as it depends on C++20. Brew's
-llvm comes with Clang 17.
+The system llvm currently comes with Clang 15, which isn't enough to compile prevail, as it depends on C++23. Brew's
+llvm comes with Clang 17 (or newer), which has sufficient C++23 support.
 
 #### Make:
 


### PR DESCRIPTION
## Summary

- Document that C++23 needs GCC 13+ / Clang 17+. Ubuntu 24.04 LTS's `build-essential` is sufficient; 22.04 needs `g++-13` from the toolchain PPA; older releases are unsupported.
- Fix a stale C++20 mention in the macOS section to say C++23 (the project moved to C++23 in CMakeLists.txt).

Closes #630.

## Test plan
- [x] Render the README locally; section reads correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)