### PR TITLE
Make EbpfDomain self-contained; orthogonalize setup_entry

### DIFF
--- a/src/analysis_context.hpp
+++ b/src/analysis_context.hpp
@@ -6,7 +6,6 @@
 #include <utility>
 
 #include "config.hpp"
-#include "crab/array_domain.hpp"
 #include "ir/program.hpp"
 #include "platform.hpp"
 #include "spec/type_descriptors.hpp"

--- a/src/analysis_context.hpp
+++ b/src/analysis_context.hpp
@@ -13,37 +13,26 @@
 
 namespace prevail {
 
-/// Bundle of per-analysis inputs: the `Program` being analysed and the
-/// options controlling it. Owned by value so the context is
-/// self-contained -- the Program cannot be moved out from under the
-/// analysis, and a context cannot outlive its Program.
+/// Bundle of analysis inputs: the `Program` being analysed and the options
+/// controlling it. Pure inputs — reusable across multiple `analyze()` calls,
+/// shareable by const ref, no mutable state. Owned by value so the context
+/// is self-contained and cannot outlive its Program.
 ///
 /// `program_info()` and `platform()` are accessors, not fields: both are
 /// reachable from `program`, so storing them as parallel references would
 /// let `context.program_info` disagree with `context.program.info()`.
 ///
-/// `VariableRegistry` is intentionally not here. The registry is a global
-/// name-interning service (like `malloc`), not per-analysis state: the
-/// same name always maps to the same id, so analyses can freely share one
-/// instance. Domain code reaches for the global `variable_registry`
-/// directly.
-///
-/// `cell_registry` IS per-analysis state: it tracks which symbolic stack
-/// cells the analysis is currently maintaining for ArrayDomain operations.
-/// It is mutated by load/store/havoc on the stack array, hence held by
-/// unique_ptr so that `const AnalysisContext&` still permits mutation of
-/// the pointee.
+/// Variable interning is handled by the global `variable_registry`: names
+/// are stable across processes and analyses, so there's no per-analysis
+/// registry to thread through here. Stack cells are owned per-`ArrayDomain`,
+/// keeping each `EbpfDomain` a self-contained value.
 struct AnalysisContext {
     Program program;
     VerifierOptions options;
-    StackCellRegistryPtr cell_registry;
 
-    AnalysisContext(Program p, VerifierOptions o)
-        : program(std::move(p)), options(std::move(o)), cell_registry(make_stack_cell_registry()) {}
+    AnalysisContext(Program p, VerifierOptions o) : program(std::move(p)), options(std::move(o)) {}
 
     const RuntimeConfig& runtime() const { return options.runtime; }
-
-    StackCellRegistry& cells() const { return *cell_registry; }
 
     const ProgramInfo& program_info() const { return program.info(); }
     const ebpf_platform_t& platform() const {

--- a/src/crab/array_domain.cpp
+++ b/src/crab/array_domain.cpp
@@ -215,9 +215,10 @@ class StackCellRegistry final {
   public:
     offset_map_t& get(const DataKind kind) { return _maps[kind]; }
 
-    // Union `other` into `*this` so the resulting registry tracks every cell
-    // either side knew about. Idempotent insert: cells already present stay.
     void merge_from(const StackCellRegistry& other) {
+        if (this == &other) {
+            return;
+        }
         for (const auto& [kind, omap] : other._maps) {
             offset_map_t& dst = _maps[kind];
             for (const auto& [_off, cell_set] : omap._map) {
@@ -229,37 +230,11 @@ class StackCellRegistry final {
     }
 };
 
-void StackCellRegistryDeleter::operator()(StackCellRegistry* ptr) const noexcept { delete ptr; }
-
-StackCellRegistryPtr make_stack_cell_registry() { return StackCellRegistryPtr{new StackCellRegistry()}; }
-
-StackCellRegistryPtr clone_stack_cell_registry(const StackCellRegistry& registry) {
-    return StackCellRegistryPtr{new StackCellRegistry(registry)};
-}
-
-ArrayDomain::ArrayDomain(const ArrayDomain& other)
-    : num_bytes(other.num_bytes), cells_(clone_stack_cell_registry(*other.cells_)) {}
-
-ArrayDomain::ArrayDomain(ArrayDomain&& other) noexcept
-    : num_bytes(std::move(other.num_bytes)), cells_(std::exchange(other.cells_, make_stack_cell_registry())) {}
-
-ArrayDomain& ArrayDomain::operator=(const ArrayDomain& other) {
-    if (this != &other) {
-        num_bytes = other.num_bytes;
-        cells_ = clone_stack_cell_registry(*other.cells_);
-    }
-    return *this;
-}
-
-ArrayDomain& ArrayDomain::operator=(ArrayDomain&& other) noexcept {
-    num_bytes = std::move(other.num_bytes);
-    std::swap(cells_, other.cells_);
-    return *this;
-}
+std::shared_ptr<StackCellRegistry> make_stack_cell_registry() { return std::make_shared<StackCellRegistry>(); }
 
 void ArrayDomain::initialize_numbers(const int lb, const int width) {
     num_bytes.reset(lb, width);
-    cells_->get(DataKind::svalues).mk_cell(offset_t{gsl::narrow_cast<Index>(lb)}, width);
+    cells_.get_mutable().get(DataKind::svalues).mk_cell(offset_t{gsl::narrow_cast<Index>(lb)}, width);
 }
 
 std::ostream& operator<<(std::ostream& o, offset_map_t& m) {
@@ -293,7 +268,7 @@ void ArrayDomain::split_cell(NumAbsDomain& inv, const DataKind kind, const int c
         load(inv, DataKind::uvalues, Interval{cell_start_index}, len, big_endian);
 
     // Create a new cell for that range.
-    offset_map_t& offset_map = cells_->get(kind);
+    offset_map_t& offset_map = cells_.get_mutable().get(kind);
     const Cell new_cell = offset_map.mk_cell(offset_t{gsl::narrow_cast<Index>(cell_start_index)}, len);
     inv.assign(cell_var(DataKind::svalues, new_cell), svalue);
     inv.assign(cell_var(DataKind::uvalues, new_cell), uvalue);
@@ -304,7 +279,7 @@ void ArrayDomain::split_cell(NumAbsDomain& inv, const DataKind kind, const int c
 void ArrayDomain::split_number_var(NumAbsDomain& inv, const DataKind kind, const Interval& ii,
                                    const Interval& elem_size, const bool big_endian) {
     assert(kind == DataKind::svalues || kind == DataKind::uvalues);
-    offset_map_t& offset_map = cells_->get(kind);
+    offset_map_t& offset_map = cells_.get_mutable().get(kind);
     const std::optional<Number> n = ii.singleton();
     if (!n) {
         // We can only split a singleton offset.
@@ -456,7 +431,7 @@ std::optional<uint8_t> get_value_byte(const NumAbsDomain& inv, const offset_t o,
 std::optional<LinearExpression> ArrayDomain::load(const NumAbsDomain& inv, const DataKind kind, const Interval& i,
                                                   const int width, const bool big_endian) {
     if (const std::optional<Number> n = i.singleton()) {
-        offset_map_t& offset_map = cells_->get(kind);
+        offset_map_t& offset_map = cells_.get_mutable().get(kind);
         const int64_t k = n->narrow<int64_t>();
         const offset_t o(k);
         const unsigned size = to_unsigned(width);
@@ -546,7 +521,7 @@ std::optional<LinearExpression> ArrayDomain::load(const NumAbsDomain& inv, const
 
 std::optional<LinearExpression> ArrayDomain::load_type(const Interval& i, const int width) {
     if (const std::optional<Number> n = i.singleton()) {
-        offset_map_t& offset_map = cells_->get(DataKind::types);
+        offset_map_t& offset_map = cells_.get_mutable().get(DataKind::types);
         const int64_t k = n->narrow<int64_t>();
         auto [only_num, only_non_num] = num_bytes.uniformity(k, width);
         if (only_num) {
@@ -606,10 +581,10 @@ split_and_find_var(ArrayDomain& array_domain, StackCellRegistry& cells, NumAbsDo
 
 std::optional<Variable> ArrayDomain::store(NumAbsDomain& inv, const DataKind kind, const Interval& idx,
                                            const Interval& elem_size, const bool big_endian) {
-    if (auto maybe_cell = split_and_find_var(*this, *cells_, inv, kind, idx, elem_size, big_endian)) {
+    if (auto maybe_cell = split_and_find_var(*this, cells_.get_mutable(), inv, kind, idx, elem_size, big_endian)) {
         // perform strong update
         auto [offset, size] = *maybe_cell;
-        const Cell c = cells_->get(kind).mk_cell(offset, size);
+        const Cell c = cells_.get_mutable().get(kind).mk_cell(offset, size);
         Variable v = cell_var(kind, c);
         return v;
     }
@@ -619,8 +594,8 @@ std::optional<Variable> ArrayDomain::store(NumAbsDomain& inv, const DataKind kin
 std::optional<Variable> ArrayDomain::store_type(TypeDomain& inv, const Interval& idx, const Interval& width,
                                                 const bool is_num) {
     constexpr auto kind = DataKind::types;
-    if (auto maybe_cell =
-            kill_and_find_var(*cells_, [&inv](const Variable v) { inv.havoc_type(v); }, kind, idx, width)) {
+    if (auto maybe_cell = kill_and_find_var(
+            cells_.get_mutable(), [&inv](const Variable v) { inv.havoc_type(v); }, kind, idx, width)) {
         // perform strong update
         auto [offset, size] = *maybe_cell;
         if (is_num) {
@@ -628,7 +603,7 @@ std::optional<Variable> ArrayDomain::store_type(TypeDomain& inv, const Interval&
         } else {
             num_bytes.havoc(offset, size);
         }
-        const Cell c = cells_->get(kind).mk_cell(offset, size);
+        const Cell c = cells_.get_mutable().get(kind).mk_cell(offset, size);
         Variable v = cell_var(kind, c);
         return v;
     } else {
@@ -650,13 +625,13 @@ std::optional<Variable> ArrayDomain::store_type(TypeDomain& inv, const Interval&
 
 void ArrayDomain::havoc(NumAbsDomain& inv, const DataKind kind, const Interval& idx, const Interval& elem_size,
                         const bool big_endian) {
-    split_and_find_var(*this, *cells_, inv, kind, idx, elem_size, big_endian);
+    split_and_find_var(*this, cells_.get_mutable(), inv, kind, idx, elem_size, big_endian);
 }
 
 void ArrayDomain::havoc_type(TypeDomain& inv, const Interval& idx, const Interval& elem_size) {
     constexpr auto kind = DataKind::types;
-    if (auto maybe_cell =
-            kill_and_find_var(*cells_, [&inv](const Variable v) { inv.havoc_type(v); }, kind, idx, elem_size)) {
+    if (auto maybe_cell = kill_and_find_var(
+            cells_.get_mutable(), [&inv](const Variable v) { inv.havoc_type(v); }, kind, idx, elem_size)) {
         auto [offset, size] = *maybe_cell;
         num_bytes.havoc(offset, size);
     }
@@ -695,12 +670,12 @@ bool ArrayDomain::operator==(const ArrayDomain& other) const { return num_bytes 
 
 void ArrayDomain::operator|=(const ArrayDomain& other) {
     num_bytes |= other.num_bytes;
-    cells_->merge_from(*other.cells_);
+    cells_.get_mutable().merge_from(*other.cells_);
 }
 
 void ArrayDomain::operator|=(ArrayDomain&& other) {
     num_bytes |= std::move(other.num_bytes);
-    cells_->merge_from(*other.cells_);
+    cells_.get_mutable().merge_from(*other.cells_);
 }
 
 // Lattice combinators build a fresh ArrayDomain whose cells map is the union of
@@ -710,29 +685,29 @@ void ArrayDomain::operator|=(ArrayDomain&& other) {
 // names so two domains independently tracking the same cell agree on its name.
 ArrayDomain ArrayDomain::operator|(const ArrayDomain& other) const {
     ArrayDomain res{num_bytes | other.num_bytes};
-    res.cells_->merge_from(*cells_);
-    res.cells_->merge_from(*other.cells_);
+    res.cells_.get_mutable().merge_from(*cells_);
+    res.cells_.get_mutable().merge_from(*other.cells_);
     return res;
 }
 
 ArrayDomain ArrayDomain::operator&(const ArrayDomain& other) const {
     ArrayDomain res{num_bytes & other.num_bytes};
-    res.cells_->merge_from(*cells_);
-    res.cells_->merge_from(*other.cells_);
+    res.cells_.get_mutable().merge_from(*cells_);
+    res.cells_.get_mutable().merge_from(*other.cells_);
     return res;
 }
 
 ArrayDomain ArrayDomain::widen(const ArrayDomain& other) const {
     ArrayDomain res{num_bytes | other.num_bytes};
-    res.cells_->merge_from(*cells_);
-    res.cells_->merge_from(*other.cells_);
+    res.cells_.get_mutable().merge_from(*cells_);
+    res.cells_.get_mutable().merge_from(*other.cells_);
     return res;
 }
 
 ArrayDomain ArrayDomain::narrow(const ArrayDomain& other) const {
     ArrayDomain res{num_bytes & other.num_bytes};
-    res.cells_->merge_from(*cells_);
-    res.cells_->merge_from(*other.cells_);
+    res.cells_.get_mutable().merge_from(*cells_);
+    res.cells_.get_mutable().merge_from(*other.cells_);
     return res;
 }
 

--- a/src/crab/array_domain.cpp
+++ b/src/crab/array_domain.cpp
@@ -70,6 +70,7 @@ static Variable cell_var(const DataKind kind, const Cell& c) {
 // macro-level improvement while adding complexity or external dependencies.
 class offset_map_t final {
     friend class ArrayDomain;
+    friend class StackCellRegistry;
 
     using cell_set_t = std::set<Cell>;
 
@@ -206,26 +207,59 @@ std::vector<Cell> offset_map_t::get_overlap_cells(const offset_t o, const unsign
     return out;
 }
 
-// Per-analysis registry of the stack cells currently tracked, keyed by DataKind.
-// Owned by AnalysisContext; threaded into ArrayDomain methods that mutate or query
-// the cell set.
+// Per-domain registry of the stack cells `ArrayDomain` is currently tracking,
+// keyed by DataKind. Owned by `ArrayDomain`; copied/merged alongside the domain.
 class StackCellRegistry final {
     std::unordered_map<DataKind, offset_map_t> _maps;
 
   public:
     offset_map_t& get(const DataKind kind) { return _maps[kind]; }
-    void clear() { _maps.clear(); }
+
+    // Union `other` into `*this` so the resulting registry tracks every cell
+    // either side knew about. Idempotent insert: cells already present stay.
+    void merge_from(const StackCellRegistry& other) {
+        for (const auto& [kind, omap] : other._maps) {
+            offset_map_t& dst = _maps[kind];
+            for (const auto& [_off, cell_set] : omap._map) {
+                for (const Cell& c : cell_set) {
+                    dst.insert_cell(c);
+                }
+            }
+        }
+    }
 };
 
 void StackCellRegistryDeleter::operator()(StackCellRegistry* ptr) const noexcept { delete ptr; }
 
 StackCellRegistryPtr make_stack_cell_registry() { return StackCellRegistryPtr{new StackCellRegistry()}; }
 
-void clear_stack_cell_registry(StackCellRegistry& registry) { registry.clear(); }
+StackCellRegistryPtr clone_stack_cell_registry(const StackCellRegistry& registry) {
+    return StackCellRegistryPtr{new StackCellRegistry(registry)};
+}
 
-void ArrayDomain::initialize_numbers(StackCellRegistry& cells, const int lb, const int width) {
+ArrayDomain::ArrayDomain(const ArrayDomain& other)
+    : num_bytes(other.num_bytes), cells_(clone_stack_cell_registry(*other.cells_)) {}
+
+ArrayDomain::ArrayDomain(ArrayDomain&& other) noexcept
+    : num_bytes(std::move(other.num_bytes)), cells_(std::exchange(other.cells_, make_stack_cell_registry())) {}
+
+ArrayDomain& ArrayDomain::operator=(const ArrayDomain& other) {
+    if (this != &other) {
+        num_bytes = other.num_bytes;
+        cells_ = clone_stack_cell_registry(*other.cells_);
+    }
+    return *this;
+}
+
+ArrayDomain& ArrayDomain::operator=(ArrayDomain&& other) noexcept {
+    num_bytes = std::move(other.num_bytes);
+    std::swap(cells_, other.cells_);
+    return *this;
+}
+
+void ArrayDomain::initialize_numbers(const int lb, const int width) {
     num_bytes.reset(lb, width);
-    cells.get(DataKind::svalues).mk_cell(offset_t{gsl::narrow_cast<Index>(lb)}, width);
+    cells_->get(DataKind::svalues).mk_cell(offset_t{gsl::narrow_cast<Index>(lb)}, width);
 }
 
 std::ostream& operator<<(std::ostream& o, offset_map_t& m) {
@@ -248,18 +282,18 @@ std::ostream& operator<<(std::ostream& o, offset_map_t& m) {
 }
 
 // Create a new cell that is a subset of an existing cell.
-void ArrayDomain::split_cell(StackCellRegistry& cells, NumAbsDomain& inv, const DataKind kind,
-                             const int cell_start_index, const unsigned int len, const bool big_endian) {
+void ArrayDomain::split_cell(NumAbsDomain& inv, const DataKind kind, const int cell_start_index, const unsigned int len,
+                             const bool big_endian) {
     assert(kind == DataKind::svalues || kind == DataKind::uvalues);
 
     // Get the values from the indicated stack range.
     const std::optional<LinearExpression> svalue =
-        load(cells, inv, DataKind::svalues, Interval{cell_start_index}, len, big_endian);
+        load(inv, DataKind::svalues, Interval{cell_start_index}, len, big_endian);
     const std::optional<LinearExpression> uvalue =
-        load(cells, inv, DataKind::uvalues, Interval{cell_start_index}, len, big_endian);
+        load(inv, DataKind::uvalues, Interval{cell_start_index}, len, big_endian);
 
     // Create a new cell for that range.
-    offset_map_t& offset_map = cells.get(kind);
+    offset_map_t& offset_map = cells_->get(kind);
     const Cell new_cell = offset_map.mk_cell(offset_t{gsl::narrow_cast<Index>(cell_start_index)}, len);
     inv.assign(cell_var(DataKind::svalues, new_cell), svalue);
     inv.assign(cell_var(DataKind::uvalues, new_cell), uvalue);
@@ -267,10 +301,10 @@ void ArrayDomain::split_cell(StackCellRegistry& cells, NumAbsDomain& inv, const 
 
 // Prepare to havoc bytes in the middle of a cell by potentially splitting the cell if it is numeric,
 // into the part to the left of the havoced portion, and the part to the right of the havoced portion.
-void ArrayDomain::split_number_var(StackCellRegistry& cells, NumAbsDomain& inv, const DataKind kind, const Interval& ii,
-                                   const Interval& elem_size, const bool big_endian) const {
+void ArrayDomain::split_number_var(NumAbsDomain& inv, const DataKind kind, const Interval& ii,
+                                   const Interval& elem_size, const bool big_endian) {
     assert(kind == DataKind::svalues || kind == DataKind::uvalues);
-    offset_map_t& offset_map = cells.get(kind);
+    offset_map_t& offset_map = cells_->get(kind);
     const std::optional<Number> n = ii.singleton();
     if (!n) {
         // We can only split a singleton offset.
@@ -299,11 +333,11 @@ void ArrayDomain::split_number_var(StackCellRegistry& cells, NumAbsDomain& inv, 
         }
         if (gsl::narrow_cast<Index>(cell_start_index) < o) {
             // Use the bytes to the left of the specified range.
-            split_cell(cells, inv, kind, cell_start_index, gsl::narrow<unsigned int>(o - cell_start_index), big_endian);
+            split_cell(inv, kind, cell_start_index, gsl::narrow<unsigned int>(o - cell_start_index), big_endian);
         }
         if (o + size < cell_end_index + 1UL) {
             // Use the bytes to the right of the specified range.
-            split_cell(cells, inv, kind, gsl::narrow<int>(o + size),
+            split_cell(inv, kind, gsl::narrow<int>(o + size),
                        gsl::narrow<unsigned int>(cell_end_index - (o + size - 1)), big_endian);
         }
     }
@@ -419,11 +453,10 @@ std::optional<uint8_t> get_value_byte(const NumAbsDomain& inv, const offset_t o,
     return bytes[o % width];
 }
 
-std::optional<LinearExpression> ArrayDomain::load(StackCellRegistry& cells, const NumAbsDomain& inv,
-                                                  const DataKind kind, const Interval& i, const int width,
-                                                  const bool big_endian) {
+std::optional<LinearExpression> ArrayDomain::load(const NumAbsDomain& inv, const DataKind kind, const Interval& i,
+                                                  const int width, const bool big_endian) {
     if (const std::optional<Number> n = i.singleton()) {
-        offset_map_t& offset_map = cells.get(kind);
+        offset_map_t& offset_map = cells_->get(kind);
         const int64_t k = n->narrow<int64_t>();
         const offset_t o(k);
         const unsigned size = to_unsigned(width);
@@ -511,10 +544,9 @@ std::optional<LinearExpression> ArrayDomain::load(StackCellRegistry& cells, cons
     return {};
 }
 
-std::optional<LinearExpression> ArrayDomain::load_type(StackCellRegistry& cells, const Interval& i,
-                                                       const int width) const {
+std::optional<LinearExpression> ArrayDomain::load_type(const Interval& i, const int width) {
     if (const std::optional<Number> n = i.singleton()) {
-        offset_map_t& offset_map = cells.get(DataKind::types);
+        offset_map_t& offset_map = cells_->get(DataKind::types);
         const int64_t k = n->narrow<int64_t>();
         auto [only_num, only_non_num] = num_bytes.uniformity(k, width);
         if (only_num) {
@@ -564,31 +596,31 @@ std::optional<LinearExpression> ArrayDomain::load_type(StackCellRegistry& cells,
 // Any cells covering that range need to be removed, and any cells that only
 // partially cover that range can be split such that any non-covered portions become new cells.
 static std::optional<std::pair<offset_t, unsigned>>
-split_and_find_var(StackCellRegistry& cells, const ArrayDomain& array_domain, NumAbsDomain& inv, const DataKind kind,
+split_and_find_var(ArrayDomain& array_domain, StackCellRegistry& cells, NumAbsDomain& inv, const DataKind kind,
                    const Interval& idx, const Interval& elem_size, const bool big_endian) {
     if (kind == DataKind::svalues || kind == DataKind::uvalues) {
-        array_domain.split_number_var(cells, inv, kind, idx, elem_size, big_endian);
+        array_domain.split_number_var(inv, kind, idx, elem_size, big_endian);
     }
     return kill_and_find_var(cells, [&inv](const Variable v) { inv.havoc(v); }, kind, idx, elem_size);
 }
 
-std::optional<Variable> ArrayDomain::store(StackCellRegistry& cells, NumAbsDomain& inv, const DataKind kind,
-                                           const Interval& idx, const Interval& elem_size,
-                                           const bool big_endian) const {
-    if (auto maybe_cell = split_and_find_var(cells, *this, inv, kind, idx, elem_size, big_endian)) {
+std::optional<Variable> ArrayDomain::store(NumAbsDomain& inv, const DataKind kind, const Interval& idx,
+                                           const Interval& elem_size, const bool big_endian) {
+    if (auto maybe_cell = split_and_find_var(*this, *cells_, inv, kind, idx, elem_size, big_endian)) {
         // perform strong update
         auto [offset, size] = *maybe_cell;
-        const Cell c = cells.get(kind).mk_cell(offset, size);
+        const Cell c = cells_->get(kind).mk_cell(offset, size);
         Variable v = cell_var(kind, c);
         return v;
     }
     return {};
 }
 
-std::optional<Variable> ArrayDomain::store_type(StackCellRegistry& cells, TypeDomain& inv, const Interval& idx,
-                                                const Interval& width, const bool is_num) {
+std::optional<Variable> ArrayDomain::store_type(TypeDomain& inv, const Interval& idx, const Interval& width,
+                                                const bool is_num) {
     constexpr auto kind = DataKind::types;
-    if (auto maybe_cell = kill_and_find_var(cells, [&inv](const Variable v) { inv.havoc_type(v); }, kind, idx, width)) {
+    if (auto maybe_cell =
+            kill_and_find_var(*cells_, [&inv](const Variable v) { inv.havoc_type(v); }, kind, idx, width)) {
         // perform strong update
         auto [offset, size] = *maybe_cell;
         if (is_num) {
@@ -596,7 +628,7 @@ std::optional<Variable> ArrayDomain::store_type(StackCellRegistry& cells, TypeDo
         } else {
             num_bytes.havoc(offset, size);
         }
-        const Cell c = cells.get(kind).mk_cell(offset, size);
+        const Cell c = cells_->get(kind).mk_cell(offset, size);
         Variable v = cell_var(kind, c);
         return v;
     } else {
@@ -616,16 +648,15 @@ std::optional<Variable> ArrayDomain::store_type(StackCellRegistry& cells, TypeDo
     return {};
 }
 
-void ArrayDomain::havoc(StackCellRegistry& cells, NumAbsDomain& inv, const DataKind kind, const Interval& idx,
-                        const Interval& elem_size, const bool big_endian) const {
-    split_and_find_var(cells, *this, inv, kind, idx, elem_size, big_endian);
+void ArrayDomain::havoc(NumAbsDomain& inv, const DataKind kind, const Interval& idx, const Interval& elem_size,
+                        const bool big_endian) {
+    split_and_find_var(*this, *cells_, inv, kind, idx, elem_size, big_endian);
 }
 
-void ArrayDomain::havoc_type(StackCellRegistry& cells, TypeDomain& inv, const Interval& idx,
-                             const Interval& elem_size) {
+void ArrayDomain::havoc_type(TypeDomain& inv, const Interval& idx, const Interval& elem_size) {
     constexpr auto kind = DataKind::types;
     if (auto maybe_cell =
-            kill_and_find_var(cells, [&inv](const Variable v) { inv.havoc_type(v); }, kind, idx, elem_size)) {
+            kill_and_find_var(*cells_, [&inv](const Variable v) { inv.havoc_type(v); }, kind, idx, elem_size)) {
         auto [offset, size] = *maybe_cell;
         num_bytes.havoc(offset, size);
     }
@@ -662,17 +693,48 @@ bool ArrayDomain::operator<=(const ArrayDomain& other) const { return num_bytes 
 
 bool ArrayDomain::operator==(const ArrayDomain& other) const { return num_bytes == other.num_bytes; }
 
-void ArrayDomain::operator|=(const ArrayDomain& other) { num_bytes |= other.num_bytes; }
+void ArrayDomain::operator|=(const ArrayDomain& other) {
+    num_bytes |= other.num_bytes;
+    cells_->merge_from(*other.cells_);
+}
 
-void ArrayDomain::operator|=(ArrayDomain&& other) { num_bytes |= std::move(other.num_bytes); }
+void ArrayDomain::operator|=(ArrayDomain&& other) {
+    num_bytes |= std::move(other.num_bytes);
+    cells_->merge_from(*other.cells_);
+}
 
-ArrayDomain ArrayDomain::operator|(const ArrayDomain& other) const { return ArrayDomain(num_bytes | other.num_bytes); }
+// Lattice combinators build a fresh ArrayDomain whose cells map is the union of
+// both sides' cells. Cell membership is purely advisory (it enables overlap
+// detection and dedup of mk_cell calls); the underlying numeric domain's join
+// determines abstract values, and it operates on globally-interned Variable
+// names so two domains independently tracking the same cell agree on its name.
+ArrayDomain ArrayDomain::operator|(const ArrayDomain& other) const {
+    ArrayDomain res{num_bytes | other.num_bytes};
+    res.cells_->merge_from(*cells_);
+    res.cells_->merge_from(*other.cells_);
+    return res;
+}
 
-ArrayDomain ArrayDomain::operator&(const ArrayDomain& other) const { return ArrayDomain(num_bytes & other.num_bytes); }
+ArrayDomain ArrayDomain::operator&(const ArrayDomain& other) const {
+    ArrayDomain res{num_bytes & other.num_bytes};
+    res.cells_->merge_from(*cells_);
+    res.cells_->merge_from(*other.cells_);
+    return res;
+}
 
-ArrayDomain ArrayDomain::widen(const ArrayDomain& other) const { return ArrayDomain(num_bytes | other.num_bytes); }
+ArrayDomain ArrayDomain::widen(const ArrayDomain& other) const {
+    ArrayDomain res{num_bytes | other.num_bytes};
+    res.cells_->merge_from(*cells_);
+    res.cells_->merge_from(*other.cells_);
+    return res;
+}
 
-ArrayDomain ArrayDomain::narrow(const ArrayDomain& other) const { return ArrayDomain(num_bytes & other.num_bytes); }
+ArrayDomain ArrayDomain::narrow(const ArrayDomain& other) const {
+    ArrayDomain res{num_bytes & other.num_bytes};
+    res.cells_->merge_from(*cells_);
+    res.cells_->merge_from(*other.cells_);
+    return res;
+}
 
 std::ostream& operator<<(std::ostream& o, const ArrayDomain& dom) { return o << dom.num_bytes; }
 } // namespace prevail

--- a/src/crab/array_domain.hpp
+++ b/src/crab/array_domain.hpp
@@ -33,36 +33,44 @@
 
 namespace prevail {
 
-/// Per-analysis registry of the stack cells the analysis is currently tracking, keyed
-/// by DataKind. Owned by AnalysisContext; shared by reference across all ArrayDomain
-/// instances belonging to one analysis run. Each entry corresponds to a cell variable
-/// at a (offset, size); the registry exists so ArrayDomain can deduplicate `mk_cell`
-/// calls and answer overlap queries.
+/// Stack-cell tracking state — kept opaque via pImpl so callers don't depend on
+/// the offset-map / cell-set internals. Owned by `ArrayDomain` (per-domain); each
+/// instance maps `DataKind → cells at (offset, size)`. The registry exists so
+/// `ArrayDomain` can deduplicate `mk_cell` calls and answer overlap queries.
 class StackCellRegistry;
 struct StackCellRegistryDeleter {
     void operator()(StackCellRegistry*) const noexcept;
 };
 using StackCellRegistryPtr = std::unique_ptr<StackCellRegistry, StackCellRegistryDeleter>;
 StackCellRegistryPtr make_stack_cell_registry();
-/// Drop all tracked cells. Call this when starting a fresh analysis run against
-/// a reused context so stale entries from a prior run don't leak into the new one.
-void clear_stack_cell_registry(StackCellRegistry& registry);
+StackCellRegistryPtr clone_stack_cell_registry(const StackCellRegistry& registry);
 
 class ArrayDomain final {
     BitsetDomain num_bytes;
+    /// Per-domain stack-cell registry. Joining two ArrayDomains unions their cell
+    /// sets; underlying Variable names are interned globally by (kind, offset, size)
+    /// so two domains independently tracking the same cell agree on its name.
+    StackCellRegistryPtr cells_;
 
   public:
     // Top at the requested size.
-    explicit ArrayDomain(const size_t stack_size) : num_bytes(BitsetDomain{stack_size}) {}
+    explicit ArrayDomain(size_t stack_size) : num_bytes(BitsetDomain{stack_size}), cells_(make_stack_cell_registry()) {}
 
     [[nodiscard]]
     int total_stack_size() const {
         return gsl::narrow<int>(num_bytes.size());
     }
 
-    // no move constructor to BitsetDomain, and therefore no copy-then-move for ArrayDomain
-    explicit ArrayDomain(const BitsetDomain& num_bytes) : num_bytes(num_bytes) {}
-    ArrayDomain(const ArrayDomain& arr) = default;
+    explicit ArrayDomain(const BitsetDomain& num_bytes) : num_bytes(num_bytes), cells_(make_stack_cell_registry()) {}
+    ArrayDomain(const ArrayDomain& other);
+    // Move operations leave the source with a valid non-null cells_ (an empty
+    // registry for move-construct; the destination's prior cells for move-assign).
+    // The invariant "cells_ is never null" holds for all accessible instances,
+    // including moved-from ones — so callers that re-touch a moved-from ArrayDomain
+    // by copy or merge stay sound.
+    ArrayDomain(ArrayDomain&& other) noexcept;
+    ArrayDomain& operator=(const ArrayDomain& other);
+    ArrayDomain& operator=(ArrayDomain&& other) noexcept;
 
     // ArrayDomain has no bottom of its own; bottom is represented externally
     // (EbpfDomain wraps the stack in std::optional).
@@ -93,26 +101,23 @@ class ArrayDomain final {
     int min_all_num_size(const NumAbsDomain& inv, Variable offset) const;
 
     [[nodiscard]]
-    static std::optional<LinearExpression> load(StackCellRegistry& cells, const NumAbsDomain& inv, DataKind kind,
-                                                const Interval& i, int width, bool big_endian);
-    std::optional<LinearExpression> load_type(StackCellRegistry& cells, const Interval& i, int width) const;
-    std::optional<Variable> store(StackCellRegistry& cells, NumAbsDomain& inv, DataKind kind, const Interval& idx,
-                                  const Interval& elem_size, bool big_endian) const;
-    std::optional<Variable> store_type(StackCellRegistry& cells, TypeDomain& inv, const Interval& idx,
-                                       const Interval& width, bool is_num);
-    void havoc(StackCellRegistry& cells, NumAbsDomain& inv, DataKind kind, const Interval& idx,
-               const Interval& elem_size, bool big_endian) const;
-    void havoc_type(StackCellRegistry& cells, TypeDomain& inv, const Interval& idx, const Interval& elem_size);
+    std::optional<LinearExpression> load(const NumAbsDomain& inv, DataKind kind, const Interval& i, int width,
+                                         bool big_endian);
+    std::optional<LinearExpression> load_type(const Interval& i, int width);
+    std::optional<Variable> store(NumAbsDomain& inv, DataKind kind, const Interval& idx, const Interval& elem_size,
+                                  bool big_endian);
+    std::optional<Variable> store_type(TypeDomain& inv, const Interval& idx, const Interval& width, bool is_num);
+    void havoc(NumAbsDomain& inv, DataKind kind, const Interval& idx, const Interval& elem_size, bool big_endian);
+    void havoc_type(TypeDomain& inv, const Interval& idx, const Interval& elem_size);
 
     // Perform array stores over an array segment
     void store_numbers(const Interval& _idx, const Interval& _width);
 
-    void split_number_var(StackCellRegistry& cells, NumAbsDomain& inv, DataKind kind, const Interval& ii,
-                          const Interval& elem_size, bool big_endian) const;
-    static void split_cell(StackCellRegistry& cells, NumAbsDomain& inv, DataKind kind, int cell_start_index,
-                           unsigned int len, bool big_endian);
+    void split_number_var(NumAbsDomain& inv, DataKind kind, const Interval& ii, const Interval& elem_size,
+                          bool big_endian);
+    void split_cell(NumAbsDomain& inv, DataKind kind, int cell_start_index, unsigned int len, bool big_endian);
 
-    void initialize_numbers(StackCellRegistry& cells, int lb, int width);
+    void initialize_numbers(int lb, int width);
 };
 
 } // namespace prevail

--- a/src/crab/array_domain.hpp
+++ b/src/crab/array_domain.hpp
@@ -29,28 +29,21 @@
 #include "arith/variable.hpp"
 #include "crab/add_bottom.hpp"
 #include "crab/bitset_domain.hpp"
+#include "crab/cow.hpp"
 #include "crab/type_domain.hpp"
 
 namespace prevail {
 
 /// Stack-cell tracking state — kept opaque via pImpl so callers don't depend on
-/// the offset-map / cell-set internals. Owned by `ArrayDomain` (per-domain); each
-/// instance maps `DataKind → cells at (offset, size)`. The registry exists so
+/// the offset-map / cell-set internals. Shared (COW) across `ArrayDomain` copies;
+/// each instance maps `DataKind -> cells at (offset, size)`. The registry exists so
 /// `ArrayDomain` can deduplicate `mk_cell` calls and answer overlap queries.
 class StackCellRegistry;
-struct StackCellRegistryDeleter {
-    void operator()(StackCellRegistry*) const noexcept;
-};
-using StackCellRegistryPtr = std::unique_ptr<StackCellRegistry, StackCellRegistryDeleter>;
-StackCellRegistryPtr make_stack_cell_registry();
-StackCellRegistryPtr clone_stack_cell_registry(const StackCellRegistry& registry);
+std::shared_ptr<StackCellRegistry> make_stack_cell_registry();
 
 class ArrayDomain final {
     BitsetDomain num_bytes;
-    /// Per-domain stack-cell registry. Joining two ArrayDomains unions their cell
-    /// sets; underlying Variable names are interned globally by (kind, offset, size)
-    /// so two domains independently tracking the same cell agree on its name.
-    StackCellRegistryPtr cells_;
+    Cow<StackCellRegistry> cells_;
 
   public:
     // Top at the requested size.
@@ -62,15 +55,11 @@ class ArrayDomain final {
     }
 
     explicit ArrayDomain(const BitsetDomain& num_bytes) : num_bytes(num_bytes), cells_(make_stack_cell_registry()) {}
-    ArrayDomain(const ArrayDomain& other);
-    // Move operations leave the source with a valid non-null cells_ (an empty
-    // registry for move-construct; the destination's prior cells for move-assign).
-    // The invariant "cells_ is never null" holds for all accessible instances,
-    // including moved-from ones — so callers that re-touch a moved-from ArrayDomain
-    // by copy or merge stay sound.
-    ArrayDomain(ArrayDomain&& other) noexcept;
-    ArrayDomain& operator=(const ArrayDomain& other);
-    ArrayDomain& operator=(ArrayDomain&& other) noexcept;
+    ArrayDomain(const ArrayDomain& other) = default;
+    ArrayDomain(ArrayDomain&& other) noexcept = default;
+    ArrayDomain& operator=(const ArrayDomain& other) = default;
+    ArrayDomain& operator=(ArrayDomain&& other) noexcept = default;
+    ~ArrayDomain() = default;
 
     // ArrayDomain has no bottom of its own; bottom is represented externally
     // (EbpfDomain wraps the stack in std::optional).

--- a/src/crab/cow.hpp
+++ b/src/crab/cow.hpp
@@ -1,0 +1,48 @@
+// Copyright (c) Prevail Verifier contributors.
+// SPDX-License-Identifier: MIT
+#pragma once
+
+#include <cassert>
+#include <memory>
+#include <utility>
+
+namespace prevail {
+
+/// Copy-on-write wrapper. Const access (`*`, `->`) is free (shared);
+/// mutable access (`get_mutable()`) detaches when the underlying object
+/// is shared with other Cow instances.
+///
+/// Requires: T is copy-constructible (get_mutable detaches via copy).
+/// Invariant: the internal shared_ptr is never null.
+template <typename T>
+class Cow final {
+    std::shared_ptr<T> ptr_;
+
+  public:
+    explicit Cow(std::shared_ptr<T> p) : ptr_(std::move(p)) { assert(ptr_); }
+
+    template <typename... Args>
+    static Cow make(Args&&... args) {
+        return Cow{std::make_shared<T>(std::forward<Args>(args)...)};
+    }
+
+    Cow(const Cow&) = default;
+    Cow(Cow&&) noexcept = default;
+    Cow& operator=(const Cow&) = default;
+    Cow& operator=(Cow&&) noexcept = default;
+
+    const T& operator*() const { return *ptr_; }
+    const T* operator->() const { return ptr_.get(); }
+
+    [[nodiscard]]
+    T& get_mutable() {
+        if (ptr_.use_count() > 1) {
+            ptr_ = std::make_shared<T>(*ptr_);
+        }
+        return *ptr_;
+    }
+
+    const T* get() const { return ptr_.get(); }
+};
+
+} // namespace prevail

--- a/src/crab/ebpf_domain.cpp
+++ b/src/crab/ebpf_domain.cpp
@@ -397,10 +397,7 @@ EbpfDomain EbpfDomain::from_constraints(const std::vector<std::pair<Variable, Ty
 }
 
 EbpfDomain EbpfDomain::from_constraints(const ParsedConstraints& constraints, const AnalysisContext& context) {
-    EbpfDomain inv =
-        context.runtime().setup_constraints
-            ? setup_entry(false, context)
-            : EbpfDomain{TypeToNumDomain::top(), ArrayDomain{to_unsigned(context.runtime().total_stack_size())}};
+    EbpfDomain inv{TypeToNumDomain::top(), ArrayDomain{to_unsigned(context.runtime().total_stack_size())}};
     for (const auto& [v1, v2] : constraints.type_equalities) {
         inv.assume_eq_types(v1, v2);
     }

--- a/src/crab/ebpf_domain.cpp
+++ b/src/crab/ebpf_domain.cpp
@@ -416,7 +416,7 @@ EbpfDomain EbpfDomain::from_constraints(const ParsedConstraints& constraints, co
     for (const Interval& range : constraints.numeric_ranges) {
         const auto [start, ub] = range.pair<int64_t>();
         const int width = gsl::narrow<int>(1 + (ub - start));
-        inv.stack->initialize_numbers(context.cells(), gsl::narrow<int>(start), width);
+        inv.stack->initialize_numbers(gsl::narrow<int>(start), width);
     }
     // TODO: handle other stack type constraints
     return inv;

--- a/src/crab/ebpf_domain.hpp
+++ b/src/crab/ebpf_domain.hpp
@@ -100,12 +100,13 @@ class EbpfDomain final {
     static EbpfDomain from_constraints(const std::vector<std::pair<Variable, TypeSet>>& type_restrictions,
                                        const std::vector<LinearConstraint>& value_constraints,
                                        size_t total_stack_size = RuntimeConfig{}.total_stack_size());
-    /// Construction from fully parsed constraints. Seeds with `setup_entry()` first
-    /// when `context.runtime().setup_constraints` is true (the standard BPF entry
-    /// preconditions: r10 stack pointer, etc.), otherwise starts blank; then layers
-    /// the parsed type equalities, type restrictions, value constraints, and stack
-    /// numeric ranges on top. String parsing is intentionally not part of this API;
-    /// callers parse upstream and pass the structured form here.
+    /// Construction from fully parsed constraints. Always seeds blank (top, with
+    /// a stack of the configured size), then layers the parsed type equalities,
+    /// type restrictions, value constraints, and stack numeric ranges on top.
+    /// Callers that want the BPF entry preconditions (r10 stack pointer, etc.)
+    /// compose `setup_entry()` explicitly — this keeps construction orthogonal
+    /// from entry-state seeding. String parsing is intentionally not part of
+    /// this API; callers parse upstream and pass the structured form here.
     static EbpfDomain from_constraints(const ParsedConstraints& constraints, const AnalysisContext& context);
     void initialize_packet(const AnalysisContext& context);
 

--- a/src/crab/ebpf_transformer.cpp
+++ b/src/crab/ebpf_transformer.cpp
@@ -201,10 +201,9 @@ void EbpfTransformer::havoc_subprogram_stack(const std::string& prefix) {
     }
     const auto frame_size = context.runtime().subprogram_stack_size;
     const int64_t stack_start = intv.singleton()->cast_to<int64_t>() - frame_size;
-    stack.havoc_type(context.cells(), dom.state.types, Interval{stack_start}, Interval{frame_size});
+    stack.havoc_type(dom.state.types, Interval{stack_start}, Interval{frame_size});
     for (const DataKind kind : iterate_kinds()) {
-        stack.havoc(context.cells(), dom.state.values, kind, Interval{stack_start}, Interval{frame_size},
-                    context.runtime().big_endian);
+        stack.havoc(dom.state.values, kind, Interval{stack_start}, Interval{frame_size}, context.runtime().big_endian);
     }
 }
 
@@ -453,7 +452,7 @@ void EbpfTransformer::do_load_stack(TypeToNumDomain& state, const Reg& target_re
     if (state.values.entail(width <= reg_pack(src_reg).stack_numeric_size)) {
         state.assign_type(target_reg, T_NUM);
     } else {
-        state.assign_type(target_reg, stack.load_type(context.cells(), addr, width));
+        state.assign_type(target_reg, stack.load_type(addr, width));
         if (!state.is_initialized(target_reg)) {
             // We don't know what we loaded, so just havoc the destination register.
             state.havoc_register(target_reg);
@@ -467,16 +466,16 @@ void EbpfTransformer::do_load_stack(TypeToNumDomain& state, const Reg& target_re
         // addr from that same register.
         const bool big_endian = context.runtime().big_endian;
         const std::optional<LinearExpression> sresult =
-            stack.load(context.cells(), state.values, DataKind::svalues, addr, width, big_endian);
+            stack.load(state.values, DataKind::svalues, addr, width, big_endian);
         const std::optional<LinearExpression> uresult =
-            stack.load(context.cells(), state.values, DataKind::uvalues, addr, width, big_endian);
+            stack.load(state.values, DataKind::uvalues, addr, width, big_endian);
         state.havoc_register_except_type(target_reg);
         state.values.assign(target.svalue, sresult);
         state.values.assign(target.uvalue, uresult);
         for (const TypeEncoding type : state.iterate_types(target_reg)) {
             for (const auto& kind : type_to_kinds.at(type)) {
                 const Variable dst_var = variable_registry.reg(kind, target_reg.v);
-                state.values.assign(dst_var, stack.load(context.cells(), state.values, kind, addr, width, big_endian));
+                state.values.assign(dst_var, stack.load(state.values, kind, addr, width, big_endian));
             }
         }
     } else {
@@ -629,60 +628,55 @@ void EbpfTransformer::do_store_stack(TypeToNumDomain& state, const LinearExpress
     const Interval width{exact_width};
     const bool big_endian = context.runtime().big_endian;
     // no aliasing of val - we don't move from stack to stack, so we can just havoc first
-    stack.havoc_type(context.cells(), state.types, addr, width);
+    stack.havoc_type(state.types, addr, width);
     for (const DataKind kind : iterate_kinds()) {
         if (kind == DataKind::svalues || kind == DataKind::uvalues) {
             continue;
         }
-        stack.havoc(context.cells(), state.values, kind, addr, width, context.runtime().big_endian);
+        stack.havoc(state.values, kind, addr, width, context.runtime().big_endian);
     }
     bool must_be_num = false;
     if (opt_val_reg && !state.is_initialized(*opt_val_reg)) {
-        stack.havoc(context.cells(), state.values, DataKind::svalues, addr, width, big_endian);
-        stack.havoc(context.cells(), state.values, DataKind::uvalues, addr, width, big_endian);
+        stack.havoc(state.values, DataKind::svalues, addr, width, big_endian);
+        stack.havoc(state.values, DataKind::uvalues, addr, width, big_endian);
     } else {
         // opt_val_reg is unset when storing an immediate value.
         must_be_num = !opt_val_reg || state.is_in_group(*opt_val_reg, TS_NUM);
         const LinearExpression val_type =
             must_be_num ? LinearExpression{T_NUM} : variable_registry.type_reg(opt_val_reg->v);
-        state.assign_type(stack.store_type(context.cells(), state.types, addr, width, must_be_num), val_type);
+        state.assign_type(stack.store_type(state.types, addr, width, must_be_num), val_type);
 
         if (exact_width == 8) {
-            stack.havoc(context.cells(), state.values, DataKind::svalues, addr, width, big_endian);
-            stack.havoc(context.cells(), state.values, DataKind::uvalues, addr, width, big_endian);
-            state.values.assign(stack.store(context.cells(), state.values, DataKind::svalues, addr, width, big_endian),
-                                val_svalue);
-            state.values.assign(stack.store(context.cells(), state.values, DataKind::uvalues, addr, width, big_endian),
-                                val_uvalue);
+            stack.havoc(state.values, DataKind::svalues, addr, width, big_endian);
+            stack.havoc(state.values, DataKind::uvalues, addr, width, big_endian);
+            state.values.assign(stack.store(state.values, DataKind::svalues, addr, width, big_endian), val_svalue);
+            state.values.assign(stack.store(state.values, DataKind::uvalues, addr, width, big_endian), val_uvalue);
 
             if (!must_be_num) {
                 for (TypeEncoding type : state.iterate_types(*opt_val_reg)) {
                     for (const DataKind kind : type_to_kinds.at(type)) {
                         const Variable src_var = variable_registry.reg(kind, opt_val_reg->v);
-                        state.values.assign(stack.store(context.cells(), state.values, kind, addr, width, big_endian),
-                                            src_var);
+                        state.values.assign(stack.store(state.values, kind, addr, width, big_endian), src_var);
                     }
                 }
             }
         } else if ((exact_width == 1 || exact_width == 2 || exact_width == 4) && must_be_num) {
             // Keep track of numbers on the stack that might be used as array indices.
-            if (const auto stack_svalue =
-                    stack.store(context.cells(), state.values, DataKind::svalues, addr, width, big_endian)) {
+            if (const auto stack_svalue = stack.store(state.values, DataKind::svalues, addr, width, big_endian)) {
                 state.values.assign(stack_svalue, val_svalue);
                 state.values->overflow_bounds(*stack_svalue, exact_width * 8, true);
             } else {
-                stack.havoc(context.cells(), state.values, DataKind::svalues, addr, width, big_endian);
+                stack.havoc(state.values, DataKind::svalues, addr, width, big_endian);
             }
-            if (const auto stack_uvalue =
-                    stack.store(context.cells(), state.values, DataKind::uvalues, addr, width, big_endian)) {
+            if (const auto stack_uvalue = stack.store(state.values, DataKind::uvalues, addr, width, big_endian)) {
                 state.values.assign(stack_uvalue, val_uvalue);
                 state.values->overflow_bounds(*stack_uvalue, exact_width * 8, false);
             } else {
-                stack.havoc(context.cells(), state.values, DataKind::uvalues, addr, width, big_endian);
+                stack.havoc(state.values, DataKind::uvalues, addr, width, big_endian);
             }
         } else {
-            stack.havoc(context.cells(), state.values, DataKind::svalues, addr, width, big_endian);
-            stack.havoc(context.cells(), state.values, DataKind::uvalues, addr, width, big_endian);
+            stack.havoc(state.values, DataKind::svalues, addr, width, big_endian);
+            stack.havoc(state.values, DataKind::uvalues, addr, width, big_endian);
         }
     }
 
@@ -875,7 +869,7 @@ void EbpfTransformer::operator()(const Call& call) {
                     }
                     const Interval addr = state.values.eval_interval(*offset);
                     for (const DataKind kind : iterate_kinds()) {
-                        stack.havoc(context.cells(), state.values, kind, addr, w, context.runtime().big_endian);
+                        stack.havoc(state.values, kind, addr, w, context.runtime().big_endian);
                     }
                     // Keep this scoped to stack-typed pointers only.
                     stack.store_numbers(addr, w);
@@ -906,7 +900,7 @@ void EbpfTransformer::operator()(const Call& call) {
                     // Pointer to a memory region that the called function may change,
                     // so we must havoc.
                     for (const DataKind kind : iterate_kinds()) {
-                        stack.havoc(context.cells(), state.values, kind, addr, width, context.runtime().big_endian);
+                        stack.havoc(state.values, kind, addr, width, context.runtime().big_endian);
                     }
                 } else {
                     store_numbers = false;

--- a/src/fwd_analyzer.cpp
+++ b/src/fwd_analyzer.cpp
@@ -163,8 +163,12 @@ AnalysisResult analyze(const Program& prog, const VerifierOptions& options) {
 }
 
 AnalysisResult analyze(const AnalysisContext& context) {
-    return InterleavedFwdFixpointIterator::run(context,
-                                               EbpfDomain::setup_entry(context.runtime().setup_constraints, context));
+    // Initialise r1 to the program's context pointer iff the program type
+    // declares a non-empty context descriptor. The verifier's `setup_constraints`
+    // option no longer gates this — it's a property of the program, not the run.
+    const auto* ctx = context.program_info().type.ctx_descriptor;
+    const bool init_r1 = ctx != nullptr && ctx->size > 0;
+    return InterleavedFwdFixpointIterator::run(context, EbpfDomain::setup_entry(init_r1, context));
 }
 
 AnalysisResult analyze(const EbpfDomain& entry_invariant, const AnalysisContext& context) {

--- a/src/fwd_analyzer.cpp
+++ b/src/fwd_analyzer.cpp
@@ -16,9 +16,8 @@
 
 namespace prevail {
 
-// The array-domain cell registry now lives in AnalysisContext, so it dies with the
-// context — no thread-local clear needed.  SplitDBM still uses a thread-local scratch
-// buffer for transient graph operations; clear it to keep peak memory down.
+// Resets the SplitDBM thread-local scratch buffer used for transient graph
+// operations. Call between analyses to keep peak memory down.
 void ebpf_verifier_clear_thread_local_state() { ZoneDomain::clear_thread_local_state(); }
 
 class InterleavedFwdFixpointIterator final {
@@ -27,9 +26,9 @@ class InterleavedFwdFixpointIterator final {
     const Cfg& _cfg;
     const Wto _wto;
     AnalysisResult& result;
-    /// Counter Variables for *this* program's loop heads. Computed once
-    /// from `_wto`. Used wherever we previously asked the registry "what
-    /// loop counters exist?" — that's analysis-specific, not registry data.
+    /// Counter Variables for *this* program's loop heads, computed once
+    /// from `_wto`. The set is analysis-specific, not derivable from the
+    /// global `variable_registry`.
     std::vector<Variable> _loop_counters;
 
     /// number of narrowing iterations. If the narrowing operator is
@@ -164,18 +163,10 @@ AnalysisResult analyze(const Program& prog, const VerifierOptions& options) {
 }
 
 AnalysisResult analyze(const AnalysisContext& context) {
-    // Reset the per-context cell registry so a reused context starts each run with
-    // an empty cell map. setup_entry() below allocates fresh cells into it.
-    clear_stack_cell_registry(context.cells());
     return InterleavedFwdFixpointIterator::run(context,
                                                EbpfDomain::setup_entry(context.runtime().setup_constraints, context));
 }
 
-// Caller-supplied entry overload.  Does NOT reset context.cells(): the entry
-// domain may already reference cells in this context's registry (e.g. when
-// built via EbpfDomain::from_constraints(..., context)), and resetting here
-// would orphan them.  Callers reusing an AnalysisContext across runs must
-// clear the registry before constructing the entry.
 AnalysisResult analyze(const EbpfDomain& entry_invariant, const AnalysisContext& context) {
     return InterleavedFwdFixpointIterator::run(context, entry_invariant);
 }
@@ -281,7 +272,9 @@ void InterleavedFwdFixpointIterator::operator()(const std::shared_ptr<WtoCycle>&
                 break;
             }
             invariant = refine(invariant, std::move(new_pre), iteration);
-            set_pre(head, std::move(invariant));
+            // Copy (not move): next iteration reads `invariant` again.
+            // Consider aliasing `invariant` to the map slot to elide this sync.
+            set_pre(head, invariant);
         }
     }
 }

--- a/src/fwd_analyzer.cpp
+++ b/src/fwd_analyzer.cpp
@@ -54,9 +54,15 @@ class InterleavedFwdFixpointIterator final {
     void set_pre(const Label& label, EbpfDomain&& v) { result.invariants.at(label).pre = std::move(v); }
     void set_pre(const Label& label, const EbpfDomain& v) { result.invariants.at(label).pre = v; }
 
-    EbpfDomain get_pre(const Label& node) const { return result.invariants.at(node).pre; }
+    [[nodiscard]]
+    const EbpfDomain& get_pre(const Label& node) const {
+        return result.invariants.at(node).pre;
+    }
 
-    EbpfDomain get_post(const Label& node) const { return result.invariants.at(node).post; }
+    [[nodiscard]]
+    const EbpfDomain& get_post(const Label& node) const {
+        return result.invariants.at(node).post;
+    }
 
     void transform_to_post(const Label& label, EbpfDomain pre) {
         const auto& ins = _prog.instruction_at(label);

--- a/src/test/ebpf_yaml.cpp
+++ b/src/test/ebpf_yaml.cpp
@@ -125,22 +125,18 @@ static EbpfDomain parse_string_invariant_to_domain(const StringInvariant& inv, c
     return EbpfDomain::from_constraints(parse_linear_constraints(inv.value()), context);
 }
 
-// Bridge for entry-domain construction. Test-only path that previously lived in
-// EbpfDomain::from_constraints(set<string>).
-//
-// ebpf_verifier_clear_thread_local_state() resets ZoneDomain::SplitDBM::scratch_ — a
-// transient cross-run buffer. Doing it at the start of an entry build keeps peak
-// memory low between test cases (relevant for callers like run_conformance_test_case
-// that don't wrap with ThreadLocalGuard). It does NOT touch ArrayDomain cells; those
-// live in AnalysisContext::cells() and are scoped to the per-test context.
+// Test-only bridge for entry-domain construction. Resets the SplitDBM
+// thread-local scratch buffer before parsing so peak memory stays bounded
+// across test cases that don't wrap with ThreadLocalGuard
+// (run_conformance_test_case is one such caller).
 static EbpfDomain string_invariant_to_entry_domain(const StringInvariant& inv, const AnalysisContext& context) {
     ebpf_verifier_clear_thread_local_state();
     return parse_string_invariant_to_domain(inv, context);
 }
 
-// Bridge for observation-domain construction, called after analyze() has produced
-// invariants. No scratch clear needed: analysis is done, and the next entry build
-// will clear if it cares.
+// Test-only bridge for observation-domain construction, called after
+// analyze() has produced invariants. Skips the scratch reset because
+// analysis is done and the next entry build will reset if it cares.
 static EbpfDomain string_invariant_to_observation_domain(const StringInvariant& inv, const AnalysisContext& context) {
     return parse_string_invariant_to_domain(inv, context);
 }

--- a/src/test/ebpf_yaml.cpp
+++ b/src/test/ebpf_yaml.cpp
@@ -128,10 +128,18 @@ static EbpfDomain parse_string_invariant_to_domain(const StringInvariant& inv, c
 // Test-only bridge for entry-domain construction. Resets the SplitDBM
 // thread-local scratch buffer before parsing so peak memory stays bounded
 // across test cases that don't wrap with ThreadLocalGuard
-// (run_conformance_test_case is one such caller).
+// (run_conformance_test_case is one such caller). When
+// `setup_constraints` is on, composes the parsed invariant with
+// `setup_entry()` so the entry state carries the standard BPF entry
+// preconditions (r10 = stack pointer, etc.) on top of whatever the
+// test specified.
 static EbpfDomain string_invariant_to_entry_domain(const StringInvariant& inv, const AnalysisContext& context) {
     ebpf_verifier_clear_thread_local_state();
-    return parse_string_invariant_to_domain(inv, context);
+    EbpfDomain dom = parse_string_invariant_to_domain(inv, context);
+    if (context.runtime().setup_constraints && !dom.is_bottom()) {
+        dom = dom & EbpfDomain::setup_entry(false, context);
+    }
+    return dom;
 }
 
 // Test-only bridge for observation-domain construction, called after

--- a/test-data/stack.yaml
+++ b/test-data/stack.yaml
@@ -875,6 +875,8 @@ post:
   - r10.type=stack
   - r10.stack_offset=512
   - s[504...507].type=number
+  - s[504...507].svalue=r3.svalue
+  - s[504...507].uvalue=r3.uvalue
 ---
 # Regression test for backward scan early-break bug in get_overlap_cells.
 # See REGRESSION.md for details.


### PR DESCRIPTION
## Summary

- **Move stack-cell registry from AnalysisContext into ArrayDomain** — each `EbpfDomain` owns its cell registry, making the domain a self-contained value. Lattice ops merge cell sets explicitly; cell-variable names stay globally interned so independent domains agree on identity. Also fixes a latent move-then-reuse bug in the narrowing loop that the shared-registry layout masked.
- **Decouple `setup_entry` from `from_constraints`** — `from_constraints` always seeds blank; callers compose `setup_entry()` explicitly. The observation-domain bridge no longer drags entry preconditions in by accident.
- **Drive `init_r1` from program metadata** — whether r1 starts as a context pointer is a property of `program_info().type.ctx_descriptor`, not the `setup_constraints` flag.
- **COW shared_ptr for the cell registry** — eliminates the 15-20% regression from per-domain cloning. Copies bump a refcount; mutations detach only when shared. `merge_from` short-circuits on pointer identity. Measured back to baseline on cilium-core benchmarks.

## Test plan

- [x] Full test suite passes (1559 cases, 1322 passed, 1 skipped, 236 expected-failures)
- [x] Performance verified: `cilium-core/bpf_host.o cil_host_policy` 0.42s (matches pre-refactor baseline)
- [x] One YAML expectation updated (`stack_numeric_size join minimum`) to reflect sound load-creates-equality precision exposed by per-domain cells

🤖 Generated with [Claude Code](https://claude.com/claude-code)