### PR TITLE
Restore callee-saved registers via rename to preserve zone edges

### DIFF
--- a/src/crab/add_bottom.hpp
+++ b/src/crab/add_bottom.hpp
@@ -164,6 +164,12 @@ class AddBottom final {
         }
     }
 
+    void rename(const std::vector<std::pair<Variable, Variable>>& renaming) {
+        if (dom) {
+            dom->rename(renaming);
+        }
+    }
+
     void add_constraint(const LinearConstraint& cst) {
         if (dom) {
             if (!dom->add_constraint(cst)) {

--- a/src/crab/ebpf_transformer.cpp
+++ b/src/crab/ebpf_transformer.cpp
@@ -142,11 +142,18 @@ void EbpfTransformer::scratch_caller_saved_registers() {
     }
 }
 
-/// Create variables specific to the new call stack frame that store
-/// copies of the states of r6 through r9.
+static std::vector<std::pair<Variable, Variable>> callee_saved_renaming(const std::string& prefix) {
+    std::vector<std::pair<Variable, Variable>> pairs;
+    for (const uint8_t r : {R6, R7, R8, R9}) {
+        for (const DataKind kind : iterate_kinds(KIND_MIN, KIND_MAX)) {
+            pairs.emplace_back(kind == DataKind::types ? variable_registry.type_reg(r) : variable_registry.reg(kind, r),
+                               variable_registry.stack_frame_var(kind, r, prefix));
+        }
+    }
+    return pairs;
+}
+
 void EbpfTransformer::save_callee_saved_registers(const std::string& prefix) {
-    // TODO: define location `stack_frame_var`, and pass to dom.state.assign().
-    //       Similarly in restore_callee_saved_registers
     for (const Reg r : {Reg{R6}, Reg{R7}, Reg{R8}, Reg{R9}}) {
         if (dom.state.is_initialized(r)) {
             const Variable type_var = variable_registry.type_reg(r.v);
@@ -158,9 +165,7 @@ void EbpfTransformer::save_callee_saved_registers(const std::string& prefix) {
                 for (const DataKind kind : kinds) {
                     const Variable src_var = variable_registry.reg(kind, r.v);
                     const Variable dst_var = variable_registry.stack_frame_var(kind, r.v, prefix);
-                    if (!dom.state.values.eval_interval(src_var).is_top()) {
-                        dom.state.values.assign(dst_var, src_var);
-                    }
+                    dom.state.values.assign(dst_var, src_var);
                 }
             }
         }
@@ -168,29 +173,17 @@ void EbpfTransformer::save_callee_saved_registers(const std::string& prefix) {
 }
 
 void EbpfTransformer::restore_callee_saved_registers(const std::string& prefix) {
-    for (uint8_t r = R6; r <= R9; r++) {
-        Reg reg{r};
-        const Variable type_var = variable_registry.stack_frame_var(DataKind::types, r, prefix);
-        if (dom.state.is_initialized(type_var)) {
-            dom.state.assign_type(reg, type_var);
-            for (const TypeEncoding type : dom.state.iterate_types(reg)) {
-                auto kinds = type_to_kinds.at(type);
-                kinds.push_back(DataKind::uvalues);
-                kinds.push_back(DataKind::svalues);
-                for (const DataKind kind : kinds) {
-                    const Variable src_var = variable_registry.stack_frame_var(kind, r, prefix);
-                    const Variable dst_var = variable_registry.reg(kind, r);
-                    if (!dom.state.values.eval_interval(src_var).is_top()) {
-                        dom.state.values.assign(dst_var, src_var);
-                    } else {
-                        dom.state.values.havoc(dst_var);
-                    }
-                    dom.state.values.havoc(src_var);
-                }
-            }
-        }
-        dom.state.havoc_type(type_var);
+    // Havoc any callee-created r6-r9 variables before restoring the saved ones.
+    for (const uint8_t r : {R6, R7, R8, R9}) {
+        dom.state.havoc_register(Reg{r});
     }
+    const auto pairs = callee_saved_renaming(prefix);
+    std::vector<std::pair<Variable, Variable>> reverse_pairs;
+    reverse_pairs.reserve(pairs.size());
+    for (const auto& [reg_var, frame_var] : pairs) {
+        reverse_pairs.emplace_back(frame_var, reg_var);
+    }
+    dom.state.rename(reverse_pairs);
 }
 
 void EbpfTransformer::havoc_subprogram_stack(const std::string& prefix) {

--- a/src/crab/finite_domain.hpp
+++ b/src/crab/finite_domain.hpp
@@ -162,6 +162,8 @@ class FiniteDomain {
     /// Forget everything we know about the value of a variable.
     void havoc(const Variable v) { dom.havoc(v); }
 
+    void rename(const std::vector<std::pair<Variable, Variable>>& renaming) { dom.rename(renaming); }
+
     [[nodiscard]]
     std::pair<std::size_t, std::size_t> size() const {
         return dom.size();

--- a/src/crab/type_domain.cpp
+++ b/src/crab/type_domain.cpp
@@ -842,6 +842,12 @@ void TypeDomain::havoc_type(const Variable& v) {
     }
 }
 
+void TypeDomain::rename(const std::vector<std::pair<Variable, Variable>>& renaming) {
+    if (auto* s = state_.get()) {
+        s->var_ids.rename(renaming);
+    }
+}
+
 std::vector<Variable> TypeDomain::variables() const {
     if (!state_) {
         return {};

--- a/src/crab/type_domain.hpp
+++ b/src/crab/type_domain.hpp
@@ -99,6 +99,8 @@ class TypeDomain {
     void havoc_type(const Reg& r);
     void havoc_type(const Variable& v);
 
+    void rename(const std::vector<std::pair<Variable, Variable>>& renaming);
+
     // Query methods
     [[nodiscard]]
     std::vector<TypeEncoding> iterate_types(const Reg& reg) const;

--- a/src/crab/type_to_num.hpp
+++ b/src/crab/type_to_num.hpp
@@ -251,6 +251,11 @@ struct TypeToNumDomain {
 
     void havoc_register(const Reg& reg);
 
+    void rename(const std::vector<std::pair<Variable, Variable>>& renaming) {
+        types.rename(renaming);
+        values.rename(renaming);
+    }
+
     [[nodiscard]]
     TypeToNumDomain widen(const TypeToNumDomain& other) const;
 

--- a/src/crab/var_id_map.hpp
+++ b/src/crab/var_id_map.hpp
@@ -82,6 +82,25 @@ class VarIdMap {
         return id_to_var_.size();
     }
 
+    /// Rename variables in-place. The underlying IDs and their relationships
+    /// are unchanged — only the Variable labels are swapped.
+    /// Precondition: no destination is also a source in the same batch.
+    void rename(const std::vector<std::pair<Variable, Variable>>& renaming) {
+        for (const auto& [from, to] : renaming) {
+            if (const auto it = var_to_id_.find(from); it != var_to_id_.end()) {
+                const size_t id = it->second;
+                var_to_id_.erase(it);
+                // Orphan any existing mapping for `to` to preserve the bijection.
+                if (const auto dest = var_to_id_.find(to); dest != var_to_id_.end()) {
+                    id_to_var_[dest->second] = std::nullopt;
+                    var_to_id_.erase(dest);
+                }
+                var_to_id_[to] = id;
+                id_to_var_[id] = to;
+            }
+        }
+    }
+
     /// Iterate over all live (Variable, ID) pairs.
     [[nodiscard]]
     const std::map<Variable, size_t>& vars() const {

--- a/src/crab/zone_domain.cpp
+++ b/src/crab/zone_domain.cpp
@@ -672,6 +672,30 @@ void ZoneDomain::forget(const VariableVector& variables) {
     normalize();
 }
 
+void ZoneDomain::rename(const std::vector<std::pair<Variable, Variable>>& renaming) {
+    assert(std::ranges::none_of(renaming, [&](const auto& pair) {
+        return std::ranges::any_of(renaming, [&](const auto& other) { return other.first == pair.second; });
+    }));
+    bool forgot_destination = false;
+    for (const auto& [from, to] : renaming) {
+        if (const auto it = vert_map_.find(from); it != vert_map_.end()) {
+            const auto vert = it->second;
+            vert_map_.erase(it);
+            if (const auto dest = vert_map_.find(to); dest != vert_map_.end()) {
+                core_->forget(dest->second);
+                rev_map_[dest->second] = std::nullopt;
+                vert_map_.erase(dest);
+                forgot_destination = true;
+            }
+            vert_map_.emplace(to, vert);
+            rev_map_[vert] = to;
+        }
+    }
+    if (forgot_destination) {
+        normalize();
+    }
+}
+
 static std::string to_string(const Variable vd, const Variable vs, const Weight& w, const bool eq) {
     std::stringstream elem;
     if (eq) {

--- a/src/crab/zone_domain.hpp
+++ b/src/crab/zone_domain.hpp
@@ -200,6 +200,8 @@ class ZoneDomain final {
 
     void forget(const VariableVector& variables);
 
+    void rename(const std::vector<std::pair<Variable, Variable>>& renaming);
+
     // return number of vertices and edges
     [[nodiscard]]
     std::pair<std::size_t, std::size_t> size() const;

--- a/test-data/calllocal.yaml
+++ b/test-data/calllocal.yaml
@@ -348,3 +348,104 @@ post:
   - s[1535].type=number
   - s[1535].svalue=1
   - s[1535].uvalue=1
+---
+test-case: call local inside bounded loop with callee-saved counter
+options: ["termination"]
+
+pre: []
+
+code:
+  <start>: |
+    r6 = 0
+  <loop>: |
+    call <helper>
+    r6 += 1
+    if r6 < 4 goto <loop>
+    r0 = r6
+    exit
+  <helper>: |
+    r0 = 42
+    exit
+
+post:
+  - r0.type=number
+  - r0.svalue=4
+  - r0.uvalue=4
+  - r6.type=number
+  - r6.svalue=pc[1]
+  - r6.uvalue=pc[1]
+  - pc[1]=4
+
+messages: []
+---
+test-case: callee reads caller r6
+pre: []
+
+code:
+  <start>: |
+    r6 = 5
+    call <helper>
+    exit
+  <helper>: |
+    r0 = r6
+    exit
+
+post:
+  - r0.type=number
+  - r0.svalue=5
+  - r0.uvalue=5
+  - r6.type=number
+  - r6.svalue=5
+  - r6.uvalue=5
+---
+test-case: call local preserves callee-saved values across call
+pre: [r6.type=number, r6.svalue=5, r6.uvalue=5, r7.type=number, r7.svalue=10, r7.uvalue=10]
+
+code:
+  <start>: |
+    call <helper>
+    r0 = r6
+    r0 += r7
+    exit
+  <helper>: |
+    r0 = 0
+    exit
+
+post:
+  - r0.type=number
+  - r0.svalue=15
+  - r0.uvalue=15
+  - r6.type=number
+  - r6.svalue=5
+  - r6.uvalue=5
+  - r7.type=number
+  - r7.svalue=10
+  - r7.uvalue=10
+---
+test-case: call local preserves relational constraint on top-interval registers
+pre: [r6.type=number, r7.type=number]
+
+code:
+  <start>: |
+    assume r7 > r6
+    call <helper>
+    if r6 < r7 goto <ok>
+    exit
+  <ok>: |
+    r0 = 0
+    exit
+  <helper>: |
+    r0 = 0
+    exit
+
+post:
+  - r0.type=number
+  - r0.svalue=0
+  - r0.uvalue=0
+  - r6.type=number
+  - r6.uvalue-r7.uvalue<=-1
+  - r7.type=number
+  - r7.uvalue=[0, +oo]
+
+messages:
+  - "2:3: Code becomes unreachable (assume r6 >= r7)"


### PR DESCRIPTION
- Add a `rename` operation to `ZoneDomain`, `TypeDomain`, `FiniteDomain`, `AddBottom`, and `TypeToNumDomain` — relabels variables in the bidirectional maps without mutating the constraint graph
- Replace `restore_callee_saved_registers` with a bulk rename (frame variables → register names), preserving all zone edges across call returns
- Save remains a copy (not a rename) so callees can read r6-r9 per the BPF calling convention
- Both `VarIdMap::rename` and `ZoneDomain::rename` properly orphan/forget existing destination variables to maintain their bijection invariants

## Motivation

When a noinline BPF function is called inside a bounded loop, the old assign+havoc restore destroyed zone relationships between loop counters and callee-saved registers. The loop counter `pc[N]` widened to `[0, +oo]` even though the loop was clearly bounded.

Fixes #1119, closes #670.

## Test plan
- [x] New test: "call local inside bounded loop with callee-saved counter" — verifies loop counter survives a local call (fails on main, passes with this change)
- [x] New test: "callee reads caller r6" — verifies callee can still read caller's r6 after save

🤖 Generated with [Claude Code](https://claude.com/claude-code)