### PR TITLE
coverage: exclude src/test from lcov (#344)

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Generate code coverage report
         run: |
           mkdir coverage
-          lcov --ignore-errors all --capture --directory build --include "*/${REPO_NAME}/src/*" --output-file coverage/lcov.info
+          lcov --ignore-errors all --capture --directory build --include "*/${REPO_NAME}/src/*" --exclude "*/${REPO_NAME}/src/test/*" --output-file coverage/lcov.info
 
       - name: Coveralls Parallel
         uses: coverallsapp/github-action@master


### PR DESCRIPTION
## Summary

`.github/workflows/coverage.yml`'s lcov filter already includes only `*/<repo>/src/*`, so the external submodules in `external/` are out of scope. But `src/test/*` is still folded in and inflates the denominator. Add `--exclude "*/<repo>/src/test/*"` so the report covers library code only.

Closes #344.

> Note: coveralls' PR check appears silent right now (the upload step runs and reports `status: done`, but PR badges/comments don't show up). This PR doesn't address that — just makes the data we *do* submit correct.

## Test plan
- [x] Workflow YAML is syntactically valid (lcov flag added in line)
- [ ] After merge, the next coverage run reports a (smaller) denominator without `src/test/*`

🤖 Generated with [Claude Code](https://claude.com/claude-code)