### PR TITLE
Thread stack cell registry through AnalysisContext

### DIFF
--- a/src/analysis_context.hpp
+++ b/src/analysis_context.hpp
@@ -6,6 +6,7 @@
 #include <utility>
 
 #include "config.hpp"
+#include "crab/array_domain.hpp"
 #include "ir/program.hpp"
 #include "platform.hpp"
 #include "spec/type_descriptors.hpp"
@@ -26,13 +27,23 @@ namespace prevail {
 /// same name always maps to the same id, so analyses can freely share one
 /// instance. Domain code reaches for the global `variable_registry`
 /// directly.
+///
+/// `cell_registry` IS per-analysis state: it tracks which symbolic stack
+/// cells the analysis is currently maintaining for ArrayDomain operations.
+/// It is mutated by load/store/havoc on the stack array, hence held by
+/// unique_ptr so that `const AnalysisContext&` still permits mutation of
+/// the pointee.
 struct AnalysisContext {
     Program program;
     VerifierOptions options;
+    StackCellRegistryPtr cell_registry;
 
-    AnalysisContext(Program p, VerifierOptions o) : program(std::move(p)), options(std::move(o)) {}
+    AnalysisContext(Program p, VerifierOptions o)
+        : program(std::move(p)), options(std::move(o)), cell_registry(make_stack_cell_registry()) {}
 
     const RuntimeConfig& runtime() const { return options.runtime; }
+
+    StackCellRegistry& cells() const { return *cell_registry; }
 
     const ProgramInfo& program_info() const { return program.info(); }
     const ebpf_platform_t& platform() const {

--- a/src/crab/array_domain.cpp
+++ b/src/crab/array_domain.cpp
@@ -206,18 +206,23 @@ std::vector<Cell> offset_map_t::get_overlap_cells(const offset_t o, const unsign
     return out;
 }
 
-// We use a global array map
-using array_map_t = std::unordered_map<DataKind, offset_map_t>;
+// Per-analysis registry of the stack cells currently tracked, keyed by DataKind.
+// Owned by AnalysisContext; threaded into ArrayDomain methods that mutate or query
+// the cell set.
+class StackCellRegistry final {
+    std::unordered_map<DataKind, offset_map_t> _maps;
 
-static thread_local LazyAllocator<array_map_t> thread_local_array_map;
+  public:
+    offset_map_t& get(const DataKind kind) { return _maps[kind]; }
+};
 
-void clear_thread_local_state() { thread_local_array_map.clear(); }
+void StackCellRegistryDeleter::operator()(StackCellRegistry* p) const noexcept { delete p; }
 
-static offset_map_t& lookup_array_map(const DataKind kind) { return (*thread_local_array_map)[kind]; }
+StackCellRegistryPtr make_stack_cell_registry() { return StackCellRegistryPtr{new StackCellRegistry()}; }
 
-void ArrayDomain::initialize_numbers(const int lb, const int width) {
+void ArrayDomain::initialize_numbers(StackCellRegistry& cells, const int lb, const int width) {
     num_bytes.reset(lb, width);
-    lookup_array_map(DataKind::svalues).mk_cell(offset_t{gsl::narrow_cast<Index>(lb)}, width);
+    cells.get(DataKind::svalues).mk_cell(offset_t{gsl::narrow_cast<Index>(lb)}, width);
 }
 
 std::ostream& operator<<(std::ostream& o, offset_map_t& m) {
@@ -240,18 +245,18 @@ std::ostream& operator<<(std::ostream& o, offset_map_t& m) {
 }
 
 // Create a new cell that is a subset of an existing cell.
-void ArrayDomain::split_cell(NumAbsDomain& inv, const DataKind kind, const int cell_start_index, const unsigned int len,
-                             const bool big_endian) {
+void ArrayDomain::split_cell(StackCellRegistry& cells, NumAbsDomain& inv, const DataKind kind,
+                             const int cell_start_index, const unsigned int len, const bool big_endian) {
     assert(kind == DataKind::svalues || kind == DataKind::uvalues);
 
     // Get the values from the indicated stack range.
     const std::optional<LinearExpression> svalue =
-        load(inv, DataKind::svalues, Interval{cell_start_index}, len, big_endian);
+        load(cells, inv, DataKind::svalues, Interval{cell_start_index}, len, big_endian);
     const std::optional<LinearExpression> uvalue =
-        load(inv, DataKind::uvalues, Interval{cell_start_index}, len, big_endian);
+        load(cells, inv, DataKind::uvalues, Interval{cell_start_index}, len, big_endian);
 
     // Create a new cell for that range.
-    offset_map_t& offset_map = lookup_array_map(kind);
+    offset_map_t& offset_map = cells.get(kind);
     const Cell new_cell = offset_map.mk_cell(offset_t{gsl::narrow_cast<Index>(cell_start_index)}, len);
     inv.assign(cell_var(DataKind::svalues, new_cell), svalue);
     inv.assign(cell_var(DataKind::uvalues, new_cell), uvalue);
@@ -259,10 +264,10 @@ void ArrayDomain::split_cell(NumAbsDomain& inv, const DataKind kind, const int c
 
 // Prepare to havoc bytes in the middle of a cell by potentially splitting the cell if it is numeric,
 // into the part to the left of the havoced portion, and the part to the right of the havoced portion.
-void ArrayDomain::split_number_var(NumAbsDomain& inv, const DataKind kind, const Interval& ii,
+void ArrayDomain::split_number_var(StackCellRegistry& cells, NumAbsDomain& inv, const DataKind kind, const Interval& ii,
                                    const Interval& elem_size, const bool big_endian) const {
     assert(kind == DataKind::svalues || kind == DataKind::uvalues);
-    offset_map_t& offset_map = lookup_array_map(kind);
+    offset_map_t& offset_map = cells.get(kind);
     const std::optional<Number> n = ii.singleton();
     if (!n) {
         // We can only split a singleton offset.
@@ -276,8 +281,8 @@ void ArrayDomain::split_number_var(NumAbsDomain& inv, const DataKind kind, const
     const auto size = n_bytes->narrow<unsigned int>();
     const offset_t o(n->narrow<Index>());
 
-    const std::vector<Cell> cells = offset_map.get_overlap_cells(o, size);
-    for (const Cell& c : cells) {
+    const std::vector<Cell> overlaps = offset_map.get_overlap_cells(o, size);
+    for (const Cell& c : overlaps) {
         const auto [cell_start_index, cell_end_index] = cell_to_interval(c.offset, c.size).pair<int>();
         if (!this->num_bytes.all_num(cell_start_index, cell_end_index + 1) ||
             cell_end_index + 1UL < cell_start_index + sizeof(int64_t)) {
@@ -291,42 +296,42 @@ void ArrayDomain::split_number_var(NumAbsDomain& inv, const DataKind kind, const
         }
         if (gsl::narrow_cast<Index>(cell_start_index) < o) {
             // Use the bytes to the left of the specified range.
-            split_cell(inv, kind, cell_start_index, gsl::narrow<unsigned int>(o - cell_start_index), big_endian);
+            split_cell(cells, inv, kind, cell_start_index, gsl::narrow<unsigned int>(o - cell_start_index), big_endian);
         }
         if (o + size < cell_end_index + 1UL) {
             // Use the bytes to the right of the specified range.
-            split_cell(inv, kind, gsl::narrow<int>(o + size),
+            split_cell(cells, inv, kind, gsl::narrow<int>(o + size),
                        gsl::narrow<unsigned int>(cell_end_index - (o + size - 1)), big_endian);
         }
     }
 }
 
-// we can only treat this as non-member because we use global state
 // Find overlapping cells for the given index range and kill (havoc + remove) them.
 // Returns the exact offset and size if the index and element size are both constant.
 template <typename HavocFn>
-static std::optional<std::pair<offset_t, unsigned>> kill_and_find_var(const HavocFn& havoc_var, const DataKind kind,
+static std::optional<std::pair<offset_t, unsigned>> kill_and_find_var(StackCellRegistry& cells,
+                                                                      const HavocFn& havoc_var, const DataKind kind,
                                                                       const Interval& ii, const Interval& elem_size) {
     std::optional<std::pair<offset_t, unsigned>> res;
 
-    offset_map_t& offset_map = lookup_array_map(kind);
-    std::vector<Cell> cells;
+    offset_map_t& offset_map = cells.get(kind);
+    std::vector<Cell> overlaps;
     if (const std::optional<Number> n = ii.singleton()) {
         if (const auto n_bytes = elem_size.singleton()) {
             auto size = n_bytes->narrow<unsigned int>();
             // -- Constant index: kill overlapping cells
             offset_t o(n->narrow<Index>());
-            cells = offset_map.get_overlap_cells(o, size);
+            overlaps = offset_map.get_overlap_cells(o, size);
             res = std::make_pair(o, size);
         }
     }
     if (!res) {
         // -- Non-constant index: kill overlapping cells
-        cells = offset_map.get_overlap_cells_symbolic_offset(ii | (ii + elem_size));
+        overlaps = offset_map.get_overlap_cells_symbolic_offset(ii | (ii + elem_size));
     }
-    if (!cells.empty()) {
+    if (!overlaps.empty()) {
         // Forget the scalars from the relevant domain
-        for (const auto& c : cells) {
+        for (const auto& c : overlaps) {
             havoc_var(cell_var(kind, c));
 
             // Forget signed and unsigned values together.
@@ -337,7 +342,7 @@ static std::optional<std::pair<offset_t, unsigned>> kill_and_find_var(const Havo
             }
         }
         // Remove the cells. If needed again they will be re-created.
-        offset_map -= cells;
+        offset_map -= overlaps;
     }
     return res;
 }
@@ -411,14 +416,15 @@ std::optional<uint8_t> get_value_byte(const NumAbsDomain& inv, const offset_t o,
     return bytes[o % width];
 }
 
-std::optional<LinearExpression> ArrayDomain::load(const NumAbsDomain& inv, const DataKind kind, const Interval& i,
-                                                  const int width, const bool big_endian) {
+std::optional<LinearExpression> ArrayDomain::load(StackCellRegistry& cells, const NumAbsDomain& inv,
+                                                  const DataKind kind, const Interval& i, const int width,
+                                                  const bool big_endian) {
     if (const std::optional<Number> n = i.singleton()) {
-        offset_map_t& offset_map = lookup_array_map(kind);
+        offset_map_t& offset_map = cells.get(kind);
         const int64_t k = n->narrow<int64_t>();
         const offset_t o(k);
         const unsigned size = to_unsigned(width);
-        if (const auto cell = lookup_array_map(kind).get_cell(o, size)) {
+        if (const auto cell = offset_map.get_cell(o, size)) {
             return cell_var(kind, *cell);
         }
         if (kind == DataKind::svalues || kind == DataKind::uvalues) {
@@ -481,15 +487,15 @@ std::optional<LinearExpression> ArrayDomain::load(const NumAbsDomain& inv, const
             }
         }
 
-        const std::vector<Cell> cells = offset_map.get_overlap_cells(o, size);
-        if (cells.empty()) {
+        const std::vector<Cell> overlaps = offset_map.get_overlap_cells(o, size);
+        if (overlaps.empty()) {
             const Cell c = offset_map.mk_cell(o, size);
             // Here it's ok to do assignment (instead of expand) because c is not a summarized variable.
             // Otherwise, it would be unsound.
             return cell_var(kind, c);
         }
         CRAB_WARN("Ignored read from cell ", kind, "[", o, "...", o + size - 1, "]", " because it overlaps with ",
-                  cells.size(), " cells");
+                  overlaps.size(), " cells");
         /*
             TODO: we can apply here "Value Recomposition" a la Mine'06 (https://arxiv.org/pdf/cs/0703074.pdf)
                 to construct values of some type from a sequence of bytes.
@@ -502,9 +508,10 @@ std::optional<LinearExpression> ArrayDomain::load(const NumAbsDomain& inv, const
     return {};
 }
 
-std::optional<LinearExpression> ArrayDomain::load_type(const Interval& i, const int width) const {
+std::optional<LinearExpression> ArrayDomain::load_type(StackCellRegistry& cells, const Interval& i,
+                                                       const int width) const {
     if (const std::optional<Number> n = i.singleton()) {
-        offset_map_t& offset_map = lookup_array_map(DataKind::types);
+        offset_map_t& offset_map = cells.get(DataKind::types);
         const int64_t k = n->narrow<int64_t>();
         auto [only_num, only_non_num] = num_bytes.uniformity(k, width);
         if (only_num) {
@@ -515,18 +522,18 @@ std::optional<LinearExpression> ArrayDomain::load_type(const Interval& i, const 
         }
         const offset_t o(k);
         const unsigned size = to_unsigned(width);
-        if (const auto cell = lookup_array_map(DataKind::types).get_cell(o, size)) {
+        if (const auto cell = offset_map.get_cell(o, size)) {
             return cell_var(DataKind::types, *cell);
         }
-        const std::vector<Cell> cells = offset_map.get_overlap_cells(o, size);
-        if (cells.empty()) {
+        const std::vector<Cell> overlaps = offset_map.get_overlap_cells(o, size);
+        if (overlaps.empty()) {
             const Cell c = offset_map.mk_cell(o, size);
             // Here it's ok to do assignment (instead of expand) because c is not a summarized variable.
             // Otherwise, it would be unsound.
             return cell_var(DataKind::types, c);
         }
         CRAB_WARN("Ignored read from cell ", DataKind::types, "[", o, "...", o + size - 1, "]",
-                  " because it overlaps with ", cells.size(), " cells");
+                  " because it overlaps with ", overlaps.size(), " cells");
         /*
             TODO: we can apply here "Value Recomposition" a la Mine'06 (https://arxiv.org/pdf/cs/0703074.pdf)
                 to construct values of some type from a sequence of bytes.
@@ -553,32 +560,32 @@ std::optional<LinearExpression> ArrayDomain::load_type(const Interval& i, const 
 // We are about to write to a given range of bytes on the stack.
 // Any cells covering that range need to be removed, and any cells that only
 // partially cover that range can be split such that any non-covered portions become new cells.
-static std::optional<std::pair<offset_t, unsigned>> split_and_find_var(const ArrayDomain& array_domain,
-                                                                       NumAbsDomain& inv, const DataKind kind,
-                                                                       const Interval& idx, const Interval& elem_size,
-                                                                       const bool big_endian) {
+static std::optional<std::pair<offset_t, unsigned>>
+split_and_find_var(StackCellRegistry& cells, const ArrayDomain& array_domain, NumAbsDomain& inv, const DataKind kind,
+                   const Interval& idx, const Interval& elem_size, const bool big_endian) {
     if (kind == DataKind::svalues || kind == DataKind::uvalues) {
-        array_domain.split_number_var(inv, kind, idx, elem_size, big_endian);
+        array_domain.split_number_var(cells, inv, kind, idx, elem_size, big_endian);
     }
-    return kill_and_find_var([&inv](const Variable v) { inv.havoc(v); }, kind, idx, elem_size);
+    return kill_and_find_var(cells, [&inv](const Variable v) { inv.havoc(v); }, kind, idx, elem_size);
 }
 
-std::optional<Variable> ArrayDomain::store(NumAbsDomain& inv, const DataKind kind, const Interval& idx,
-                                           const Interval& elem_size, const bool big_endian) const {
-    if (auto maybe_cell = split_and_find_var(*this, inv, kind, idx, elem_size, big_endian)) {
+std::optional<Variable> ArrayDomain::store(StackCellRegistry& cells, NumAbsDomain& inv, const DataKind kind,
+                                           const Interval& idx, const Interval& elem_size,
+                                           const bool big_endian) const {
+    if (auto maybe_cell = split_and_find_var(cells, *this, inv, kind, idx, elem_size, big_endian)) {
         // perform strong update
         auto [offset, size] = *maybe_cell;
-        const Cell c = lookup_array_map(kind).mk_cell(offset, size);
+        const Cell c = cells.get(kind).mk_cell(offset, size);
         Variable v = cell_var(kind, c);
         return v;
     }
     return {};
 }
 
-std::optional<Variable> ArrayDomain::store_type(TypeDomain& inv, const Interval& idx, const Interval& width,
-                                                const bool is_num) {
+std::optional<Variable> ArrayDomain::store_type(StackCellRegistry& cells, TypeDomain& inv, const Interval& idx,
+                                                const Interval& width, const bool is_num) {
     constexpr auto kind = DataKind::types;
-    if (auto maybe_cell = kill_and_find_var([&inv](const Variable v) { inv.havoc_type(v); }, kind, idx, width)) {
+    if (auto maybe_cell = kill_and_find_var(cells, [&inv](const Variable v) { inv.havoc_type(v); }, kind, idx, width)) {
         // perform strong update
         auto [offset, size] = *maybe_cell;
         if (is_num) {
@@ -586,7 +593,7 @@ std::optional<Variable> ArrayDomain::store_type(TypeDomain& inv, const Interval&
         } else {
             num_bytes.havoc(offset, size);
         }
-        const Cell c = lookup_array_map(kind).mk_cell(offset, size);
+        const Cell c = cells.get(kind).mk_cell(offset, size);
         Variable v = cell_var(kind, c);
         return v;
     } else {
@@ -606,14 +613,16 @@ std::optional<Variable> ArrayDomain::store_type(TypeDomain& inv, const Interval&
     return {};
 }
 
-void ArrayDomain::havoc(NumAbsDomain& inv, const DataKind kind, const Interval& idx, const Interval& elem_size,
-                        const bool big_endian) const {
-    split_and_find_var(*this, inv, kind, idx, elem_size, big_endian);
+void ArrayDomain::havoc(StackCellRegistry& cells, NumAbsDomain& inv, const DataKind kind, const Interval& idx,
+                        const Interval& elem_size, const bool big_endian) const {
+    split_and_find_var(cells, *this, inv, kind, idx, elem_size, big_endian);
 }
 
-void ArrayDomain::havoc_type(TypeDomain& inv, const Interval& idx, const Interval& elem_size) {
+void ArrayDomain::havoc_type(StackCellRegistry& cells, TypeDomain& inv, const Interval& idx,
+                             const Interval& elem_size) {
     constexpr auto kind = DataKind::types;
-    if (auto maybe_cell = kill_and_find_var([&inv](const Variable v) { inv.havoc_type(v); }, kind, idx, elem_size)) {
+    if (auto maybe_cell =
+            kill_and_find_var(cells, [&inv](const Variable v) { inv.havoc_type(v); }, kind, idx, elem_size)) {
         auto [offset, size] = *maybe_cell;
         num_bytes.havoc(offset, size);
     }

--- a/src/crab/array_domain.cpp
+++ b/src/crab/array_domain.cpp
@@ -214,11 +214,14 @@ class StackCellRegistry final {
 
   public:
     offset_map_t& get(const DataKind kind) { return _maps[kind]; }
+    void clear() { _maps.clear(); }
 };
 
 void StackCellRegistryDeleter::operator()(StackCellRegistry* p) const noexcept { delete p; }
 
 StackCellRegistryPtr make_stack_cell_registry() { return StackCellRegistryPtr{new StackCellRegistry()}; }
+
+void clear_stack_cell_registry(StackCellRegistry& registry) { registry.clear(); }
 
 void ArrayDomain::initialize_numbers(StackCellRegistry& cells, const int lb, const int width) {
     num_bytes.reset(lb, width);

--- a/src/crab/array_domain.cpp
+++ b/src/crab/array_domain.cpp
@@ -217,7 +217,7 @@ class StackCellRegistry final {
     void clear() { _maps.clear(); }
 };
 
-void StackCellRegistryDeleter::operator()(StackCellRegistry* p) const noexcept { delete p; }
+void StackCellRegistryDeleter::operator()(StackCellRegistry* ptr) const noexcept { delete ptr; }
 
 StackCellRegistryPtr make_stack_cell_registry() { return StackCellRegistryPtr{new StackCellRegistry()}; }
 

--- a/src/crab/array_domain.hpp
+++ b/src/crab/array_domain.hpp
@@ -23,6 +23,7 @@
 
 #pragma once
 
+#include <memory>
 #include <optional>
 
 #include "arith/variable.hpp"
@@ -32,7 +33,17 @@
 
 namespace prevail {
 
-void clear_thread_local_state();
+/// Per-analysis registry of the stack cells the analysis is currently tracking, keyed
+/// by DataKind. Owned by AnalysisContext; shared by reference across all ArrayDomain
+/// instances belonging to one analysis run. Each entry corresponds to a cell variable
+/// at a (offset, size); the registry exists so ArrayDomain can deduplicate `mk_cell`
+/// calls and answer overlap queries.
+class StackCellRegistry;
+struct StackCellRegistryDeleter {
+    void operator()(StackCellRegistry*) const noexcept;
+};
+using StackCellRegistryPtr = std::unique_ptr<StackCellRegistry, StackCellRegistryDeleter>;
+StackCellRegistryPtr make_stack_cell_registry();
 
 class ArrayDomain final {
     BitsetDomain num_bytes;
@@ -79,23 +90,26 @@ class ArrayDomain final {
     int min_all_num_size(const NumAbsDomain& inv, Variable offset) const;
 
     [[nodiscard]]
-    static std::optional<LinearExpression> load(const NumAbsDomain& inv, DataKind kind, const Interval& i, int width,
-                                                bool big_endian);
-    std::optional<LinearExpression> load_type(const Interval& i, int width) const;
-    std::optional<Variable> store(NumAbsDomain& inv, DataKind kind, const Interval& idx, const Interval& elem_size,
-                                  bool big_endian) const;
-    std::optional<Variable> store_type(TypeDomain& inv, const Interval& idx, const Interval& width, bool is_num);
-    void havoc(NumAbsDomain& inv, DataKind kind, const Interval& idx, const Interval& elem_size, bool big_endian) const;
-    void havoc_type(TypeDomain& inv, const Interval& idx, const Interval& elem_size);
+    static std::optional<LinearExpression> load(StackCellRegistry& cells, const NumAbsDomain& inv, DataKind kind,
+                                                const Interval& i, int width, bool big_endian);
+    std::optional<LinearExpression> load_type(StackCellRegistry& cells, const Interval& i, int width) const;
+    std::optional<Variable> store(StackCellRegistry& cells, NumAbsDomain& inv, DataKind kind, const Interval& idx,
+                                  const Interval& elem_size, bool big_endian) const;
+    std::optional<Variable> store_type(StackCellRegistry& cells, TypeDomain& inv, const Interval& idx,
+                                       const Interval& width, bool is_num);
+    void havoc(StackCellRegistry& cells, NumAbsDomain& inv, DataKind kind, const Interval& idx,
+               const Interval& elem_size, bool big_endian) const;
+    void havoc_type(StackCellRegistry& cells, TypeDomain& inv, const Interval& idx, const Interval& elem_size);
 
     // Perform array stores over an array segment
     void store_numbers(const Interval& _idx, const Interval& _width);
 
-    void split_number_var(NumAbsDomain& inv, DataKind kind, const Interval& ii, const Interval& elem_size,
-                          bool big_endian) const;
-    static void split_cell(NumAbsDomain& inv, DataKind kind, int cell_start_index, unsigned int len, bool big_endian);
+    void split_number_var(StackCellRegistry& cells, NumAbsDomain& inv, DataKind kind, const Interval& ii,
+                          const Interval& elem_size, bool big_endian) const;
+    static void split_cell(StackCellRegistry& cells, NumAbsDomain& inv, DataKind kind, int cell_start_index,
+                           unsigned int len, bool big_endian);
 
-    void initialize_numbers(int lb, int width);
+    void initialize_numbers(StackCellRegistry& cells, int lb, int width);
 };
 
 } // namespace prevail

--- a/src/crab/array_domain.hpp
+++ b/src/crab/array_domain.hpp
@@ -44,6 +44,9 @@ struct StackCellRegistryDeleter {
 };
 using StackCellRegistryPtr = std::unique_ptr<StackCellRegistry, StackCellRegistryDeleter>;
 StackCellRegistryPtr make_stack_cell_registry();
+/// Drop all tracked cells. Call this when starting a fresh analysis run against
+/// a reused context so stale entries from a prior run don't leak into the new one.
+void clear_stack_cell_registry(StackCellRegistry& registry);
 
 class ArrayDomain final {
     BitsetDomain num_bytes;

--- a/src/crab/ebpf_domain.cpp
+++ b/src/crab/ebpf_domain.cpp
@@ -419,7 +419,7 @@ EbpfDomain EbpfDomain::from_constraints(const std::set<std::string>& constraints
     for (const Interval& range : numeric_ranges) {
         const auto [start, ub] = range.pair<int64_t>();
         const int width = gsl::narrow<int>(1 + (ub - start));
-        inv.stack->initialize_numbers(gsl::narrow<int>(start), width);
+        inv.stack->initialize_numbers(context.cells(), gsl::narrow<int>(start), width);
     }
     // TODO: handle other stack type constraints
     return inv;

--- a/src/crab/ebpf_transformer.cpp
+++ b/src/crab/ebpf_transformer.cpp
@@ -201,9 +201,10 @@ void EbpfTransformer::havoc_subprogram_stack(const std::string& prefix) {
     }
     const auto frame_size = context.runtime().subprogram_stack_size;
     const int64_t stack_start = intv.singleton()->cast_to<int64_t>() - frame_size;
-    stack.havoc_type(dom.state.types, Interval{stack_start}, Interval{frame_size});
+    stack.havoc_type(context.cells(), dom.state.types, Interval{stack_start}, Interval{frame_size});
     for (const DataKind kind : iterate_kinds()) {
-        stack.havoc(dom.state.values, kind, Interval{stack_start}, Interval{frame_size}, context.runtime().big_endian);
+        stack.havoc(context.cells(), dom.state.values, kind, Interval{stack_start}, Interval{frame_size},
+                    context.runtime().big_endian);
     }
 }
 
@@ -452,7 +453,7 @@ void EbpfTransformer::do_load_stack(TypeToNumDomain& state, const Reg& target_re
     if (state.values.entail(width <= reg_pack(src_reg).stack_numeric_size)) {
         state.assign_type(target_reg, T_NUM);
     } else {
-        state.assign_type(target_reg, stack.load_type(addr, width));
+        state.assign_type(target_reg, stack.load_type(context.cells(), addr, width));
         if (!state.is_initialized(target_reg)) {
             // We don't know what we loaded, so just havoc the destination register.
             state.havoc_register(target_reg);
@@ -466,16 +467,16 @@ void EbpfTransformer::do_load_stack(TypeToNumDomain& state, const Reg& target_re
         // addr from that same register.
         const bool big_endian = context.runtime().big_endian;
         const std::optional<LinearExpression> sresult =
-            stack.load(state.values, DataKind::svalues, addr, width, big_endian);
+            stack.load(context.cells(), state.values, DataKind::svalues, addr, width, big_endian);
         const std::optional<LinearExpression> uresult =
-            stack.load(state.values, DataKind::uvalues, addr, width, big_endian);
+            stack.load(context.cells(), state.values, DataKind::uvalues, addr, width, big_endian);
         state.havoc_register_except_type(target_reg);
         state.values.assign(target.svalue, sresult);
         state.values.assign(target.uvalue, uresult);
         for (const TypeEncoding type : state.iterate_types(target_reg)) {
             for (const auto& kind : type_to_kinds.at(type)) {
                 const Variable dst_var = variable_registry.reg(kind, target_reg.v);
-                state.values.assign(dst_var, stack.load(state.values, kind, addr, width, big_endian));
+                state.values.assign(dst_var, stack.load(context.cells(), state.values, kind, addr, width, big_endian));
             }
         }
     } else {
@@ -628,55 +629,60 @@ void EbpfTransformer::do_store_stack(TypeToNumDomain& state, const LinearExpress
     const Interval width{exact_width};
     const bool big_endian = context.runtime().big_endian;
     // no aliasing of val - we don't move from stack to stack, so we can just havoc first
-    stack.havoc_type(state.types, addr, width);
+    stack.havoc_type(context.cells(), state.types, addr, width);
     for (const DataKind kind : iterate_kinds()) {
         if (kind == DataKind::svalues || kind == DataKind::uvalues) {
             continue;
         }
-        stack.havoc(state.values, kind, addr, width, context.runtime().big_endian);
+        stack.havoc(context.cells(), state.values, kind, addr, width, context.runtime().big_endian);
     }
     bool must_be_num = false;
     if (opt_val_reg && !state.is_initialized(*opt_val_reg)) {
-        stack.havoc(state.values, DataKind::svalues, addr, width, big_endian);
-        stack.havoc(state.values, DataKind::uvalues, addr, width, big_endian);
+        stack.havoc(context.cells(), state.values, DataKind::svalues, addr, width, big_endian);
+        stack.havoc(context.cells(), state.values, DataKind::uvalues, addr, width, big_endian);
     } else {
         // opt_val_reg is unset when storing an immediate value.
         must_be_num = !opt_val_reg || state.is_in_group(*opt_val_reg, TS_NUM);
         const LinearExpression val_type =
             must_be_num ? LinearExpression{T_NUM} : variable_registry.type_reg(opt_val_reg->v);
-        state.assign_type(stack.store_type(state.types, addr, width, must_be_num), val_type);
+        state.assign_type(stack.store_type(context.cells(), state.types, addr, width, must_be_num), val_type);
 
         if (exact_width == 8) {
-            stack.havoc(state.values, DataKind::svalues, addr, width, big_endian);
-            stack.havoc(state.values, DataKind::uvalues, addr, width, big_endian);
-            state.values.assign(stack.store(state.values, DataKind::svalues, addr, width, big_endian), val_svalue);
-            state.values.assign(stack.store(state.values, DataKind::uvalues, addr, width, big_endian), val_uvalue);
+            stack.havoc(context.cells(), state.values, DataKind::svalues, addr, width, big_endian);
+            stack.havoc(context.cells(), state.values, DataKind::uvalues, addr, width, big_endian);
+            state.values.assign(stack.store(context.cells(), state.values, DataKind::svalues, addr, width, big_endian),
+                                val_svalue);
+            state.values.assign(stack.store(context.cells(), state.values, DataKind::uvalues, addr, width, big_endian),
+                                val_uvalue);
 
             if (!must_be_num) {
                 for (TypeEncoding type : state.iterate_types(*opt_val_reg)) {
                     for (const DataKind kind : type_to_kinds.at(type)) {
                         const Variable src_var = variable_registry.reg(kind, opt_val_reg->v);
-                        state.values.assign(stack.store(state.values, kind, addr, width, big_endian), src_var);
+                        state.values.assign(stack.store(context.cells(), state.values, kind, addr, width, big_endian),
+                                            src_var);
                     }
                 }
             }
         } else if ((exact_width == 1 || exact_width == 2 || exact_width == 4) && must_be_num) {
             // Keep track of numbers on the stack that might be used as array indices.
-            if (const auto stack_svalue = stack.store(state.values, DataKind::svalues, addr, width, big_endian)) {
+            if (const auto stack_svalue =
+                    stack.store(context.cells(), state.values, DataKind::svalues, addr, width, big_endian)) {
                 state.values.assign(stack_svalue, val_svalue);
                 state.values->overflow_bounds(*stack_svalue, exact_width * 8, true);
             } else {
-                stack.havoc(state.values, DataKind::svalues, addr, width, big_endian);
+                stack.havoc(context.cells(), state.values, DataKind::svalues, addr, width, big_endian);
             }
-            if (const auto stack_uvalue = stack.store(state.values, DataKind::uvalues, addr, width, big_endian)) {
+            if (const auto stack_uvalue =
+                    stack.store(context.cells(), state.values, DataKind::uvalues, addr, width, big_endian)) {
                 state.values.assign(stack_uvalue, val_uvalue);
                 state.values->overflow_bounds(*stack_uvalue, exact_width * 8, false);
             } else {
-                stack.havoc(state.values, DataKind::uvalues, addr, width, big_endian);
+                stack.havoc(context.cells(), state.values, DataKind::uvalues, addr, width, big_endian);
             }
         } else {
-            stack.havoc(state.values, DataKind::svalues, addr, width, big_endian);
-            stack.havoc(state.values, DataKind::uvalues, addr, width, big_endian);
+            stack.havoc(context.cells(), state.values, DataKind::svalues, addr, width, big_endian);
+            stack.havoc(context.cells(), state.values, DataKind::uvalues, addr, width, big_endian);
         }
     }
 
@@ -869,7 +875,7 @@ void EbpfTransformer::operator()(const Call& call) {
                     }
                     const Interval addr = state.values.eval_interval(*offset);
                     for (const DataKind kind : iterate_kinds()) {
-                        stack.havoc(state.values, kind, addr, w, context.runtime().big_endian);
+                        stack.havoc(context.cells(), state.values, kind, addr, w, context.runtime().big_endian);
                     }
                     // Keep this scoped to stack-typed pointers only.
                     stack.store_numbers(addr, w);
@@ -900,7 +906,7 @@ void EbpfTransformer::operator()(const Call& call) {
                     // Pointer to a memory region that the called function may change,
                     // so we must havoc.
                     for (const DataKind kind : iterate_kinds()) {
-                        stack.havoc(state.values, kind, addr, width, context.runtime().big_endian);
+                        stack.havoc(context.cells(), state.values, kind, addr, width, context.runtime().big_endian);
                     }
                 } else {
                     store_numbers = false;

--- a/src/fwd_analyzer.cpp
+++ b/src/fwd_analyzer.cpp
@@ -16,12 +16,10 @@
 
 namespace prevail {
 
-static void clear_analysis_thread_local_state() { clear_thread_local_state(); }
-
-void ebpf_verifier_clear_thread_local_state() {
-    clear_thread_local_state();
-    ZoneDomain::clear_thread_local_state();
-}
+// The array-domain cell registry now lives in AnalysisContext, so it dies with the
+// context — no thread-local clear needed.  SplitDBM still uses a thread-local scratch
+// buffer for transient graph operations; clear it to keep peak memory down.
+void ebpf_verifier_clear_thread_local_state() { ZoneDomain::clear_thread_local_state(); }
 
 class InterleavedFwdFixpointIterator final {
     const AnalysisContext& context;
@@ -170,13 +168,11 @@ AnalysisResult analyze(const Program& prog, const StringInvariant& entry_invaria
 }
 
 AnalysisResult analyze(const AnalysisContext& context) {
-    clear_analysis_thread_local_state();
     return InterleavedFwdFixpointIterator::run(context,
                                                EbpfDomain::setup_entry(context.runtime().setup_constraints, context));
 }
 
 AnalysisResult analyze(const StringInvariant& entry_invariant, const AnalysisContext& context) {
-    clear_analysis_thread_local_state();
     return InterleavedFwdFixpointIterator::run(
         context, EbpfDomain::from_constraints(entry_invariant.value(), context.runtime().setup_constraints, context));
 }

--- a/src/fwd_analyzer.cpp
+++ b/src/fwd_analyzer.cpp
@@ -168,11 +168,17 @@ AnalysisResult analyze(const Program& prog, const StringInvariant& entry_invaria
 }
 
 AnalysisResult analyze(const AnalysisContext& context) {
+    // Reset the per-context cell registry so a reused context starts each run with
+    // an empty cell map. setup_entry() below allocates fresh cells into it.
+    clear_stack_cell_registry(context.cells());
     return InterleavedFwdFixpointIterator::run(context,
                                                EbpfDomain::setup_entry(context.runtime().setup_constraints, context));
 }
 
 AnalysisResult analyze(const StringInvariant& entry_invariant, const AnalysisContext& context) {
+    // Same rationale as analyze(context): from_constraints below populates the cell
+    // registry as part of building the entry domain.
+    clear_stack_cell_registry(context.cells());
     return InterleavedFwdFixpointIterator::run(
         context, EbpfDomain::from_constraints(entry_invariant.value(), context.runtime().setup_constraints, context));
 }


### PR DESCRIPTION
## Summary
- Moves the array-domain cell map (per-`DataKind` tracking of which stack cells the analysis currently maintains a symbolic variable for) out of a thread-local `LazyAllocator` and into a `StackCellRegistry` owned by `AnalysisContext`.
- The old design required clearing the thread-local between analyses; if anything constructed an `ArrayDomain` and then re-cleared the map, the domain's cells became orphaned and subsequent stack ops silently saw an empty map. That bug surfaced in #1115's test-bridge refactor and was worked around with an inline band-aid; this PR is the structural fix called out by that comment.
- `StackCellRegistry` is forward-declared in `array_domain.hpp` and held by `unique_ptr` with a custom deleter, so the header doesn't need the full definition. `AnalysisContext` exposes `cells()` returning `StackCellRegistry&` even through `const` access — the registry's mutability is intentional and tracked separately from the context's logical immutability.
- `ArrayDomain` methods that touch the cell map (`load`, `store`, `havoc`, `initialize_numbers`, `split_cell`, `split_number_var`, `load_type`, `store_type`, `havoc_type`) now take `StackCellRegistry&` explicitly. Call sites in `ebpf_transformer.cpp` and `ebpf_domain.cpp` pass `context.cells()`.
- `ebpf_verifier_clear_thread_local_state()` now only clears SplitDBM's transient scratch buffer; the array map is no longer thread-local. `analyze(...)`'s pre-run clears of the array map are removed since the registry dies with the context.

## Test plan
- [x] Library and tests build cleanly (`cmake --build cmake-build-debug --target prevail tests run_yaml`).
- [x] `./bin/tests "[yaml],[conformance]"` — 1357/1357 assertions pass.
- [x] Full `./bin/tests` integration suite — 1322 passed / 236 fail-as-expected (`[!shouldfail]` real-world eBPF programs) / 1 skipped. Identical counts to `main`.