### PR TITLE
Thread CallBtf::module through kfunc resolution

### DIFF
--- a/src/ir/call_resolver.cpp
+++ b/src/ir/call_resolver.cpp
@@ -76,7 +76,7 @@ ResolvedCall resolve_kfunc(const Call& call, const ProgramInfo& info) {
         return make_unsupported(call, std::to_string(call.func), "kfunc resolution is unavailable on this platform");
     }
     std::string why_not;
-    if (const auto c = info.platform->resolve_kfunc_call(call.func, info.type, &why_not)) {
+    if (const auto c = info.platform->resolve_kfunc_call(call.func, call.module, info.type, &why_not)) {
         // Stamp the key from our argument so the invariant is enforced here
         // rather than relying on every platform implementation to set it.
         ResolvedCall r = *c;

--- a/src/ir/call_resolver.hpp
+++ b/src/ir/call_resolver.hpp
@@ -7,10 +7,10 @@
 
 namespace prevail {
 
-/// Resolves a Call's (func, kind) key against a program's platform and type
-/// to produce the full ABI/diagnostic info:
+/// Resolves a Call's (func, kind, module) key against a program's platform and
+/// type to produce the full ABI/diagnostic info:
 ///   * CallKind::helper  -> platform.get_helper_prototype(func, type)
-///   * CallKind::kfunc   -> platform.resolve_kfunc_call(func, type)
+///   * CallKind::kfunc   -> platform.resolve_kfunc_call(func, module, type)
 ///   * CallKind::builtin -> platform.get_builtin_call(func)
 ///
 /// When resolution fails the returned ResolvedCall has is_supported == false

--- a/src/ir/cfg_builder.cpp
+++ b/src/ir/cfg_builder.cpp
@@ -171,7 +171,7 @@ static std::optional<ResolvedCall> resolve_kfunc_call(const CallBtf& call_btf, c
         }
         return std::nullopt;
     }
-    return info.platform->resolve_kfunc_call(call_btf.btf_id, info.type, why_not);
+    return info.platform->resolve_kfunc_call(call_btf.btf_id, call_btf.module, info.type, why_not);
 }
 
 // CallBtf in the instruction stream is replaced by a key-only Call{func,
@@ -317,7 +317,13 @@ static ResolvedKfuncCalls pass_resolve_kfunc_calls(const InstructionSeq& insts, 
         if (!r) {
             throw InvalidControlFlow{"not implemented: " + why_not + " (at " + to_string(label) + ")"};
         }
-        resolved.insert_or_assign(label, r->call);
+        // Stamp the key directly from the source CallBtf so we do not rely on
+        // every platform implementation to populate Call::module — two kfuncs
+        // sharing a BTF id across modules must remain distinguishable in the
+        // lowered IR.
+        Call lowered = r->call;
+        lowered.module = call_btf->module;
+        resolved.insert_or_assign(label, lowered);
     }
     return resolved;
 }

--- a/src/ir/cfg_builder.cpp
+++ b/src/ir/cfg_builder.cpp
@@ -317,12 +317,19 @@ static ResolvedKfuncCalls pass_resolve_kfunc_calls(const InstructionSeq& insts, 
         if (!r) {
             throw InvalidControlFlow{"not implemented: " + why_not + " (at " + to_string(label) + ")"};
         }
-        // Stamp the key directly from the source CallBtf so we do not rely on
-        // every platform implementation to populate Call::module — two kfuncs
-        // sharing a BTF id across modules must remain distinguishable in the
-        // lowered IR.
-        Call lowered = r->call;
-        lowered.module = call_btf->module;
+        // Build the lowered Call key directly from the source CallBtf rather
+        // than trusting any field the platform returned. The lowered IR's
+        // identity is the pre-resolution (btf_id, module) pair plus the fixed
+        // CallKind::kfunc tag; nothing else can soundly change it. Constructing
+        // the key here makes that invariant audit-visible and removes a class
+        // of bugs where a misbehaving resolver mis-keys the lowered IR — in
+        // particular, two kfuncs sharing a BTF id across modules must remain
+        // distinguishable.
+        const Call lowered{
+            .func = call_btf->btf_id,
+            .kind = CallKind::kfunc,
+            .module = call_btf->module,
+        };
         resolved.insert_or_assign(label, lowered);
     }
     return resolved;

--- a/src/ir/syntax.hpp
+++ b/src/ir/syntax.hpp
@@ -189,20 +189,26 @@ struct ArgPair {
 
 enum class CallKind {
     helper,  ///< Resolved via platform.get_helper_prototype(func, program_type).
-    kfunc,   ///< Resolved via platform.resolve_kfunc_call(btf_id, program_type).
+    kfunc,   ///< Resolved via platform.resolve_kfunc_call(btf_id, module, program_type).
     builtin, ///< Resolved via platform.get_builtin_call(func). Used for compiler
              ///< intrinsics (memset/memcpy/...) emitted at specific PCs where the
              ///< ELF loader flagged the call as a relocation target.
 };
 
-/// Static call to a helper / kfunc / compiler intrinsic. Pure key: the pair
-/// (func, kind) identifies the target given a ProgramInfo, and `resolve(call,
-/// info)` produces the full ResolvedCall with name, support status, and
-/// contract. Sibling key-only call instructions are `Callx` (register-indirect)
-/// and `CallBtf` (pre-resolution kfunc).
+/// Static call to a helper / kfunc / compiler intrinsic. Pure key: the triple
+/// (func, kind, module) identifies the target given a ProgramInfo, and
+/// `resolve(call, info)` produces the full ResolvedCall with name, support
+/// status, and contract. Sibling key-only call instructions are `Callx`
+/// (register-indirect) and `CallBtf` (pre-resolution kfunc).
+///
+/// `module` is only meaningful when `kind == CallKind::kfunc`: it carries the
+/// `CallBtf::module` from which this call was lowered, so that two kfuncs
+/// sharing the same BTF id across distinct kernel modules remain
+/// distinguishable. For helper and builtin calls the field is unused (0).
 struct Call {
     int32_t func{};
     CallKind kind{CallKind::helper};
+    int16_t module{};
 
     constexpr bool operator==(const Call&) const = default;
 };

--- a/src/linux/kfunc.cpp
+++ b/src/linux/kfunc.cpp
@@ -16,15 +16,23 @@ namespace {
 
 struct KfuncPrototypeEntry {
     int32_t btf_id{};
+    int16_t module{};
     EbpfHelperPrototype proto{};
     KfuncFlags flags = KfuncFlags::none;
     std::string_view required_program_type;
     bool requires_privileged = false;
 };
 
-constexpr std::array<KfuncPrototypeEntry, 12> kfunc_prototypes{{
+constexpr std::array<KfuncPrototypeEntry, 13> kfunc_prototypes{{
     {.btf_id = 12, .proto = {.name = "kfunc_test_id_overlap_tail_call", .return_type = EBPF_RETURN_TYPE_INTEGER}},
     {.btf_id = 1000, .proto = {.name = "kfunc_test_ret_int", .return_type = EBPF_RETURN_TYPE_INTEGER}},
+    // Same BTF id as the prior entry, but provided by a different kernel module.
+    // Used to verify that (btf_id, module) is the disambiguating key for kfunc
+    // resolution — without this, two kfuncs sharing a BTF id across modules
+    // would alias to the same prototype. See issue #1098.
+    {.btf_id = 1000,
+     .module = 1,
+     .proto = {.name = "kfunc_test_ret_int_other_module", .return_type = EBPF_RETURN_TYPE_INTEGER}},
     {.btf_id = 1001,
      .proto = {.name = "kfunc_test_ctx_arg",
                .return_type = EBPF_RETURN_TYPE_INTEGER,
@@ -60,9 +68,18 @@ constexpr std::array<KfuncPrototypeEntry, 12> kfunc_prototypes{{
     {.btf_id = 1010, .proto = {.name = "bpf_cpumask_release", .return_type = EBPF_RETURN_TYPE_INTEGER}},
 }};
 
-constexpr bool kfunc_prototypes_are_sorted_by_btf_id() {
+constexpr bool kfunc_prototypes_are_sorted_by_key() {
+    // Strict ordering on the (btf_id, module) pair: same btf_id is allowed
+    // across distinct modules, but no exact duplicates and no out-of-order
+    // pairs. This is what lets lookup_kfunc_prototype binary-search by btf_id
+    // and then linear-scan the (small) module run to disambiguate.
     for (size_t i = 1; i < kfunc_prototypes.size(); ++i) {
-        if (kfunc_prototypes[i - 1].btf_id >= kfunc_prototypes[i].btf_id) {
+        const auto& a = kfunc_prototypes[i - 1];
+        const auto& b = kfunc_prototypes[i];
+        if (a.btf_id > b.btf_id) {
+            return false;
+        }
+        if (a.btf_id == b.btf_id && a.module >= b.module) {
             return false;
         }
     }
@@ -78,15 +95,16 @@ constexpr bool kfunc_prototypes_have_names() {
     return true;
 }
 
-static_assert(kfunc_prototypes_are_sorted_by_btf_id(), "kfunc_prototypes must be strictly sorted by btf_id");
+static_assert(kfunc_prototypes_are_sorted_by_key(), "kfunc_prototypes must be strictly sorted by (btf_id, module)");
 static_assert(kfunc_prototypes_have_names(), "kfunc_prototypes entries must define proto.name");
 
-std::optional<KfuncPrototypeEntry> lookup_kfunc_prototype(const int32_t btf_id) {
-    const auto it =
-        std::lower_bound(kfunc_prototypes.begin(), kfunc_prototypes.end(), btf_id,
-                         [](const KfuncPrototypeEntry& entry, const int32_t id) { return entry.btf_id < id; });
-    if (it != kfunc_prototypes.end() && it->btf_id == btf_id) {
-        return *it;
+std::optional<KfuncPrototypeEntry> lookup_kfunc_prototype(const int32_t btf_id, const int16_t module) {
+    auto it = std::lower_bound(kfunc_prototypes.begin(), kfunc_prototypes.end(), btf_id,
+                               [](const KfuncPrototypeEntry& entry, const int32_t id) { return entry.btf_id < id; });
+    for (; it != kfunc_prototypes.end() && it->btf_id == btf_id; ++it) {
+        if (it->module == module) {
+            return *it;
+        }
     }
     return std::nullopt;
 }
@@ -99,17 +117,21 @@ void set_unsupported(std::string* why_not, const std::string& reason) {
 
 } // namespace
 
-std::optional<ResolvedCall> make_kfunc_call(const int32_t btf_id, const EbpfProgramType& program_type,
-                                            std::string* why_not) {
-    const auto entry = lookup_kfunc_prototype(btf_id);
+std::optional<ResolvedCall> make_kfunc_call(const int32_t btf_id, const int16_t module,
+                                            const EbpfProgramType& program_type, std::string* why_not) {
+    const auto entry = lookup_kfunc_prototype(btf_id, module);
     if (!entry) {
-        set_unsupported(why_not, "kfunc prototype lookup failed for BTF id " + std::to_string(btf_id));
+        std::string reason = "kfunc prototype lookup failed for BTF id " + std::to_string(btf_id);
+        if (module != 0) {
+            reason += " in module " + std::to_string(module);
+        }
+        set_unsupported(why_not, reason);
         return std::nullopt;
     }
     const auto& proto = entry->proto;
 
     ResolvedCall res;
-    res.call = Call{.func = btf_id, .kind = CallKind::kfunc};
+    res.call = Call{.func = btf_id, .kind = CallKind::kfunc, .module = module};
     res.name = proto.name;
     res.contract.reallocate_packet = proto.reallocate_packet;
     res.contract.is_map_lookup = proto.return_type == EBPF_RETURN_TYPE_PTR_TO_MAP_VALUE_OR_NULL;

--- a/src/linux/kfunc.hpp
+++ b/src/linux/kfunc.hpp
@@ -47,9 +47,12 @@ constexpr KfuncFlags& operator^=(KfuncFlags& a, const KfuncFlags b) {
     return a;
 }
 
-// Resolve a Linux kfunc BTF ID to a ResolvedCall used by the verifier.
-// Returns nullopt and populates `why_not` if the ID is unknown or currently unsupported.
-std::optional<ResolvedCall> make_kfunc_call(int32_t btf_id, const EbpfProgramType& program_type,
+// Resolve a Linux kfunc identified by (`btf_id`, `module`) to a ResolvedCall
+// used by the verifier. `module` is the kernel module identifier (0 == vmlinux),
+// matching `CallBtf::module`. BTF ids are not unique across modules, so callers
+// must pass both. Returns nullopt and populates `why_not` if the (btf_id, module)
+// pair is unknown or currently unsupported.
+std::optional<ResolvedCall> make_kfunc_call(int32_t btf_id, int16_t module, const EbpfProgramType& program_type,
                                             std::string* why_not = nullptr);
 
 } // namespace prevail

--- a/src/linux/linux_platform.cpp
+++ b/src/linux/linux_platform.cpp
@@ -350,9 +350,9 @@ const EbpfMapDescriptor& get_map_descriptor_linux(const int map_fd, const std::v
     throw UnmarshalError("map_fd " + std::to_string(map_fd) + " not found");
 }
 
-static std::optional<ResolvedCall> resolve_kfunc_call_linux(const int32_t btf_id, const EbpfProgramType& program_type,
-                                                            std::string* why_not) {
-    return make_kfunc_call(btf_id, program_type, why_not);
+static std::optional<ResolvedCall> resolve_kfunc_call_linux(const int32_t btf_id, const int16_t module,
+                                                            const EbpfProgramType& program_type, std::string* why_not) {
+    return make_kfunc_call(btf_id, module, program_type, why_not);
 }
 
 namespace {

--- a/src/platform.hpp
+++ b/src/platform.hpp
@@ -37,7 +37,12 @@ typedef std::optional<int32_t> (*ebpf_resolve_builtin_call_fn)(const std::string
 typedef std::optional<KsymBtfId> (*ebpf_resolve_ksym_btf_id_fn)(const std::string& name);
 typedef std::optional<ResolvedCall> (*ebpf_get_builtin_call_fn)(int32_t id);
 
-typedef std::optional<ResolvedCall> (*ebpf_resolve_kfunc_call_fn)(int32_t btf_id, const EbpfProgramType& program_type,
+// `module` identifies the kernel module providing the kfunc (0 == vmlinux),
+// matching `CallBtf::module`. It is passed alongside `btf_id` because BTF ids
+// are not unique across modules — two modules may legitimately use the same id
+// for different kfuncs.
+typedef std::optional<ResolvedCall> (*ebpf_resolve_kfunc_call_fn)(int32_t btf_id, int16_t module,
+                                                                  const EbpfProgramType& program_type,
                                                                   std::string* why_not);
 
 // Parse map records and allocate map fd's.

--- a/src/test/ebpf_yaml.cpp
+++ b/src/test/ebpf_yaml.cpp
@@ -69,12 +69,12 @@ static std::optional<ResolvedCall> ebpf_get_builtin_call(const int32_t id) {
     return g_ebpf_platform_linux.get_builtin_call(id);
 }
 
-static std::optional<ResolvedCall> ebpf_resolve_kfunc_call(const int32_t btf_id, const EbpfProgramType& program_type,
-                                                           std::string* why_not) {
+static std::optional<ResolvedCall> ebpf_resolve_kfunc_call(const int32_t btf_id, const int16_t module,
+                                                           const EbpfProgramType& program_type, std::string* why_not) {
     if (!g_ebpf_platform_linux.resolve_kfunc_call) {
         return std::nullopt;
     }
-    return g_ebpf_platform_linux.resolve_kfunc_call(btf_id, program_type, why_not);
+    return g_ebpf_platform_linux.resolve_kfunc_call(btf_id, module, program_type, why_not);
 }
 
 static void ebpf_parse_maps_section(vector<EbpfMapDescriptor>&, const char*, size_t, int, const ebpf_platform_t*,

--- a/src/test/test_marshal.cpp
+++ b/src/test/test_marshal.cpp
@@ -997,6 +997,52 @@ TEST_CASE("instruction feature handling after unmarshal", "[unmarshal]") {
         REQUIRE(verify(prog, {}));
     }
 
+    SECTION("kfunc resolution disambiguates same BTF id across modules") {
+        RawProgram vmlinux_raw{
+            "",
+            "",
+            0,
+            "",
+            {EbpfInst{.opcode = INST_OP_CALL, .src = INST_CALL_BTF_HELPER, .offset = 0, .imm = 1000}, exit},
+            info};
+        auto vmlinux_or_error = unmarshal(vmlinux_raw, {});
+        REQUIRE(std::holds_alternative<InstructionSeq>(vmlinux_or_error));
+        const Program vmlinux_prog = Program::from_sequence(std::get<InstructionSeq>(vmlinux_or_error), info, {});
+        const auto* vmlinux_call = std::get_if<Call>(&vmlinux_prog.instruction_at(Label{0}));
+        REQUIRE(vmlinux_call != nullptr);
+        REQUIRE(vmlinux_call->module == 0);
+        REQUIRE(resolve(*vmlinux_call, info).name == "kfunc_test_ret_int");
+
+        RawProgram module_raw{
+            "",
+            "",
+            0,
+            "",
+            {EbpfInst{.opcode = INST_OP_CALL, .src = INST_CALL_BTF_HELPER, .offset = 1, .imm = 1000}, exit},
+            info};
+        auto module_or_error = unmarshal(module_raw, {});
+        REQUIRE(std::holds_alternative<InstructionSeq>(module_or_error));
+        const Program module_prog = Program::from_sequence(std::get<InstructionSeq>(module_or_error), info, {});
+        const auto* module_call = std::get_if<Call>(&module_prog.instruction_at(Label{0}));
+        REQUIRE(module_call != nullptr);
+        REQUIRE(module_call->module == 1);
+        REQUIRE(resolve(*module_call, info).name == "kfunc_test_ret_int_other_module");
+
+        RawProgram unknown_module_raw{
+            "",
+            "",
+            0,
+            "",
+            {EbpfInst{.opcode = INST_OP_CALL, .src = INST_CALL_BTF_HELPER, .offset = 2, .imm = 1000}, exit},
+            info};
+        auto unknown_or_error = unmarshal(unknown_module_raw, {});
+        REQUIRE(std::holds_alternative<InstructionSeq>(unknown_or_error));
+        REQUIRE_THROWS_WITH(
+            Program::from_sequence(std::get<InstructionSeq>(unknown_or_error), info, {}),
+            Catch::Matchers::ContainsSubstring("kfunc prototype lookup failed for BTF id 1000 in module 2") &&
+                Catch::Matchers::ContainsSubstring("(at 0)"));
+    }
+
     SECTION("kfunc in subprogram is not misclassified when BTF id overlaps helper id") {
         RawProgram raw_prog{"",
                             "",


### PR DESCRIPTION
## Summary

When a `CallBtf` was lowered to a `Call` in `cfg_builder::pass_resolve_kfunc_calls`, only `btf_id` was forwarded to the platform's kfunc resolver — `CallBtf::module` was silently dropped. Because BTF ids are not unique across kernel modules, two kfuncs sharing an id but provided by different modules aliased to the same prototype, producing unsound or imprecise analysis.

This PR threads `module` through the lowering and resolution path so the `(btf_id, module)` pair is the disambiguating key.

- `Call` gains an `int16_t module` field (only meaningful for `CallKind::kfunc`).
- `ebpf_resolve_kfunc_call_fn` takes `module` alongside `btf_id`.
- `pass_resolve_kfunc_calls` stamps `Call::module` from the source `CallBtf`, so two kfuncs sharing a BTF id remain distinguishable in the lowered IR even if a platform implementation forgets to populate the field on its returned `ResolvedCall`.
- The Linux kfunc prototype table is now keyed on `(btf_id, module)`, sorted strictly on that pair, and looked up via binary-search-by-btf_id + linear-scan-by-module.
- All platform shims (`linux_platform.cpp`, the YAML test platform) are updated to the new signature.

Closes #1098.

## Test plan

- [x] `./bin/tests` — full suite passes (1322 passed, 236 failed-as-expected, 1 skipped; same shape as `main`).
- [x] New section `instruction feature handling after unmarshal::kfunc resolution disambiguates same BTF id across modules` covers:
  - same `btf_id` with `module=0` resolves to the vmlinux prototype name,
  - same `btf_id` with `module=1` resolves to a distinct module-provided prototype name,
  - an unknown `(btf_id, module)` pair surfaces a module-qualified diagnostic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)