### PR TITLE
Rename ElfProgramInfo invalid → reject_load (#1043)

### DIFF
--- a/scripts/generate_elf_inventory.py
+++ b/scripts/generate_elf_inventory.py
@@ -12,7 +12,7 @@ import sys
 from pathlib import Path
 
 
-PROGRAM_LINE = re.compile(r"^section=(?P<section>\S+) function=(?P<function>\S+)(?: \[invalid: (?P<reason>.*)\])?$")
+PROGRAM_LINE = re.compile(r"^section=(?P<section>\S+) function=(?P<function>\S+)(?: \[reject_load: (?P<reason>.*)\])?$")
 
 
 def is_elf_file(path: Path) -> bool:
@@ -49,9 +49,9 @@ def parse_check_output(output_lines: list[str]) -> tuple[dict[str, list[dict[str
         function = match.group("function")
         reason = match.group("reason")
 
-        program = {"function": function, "invalid": reason is not None}
+        program = {"function": function, "reject_load": reason is not None}
         if reason:
-            program["invalid_reason"] = reason
+            program["reject_load_reason"] = reason
         sections.setdefault(section, []).append(program)
 
     for section in sections:

--- a/scripts/update_verify_expectations.py
+++ b/scripts/update_verify_expectations.py
@@ -130,8 +130,8 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def classify_invalid_program_from_inventory(program: dict) -> tuple[str, str | None, str] | None:
-    if not program.get("invalid", False):
+def classify_reject_load_from_inventory(program: dict) -> tuple[str, str | None, str] | None:
+    if not program.get("reject_load", False):
         return None
     return "reject_load", None, ""
 
@@ -199,7 +199,7 @@ def refresh_expectations(
         else:
             program = next(p for p in odata["sections"][section] if p["function"] == function_name)
         reported_function = function_name or program["function"]
-        inventory_classification = classify_invalid_program_from_inventory(program)
+        inventory_classification = classify_reject_load_from_inventory(program)
         if inventory_classification is not None:
             status, kind, reason = inventory_classification
             return (

--- a/src/io/elf_loader.cpp
+++ b/src/io/elf_loader.cpp
@@ -122,8 +122,8 @@ void ElfObject::ElfObjectState::mark_section_validity(const std::string& section
         return;
     }
     for (const size_t index : section_program_indices.at(section_name)) {
-        programs[index].invalid = !valid;
-        programs[index].invalid_reason = valid ? std::string{} : reason;
+        programs[index].reject_load = !valid;
+        programs[index].reject_load_reason = valid ? std::string{} : reason;
     }
 }
 

--- a/src/io/elf_loader.hpp
+++ b/src/io/elf_loader.hpp
@@ -21,8 +21,8 @@ struct ElfProgramInfo {
     std::string section_name;
     std::string function_name;
     uint32_t section_offset{};
-    bool invalid{};
-    std::string invalid_reason;
+    bool reject_load{};
+    std::string reject_load_reason;
 };
 
 /// @note Not thread-safe. Callers must synchronize externally.
@@ -37,7 +37,7 @@ class ElfObject {
     const std::vector<ElfProgramInfo>& list_programs();
     const std::vector<RawProgram>& get_programs(const std::string& desired_section = {},
                                                 const std::string& desired_program = {});
-    static bool is_valid(const ElfProgramInfo& program) noexcept { return !program.invalid; }
+    static bool is_valid(const ElfProgramInfo& program) noexcept { return !program.reject_load; }
 
   private:
     struct ElfObjectState;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -191,8 +191,8 @@ int main(int argc, char** argv) {
         try {
             for (const ElfProgramInfo& prog : elf.list_programs()) {
                 std::cout << "section=" << prog.section_name << " function=" << prog.function_name;
-                if (prog.invalid) {
-                    std::cout << " [invalid: " << prog.invalid_reason << "]";
+                if (prog.reject_load) {
+                    std::cout << " [reject_load: " << prog.reject_load_reason << "]";
                 }
                 std::cout << std::endl;
             }

--- a/test-data/elf_inventory.json
+++ b/test-data/elf_inventory.json
@@ -12,7 +12,7 @@
             "uretprobe/readline": [
               {
                 "function": "printret",
-                "invalid": false
+                "reject_load": false
               }
             ]
           },
@@ -35,13 +35,13 @@
             "kprobe/cap_capable": [
               {
                 "function": "kprobe__cap_capable_entry",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "kretprobe/cap_capable": [
               {
                 "function": "kprobe__cap_capable_exit",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -55,7 +55,7 @@
             "tracepoint/sched/sched_process_exit": [
               {
                 "function": "sched_process_exit",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -69,31 +69,31 @@
             "kprobe/security_inode_create": [
               {
                 "function": "security_inode_create",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "kprobe/vfs_create": [
               {
                 "function": "vfs_create",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "kprobe/vfs_open": [
               {
                 "function": "vfs_open",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "kprobe/vfs_unlink": [
               {
                 "function": "vfs_unlink",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "kretprobe/vfs_unlink": [
               {
                 "function": "vfs_unlink_ret",
-                "invalid": false
+                "reject_load": false
               }
             ]
           },
@@ -131,7 +131,7 @@
             "kprobe/oom_kill_process": [
               {
                 "function": "oom_kill_process",
-                "invalid": false
+                "reject_load": false
               }
             ]
           },
@@ -154,25 +154,25 @@
             "kprobe/tcp_v4_connect": [
               {
                 "function": "tcp_v4_connect",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "kprobe/tcp_v6_connect": [
               {
                 "function": "tcp_v6_connect",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "kretprobe/tcp_v4_connect": [
               {
                 "function": "tcp_v4_connect_ret",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "kretprobe/tcp_v6_connect": [
               {
                 "function": "tcp_v6_connect_ret",
-                "invalid": false
+                "reject_load": false
               }
             ]
           },
@@ -205,19 +205,19 @@
             "2/1": [
               {
                 "function": "2/1",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "2/2": [
               {
                 "function": "2/2",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "from-netdev": [
               {
                 "function": "from-netdev",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -231,19 +231,19 @@
             "2/1": [
               {
                 "function": "2/1",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "2/2": [
               {
                 "function": "2/2",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "from-netdev": [
               {
                 "function": "from-netdev",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -257,19 +257,19 @@
             "2/1": [
               {
                 "function": "2/1",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "2/2": [
               {
                 "function": "2/2",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "from-netdev": [
               {
                 "function": "from-netdev",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -283,55 +283,55 @@
             "1/0x1010": [
               {
                 "function": "1/0x1010",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "2/1": [
               {
                 "function": "2/1",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "2/2": [
               {
                 "function": "2/2",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "2/3": [
               {
                 "function": "2/3",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "2/4": [
               {
                 "function": "2/4",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "2/5": [
               {
                 "function": "2/5",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "2/6": [
               {
                 "function": "2/6",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "2/7": [
               {
                 "function": "2/7",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "from-container": [
               {
                 "function": "from-container",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -345,55 +345,55 @@
             "1/0x1010": [
               {
                 "function": "1/0x1010",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "2/1": [
               {
                 "function": "2/1",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "2/2": [
               {
                 "function": "2/2",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "2/3": [
               {
                 "function": "2/3",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "2/4": [
               {
                 "function": "2/4",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "2/5": [
               {
                 "function": "2/5",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "2/6": [
               {
                 "function": "2/6",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "2/7": [
               {
                 "function": "2/7",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "from-container": [
               {
                 "function": "from-container",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -407,55 +407,55 @@
             "1/0xdc06": [
               {
                 "function": "1/0xdc06",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "2/1": [
               {
                 "function": "2/1",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "2/10": [
               {
                 "function": "2/10",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "2/3": [
               {
                 "function": "2/3",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "2/4": [
               {
                 "function": "2/4",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "2/5": [
               {
                 "function": "2/5",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "2/6": [
               {
                 "function": "2/6",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "2/7": [
               {
                 "function": "2/7",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "from-container": [
               {
                 "function": "from-container",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -469,49 +469,49 @@
             "2/1": [
               {
                 "function": "2/1",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "2/2": [
               {
                 "function": "2/2",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "2/3": [
               {
                 "function": "2/3",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "2/4": [
               {
                 "function": "2/4",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "2/5": [
               {
                 "function": "2/5",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "2/7": [
               {
                 "function": "2/7",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "3/2": [
               {
                 "function": "3/2",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "from-netdev": [
               {
                 "function": "from-netdev",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -525,49 +525,49 @@
             "2/1": [
               {
                 "function": "2/1",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "2/2": [
               {
                 "function": "2/2",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "2/3": [
               {
                 "function": "2/3",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "2/4": [
               {
                 "function": "2/4",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "2/5": [
               {
                 "function": "2/5",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "2/7": [
               {
                 "function": "2/7",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "3/2": [
               {
                 "function": "3/2",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "from-overlay": [
               {
                 "function": "from-overlay",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -586,7 +586,7 @@
             ".text": [
               {
                 "function": "func",
-                "invalid": false
+                "reject_load": false
               }
             ]
           },
@@ -609,7 +609,7 @@
             "test": [
               {
                 "function": "test_repro",
-                "invalid": false
+                "reject_load": false
               }
             ]
           },
@@ -632,8 +632,8 @@
             ".text": [
               {
                 "function": "func",
-                "invalid": true,
-                "invalid_reason": "Subprogram not found: ebpf_map_update_elem"
+                "reject_load": true,
+                "reject_load_reason": "Subprogram not found: ebpf_map_update_elem"
               }
             ]
           },
@@ -654,7 +654,7 @@
             "test": [
               {
                 "function": "test_bounded_loop",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -668,17 +668,17 @@
             ".text": [
               {
                 "function": "add1",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "add2",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "test": [
               {
                 "function": "func",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -692,13 +692,13 @@
             ".text": [
               {
                 "function": "loop_callback",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "xdp": [
               {
                 "function": "test_bpf_loop",
-                "invalid": false
+                "reject_load": false
               }
             ]
           },
@@ -726,7 +726,7 @@
             ".text": [
               {
                 "function": "func",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -740,7 +740,7 @@
             "xdp": [
               {
                 "function": "ConvergedBranch",
-                "invalid": false
+                "reject_load": false
               }
             ]
           },
@@ -763,7 +763,7 @@
             "socket_filter": [
               {
                 "function": "ConvergedBranch",
-                "invalid": false
+                "reject_load": false
               }
             ]
           },
@@ -786,7 +786,7 @@
             "xdp": [
               {
                 "function": "test_cpumap",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -800,7 +800,7 @@
             "sockops": [
               {
                 "function": "func",
-                "invalid": false
+                "reject_load": false
               }
             ]
           },
@@ -823,7 +823,7 @@
             "xdp": [
               {
                 "function": "dependent_read",
-                "invalid": false
+                "reject_load": false
               }
             ]
           },
@@ -846,7 +846,7 @@
             "xdp": [
               {
                 "function": "test_devmap",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -860,7 +860,7 @@
             "test": [
               {
                 "function": "test_divzero",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -874,7 +874,7 @@
             ".text": [
               {
                 "function": "func",
-                "invalid": false
+                "reject_load": false
               }
             ]
           },
@@ -897,7 +897,7 @@
             ".text": [
               {
                 "function": "func",
-                "invalid": false
+                "reject_load": false
               }
             ]
           },
@@ -920,8 +920,8 @@
             ".text": [
               {
                 "function": "func",
-                "invalid": true,
-                "invalid_reason": "Subprogram not found: bpf_map_lookup_elem"
+                "reject_load": true,
+                "reject_load_reason": "Subprogram not found: bpf_map_lookup_elem"
               }
             ]
           }
@@ -935,17 +935,17 @@
             ".text": [
               {
                 "function": "add_and_store",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "process_entry",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "xdp": [
               {
                 "function": "test_global_func",
-                "invalid": false
+                "reject_load": false
               }
             ]
           },
@@ -975,7 +975,7 @@
             ".text": [
               {
                 "function": "func",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -989,7 +989,7 @@
             ".text": [
               {
                 "function": "func",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -1003,7 +1003,7 @@
             ".text": [
               {
                 "function": "func",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -1017,7 +1017,7 @@
             "test": [
               {
                 "function": "test_infinite_loop",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -1031,7 +1031,7 @@
             ".text": [
               {
                 "function": "func",
-                "invalid": false
+                "reject_load": false
               }
             ]
           },
@@ -1054,7 +1054,7 @@
             "test_md": [
               {
                 "function": "foo",
-                "invalid": false
+                "reject_load": false
               }
             ]
           },
@@ -1077,7 +1077,7 @@
             "xdp": [
               {
                 "function": "test_lpm_trie",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -1091,7 +1091,7 @@
             ".text": [
               {
                 "function": "func",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -1105,7 +1105,7 @@
             ".text": [
               {
                 "function": "func",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -1119,7 +1119,7 @@
             ".text": [
               {
                 "function": "func",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -1133,7 +1133,7 @@
             ".text": [
               {
                 "function": "func",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -1147,7 +1147,7 @@
             ".text": [
               {
                 "function": "func",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -1161,7 +1161,7 @@
             ".text": [
               {
                 "function": "func",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -1175,7 +1175,7 @@
             ".text": [
               {
                 "function": "func",
-                "invalid": false
+                "reject_load": false
               }
             ]
           },
@@ -1198,7 +1198,7 @@
             "test": [
               {
                 "function": "test_repro",
-                "invalid": false
+                "reject_load": false
               }
             ]
           },
@@ -1221,7 +1221,7 @@
             "xdp": [
               {
                 "function": "test_packet_access",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -1235,7 +1235,7 @@
             "xdp": [
               {
                 "function": "read_write_packet_start",
-                "invalid": false
+                "reject_load": false
               }
             ]
           },
@@ -1258,7 +1258,7 @@
             "socket_filter": [
               {
                 "function": "reallocate_invalidates",
-                "invalid": false
+                "reject_load": false
               }
             ]
           },
@@ -1281,7 +1281,7 @@
             "xdp": [
               {
                 "function": "read_write_packet_start",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -1295,7 +1295,7 @@
             "xdp": [
               {
                 "function": "test_percpu_array",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -1309,7 +1309,7 @@
             "xdp": [
               {
                 "function": "test_percpu_hash",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -1323,7 +1323,7 @@
             "xdp": [
               {
                 "function": "test_perf_event",
-                "invalid": false
+                "reject_load": false
               }
             ]
           },
@@ -1346,23 +1346,23 @@
             ".text": [
               {
                 "function": "func",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "func0",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "func1",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "func2",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "func3",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -1376,7 +1376,7 @@
             "xdp": [
               {
                 "function": "test_ptr_arith",
-                "invalid": false
+                "reject_load": false
               }
             ]
           },
@@ -1399,7 +1399,7 @@
             ".text": [
               {
                 "function": "func",
-                "invalid": false
+                "reject_load": false
               }
             ]
           },
@@ -1422,7 +1422,7 @@
             ".text": [
               {
                 "function": "func",
-                "invalid": false
+                "reject_load": false
               }
             ]
           },
@@ -1445,7 +1445,7 @@
             ".text": [
               {
                 "function": "test",
-                "invalid": false
+                "reject_load": false
               }
             ]
           },
@@ -1468,7 +1468,7 @@
             "sk_skb/stream_verdict": [
               {
                 "function": "test_sockmap",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -1482,7 +1482,7 @@
             ".text": [
               {
                 "function": "func",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -1496,7 +1496,7 @@
             ".text": [
               {
                 "function": "func",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -1510,13 +1510,13 @@
             "xdp_prog": [
               {
                 "function": "caller",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "xdp_prog/0": [
               {
                 "function": "callee",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -1530,13 +1530,13 @@
             "xdp_prog": [
               {
                 "function": "caller",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "xdp_prog/0": [
               {
                 "function": "callee",
-                "invalid": false
+                "reject_load": false
               }
             ]
           },
@@ -1559,7 +1559,7 @@
             ".text": [
               {
                 "function": "func",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -1573,7 +1573,7 @@
             ".text": [
               {
                 "function": "func",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -1587,7 +1587,7 @@
             ".text": [
               {
                 "function": "func",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -1601,7 +1601,7 @@
             ".text": [
               {
                 "function": "func",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -1615,7 +1615,7 @@
             "xdp": [
               {
                 "function": "func",
-                "invalid": false
+                "reject_load": false
               }
             ]
           },
@@ -1641,13 +1641,13 @@
             "2/1": [
               {
                 "function": "2/1",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "from-netdev": [
               {
                 "function": "from-netdev",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -1661,79 +1661,79 @@
             "1/0x1010": [
               {
                 "function": "1/0x1010",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "2/1": [
               {
                 "function": "2/1",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "2/10": [
               {
                 "function": "2/10",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "2/11": [
               {
                 "function": "2/11",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "2/12": [
               {
                 "function": "2/12",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "2/3": [
               {
                 "function": "2/3",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "2/4": [
               {
                 "function": "2/4",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "2/5": [
               {
                 "function": "2/5",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "2/6": [
               {
                 "function": "2/6",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "2/7": [
               {
                 "function": "2/7",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "2/8": [
               {
                 "function": "2/8",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "2/9": [
               {
                 "function": "2/9",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "from-container": [
               {
                 "function": "from-container",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -1747,37 +1747,37 @@
             "2/1": [
               {
                 "function": "2/1",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "2/3": [
               {
                 "function": "2/3",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "2/4": [
               {
                 "function": "2/4",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "2/5": [
               {
                 "function": "2/5",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "2/7": [
               {
                 "function": "2/7",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "from-netdev": [
               {
                 "function": "from-netdev",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -1791,37 +1791,37 @@
             "2/1": [
               {
                 "function": "2/1",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "2/3": [
               {
                 "function": "2/3",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "2/4": [
               {
                 "function": "2/4",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "2/5": [
               {
                 "function": "2/5",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "2/7": [
               {
                 "function": "2/7",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "from-overlay": [
               {
                 "function": "from-overlay",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -1835,7 +1835,7 @@
             "from-netdev": [
               {
                 "function": "from-netdev",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -1849,73 +1849,73 @@
             "2/1": [
               {
                 "function": "__send_drop_notify",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "2/10": [
               {
                 "function": "tail_lb_ipv6",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "2/15": [
               {
                 "function": "tail_nodeport_nat_ipv4",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "2/16": [
               {
                 "function": "tail_nodeport_nat_ipv6",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "2/17": [
               {
                 "function": "tail_rev_nodeport_lb4",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "2/18": [
               {
                 "function": "tail_rev_nodeport_lb6",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "2/19": [
               {
                 "function": "tail_handle_nat_fwd_ipv4",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "2/20": [
               {
                 "function": "tail_nodeport_ipv4_dsr",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "2/21": [
               {
                 "function": "tail_nodeport_ipv6_dsr",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "2/24": [
               {
                 "function": "tail_handle_nat_fwd_ipv6",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "2/7": [
               {
                 "function": "tail_lb_ipv4",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "from-netdev": [
               {
                 "function": "bpf_xdp_entry",
-                "invalid": false
+                "reject_load": false
               }
             ]
           },
@@ -1983,73 +1983,73 @@
             "2/1": [
               {
                 "function": "__send_drop_notify",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "2/10": [
               {
                 "function": "tail_lb_ipv6",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "2/15": [
               {
                 "function": "tail_nodeport_nat_ipv4",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "2/16": [
               {
                 "function": "tail_nodeport_nat_ipv6",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "2/17": [
               {
                 "function": "tail_rev_nodeport_lb4",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "2/18": [
               {
                 "function": "tail_rev_nodeport_lb6",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "2/19": [
               {
                 "function": "tail_handle_nat_fwd_ipv4",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "2/20": [
               {
                 "function": "tail_nodeport_ipv4_dsr",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "2/21": [
               {
                 "function": "tail_nodeport_ipv6_dsr",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "2/24": [
               {
                 "function": "tail_handle_nat_fwd_ipv6",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "2/7": [
               {
                 "function": "tail_lb_ipv4",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "from-netdev": [
               {
                 "function": "bpf_xdp_entry",
-                "invalid": false
+                "reject_load": false
               }
             ]
           },
@@ -2117,73 +2117,73 @@
             "2/1": [
               {
                 "function": "__send_drop_notify",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "2/10": [
               {
                 "function": "tail_lb_ipv6",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "2/15": [
               {
                 "function": "tail_nodeport_nat_ipv4",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "2/16": [
               {
                 "function": "tail_nodeport_nat_ipv6",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "2/17": [
               {
                 "function": "tail_rev_nodeport_lb4",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "2/18": [
               {
                 "function": "tail_rev_nodeport_lb6",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "2/19": [
               {
                 "function": "tail_handle_nat_fwd_ipv4",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "2/20": [
               {
                 "function": "tail_nodeport_ipv4_dsr",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "2/21": [
               {
                 "function": "tail_nodeport_ipv6_dsr",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "2/24": [
               {
                 "function": "tail_handle_nat_fwd_ipv6",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "2/7": [
               {
                 "function": "tail_lb_ipv4",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "from-netdev": [
               {
                 "function": "bpf_xdp_entry",
-                "invalid": false
+                "reject_load": false
               }
             ]
           },
@@ -2251,61 +2251,61 @@
             "2/1": [
               {
                 "function": "__send_drop_notify",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "2/10": [
               {
                 "function": "tail_lb_ipv6",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "2/15": [
               {
                 "function": "tail_nodeport_nat_ipv4",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "2/16": [
               {
                 "function": "tail_nodeport_nat_ipv6",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "2/17": [
               {
                 "function": "tail_rev_nodeport_lb4",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "2/18": [
               {
                 "function": "tail_rev_nodeport_lb6",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "2/19": [
               {
                 "function": "tail_handle_nat_fwd_ipv4",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "2/24": [
               {
                 "function": "tail_handle_nat_fwd_ipv6",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "2/7": [
               {
                 "function": "tail_lb_ipv4",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "from-netdev": [
               {
                 "function": "bpf_xdp_entry",
-                "invalid": false
+                "reject_load": false
               }
             ]
           },
@@ -2363,61 +2363,61 @@
             "2/1": [
               {
                 "function": "__send_drop_notify",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "2/10": [
               {
                 "function": "tail_lb_ipv6",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "2/15": [
               {
                 "function": "tail_nodeport_nat_ipv4",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "2/16": [
               {
                 "function": "tail_nodeport_nat_ipv6",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "2/17": [
               {
                 "function": "tail_rev_nodeport_lb4",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "2/18": [
               {
                 "function": "tail_rev_nodeport_lb6",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "2/19": [
               {
                 "function": "tail_handle_nat_fwd_ipv4",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "2/24": [
               {
                 "function": "tail_handle_nat_fwd_ipv6",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "2/7": [
               {
                 "function": "tail_lb_ipv4",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "from-netdev": [
               {
                 "function": "bpf_xdp_entry",
-                "invalid": false
+                "reject_load": false
               }
             ]
           },
@@ -2480,11 +2480,11 @@
             "tc/tail": [
               {
                 "function": "tail_icmp6_handle_ns",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "tail_icmp6_send_time_exceeded",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -2498,147 +2498,147 @@
             ".text": [
               {
                 "function": "__check_device_mtu",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "__check_eth_header_length",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "tc/entry": [
               {
                 "function": "cil_from_host",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "cil_from_netdev",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "cil_host_policy",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "cil_to_host",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "cil_to_netdev",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "tc/tail": [
               {
                 "function": "tail_drop_notify",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "tail_handle_ipv4_cont_from_host",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "tail_handle_ipv4_cont_from_netdev",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "tail_handle_ipv4_from_host",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "tail_handle_ipv4_from_netdev",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "tail_handle_ipv6_cont_from_host",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "tail_handle_ipv6_cont_from_netdev",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "tail_handle_ipv6_from_host",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "tail_handle_ipv6_from_netdev",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "tail_handle_nat_fwd_ipv4",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "tail_handle_nat_fwd_ipv6",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "tail_handle_snat_fwd_ipv4",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "tail_handle_snat_fwd_ipv6",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "tail_icmp6_handle_ns",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "tail_icmp6_send_time_exceeded",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "tail_ipv4_host_policy_ingress",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "tail_ipv6_host_policy_ingress",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "tail_nodeport_ipv4_dsr",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "tail_nodeport_ipv6_dsr",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "tail_nodeport_nat_egress_ipv4",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "tail_nodeport_nat_egress_ipv6",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "tail_nodeport_nat_ingress_ipv4",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "tail_nodeport_nat_ingress_ipv6",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "tail_nodeport_rev_dnat_egress_ipv6",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "tail_nodeport_rev_dnat_ingress_ipv6",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "tail_nodeport_rev_dnat_ipv4",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "tail_srv6_decap",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "tail_srv6_encap",
-                "invalid": false
+                "reject_load": false
               }
             ]
           },
@@ -2767,147 +2767,147 @@
             ".text": [
               {
                 "function": "__check_device_mtu",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "tc/entry": [
               {
                 "function": "cil_from_container",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "cil_lxc_policy",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "cil_lxc_policy_egress",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "cil_to_container",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "tc/tail": [
               {
                 "function": "tail_drop_notify",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "tail_handle_arp",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "tail_handle_ipv4",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "tail_handle_ipv4_cont",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "tail_handle_ipv6",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "tail_handle_ipv6_cont",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "tail_icmp6_handle_ns",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "tail_icmp6_send_time_exceeded",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "tail_ipv4_ct_egress",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "tail_ipv4_ct_ingress",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "tail_ipv4_ct_ingress_policy_only",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "tail_ipv4_policy",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "tail_ipv4_to_endpoint",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "tail_ipv6_ct_egress",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "tail_ipv6_ct_ingress",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "tail_ipv6_ct_ingress_policy_only",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "tail_ipv6_policy",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "tail_ipv6_to_endpoint",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "tail_nodeport_ipv4_dsr",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "tail_nodeport_ipv6_dsr",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "tail_nodeport_nat_egress_ipv4",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "tail_nodeport_nat_egress_ipv6",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "tail_nodeport_nat_ingress_ipv4",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "tail_nodeport_nat_ingress_ipv6",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "tail_nodeport_rev_dnat_egress_ipv6",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "tail_nodeport_rev_dnat_ingress_ipv6",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "tail_nodeport_rev_dnat_ipv4",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "tail_policy_denied_ipv4",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "tail_srv6_decap",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "tail_srv6_encap",
-                "invalid": false
+                "reject_load": false
               }
             ]
           },
@@ -2984,13 +2984,13 @@
             "tc/entry": [
               {
                 "function": "cil_from_network",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "tc/tail": [
               {
                 "function": "tail_drop_notify",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -3004,99 +3004,99 @@
             ".text": [
               {
                 "function": "__check_device_mtu",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "__mcast_ep_delivery",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "tc/entry": [
               {
                 "function": "cil_from_overlay",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "cil_to_overlay",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "tc/tail": [
               {
                 "function": "tail_drop_notify",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "tail_handle_arp",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "tail_handle_ipv4",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "tail_handle_ipv6",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "tail_handle_nat_fwd_ipv4",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "tail_handle_nat_fwd_ipv6",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "tail_handle_snat_fwd_ipv4",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "tail_handle_snat_fwd_ipv6",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "tail_icmp6_send_time_exceeded",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "tail_mcast_ep_delivery",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "tail_nodeport_ipv4_dsr",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "tail_nodeport_ipv6_dsr",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "tail_nodeport_nat_egress_ipv4",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "tail_nodeport_nat_egress_ipv6",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "tail_nodeport_nat_ingress_ipv4",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "tail_nodeport_nat_ingress_ipv6",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "tail_nodeport_rev_dnat_egress_ipv6",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "tail_nodeport_rev_dnat_ingress_ipv6",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "tail_nodeport_rev_dnat_ipv4",
-                "invalid": false
+                "reject_load": false
               }
             ]
           },
@@ -3163,55 +3163,55 @@
             "cgroup/connect4": [
               {
                 "function": "cil_sock4_connect",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "cgroup/connect6": [
               {
                 "function": "cil_sock6_connect",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "cgroup/post_bind4": [
               {
                 "function": "cil_sock4_post_bind",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "cgroup/post_bind6": [
               {
                 "function": "cil_sock6_post_bind",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "cgroup/recvmsg4": [
               {
                 "function": "cil_sock4_recvmsg",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "cgroup/recvmsg6": [
               {
                 "function": "cil_sock6_recvmsg",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "cgroup/sendmsg4": [
               {
                 "function": "cil_sock4_sendmsg",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "cgroup/sendmsg6": [
               {
                 "function": "cil_sock6_sendmsg",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "cgroup/sock_release": [
               {
                 "function": "cil_sock_release",
-                "invalid": false
+                "reject_load": false
               }
             ]
           },
@@ -3234,87 +3234,87 @@
             ".text": [
               {
                 "function": "__check_device_mtu",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "tc/entry": [
               {
                 "function": "cil_from_wireguard",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "cil_to_wireguard",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "tc/tail": [
               {
                 "function": "tail_drop_notify",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "tail_handle_ipv4",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "tail_handle_ipv6",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "tail_handle_nat_fwd_ipv4",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "tail_handle_nat_fwd_ipv6",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "tail_handle_snat_fwd_ipv4",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "tail_handle_snat_fwd_ipv6",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "tail_icmp6_send_time_exceeded",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "tail_nodeport_ipv4_dsr",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "tail_nodeport_ipv6_dsr",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "tail_nodeport_nat_egress_ipv4",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "tail_nodeport_nat_egress_ipv6",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "tail_nodeport_nat_ingress_ipv4",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "tail_nodeport_nat_ingress_ipv6",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "tail_nodeport_rev_dnat_egress_ipv6",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "tail_nodeport_rev_dnat_ingress_ipv6",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "tail_nodeport_rev_dnat_ipv4",
-                "invalid": false
+                "reject_load": false
               }
             ]
           },
@@ -3361,63 +3361,63 @@
             ".text": [
               {
                 "function": "__check_device_mtu",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "xdp/entry": [
               {
                 "function": "cil_xdp_entry",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "xdp/tail": [
               {
                 "function": "tail_drop_notify",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "tail_lb_ipv4",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "tail_lb_ipv6",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "tail_nodeport_ipv4_dsr",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "tail_nodeport_ipv6_dsr",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "tail_nodeport_nat_egress_ipv4",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "tail_nodeport_nat_egress_ipv6",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "tail_nodeport_nat_ingress_ipv4",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "tail_nodeport_nat_ingress_ipv6",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "tail_nodeport_rev_dnat_egress_ipv6",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "tail_nodeport_rev_dnat_ingress_ipv6",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "tail_nodeport_rev_dnat_ipv4",
-                "invalid": false
+                "reject_load": false
               }
             ]
           },
@@ -3519,13 +3519,13 @@
             "socket/main": [
               {
                 "function": "tail_main",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "socket/tail": [
               {
                 "function": "tail_1",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -3539,7 +3539,7 @@
             "sk_lookup/": [
               {
                 "function": "freeze_rodata",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -3553,18 +3553,18 @@
             "socket": [
               {
                 "function": "poisoned_double",
-                "invalid": true,
-                "invalid_reason": "Subprogram not found: invalid_kfunc"
+                "reject_load": true,
+                "reject_load_reason": "Subprogram not found: invalid_kfunc"
               },
               {
                 "function": "poisoned_kfunc",
-                "invalid": true,
-                "invalid_reason": "Subprogram not found: invalid_kfunc"
+                "reject_load": true,
+                "reject_load_reason": "Subprogram not found: invalid_kfunc"
               },
               {
                 "function": "poisoned_single",
-                "invalid": true,
-                "invalid_reason": "Subprogram not found: invalid_kfunc"
+                "reject_load": true,
+                "reject_load_reason": "Subprogram not found: invalid_kfunc"
               }
             ]
           },
@@ -3590,19 +3590,19 @@
             "fentry/target": [
               {
                 "function": "trace_on_entry",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "fexit/target": [
               {
                 "function": "trace_on_exit",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "tc": [
               {
                 "function": "target",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -3616,19 +3616,19 @@
             ".text": [
               {
                 "function": "subprog",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "freplace/subprog": [
               {
                 "function": "replacement",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "raw_tracepoint/sched_process_exec": [
               {
                 "function": "sched_process_exec",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -3642,8 +3642,8 @@
             "socket": [
               {
                 "function": "call_fwd",
-                "invalid": true,
-                "invalid_reason": "Subprogram not found: fwd"
+                "reject_load": true,
+                "reject_load_reason": "Subprogram not found: fwd"
               }
             ]
           },
@@ -3664,8 +3664,8 @@
             "tc": [
               {
                 "function": "call_kfunc",
-                "invalid": true,
-                "invalid_reason": "Subprogram not found: bpf_kfunc_call_test_mem_len_pass1"
+                "reject_load": true,
+                "reject_load_reason": "Subprogram not found: bpf_kfunc_call_test_mem_len_pass1"
               }
             ]
           },
@@ -3706,7 +3706,7 @@
             "xdp": [
               {
                 "function": "xdp_prog",
-                "invalid": false
+                "reject_load": false
               }
             ]
           },
@@ -3739,7 +3739,7 @@
             "socket": [
               {
                 "function": "kconfig",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -3756,27 +3756,27 @@
             "fentry/bpf_fentry_test2": [
               {
                 "function": "benchmark",
-                "invalid": true,
-                "invalid_reason": "Subprogram not found: bpf_fentry_test1"
+                "reject_load": true,
+                "reject_load_reason": "Subprogram not found: bpf_fentry_test1"
               }
             ],
             "tc": [
               {
                 "function": "call_kfunc",
-                "invalid": true,
-                "invalid_reason": "Subprogram not found: bpf_skb_ct_lookup"
+                "reject_load": true,
+                "reject_load_reason": "Subprogram not found: bpf_skb_ct_lookup"
               }
             ],
             "tp_btf/task_newtask": [
               {
                 "function": "call_weak_kfunc",
-                "invalid": true,
-                "invalid_reason": "Unresolved symbols found."
+                "reject_load": true,
+                "reject_load_reason": "Unresolved symbols found."
               },
               {
                 "function": "weak_kfunc_missing",
-                "invalid": true,
-                "invalid_reason": "Unresolved symbols found."
+                "reject_load": true,
+                "reject_load_reason": "Unresolved symbols found."
               }
             ]
           },
@@ -3800,8 +3800,8 @@
             "tc": [
               {
                 "function": "call_kfunc",
-                "invalid": true,
-                "invalid_reason": "Subprogram not found: bpf_testmod_test_mod_kfunc"
+                "reject_load": true,
+                "reject_load_reason": "Subprogram not found: bpf_testmod_test_mod_kfunc"
               }
             ]
           },
@@ -3826,13 +3826,13 @@
             "socket": [
               {
                 "function": "ksym_missing_test",
-                "invalid": true,
-                "invalid_reason": "Unresolved symbols found."
+                "reject_load": true,
+                "reject_load_reason": "Unresolved symbols found."
               },
               {
                 "function": "ksym_test",
-                "invalid": true,
-                "invalid_reason": "Unresolved symbols found."
+                "reject_load": true,
+                "reject_load_reason": "Unresolved symbols found."
               }
             ]
           }
@@ -3846,55 +3846,55 @@
             ".text": [
               {
                 "function": "l1",
-                "invalid": true,
-                "invalid_reason": "Legacy map symbol 'map_legacy_l2_s' has invalid offset: not aligned to 40-byte boundary or out of section bounds"
+                "reject_load": true,
+                "reject_load_reason": "Legacy map symbol 'map_legacy_l2_s' has invalid offset: not aligned to 40-byte boundary or out of section bounds"
               },
               {
                 "function": "l1_s",
-                "invalid": true,
-                "invalid_reason": "Legacy map symbol 'map_legacy_l2_s' has invalid offset: not aligned to 40-byte boundary or out of section bounds"
+                "reject_load": true,
+                "reject_load_reason": "Legacy map symbol 'map_legacy_l2_s' has invalid offset: not aligned to 40-byte boundary or out of section bounds"
               },
               {
                 "function": "l1_w",
-                "invalid": true,
-                "invalid_reason": "Legacy map symbol 'map_legacy_l2_s' has invalid offset: not aligned to 40-byte boundary or out of section bounds"
+                "reject_load": true,
+                "reject_load_reason": "Legacy map symbol 'map_legacy_l2_s' has invalid offset: not aligned to 40-byte boundary or out of section bounds"
               },
               {
                 "function": "l2",
-                "invalid": true,
-                "invalid_reason": "Legacy map symbol 'map_legacy_l2_s' has invalid offset: not aligned to 40-byte boundary or out of section bounds"
+                "reject_load": true,
+                "reject_load_reason": "Legacy map symbol 'map_legacy_l2_s' has invalid offset: not aligned to 40-byte boundary or out of section bounds"
               },
               {
                 "function": "ww",
-                "invalid": true,
-                "invalid_reason": "Legacy map symbol 'map_legacy_l2_s' has invalid offset: not aligned to 40-byte boundary or out of section bounds"
+                "reject_load": true,
+                "reject_load_reason": "Legacy map symbol 'map_legacy_l2_s' has invalid offset: not aligned to 40-byte boundary or out of section bounds"
               }
             ],
             "socket": [
               {
                 "function": "entry_l1",
-                "invalid": true,
-                "invalid_reason": "Legacy map symbol 'map_legacy_l2_s' has invalid offset: not aligned to 40-byte boundary or out of section bounds"
+                "reject_load": true,
+                "reject_load_reason": "Legacy map symbol 'map_legacy_l2_s' has invalid offset: not aligned to 40-byte boundary or out of section bounds"
               },
               {
                 "function": "entry_l1_s",
-                "invalid": true,
-                "invalid_reason": "Legacy map symbol 'map_legacy_l2_s' has invalid offset: not aligned to 40-byte boundary or out of section bounds"
+                "reject_load": true,
+                "reject_load_reason": "Legacy map symbol 'map_legacy_l2_s' has invalid offset: not aligned to 40-byte boundary or out of section bounds"
               },
               {
                 "function": "entry_l1_w",
-                "invalid": true,
-                "invalid_reason": "Legacy map symbol 'map_legacy_l2_s' has invalid offset: not aligned to 40-byte boundary or out of section bounds"
+                "reject_load": true,
+                "reject_load_reason": "Legacy map symbol 'map_legacy_l2_s' has invalid offset: not aligned to 40-byte boundary or out of section bounds"
               },
               {
                 "function": "entry_l2",
-                "invalid": true,
-                "invalid_reason": "Legacy map symbol 'map_legacy_l2_s' has invalid offset: not aligned to 40-byte boundary or out of section bounds"
+                "reject_load": true,
+                "reject_load_reason": "Legacy map symbol 'map_legacy_l2_s' has invalid offset: not aligned to 40-byte boundary or out of section bounds"
               },
               {
                 "function": "entry_ww",
-                "invalid": true,
-                "invalid_reason": "Legacy map symbol 'map_legacy_l2_s' has invalid offset: not aligned to 40-byte boundary or out of section bounds"
+                "reject_load": true,
+                "reject_load_reason": "Legacy map symbol 'map_legacy_l2_s' has invalid offset: not aligned to 40-byte boundary or out of section bounds"
               }
             ]
           }
@@ -3908,41 +3908,41 @@
             ".text": [
               {
                 "function": "l1",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "l1_s",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "l1_w",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "ww",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "socket": [
               {
                 "function": "entry_l1_s",
-                "invalid": true,
-                "invalid_reason": "Subprogram not found: l2"
+                "reject_load": true,
+                "reject_load_reason": "Subprogram not found: l2"
               },
               {
                 "function": "entry_l1_w",
-                "invalid": true,
-                "invalid_reason": "Subprogram not found: l2"
+                "reject_load": true,
+                "reject_load_reason": "Subprogram not found: l2"
               },
               {
                 "function": "entry_l2",
-                "invalid": true,
-                "invalid_reason": "Subprogram not found: l2"
+                "reject_load": true,
+                "reject_load_reason": "Subprogram not found: l2"
               },
               {
                 "function": "entry_ww",
-                "invalid": true,
-                "invalid_reason": "Subprogram not found: l2"
+                "reject_load": true,
+                "reject_load_reason": "Subprogram not found: l2"
               }
             ]
           },
@@ -3965,41 +3965,41 @@
             ".text": [
               {
                 "function": "l1_s",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "l1_w",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "l2",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "ww",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "socket": [
               {
                 "function": "entry_l1",
-                "invalid": true,
-                "invalid_reason": "Subprogram not found: l1"
+                "reject_load": true,
+                "reject_load_reason": "Subprogram not found: l1"
               },
               {
                 "function": "entry_l1_s",
-                "invalid": true,
-                "invalid_reason": "Subprogram not found: l1"
+                "reject_load": true,
+                "reject_load_reason": "Subprogram not found: l1"
               },
               {
                 "function": "entry_l1_w",
-                "invalid": true,
-                "invalid_reason": "Subprogram not found: l1"
+                "reject_load": true,
+                "reject_load_reason": "Subprogram not found: l1"
               },
               {
                 "function": "entry_ww",
-                "invalid": true,
-                "invalid_reason": "Subprogram not found: l1"
+                "reject_load": true,
+                "reject_load_reason": "Subprogram not found: l1"
               }
             ]
           },
@@ -4027,55 +4027,55 @@
             ".text": [
               {
                 "function": "global_fn",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "global_fn2",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "other": [
               {
                 "function": "global_fn3",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "socket": [
               {
                 "function": "no_relocation",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "socket/2": [
               {
                 "function": "asm_relocation",
-                "invalid": true,
-                "invalid_reason": "Unresolved symbols found."
+                "reject_load": true,
+                "reject_load_reason": "Unresolved symbols found."
               }
             ],
             "socket/3": [
               {
                 "function": "data_sections",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "socket/4": [
               {
                 "function": "anon_const",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "static": [
               {
                 "function": "static_fn",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "xdp": [
               {
                 "function": "xdp_prog",
-                "invalid": true,
-                "invalid_reason": "Unresolved symbols found."
+                "reject_load": true,
+                "reject_load_reason": "Unresolved symbols found."
               }
             ]
           },
@@ -4122,55 +4122,55 @@
             ".text": [
               {
                 "function": "global_fn",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "global_fn2",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "other": [
               {
                 "function": "global_fn3",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "socket": [
               {
                 "function": "no_relocation",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "socket/2": [
               {
                 "function": "asm_relocation",
-                "invalid": true,
-                "invalid_reason": "Unresolved symbols found."
+                "reject_load": true,
+                "reject_load_reason": "Unresolved symbols found."
               }
             ],
             "socket/3": [
               {
                 "function": "data_sections",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "socket/4": [
               {
                 "function": "anon_const",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "static": [
               {
                 "function": "static_fn",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "xdp": [
               {
                 "function": "xdp_prog",
-                "invalid": true,
-                "invalid_reason": "Unresolved symbols found."
+                "reject_load": true,
+                "reject_load_reason": "Unresolved symbols found."
               }
             ]
           },
@@ -4217,55 +4217,55 @@
             ".text": [
               {
                 "function": "global_fn",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "global_fn2",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "other": [
               {
                 "function": "global_fn3",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "socket": [
               {
                 "function": "no_relocation",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "socket/2": [
               {
                 "function": "asm_relocation",
-                "invalid": true,
-                "invalid_reason": "Unresolved symbols found."
+                "reject_load": true,
+                "reject_load_reason": "Unresolved symbols found."
               }
             ],
             "socket/3": [
               {
                 "function": "data_sections",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "socket/4": [
               {
                 "function": "anon_const",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "static": [
               {
                 "function": "static_fn",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "xdp": [
               {
                 "function": "xdp_prog",
-                "invalid": true,
-                "invalid_reason": "Unresolved symbols found."
+                "reject_load": true,
+                "reject_load_reason": "Unresolved symbols found."
               }
             ]
           },
@@ -4312,55 +4312,55 @@
             ".text": [
               {
                 "function": "global_fn",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "global_fn2",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "other": [
               {
                 "function": "global_fn3",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "socket": [
               {
                 "function": "no_relocation",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "socket/2": [
               {
                 "function": "asm_relocation",
-                "invalid": true,
-                "invalid_reason": "Unresolved symbols found."
+                "reject_load": true,
+                "reject_load_reason": "Unresolved symbols found."
               }
             ],
             "socket/3": [
               {
                 "function": "data_sections",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "socket/4": [
               {
                 "function": "anon_const",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "static": [
               {
                 "function": "static_fn",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "xdp": [
               {
                 "function": "xdp_prog",
-                "invalid": true,
-                "invalid_reason": "Unresolved symbols found."
+                "reject_load": true,
+                "reject_load_reason": "Unresolved symbols found."
               }
             ]
           },
@@ -4404,54 +4404,54 @@
             ".text": [
               {
                 "function": "global_fn",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "global_fn2",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "other": [
               {
                 "function": "global_fn3",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "socket": [
               {
                 "function": "no_relocation",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "socket/2": [
               {
                 "function": "asm_relocation",
-                "invalid": true,
-                "invalid_reason": "Unresolved symbols found."
+                "reject_load": true,
+                "reject_load_reason": "Unresolved symbols found."
               }
             ],
             "socket/3": [
               {
                 "function": "data_sections",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "socket/4": [
               {
                 "function": "anon_const",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "static": [
               {
                 "function": "static_fn",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "xdp": [
               {
                 "function": "xdp_prog",
-                "invalid": false
+                "reject_load": false
               }
             ]
           },
@@ -4493,181 +4493,181 @@
             "kprobe/sys_execvea0": [
               {
                 "function": "kprobe_execve0",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "kprobe/sys_execvea1": [
               {
                 "function": "kprobe_execve1",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "kprobe/sys_execvea10": [
               {
                 "function": "kprobe_execve10",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "kprobe/sys_execvea11": [
               {
                 "function": "kprobe_execve11",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "kprobe/sys_execvea12": [
               {
                 "function": "kprobe_execve12",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "kprobe/sys_execvea13": [
               {
                 "function": "kprobe_execve13",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "kprobe/sys_execvea14": [
               {
                 "function": "kprobe_execve14",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "kprobe/sys_execvea15": [
               {
                 "function": "kprobe_execve15",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "kprobe/sys_execvea16": [
               {
                 "function": "kprobe_execve16",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "kprobe/sys_execvea17": [
               {
                 "function": "kprobe_execve17",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "kprobe/sys_execvea18": [
               {
                 "function": "kprobe_execve18",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "kprobe/sys_execvea19": [
               {
                 "function": "kprobe_execve19",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "kprobe/sys_execvea2": [
               {
                 "function": "kprobe_execve2",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "kprobe/sys_execvea20": [
               {
                 "function": "kprobe_execve20",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "kprobe/sys_execvea21": [
               {
                 "function": "kprobe_execve21",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "kprobe/sys_execvea22": [
               {
                 "function": "kprobe_execve22",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "kprobe/sys_execvea23": [
               {
                 "function": "kprobe_execve23",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "kprobe/sys_execvea24": [
               {
                 "function": "kprobe_execve24",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "kprobe/sys_execvea25": [
               {
                 "function": "kprobe_execve25",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "kprobe/sys_execvea26": [
               {
                 "function": "kprobe_execve26",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "kprobe/sys_execvea27": [
               {
                 "function": "kprobe_execve27",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "kprobe/sys_execvea28": [
               {
                 "function": "kprobe_execve28",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "kprobe/sys_execvea29": [
               {
                 "function": "kprobe_execve29",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "kprobe/sys_execvea3": [
               {
                 "function": "kprobe_execve3",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "kprobe/sys_execvea4": [
               {
                 "function": "kprobe_execve4",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "kprobe/sys_execvea5": [
               {
                 "function": "kprobe_execve5",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "kprobe/sys_execvea6": [
               {
                 "function": "kprobe_execve6",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "kprobe/sys_execvea7": [
               {
                 "function": "kprobe_execve7",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "kprobe/sys_execvea8": [
               {
                 "function": "kprobe_execve8",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "kprobe/sys_execvea9": [
               {
                 "function": "kprobe_execve9",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -4691,7 +4691,7 @@
             "raw_tracepoint/sched_process_exec": [
               {
                 "function": "sched_process_exec",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -4705,7 +4705,7 @@
             "xdp": [
               {
                 "function": "filter",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -4719,7 +4719,7 @@
             "struct_ops/test_1": [
               {
                 "function": "test_1",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -4733,13 +4733,13 @@
             ".text": [
               {
                 "function": "sub_prog",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "xdp": [
               {
                 "function": "fp_relocation",
-                "invalid": false
+                "reject_load": false
               }
             ]
           },
@@ -4762,35 +4762,35 @@
             "socket": [
               {
                 "function": "add_atomic",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "check_array",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "check_struct",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "check_struct_pad",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "get_bss",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "get_data",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "get_rodata",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "set_vars",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -4809,7 +4809,7 @@
             "cgroup_skb/egress": [
               {
                 "function": "count_egress_packets",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -4823,7 +4823,7 @@
             "fentry/tcp_connect": [
               {
                 "function": "tcp_connect",
-                "invalid": false
+                "reject_load": false
               }
             ]
           },
@@ -4846,7 +4846,7 @@
             "kprobe/sys_execve": [
               {
                 "function": "kprobe_execve",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -4860,7 +4860,7 @@
             "kprobe/sys_execve": [
               {
                 "function": "kprobe_execve",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -4874,7 +4874,7 @@
             "kprobe/sys_execve": [
               {
                 "function": "kprobe_execve",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -4888,7 +4888,7 @@
             "kprobe/sys_execve": [
               {
                 "function": "kprobe_execve",
-                "invalid": false
+                "reject_load": false
               }
             ]
           },
@@ -4911,7 +4911,7 @@
             "fentry/tcp_close": [
               {
                 "function": "tcp_close",
-                "invalid": false
+                "reject_load": false
               }
             ]
           },
@@ -4934,7 +4934,7 @@
             "sockops": [
               {
                 "function": "bpf_sockops_cb",
-                "invalid": false
+                "reject_load": false
               }
             ]
           },
@@ -4957,11 +4957,11 @@
             "tc": [
               {
                 "function": "egress_prog_func",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "ingress_prog_func",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -4975,7 +4975,7 @@
             "tracepoint/kmem/mm_page_alloc": [
               {
                 "function": "mm_page_alloc",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -4989,7 +4989,7 @@
             "uretprobe/bash_readline": [
               {
                 "function": "uretprobe_bash_readline",
-                "invalid": false
+                "reject_load": false
               }
             ]
           },
@@ -5012,7 +5012,7 @@
             "xdp": [
               {
                 "function": "xdp_prog_func",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -5031,571 +5031,571 @@
             "raw_tracepoint/filler/cpu_hotplug_e": [
               {
                 "function": "bpf_cpu_hotplug_e",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "raw_tracepoint/filler/proc_startupdate": [
               {
                 "function": "bpf_proc_startupdate",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "raw_tracepoint/filler/proc_startupdate_2": [
               {
                 "function": "bpf_proc_startupdate_2",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "raw_tracepoint/filler/proc_startupdate_3": [
               {
                 "function": "bpf_proc_startupdate_3",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "raw_tracepoint/filler/sched_drop": [
               {
                 "function": "bpf_sched_drop",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "raw_tracepoint/filler/sched_switch_e": [
               {
                 "function": "bpf_sched_switch_e",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "raw_tracepoint/filler/sys_accept4_e": [
               {
                 "function": "bpf_sys_accept4_e",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "raw_tracepoint/filler/sys_accept_x": [
               {
                 "function": "bpf_sys_accept_x",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "raw_tracepoint/filler/sys_access_e": [
               {
                 "function": "bpf_sys_access_e",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "raw_tracepoint/filler/sys_autofill": [
               {
                 "function": "bpf_sys_autofill",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "raw_tracepoint/filler/sys_bpf_x": [
               {
                 "function": "bpf_sys_bpf_x",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "raw_tracepoint/filler/sys_brk_munmap_mmap_x": [
               {
                 "function": "bpf_sys_brk_munmap_mmap_x",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "raw_tracepoint/filler/sys_chmod_x": [
               {
                 "function": "bpf_sys_chmod_x",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "raw_tracepoint/filler/sys_connect_x": [
               {
                 "function": "bpf_sys_connect_x",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "raw_tracepoint/filler/sys_creat_x": [
               {
                 "function": "bpf_sys_creat_x",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "raw_tracepoint/filler/sys_empty": [
               {
                 "function": "bpf_sys_empty",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "raw_tracepoint/filler/sys_eventfd_e": [
               {
                 "function": "bpf_sys_eventfd_e",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "raw_tracepoint/filler/sys_execve_e": [
               {
                 "function": "bpf_sys_execve_e",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "raw_tracepoint/filler/sys_fchmod_x": [
               {
                 "function": "bpf_sys_fchmod_x",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "raw_tracepoint/filler/sys_fchmodat_x": [
               {
                 "function": "bpf_sys_fchmodat_x",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "raw_tracepoint/filler/sys_fcntl_e": [
               {
                 "function": "bpf_sys_fcntl_e",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "raw_tracepoint/filler/sys_flock_e": [
               {
                 "function": "bpf_sys_flock_e",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "raw_tracepoint/filler/sys_futex_e": [
               {
                 "function": "bpf_sys_futex_e",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "raw_tracepoint/filler/sys_generic": [
               {
                 "function": "bpf_sys_generic",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "raw_tracepoint/filler/sys_getresuid_and_gid_x": [
               {
                 "function": "bpf_sys_getresuid_and_gid_x",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "raw_tracepoint/filler/sys_getrlimit_setrlimit_e": [
               {
                 "function": "bpf_sys_getrlimit_setrlimit_e",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "raw_tracepoint/filler/sys_getrlimit_setrlrimit_x": [
               {
                 "function": "bpf_sys_getrlimit_setrlrimit_x",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "raw_tracepoint/filler/sys_getsockopt_x": [
               {
                 "function": "bpf_sys_getsockopt_x",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "raw_tracepoint/filler/sys_linkat_x": [
               {
                 "function": "bpf_sys_linkat_x",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "raw_tracepoint/filler/sys_llseek_e": [
               {
                 "function": "bpf_sys_llseek_e",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "raw_tracepoint/filler/sys_lseek_e": [
               {
                 "function": "bpf_sys_lseek_e",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "raw_tracepoint/filler/sys_mkdirat_x": [
               {
                 "function": "bpf_sys_mkdirat_x",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "raw_tracepoint/filler/sys_mmap_e": [
               {
                 "function": "bpf_sys_mmap_e",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "raw_tracepoint/filler/sys_mount_e": [
               {
                 "function": "bpf_sys_mount_e",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "raw_tracepoint/filler/sys_nanosleep_e": [
               {
                 "function": "bpf_sys_nanosleep_e",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "raw_tracepoint/filler/sys_open_x": [
               {
                 "function": "bpf_sys_open_x",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "raw_tracepoint/filler/sys_openat_x": [
               {
                 "function": "bpf_sys_openat_x",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "raw_tracepoint/filler/sys_pagefault_e": [
               {
                 "function": "bpf_sys_pagefault_e",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "raw_tracepoint/filler/sys_pipe_x": [
               {
                 "function": "bpf_sys_pipe_x",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "raw_tracepoint/filler/sys_poll_e": [
               {
                 "function": "bpf_sys_poll_e",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "raw_tracepoint/filler/sys_poll_x": [
               {
                 "function": "bpf_sys_poll_x",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "raw_tracepoint/filler/sys_ppoll_e": [
               {
                 "function": "bpf_sys_ppoll_e",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "raw_tracepoint/filler/sys_pread64_e": [
               {
                 "function": "bpf_sys_pread64_e",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "raw_tracepoint/filler/sys_preadv64_e": [
               {
                 "function": "bpf_sys_preadv64_e",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "raw_tracepoint/filler/sys_prlimit_e": [
               {
                 "function": "bpf_sys_prlimit_e",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "raw_tracepoint/filler/sys_prlimit_x": [
               {
                 "function": "bpf_sys_prlimit_x",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "raw_tracepoint/filler/sys_procexit_e": [
               {
                 "function": "bpf_sys_procexit_e",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "raw_tracepoint/filler/sys_ptrace_e": [
               {
                 "function": "bpf_sys_ptrace_e",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "raw_tracepoint/filler/sys_ptrace_x": [
               {
                 "function": "bpf_sys_ptrace_x",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "raw_tracepoint/filler/sys_pwrite64_e": [
               {
                 "function": "bpf_sys_pwrite64_e",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "raw_tracepoint/filler/sys_pwritev_e": [
               {
                 "function": "bpf_sys_pwritev_e",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "raw_tracepoint/filler/sys_quotactl_e": [
               {
                 "function": "bpf_sys_quotactl_e",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "raw_tracepoint/filler/sys_quotactl_x": [
               {
                 "function": "bpf_sys_quotactl_x",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "raw_tracepoint/filler/sys_read_x": [
               {
                 "function": "bpf_sys_read_x",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "raw_tracepoint/filler/sys_readv_preadv_x": [
               {
                 "function": "bpf_sys_readv_preadv_x",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "raw_tracepoint/filler/sys_recv_x": [
               {
                 "function": "bpf_sys_recv_x",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "raw_tracepoint/filler/sys_recvfrom_x": [
               {
                 "function": "bpf_sys_recvfrom_x",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "raw_tracepoint/filler/sys_recvmsg_x": [
               {
                 "function": "bpf_sys_recvmsg_x",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "raw_tracepoint/filler/sys_recvmsg_x_2": [
               {
                 "function": "bpf_sys_recvmsg_x_2",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "raw_tracepoint/filler/sys_renameat2_x": [
               {
                 "function": "bpf_sys_renameat2_x",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "raw_tracepoint/filler/sys_renameat_x": [
               {
                 "function": "bpf_sys_renameat_x",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "raw_tracepoint/filler/sys_semctl_e": [
               {
                 "function": "bpf_sys_semctl_e",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "raw_tracepoint/filler/sys_semget_e": [
               {
                 "function": "bpf_sys_semget_e",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "raw_tracepoint/filler/sys_semop_x": [
               {
                 "function": "bpf_sys_semop_x",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "raw_tracepoint/filler/sys_send_e": [
               {
                 "function": "bpf_sys_send_e",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "raw_tracepoint/filler/sys_send_x": [
               {
                 "function": "bpf_sys_send_x",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "raw_tracepoint/filler/sys_sendfile_e": [
               {
                 "function": "bpf_sys_sendfile_e",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "raw_tracepoint/filler/sys_sendfile_x": [
               {
                 "function": "bpf_sys_sendfile_x",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "raw_tracepoint/filler/sys_sendmsg_e": [
               {
                 "function": "bpf_sys_sendmsg_e",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "raw_tracepoint/filler/sys_sendmsg_x": [
               {
                 "function": "bpf_sys_sendmsg_x",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "raw_tracepoint/filler/sys_sendto_e": [
               {
                 "function": "bpf_sys_sendto_e",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "raw_tracepoint/filler/sys_setns_e": [
               {
                 "function": "bpf_sys_setns_e",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "raw_tracepoint/filler/sys_setsockopt_x": [
               {
                 "function": "bpf_sys_setsockopt_x",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "raw_tracepoint/filler/sys_shutdown_e": [
               {
                 "function": "bpf_sys_shutdown_e",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "raw_tracepoint/filler/sys_signaldeliver_e": [
               {
                 "function": "bpf_sys_signaldeliver_e",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "raw_tracepoint/filler/sys_single": [
               {
                 "function": "bpf_sys_single",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "raw_tracepoint/filler/sys_single_x": [
               {
                 "function": "bpf_sys_single_x",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "raw_tracepoint/filler/sys_socket_bind_x": [
               {
                 "function": "bpf_sys_socket_bind_x",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "raw_tracepoint/filler/sys_socket_x": [
               {
                 "function": "bpf_sys_socket_x",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "raw_tracepoint/filler/sys_socketpair_x": [
               {
                 "function": "bpf_sys_socketpair_x",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "raw_tracepoint/filler/sys_symlinkat_x": [
               {
                 "function": "bpf_sys_symlinkat_x",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "raw_tracepoint/filler/sys_sysdigevent_e": [
               {
                 "function": "bpf_sys_sysdigevent_e",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "raw_tracepoint/filler/sys_unlinkat_x": [
               {
                 "function": "bpf_sys_unlinkat_x",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "raw_tracepoint/filler/sys_unshare_e": [
               {
                 "function": "bpf_sys_unshare_e",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "raw_tracepoint/filler/sys_write_x": [
               {
                 "function": "bpf_sys_write_x",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "raw_tracepoint/filler/sys_writev_e": [
               {
                 "function": "bpf_sys_writev_e",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "raw_tracepoint/filler/sys_writev_pwritev_x": [
               {
                 "function": "bpf_sys_writev_pwritev_x",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "raw_tracepoint/filler/terminate_filler": [
               {
                 "function": "bpf_terminate_filler",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "raw_tracepoint/page_fault_kernel": [
               {
                 "function": "bpf_page_fault_kernel",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "raw_tracepoint/page_fault_user": [
               {
                 "function": "bpf_page_fault_user",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "raw_tracepoint/sched_process_exit": [
               {
                 "function": "bpf_sched_process_exit",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "raw_tracepoint/sched_switch": [
               {
                 "function": "bpf_sched_switch",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "raw_tracepoint/signal_deliver": [
               {
                 "function": "bpf_signal_deliver",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "raw_tracepoint/sys_enter": [
               {
                 "function": "bpf_sys_enter",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "raw_tracepoint/sys_exit": [
               {
                 "function": "bpf_sys_exit",
-                "invalid": false
+                "reject_load": false
               }
             ]
           },
@@ -5718,29 +5718,29 @@
             "cgroup/connect4": [
               {
                 "function": "authorize_connect4",
-                "invalid": true,
-                "invalid_reason": "Unsupported or invalid CO-RE/BTF relocation data: Invalid .BTF section - invalid BTF_KIND - 0"
+                "reject_load": true,
+                "reject_load_reason": "Unsupported or invalid CO-RE/BTF relocation data: Invalid .BTF section - invalid BTF_KIND - 0"
               }
             ],
             "cgroup/connect6": [
               {
                 "function": "authorize_connect6",
-                "invalid": true,
-                "invalid_reason": "Unsupported or invalid CO-RE/BTF relocation data: Invalid .BTF section - invalid BTF_KIND - 0"
+                "reject_load": true,
+                "reject_load_reason": "Unsupported or invalid CO-RE/BTF relocation data: Invalid .BTF section - invalid BTF_KIND - 0"
               }
             ],
             "cgroup/recv_accept4": [
               {
                 "function": "cgroup/recv_accept4",
-                "invalid": true,
-                "invalid_reason": "Unsupported or invalid CO-RE/BTF relocation data: Invalid .BTF section - invalid BTF_KIND - 0"
+                "reject_load": true,
+                "reject_load_reason": "Unsupported or invalid CO-RE/BTF relocation data: Invalid .BTF section - invalid BTF_KIND - 0"
               }
             ],
             "cgroup/recv_accept6": [
               {
                 "function": "authorize_recv_accept6",
-                "invalid": true,
-                "invalid_reason": "Unsupported or invalid CO-RE/BTF relocation data: Invalid .BTF section - invalid BTF_KIND - 0"
+                "reject_load": true,
+                "reject_load_reason": "Unsupported or invalid CO-RE/BTF relocation data: Invalid .BTF section - invalid BTF_KIND - 0"
               }
             ]
           },
@@ -5770,7 +5770,7 @@
             "xdp": [
               {
                 "function": "DropPacket",
-                "invalid": false
+                "reject_load": false
               }
             ]
           },
@@ -5801,29 +5801,29 @@
             "cgroup/connect4": [
               {
                 "function": "authorize_connect4",
-                "invalid": true,
-                "invalid_reason": "Unsupported or invalid CO-RE/BTF relocation data: Invalid .BTF section - invalid BTF_KIND - 0"
+                "reject_load": true,
+                "reject_load_reason": "Unsupported or invalid CO-RE/BTF relocation data: Invalid .BTF section - invalid BTF_KIND - 0"
               }
             ],
             "cgroup/connect6": [
               {
                 "function": "authorize_connect6",
-                "invalid": true,
-                "invalid_reason": "Unsupported or invalid CO-RE/BTF relocation data: Invalid .BTF section - invalid BTF_KIND - 0"
+                "reject_load": true,
+                "reject_load_reason": "Unsupported or invalid CO-RE/BTF relocation data: Invalid .BTF section - invalid BTF_KIND - 0"
               }
             ],
             "cgroup/recv_accept4": [
               {
                 "function": "cgroup/recv_accept4",
-                "invalid": true,
-                "invalid_reason": "Unsupported or invalid CO-RE/BTF relocation data: Invalid .BTF section - invalid BTF_KIND - 0"
+                "reject_load": true,
+                "reject_load_reason": "Unsupported or invalid CO-RE/BTF relocation data: Invalid .BTF section - invalid BTF_KIND - 0"
               }
             ],
             "cgroup/recv_accept6": [
               {
                 "function": "authorize_recv_accept6",
-                "invalid": true,
-                "invalid_reason": "Unsupported or invalid CO-RE/BTF relocation data: Invalid .BTF section - invalid BTF_KIND - 0"
+                "reject_load": true,
+                "reject_load_reason": "Unsupported or invalid CO-RE/BTF relocation data: Invalid .BTF section - invalid BTF_KIND - 0"
               }
             ]
           },
@@ -5853,16 +5853,16 @@
             "xdp_prog": [
               {
                 "function": "lookup_update",
-                "invalid": false
+                "reject_load": false
               }
             ]
           },
           "test_overrides": {
             "sections": {
               "xdp_prog": {
-                "status": "expected_failure",
                 "kind": "VerifierMapTyping",
-                "reason": "Map-in-map lookup chains not supported"
+                "reason": "Map-in-map lookup chains not supported",
+                "status": "expected_failure"
               }
             }
           }
@@ -5886,7 +5886,7 @@
             ".text": [
               {
                 "function": "func",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -5900,7 +5900,7 @@
             "bind": [
               {
                 "function": "BindMonitor",
-                "invalid": false
+                "reject_load": false
               }
             ]
           },
@@ -5921,7 +5921,7 @@
             ".text": [
               {
                 "function": "func",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -5935,7 +5935,7 @@
             ".text": [
               {
                 "function": "func",
-                "invalid": false
+                "reject_load": false
               }
             ]
           },
@@ -5956,217 +5956,217 @@
             "bind": [
               {
                 "function": "bind_test_caller",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "bind/0": [
               {
                 "function": "bind_test_callee0",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "bind/1": [
               {
                 "function": "bind_test_callee1",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "bind/10": [
               {
                 "function": "bind_test_callee10",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "bind/11": [
               {
                 "function": "bind_test_callee11",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "bind/12": [
               {
                 "function": "bind_test_callee12",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "bind/13": [
               {
                 "function": "bind_test_callee13",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "bind/14": [
               {
                 "function": "bind_test_callee14",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "bind/15": [
               {
                 "function": "bind_test_callee15",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "bind/16": [
               {
                 "function": "bind_test_callee16",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "bind/17": [
               {
                 "function": "bind_test_callee17",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "bind/18": [
               {
                 "function": "bind_test_callee18",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "bind/19": [
               {
                 "function": "bind_test_callee19",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "bind/2": [
               {
                 "function": "bind_test_callee2",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "bind/20": [
               {
                 "function": "bind_test_callee20",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "bind/21": [
               {
                 "function": "bind_test_callee21",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "bind/22": [
               {
                 "function": "bind_test_callee22",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "bind/23": [
               {
                 "function": "bind_test_callee23",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "bind/24": [
               {
                 "function": "bind_test_callee24",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "bind/25": [
               {
                 "function": "bind_test_callee25",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "bind/26": [
               {
                 "function": "bind_test_callee26",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "bind/27": [
               {
                 "function": "bind_test_callee27",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "bind/28": [
               {
                 "function": "bind_test_callee28",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "bind/29": [
               {
                 "function": "bind_test_callee29",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "bind/3": [
               {
                 "function": "bind_test_callee3",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "bind/30": [
               {
                 "function": "bind_test_callee30",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "bind/31": [
               {
                 "function": "bind_test_callee31",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "bind/32": [
               {
                 "function": "bind_test_callee32",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "bind/33": [
               {
                 "function": "bind_test_callee33",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "bind/34": [
               {
                 "function": "bind_test_callee34",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "bind/4": [
               {
                 "function": "bind_test_callee4",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "bind/5": [
               {
                 "function": "bind_test_callee5",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "bind/6": [
               {
                 "function": "bind_test_callee6",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "bind/7": [
               {
                 "function": "bind_test_callee7",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "bind/8": [
               {
                 "function": "bind_test_callee8",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "bind/9": [
               {
                 "function": "bind_test_callee9",
-                "invalid": false
+                "reject_load": false
               }
             ]
           },
@@ -6297,7 +6297,7 @@
             "xdp": [
               {
                 "function": "xdp_root",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -6316,13 +6316,13 @@
             "tp/sched/sched_process_exec": [
               {
                 "function": "handle_exec",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "tp/sched/sched_process_exit": [
               {
                 "function": "handle_exit",
-                "invalid": false
+                "reject_load": false
               }
             ]
           },
@@ -6350,13 +6350,13 @@
             "tp/sched/sched_process_exec": [
               {
                 "function": "handle_exec",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "tp/sched/sched_process_exit": [
               {
                 "function": "handle_exit",
-                "invalid": false
+                "reject_load": false
               }
             ]
           },
@@ -6379,13 +6379,13 @@
             "fentry/do_unlinkat": [
               {
                 "function": "do_unlinkat",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "fexit/do_unlinkat": [
               {
                 "function": "do_unlinkat_exit",
-                "invalid": false
+                "reject_load": false
               }
             ]
           },
@@ -6413,13 +6413,13 @@
             "kprobe/do_unlinkat": [
               {
                 "function": "do_unlinkat",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "kretprobe/do_unlinkat": [
               {
                 "function": "do_unlinkat_exit",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -6433,13 +6433,13 @@
             "ksyscall/kill": [
               {
                 "function": "entry_probe",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "ksyscall/tgkill": [
               {
                 "function": "tgkill_entry",
-                "invalid": false
+                "reject_load": false
               }
             ]
           },
@@ -6467,7 +6467,7 @@
             "lsm/bpf": [
               {
                 "function": "lsm_bpf",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -6481,7 +6481,7 @@
             "tp/syscalls/sys_enter_write": [
               {
                 "function": "handle_tp",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -6495,7 +6495,7 @@
             "tp/syscalls/sys_enter_write": [
               {
                 "function": "handle_tp",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -6509,7 +6509,7 @@
             "tp/syscalls/sys_enter_write": [
               {
                 "function": "handle_tp",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -6523,7 +6523,7 @@
             "perf_event": [
               {
                 "function": "profile",
-                "invalid": false
+                "reject_load": false
               }
             ]
           },
@@ -6546,7 +6546,7 @@
             "socket": [
               {
                 "function": "socket_handler",
-                "invalid": false
+                "reject_load": false
               }
             ]
           },
@@ -6569,7 +6569,7 @@
             "iter/task": [
               {
                 "function": "get_tasks",
-                "invalid": false
+                "reject_load": false
               }
             ]
           },
@@ -6592,7 +6592,7 @@
             "tc": [
               {
                 "function": "tc_ingress",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -6606,25 +6606,25 @@
             "uprobe": [
               {
                 "function": "uprobe_add",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "uprobe//proc/self/exe:uprobed_sub": [
               {
                 "function": "uprobe_sub",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "uretprobe": [
               {
                 "function": "uretprobe_add",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "uretprobe//proc/self/exe:uprobed_sub": [
               {
                 "function": "uretprobe_sub",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -6638,27 +6638,27 @@
             ".text": [
               {
                 "function": "bpf_usdt_arg",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "bpf_usdt_arg_cnt",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "bpf_usdt_cookie",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "usdt": [
               {
                 "function": "usdt_manual_attach",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "usdt/libc.so.6:libc:setjmp": [
               {
                 "function": "usdt_auto_attach",
-                "invalid": false
+                "reject_load": false
               }
             ]
           },
@@ -6700,13 +6700,13 @@
             "tracepoint/power/cpu_frequency": [
               {
                 "function": "tracepoint/power/cpu_frequency",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "tracepoint/power/cpu_idle": [
               {
                 "function": "tracepoint/power/cpu_idle",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -6720,13 +6720,13 @@
             "kprobe/trace_preempt_off": [
               {
                 "function": "kprobe/trace_preempt_off",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "kprobe/trace_preempt_on": [
               {
                 "function": "kprobe/trace_preempt_on",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -6740,7 +6740,7 @@
             "len_hist": [
               {
                 "function": "len_hist",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -6754,49 +6754,49 @@
             "kprobe/sys_connect": [
               {
                 "function": "kprobe/sys_connect",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "kprobe/sys_getegid": [
               {
                 "function": "kprobe/sys_getegid",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "kprobe/sys_geteuid": [
               {
                 "function": "kprobe/sys_geteuid",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "kprobe/sys_getgid": [
               {
                 "function": "kprobe/sys_getgid",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "kprobe/sys_getpgid": [
               {
                 "function": "kprobe/sys_getpgid",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "kprobe/sys_getppid": [
               {
                 "function": "kprobe/sys_getppid",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "kprobe/sys_gettid": [
               {
                 "function": "kprobe/sys_gettid",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "kprobe/sys_getuid": [
               {
                 "function": "kprobe/sys_getuid",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -6810,13 +6810,13 @@
             "kprobe/try_to_wake_up": [
               {
                 "function": "kprobe/try_to_wake_up",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "tracepoint/sched/sched_switch": [
               {
                 "function": "tracepoint/sched/sched_switch",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -6830,7 +6830,7 @@
             "perf_event": [
               {
                 "function": "perf_event",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -6844,13 +6844,13 @@
             "cgroup/sock1": [
               {
                 "function": "cgroup/sock1",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "cgroup/sock2": [
               {
                 "function": "cgroup/sock2",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -6864,7 +6864,7 @@
             "socket1": [
               {
                 "function": "socket1",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -6878,7 +6878,7 @@
             "socket2": [
               {
                 "function": "socket2",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -6892,31 +6892,31 @@
             "socket/0": [
               {
                 "function": "socket/0",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "socket/1": [
               {
                 "function": "socket/1",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "socket/2": [
               {
                 "function": "socket/2",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "socket/3": [
               {
                 "function": "socket/3",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "socket/4": [
               {
                 "function": "socket/4",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -6930,103 +6930,103 @@
             "kprobe/__htab_percpu_map_update_elem": [
               {
                 "function": "kprobe/__htab_percpu_map_update_elem",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "kprobe/_raw_spin_lock": [
               {
                 "function": "kprobe/_raw_spin_lock",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "kprobe/_raw_spin_lock_bh": [
               {
                 "function": "kprobe/_raw_spin_lock_bh",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "kprobe/_raw_spin_lock_irq": [
               {
                 "function": "kprobe/_raw_spin_lock_irq",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "kprobe/_raw_spin_lock_irqsave": [
               {
                 "function": "kprobe/_raw_spin_lock_irqsave",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "kprobe/_raw_spin_trylock": [
               {
                 "function": "kprobe/_raw_spin_trylock",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "kprobe/_raw_spin_trylock_bh": [
               {
                 "function": "kprobe/_raw_spin_trylock_bh",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "kprobe/_raw_spin_unlock": [
               {
                 "function": "kprobe/_raw_spin_unlock",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "kprobe/_raw_spin_unlock_bh": [
               {
                 "function": "kprobe/_raw_spin_unlock_bh",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "kprobe/_raw_spin_unlock_irqrestore": [
               {
                 "function": "kprobe/_raw_spin_unlock_irqrestore",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "kprobe/htab_map_alloc": [
               {
                 "function": "kprobe/htab_map_alloc",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "kprobe/htab_map_update_elem": [
               {
                 "function": "kprobe/htab_map_update_elem",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "kprobe/mutex_spin_on_owner": [
               {
                 "function": "kprobe/mutex_spin_on_owner",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "kprobe/rwsem_spin_on_owner": [
               {
                 "function": "kprobe/rwsem_spin_on_owner",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "kprobe/spin_lock": [
               {
                 "function": "kprobe/spin_lock",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "kprobe/spin_unlock": [
               {
                 "function": "kprobe/spin_unlock",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "kprobe/spin_unlock_irqrestore": [
               {
                 "function": "kprobe/spin_unlock_irqrestore",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -7040,13 +7040,13 @@
             "tracepoint/syscalls/sys_enter_open": [
               {
                 "function": "tracepoint/syscalls/sys_enter_open",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "tracepoint/syscalls/sys_exit_open": [
               {
                 "function": "tracepoint/syscalls/sys_exit_open",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -7060,13 +7060,13 @@
             "kprobe/blk_start_request": [
               {
                 "function": "kprobe/blk_start_request",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "kretprobe/blk_account_io_completion": [
               {
                 "function": "kretprobe/blk_account_io_completion",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -7080,25 +7080,25 @@
             "drop_non_tun_vip": [
               {
                 "function": "drop_non_tun_vip",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "l2_to_ip6tun_ingress_redirect": [
               {
                 "function": "l2_to_ip6tun_ingress_redirect",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "l2_to_iptun_ingress_forward": [
               {
                 "function": "l2_to_iptun_ingress_forward",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "l2_to_iptun_ingress_redirect": [
               {
                 "function": "l2_to_iptun_ingress_redirect",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -7112,31 +7112,31 @@
             "classifier": [
               {
                 "function": "classifier",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "clone_redirect_recv": [
               {
                 "function": "clone_redirect_recv",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "clone_redirect_xmit": [
               {
                 "function": "clone_redirect_xmit",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "redirect_recv": [
               {
                 "function": "redirect_recv",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "redirect_xmit": [
               {
                 "function": "redirect_xmit",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -7150,7 +7150,7 @@
             "sockops": [
               {
                 "function": "sockops",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -7164,7 +7164,7 @@
             "sockops": [
               {
                 "function": "sockops",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -7178,7 +7178,7 @@
             "sockops": [
               {
                 "function": "sockops",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -7192,7 +7192,7 @@
             "sockops": [
               {
                 "function": "sockops",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -7206,7 +7206,7 @@
             "sockops": [
               {
                 "function": "sockops",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -7220,7 +7220,7 @@
             "sockops": [
               {
                 "function": "sockops",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -7234,7 +7234,7 @@
             "sockops": [
               {
                 "function": "sockops",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -7248,7 +7248,7 @@
             "filter": [
               {
                 "function": "filter",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -7262,7 +7262,7 @@
             "kprobe/sys_sync": [
               {
                 "function": "kprobe/sys_sync",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -7276,7 +7276,7 @@
             "kprobe/sys_connect": [
               {
                 "function": "kprobe/sys_connect",
-                "invalid": false
+                "reject_load": false
               }
             ]
           },
@@ -7299,13 +7299,13 @@
             "kprobe/__set_task_comm": [
               {
                 "function": "kprobe/__set_task_comm",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "kprobe/urandom_read": [
               {
                 "function": "kprobe/urandom_read",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -7319,13 +7319,13 @@
             "raw_tracepoint/task_rename": [
               {
                 "function": "raw_tracepoint/task_rename",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "raw_tracepoint/urandom_read": [
               {
                 "function": "raw_tracepoint/urandom_read",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -7339,13 +7339,13 @@
             "tracepoint/random/urandom_read": [
               {
                 "function": "tracepoint/random/urandom_read",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "tracepoint/task/task_rename": [
               {
                 "function": "tracepoint/task/task_rename",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -7359,7 +7359,7 @@
             "kprobe/sys_connect": [
               {
                 "function": "kprobe/sys_connect",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -7373,7 +7373,7 @@
             "perf_event": [
               {
                 "function": "perf_event",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -7387,7 +7387,7 @@
             "kprobe/sys_write": [
               {
                 "function": "kprobe/sys_write",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -7401,7 +7401,7 @@
             "kprobe/__netif_receive_skb_core": [
               {
                 "function": "kprobe/__netif_receive_skb_core",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -7415,13 +7415,13 @@
             "kprobe/kfree_skb": [
               {
                 "function": "kprobe/kfree_skb",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "kprobe/sys_write": [
               {
                 "function": "kprobe/sys_write",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -7435,13 +7435,13 @@
             "kprobe/blk_account_io_completion": [
               {
                 "function": "kprobe/blk_account_io_completion",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "kprobe/blk_start_request": [
               {
                 "function": "kprobe/blk_start_request",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -7455,13 +7455,13 @@
             "kprobe/kmem_cache_free": [
               {
                 "function": "kprobe/kmem_cache_free",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "kretprobe/kmem_cache_alloc_node": [
               {
                 "function": "kretprobe/kmem_cache_alloc_node",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -7475,25 +7475,25 @@
             "kprobe/0": [
               {
                 "function": "kprobe/0",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "kprobe/1": [
               {
                 "function": "kprobe/1",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "kprobe/9": [
               {
                 "function": "kprobe/9",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "kprobe/__seccomp_filter": [
               {
                 "function": "kprobe/__seccomp_filter",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -7507,13 +7507,13 @@
             "kprobe/htab_map_get_next_key": [
               {
                 "function": "kprobe/htab_map_get_next_key",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "kprobe/htab_map_lookup_elem": [
               {
                 "function": "kprobe/htab_map_lookup_elem",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -7527,7 +7527,7 @@
             "kprobe/open_ctree": [
               {
                 "function": "kprobe/open_ctree",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -7541,7 +7541,7 @@
             "xdp1": [
               {
                 "function": "xdp1",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -7555,7 +7555,7 @@
             "xdp1": [
               {
                 "function": "xdp1",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -7569,13 +7569,13 @@
             "tc_mark": [
               {
                 "function": "tc_mark",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "xdp_mark": [
               {
                 "function": "xdp_mark",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -7589,7 +7589,7 @@
             "xdp_icmp": [
               {
                 "function": "xdp_icmp",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -7603,13 +7603,13 @@
             "xdp_fwd": [
               {
                 "function": "xdp_fwd",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "xdp_fwd_direct": [
               {
                 "function": "xdp_fwd_direct",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -7623,49 +7623,49 @@
             "tracepoint/xdp/xdp_cpumap_enqueue": [
               {
                 "function": "tracepoint/xdp/xdp_cpumap_enqueue",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "tracepoint/xdp/xdp_cpumap_kthread": [
               {
                 "function": "tracepoint/xdp/xdp_cpumap_kthread",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "tracepoint/xdp/xdp_devmap_xmit": [
               {
                 "function": "tracepoint/xdp/xdp_devmap_xmit",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "tracepoint/xdp/xdp_exception": [
               {
                 "function": "tracepoint/xdp/xdp_exception",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "tracepoint/xdp/xdp_redirect": [
               {
                 "function": "tracepoint/xdp/xdp_redirect",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "tracepoint/xdp/xdp_redirect_err": [
               {
                 "function": "tracepoint/xdp/xdp_redirect_err",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "tracepoint/xdp/xdp_redirect_map": [
               {
                 "function": "tracepoint/xdp/xdp_redirect_map",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "tracepoint/xdp/xdp_redirect_map_err": [
               {
                 "function": "tracepoint/xdp/xdp_redirect_map_err",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -7679,67 +7679,67 @@
             "tracepoint/xdp/xdp_cpumap_enqueue": [
               {
                 "function": "tracepoint/xdp/xdp_cpumap_enqueue",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "tracepoint/xdp/xdp_cpumap_kthread": [
               {
                 "function": "tracepoint/xdp/xdp_cpumap_kthread",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "tracepoint/xdp/xdp_exception": [
               {
                 "function": "tracepoint/xdp/xdp_exception",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "tracepoint/xdp/xdp_redirect_err": [
               {
                 "function": "tracepoint/xdp/xdp_redirect_err",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "tracepoint/xdp/xdp_redirect_map_err": [
               {
                 "function": "tracepoint/xdp/xdp_redirect_map_err",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "xdp_cpu_map0": [
               {
                 "function": "xdp_cpu_map0",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "xdp_cpu_map1_touch_data": [
               {
                 "function": "xdp_cpu_map1_touch_data",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "xdp_cpu_map2_round_robin": [
               {
                 "function": "xdp_cpu_map2_round_robin",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "xdp_cpu_map3_proto_separate": [
               {
                 "function": "xdp_cpu_map3_proto_separate",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "xdp_cpu_map4_ddos_filter_pktgen": [
               {
                 "function": "xdp_cpu_map4_ddos_filter_pktgen",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "xdp_cpu_map5_lb_hash_ip_pairs": [
               {
                 "function": "xdp_cpu_map5_lb_hash_ip_pairs",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -7753,13 +7753,13 @@
             "xdp_redirect": [
               {
                 "function": "xdp_redirect",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "xdp_redirect_dummy": [
               {
                 "function": "xdp_redirect_dummy",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -7773,13 +7773,13 @@
             "xdp_redirect_dummy": [
               {
                 "function": "xdp_redirect_dummy",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "xdp_redirect_map": [
               {
                 "function": "xdp_redirect_map",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -7793,7 +7793,7 @@
             "xdp_router_ipv4": [
               {
                 "function": "xdp_router_ipv4",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -7807,7 +7807,7 @@
             "xdp_prog0": [
               {
                 "function": "xdp_prog0",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -7821,7 +7821,7 @@
             "xdp_sample": [
               {
                 "function": "xdp_sample",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -7835,7 +7835,7 @@
             "xdp_tx_iptunnel": [
               {
                 "function": "xdp_tx_iptunnel",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -7849,7 +7849,7 @@
             "xdp_sock": [
               {
                 "function": "xdp_sock",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -7868,31 +7868,31 @@
             "raw_tp/sys_enter": [
               {
                 "function": "add",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "and",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "cmpxchg",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "or",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "sub",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "xchg",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "xor",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -7906,17 +7906,17 @@
             ".text": [
               {
                 "function": "check_elem",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "fentry/__x64_sys_getpgid": [
               {
                 "function": "check_bloom",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "inner_map",
-                "invalid": false
+                "reject_load": false
               }
             ]
           },
@@ -7953,38 +7953,38 @@
             "struct_ops": [
               {
                 "function": "bpf_cubic_acked",
-                "invalid": true,
-                "invalid_reason": "Subprogram not found: tcp_slow_start"
+                "reject_load": true,
+                "reject_load_reason": "Subprogram not found: tcp_slow_start"
               },
               {
                 "function": "bpf_cubic_cong_avoid",
-                "invalid": true,
-                "invalid_reason": "Subprogram not found: tcp_slow_start"
+                "reject_load": true,
+                "reject_load_reason": "Subprogram not found: tcp_slow_start"
               },
               {
                 "function": "bpf_cubic_cwnd_event",
-                "invalid": true,
-                "invalid_reason": "Subprogram not found: tcp_slow_start"
+                "reject_load": true,
+                "reject_load_reason": "Subprogram not found: tcp_slow_start"
               },
               {
                 "function": "bpf_cubic_init",
-                "invalid": true,
-                "invalid_reason": "Subprogram not found: tcp_slow_start"
+                "reject_load": true,
+                "reject_load_reason": "Subprogram not found: tcp_slow_start"
               },
               {
                 "function": "bpf_cubic_recalc_ssthresh",
-                "invalid": true,
-                "invalid_reason": "Subprogram not found: tcp_slow_start"
+                "reject_load": true,
+                "reject_load_reason": "Subprogram not found: tcp_slow_start"
               },
               {
                 "function": "bpf_cubic_state",
-                "invalid": true,
-                "invalid_reason": "Subprogram not found: tcp_slow_start"
+                "reject_load": true,
+                "reject_load_reason": "Subprogram not found: tcp_slow_start"
               },
               {
                 "function": "bpf_cubic_undo_cwnd",
-                "invalid": true,
-                "invalid_reason": "Subprogram not found: tcp_slow_start"
+                "reject_load": true,
+                "reject_load_reason": "Subprogram not found: tcp_slow_start"
               }
             ]
           },
@@ -8025,38 +8025,38 @@
             "struct_ops": [
               {
                 "function": "bpf_dctcp_cong_avoid",
-                "invalid": true,
-                "invalid_reason": "Subprogram not found: tcp_reno_cong_avoid"
+                "reject_load": true,
+                "reject_load_reason": "Subprogram not found: tcp_reno_cong_avoid"
               },
               {
                 "function": "bpf_dctcp_cwnd_event",
-                "invalid": true,
-                "invalid_reason": "Subprogram not found: tcp_reno_cong_avoid"
+                "reject_load": true,
+                "reject_load_reason": "Subprogram not found: tcp_reno_cong_avoid"
               },
               {
                 "function": "bpf_dctcp_cwnd_undo",
-                "invalid": true,
-                "invalid_reason": "Subprogram not found: tcp_reno_cong_avoid"
+                "reject_load": true,
+                "reject_load_reason": "Subprogram not found: tcp_reno_cong_avoid"
               },
               {
                 "function": "bpf_dctcp_init",
-                "invalid": true,
-                "invalid_reason": "Subprogram not found: tcp_reno_cong_avoid"
+                "reject_load": true,
+                "reject_load_reason": "Subprogram not found: tcp_reno_cong_avoid"
               },
               {
                 "function": "bpf_dctcp_ssthresh",
-                "invalid": true,
-                "invalid_reason": "Subprogram not found: tcp_reno_cong_avoid"
+                "reject_load": true,
+                "reject_load_reason": "Subprogram not found: tcp_reno_cong_avoid"
               },
               {
                 "function": "bpf_dctcp_state",
-                "invalid": true,
-                "invalid_reason": "Subprogram not found: tcp_reno_cong_avoid"
+                "reject_load": true,
+                "reject_load_reason": "Subprogram not found: tcp_reno_cong_avoid"
               },
               {
                 "function": "bpf_dctcp_update_alpha",
-                "invalid": true,
-                "invalid_reason": "Subprogram not found: tcp_reno_cong_avoid"
+                "reject_load": true,
+                "reject_load_reason": "Subprogram not found: tcp_reno_cong_avoid"
               }
             ]
           },
@@ -8097,13 +8097,13 @@
             "fentry/__x64_sys_nanosleep": [
               {
                 "function": "nanosleep_fentry",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "fexit/__x64_sys_nanosleep": [
               {
                 "function": "nanosleep_fexit",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -8117,7 +8117,7 @@
             "freplace/get_constant": [
               {
                 "function": "security_new_get_constant",
-                "invalid": false
+                "reject_load": false
               }
             ]
           },
@@ -8140,7 +8140,7 @@
             "tracepoint/syscalls/sys_enter_nanosleep": [
               {
                 "function": "trace",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -8154,19 +8154,19 @@
             "fentry/eth_type_trans": [
               {
                 "function": "fentry_eth_type_trans",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "fexit/eth_type_trans": [
               {
                 "function": "fexit_eth_type_trans",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "tp_btf/kfree_skb": [
               {
                 "function": "trace_kfree_skb",
-                "invalid": false
+                "reject_load": false
               }
             ]
           },
@@ -8199,7 +8199,7 @@
             "raw_tracepoint/kfree_skb": [
               {
                 "function": "nested_loops",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -8213,7 +8213,7 @@
             "raw_tracepoint/consume_skb": [
               {
                 "function": "while_true",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -8227,7 +8227,7 @@
             "raw_tracepoint/consume_skb": [
               {
                 "function": "while_true",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -8241,7 +8241,7 @@
             "socket": [
               {
                 "function": "combinations",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -8255,7 +8255,7 @@
             "socket": [
               {
                 "function": "while_true",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -8269,86 +8269,86 @@
             ".text": [
               {
                 "function": "check",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "check_array_of_maps",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "check_cgroup_storage",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "check_cpumap",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "check_default_noinline",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "check_devmap",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "check_devmap_hash",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "check_hash_of_maps",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "check_lpm_trie",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "check_lru_percpu_hash",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "check_percpu_cgroup_storage",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "check_queue",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "check_reuseport_sockarray",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "check_ringbuf",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "check_sk_storage",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "check_sockhash",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "check_sockmap",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "check_stack",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "check_xskmap",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "cgroup_skb/egress": [
               {
                 "function": "cg_skb",
-                "invalid": true,
-                "invalid_reason": "Subprogram not found: bpf_map_sum_elem_count"
+                "reject_load": true,
+                "reject_load_reason": "Subprogram not found: bpf_map_sum_elem_count"
               }
             ]
           },
@@ -8468,19 +8468,19 @@
             "cgroup/connect6": [
               {
                 "function": "set_cookie",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "fexit/inet_stream_connect": [
               {
                 "function": "update_cookie_tracing",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "sockops": [
               {
                 "function": "update_cookie_sockops",
-                "invalid": false
+                "reject_load": false
               }
             ]
           },
@@ -8497,9 +8497,9 @@
                 "status": "expected_failure"
               },
               "sockops": {
-                "status": "expected_failure",
                 "kind": "VerifierTypeTracking",
-                "reason": "Socket type not tracked through sockops context access"
+                "reason": "Socket type not tracked through sockops context access",
+                "status": "expected_failure"
               }
             }
           }
@@ -8513,7 +8513,7 @@
             "sk_skb1": [
               {
                 "function": "bpf_prog1",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -8527,7 +8527,7 @@
             "sk_skb2": [
               {
                 "function": "bpf_prog2",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -8541,19 +8541,19 @@
             "tc": [
               {
                 "function": "classifier_0",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "classifier_1",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "classifier_2",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "entry",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -8567,27 +8567,27 @@
             "tc": [
               {
                 "function": "classifier_0",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "classifier_1",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "classifier_2",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "classifier_3",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "classifier_4",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "entry",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -8601,11 +8601,11 @@
             "tc": [
               {
                 "function": "classifier_0",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "entry",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -8619,25 +8619,25 @@
             ".text": [
               {
                 "function": "f0",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "f1",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "f2",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "f3",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "tc": [
               {
                 "function": "global_func1",
-                "invalid": false
+                "reject_load": false
               }
             ]
           },
@@ -8667,21 +8667,21 @@
             ".text": [
               {
                 "function": "bar",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "baz",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "foo",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "cgroup_skb/ingress": [
               {
                 "function": "test_cls",
-                "invalid": false
+                "reject_load": false
               }
             ]
           },
@@ -8711,35 +8711,35 @@
             ".text": [
               {
                 "function": "static_subprog",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "static_subprog_lock",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "static_subprog_unlock",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "cgroup_skb/ingress": [
               {
                 "function": "bpf_spin_lock_test",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "tc": [
               {
                 "function": "lock_static_subprog_call",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "lock_static_subprog_lock",
-                "invalid": false
+                "reject_load": false
               },
               {
                 "function": "lock_static_subprog_unlock",
-                "invalid": false
+                "reject_load": false
               }
             ]
           },
@@ -8767,13 +8767,13 @@
             "cgroup/sock1": [
               {
                 "function": "bpf_prog1",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "cgroup/sock2": [
               {
                 "function": "bpf_prog2",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -8787,7 +8787,7 @@
             "socket1": [
               {
                 "function": "bpf_prog1",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -8801,7 +8801,7 @@
             "socket2": [
               {
                 "function": "bpf_prog2",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -8815,31 +8815,31 @@
             "socket/0": [
               {
                 "function": "main_prog",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "socket/1": [
               {
                 "function": "bpf_func_PARSE_VLAN",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "socket/2": [
               {
                 "function": "bpf_func_PARSE_MPLS",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "socket/3": [
               {
                 "function": "bpf_func_PARSE_IP",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "socket/4": [
               {
                 "function": "bpf_func_PARSE_IPV6",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -8853,7 +8853,7 @@
             "kprobe/__x64_sys_write": [
               {
                 "function": "bpf_prog1",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -8867,7 +8867,7 @@
             "kprobe/__netif_receive_skb_core": [
               {
                 "function": "bpf_prog1",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -8881,13 +8881,13 @@
             "kprobe/__x64_sys_write": [
               {
                 "function": "bpf_prog3",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "kprobe/kfree_skb": [
               {
                 "function": "bpf_prog2",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -8901,13 +8901,13 @@
             "kprobe/blk_account_io_done": [
               {
                 "function": "bpf_prog2",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "kprobe/blk_mq_start_request": [
               {
                 "function": "bpf_prog1",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -8921,13 +8921,13 @@
             "kprobe/kmem_cache_free": [
               {
                 "function": "bpf_prog1",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "kretprobe/kmem_cache_alloc_node": [
               {
                 "function": "bpf_prog2",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -8941,13 +8941,13 @@
             "kprobe/htab_map_get_next_key": [
               {
                 "function": "bpf_prog1",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "kprobe/htab_map_lookup_elem": [
               {
                 "function": "bpf_prog2",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -8961,7 +8961,7 @@
             "kprobe/open_ctree": [
               {
                 "function": "bpf_prog1",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -8980,115 +8980,115 @@
             "af_xdp": [
               {
                 "function": "af_xdp",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "downcall": [
               {
                 "function": "downcall",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "egress": [
               {
                 "function": "egress",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "ingress": [
               {
                 "function": "ingress",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "tail-0": [
               {
                 "function": "tail-0",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "tail-1": [
               {
                 "function": "tail-1",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "tail-11": [
               {
                 "function": "tail-11",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "tail-12": [
               {
                 "function": "tail-12",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "tail-13": [
               {
                 "function": "tail-13",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "tail-2": [
               {
                 "function": "tail-2",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "tail-3": [
               {
                 "function": "tail-3",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "tail-32": [
               {
                 "function": "tail-32",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "tail-33": [
               {
                 "function": "tail-33",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "tail-35": [
               {
                 "function": "tail-35",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "tail-4": [
               {
                 "function": "tail-4",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "tail-5": [
               {
                 "function": "tail-5",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "tail-7": [
               {
                 "function": "tail-7",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "tail-8": [
               {
                 "function": "tail-8",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "xdp": [
               {
                 "function": "xdp",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -9107,25 +9107,25 @@
             "tracepoint/irq/softirq_entry": [
               {
                 "function": "tracepoint/irq/softirq_entry",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "tracepoint/irq/softirq_exit": [
               {
                 "function": "tracepoint/irq/softirq_exit",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "tracepoint/irq/softirq_raise": [
               {
                 "function": "tracepoint/irq/softirq_raise",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "tracepoint/napi/napi_poll": [
               {
                 "function": "tracepoint/napi/napi_poll",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -9139,7 +9139,7 @@
             "ingress_redirect": [
               {
                 "function": "ingress_redirect",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -9153,7 +9153,7 @@
             "xdp_bench01": [
               {
                 "function": "xdp_bench01",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -9167,7 +9167,7 @@
             "xdp_bench02": [
               {
                 "function": "xdp_bench02",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -9181,13 +9181,13 @@
             ".text": [
               {
                 "function": ".text",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "xdp_prog": [
               {
                 "function": "xdp_prog",
-                "invalid": false
+                "reject_load": false
               }
             ]
           },
@@ -9215,25 +9215,25 @@
             "tracepoint/xdp/xdp_redirect": [
               {
                 "function": "tracepoint/xdp/xdp_redirect",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "tracepoint/xdp/xdp_redirect_err": [
               {
                 "function": "tracepoint/xdp/xdp_redirect_err",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "tracepoint/xdp/xdp_redirect_map": [
               {
                 "function": "tracepoint/xdp/xdp_redirect_map",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "tracepoint/xdp/xdp_redirect_map_err": [
               {
                 "function": "tracepoint/xdp/xdp_redirect_map_err",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -9247,67 +9247,67 @@
             "tracepoint/xdp/xdp_cpumap_enqueue": [
               {
                 "function": "tracepoint/xdp/xdp_cpumap_enqueue",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "tracepoint/xdp/xdp_cpumap_kthread": [
               {
                 "function": "tracepoint/xdp/xdp_cpumap_kthread",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "tracepoint/xdp/xdp_exception": [
               {
                 "function": "tracepoint/xdp/xdp_exception",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "tracepoint/xdp/xdp_redirect_err": [
               {
                 "function": "tracepoint/xdp/xdp_redirect_err",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "tracepoint/xdp/xdp_redirect_map_err": [
               {
                 "function": "tracepoint/xdp/xdp_redirect_map_err",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "xdp_cpu_map0": [
               {
                 "function": "xdp_cpu_map0",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "xdp_cpu_map1_touch_data": [
               {
                 "function": "xdp_cpu_map1_touch_data",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "xdp_cpu_map2_round_robin": [
               {
                 "function": "xdp_cpu_map2_round_robin",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "xdp_cpu_map3_proto_separate": [
               {
                 "function": "xdp_cpu_map3_proto_separate",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "xdp_cpu_map4_ddos_filter_pktgen": [
               {
                 "function": "xdp_cpu_map4_ddos_filter_pktgen",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "xdp_cpu_map5_ip_l3_flow_hash": [
               {
                 "function": "xdp_cpu_map5_ip_l3_flow_hash",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -9321,19 +9321,19 @@
             "xdp_redirect_dummy": [
               {
                 "function": "xdp_redirect_dummy",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "xdp_redirect_map": [
               {
                 "function": "xdp_redirect_map",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "xdp_redirect_map_rr": [
               {
                 "function": "xdp_redirect_map_rr",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -9347,7 +9347,7 @@
             "xdp_tcpdump_to_perf_ring": [
               {
                 "function": "xdp_tcpdump_to_perf_ring",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -9361,7 +9361,7 @@
             "xdp_ttl": [
               {
                 "function": "xdp_ttl",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -9375,31 +9375,31 @@
             "tc_vlan_push": [
               {
                 "function": "tc_vlan_push",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "xdp_drop_vlan_4011": [
               {
                 "function": "xdp_drop_vlan_4011",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "xdp_vlan_change": [
               {
                 "function": "xdp_vlan_change",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "xdp_vlan_remove_outer": [
               {
                 "function": "xdp_vlan_remove_outer",
-                "invalid": false
+                "reject_load": false
               }
             ],
             "xdp_vlan_remove_outer2": [
               {
                 "function": "xdp_vlan_remove_outer2",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -9418,7 +9418,7 @@
             "filter": [
               {
                 "function": "filter",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -9432,7 +9432,7 @@
             "filter": [
               {
                 "function": "filter",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -9446,7 +9446,7 @@
             "loadbalancer": [
               {
                 "function": "loadbalancer",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -9460,7 +9460,7 @@
             "filter": [
               {
                 "function": "filter",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }
@@ -9474,7 +9474,7 @@
             "xdp": [
               {
                 "function": "xdp",
-                "invalid": false
+                "reject_load": false
               }
             ]
           }


### PR DESCRIPTION
## Summary

The CLI's `-l` output annotates programs that failed to load with `[invalid: …]`, which collides with two pre-existing meanings:

1. The ebpf-samples `invalid/` project (whose ELFs are intentionally malformed).
2. The broader "verifier rejected the program" usage.

`scripts/update_verify_expectations.py` already classifies these cases as `reject_load`; this PR applies that terminology consistently across the toolchain:

- `ElfProgramInfo::invalid` → `reject_load` (and `invalid_reason` → `reject_load_reason`).
- CLI emission `[invalid: …]` → `[reject_load: …]`.
- `generate_elf_inventory.py` regex and emitted JSON keys.
- `update_verify_expectations.py` reader and helper name.
- Keys in `test-data/elf_inventory.json` rewritten in place (the `invalid/` project _name_ is preserved — only the program-level boolean and reason keys were renamed).

Closes #1043.

## Test plan
- [x] `cmake --build build --target prevail-cli` succeeds
- [x] `bin/prevail -l ebpf-samples/invalid/<sample>` prints `[reject_load: …]`
- [x] `test-data/elf_inventory.json` still has `"invalid"` as a project name (1 occurrence) and 0 occurrences as a record key
- [ ] CI tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)