### PR TITLE
Enforce map-function compatibility checks

### DIFF
--- a/src/crab/ebpf_checker.cpp
+++ b/src/crab/ebpf_checker.cpp
@@ -45,6 +45,7 @@ class EbpfChecker final {
     void operator()(const ValidAccess&) const;
     void operator()(const ValidCallbackTarget&) const;
     void operator()(const ValidMapKeyValue&) const;
+    void operator()(const ValidMapType&) const;
     void operator()(const ValidSize&) const;
     void operator()(const ValidArgZero&) const;
     void operator()(const ValidStore&) const;
@@ -286,6 +287,19 @@ void EbpfChecker::operator()(const ValidMapKeyValue& s) const {
         }
         default: throw_fail("Only stack, packet, or shared can be used as a parameter");
         }
+    }
+}
+
+void EbpfChecker::operator()(const ValidMapType& s) const {
+    if (dom.state.is_bottom()) {
+        return;
+    }
+    const auto map_type = dom.get_map_type(s.map_fd_reg, context);
+    if (!map_type.has_value() || *map_type == 0) {
+        return;
+    }
+    if ((s.allowed_map_types & (uint64_t{1} << *map_type)) == 0) {
+        throw_fail("map type " + std::to_string(*map_type) + " is not allowed for " + s.helper_name);
     }
 }
 

--- a/src/crab/ebpf_checker.cpp
+++ b/src/crab/ebpf_checker.cpp
@@ -295,7 +295,7 @@ void EbpfChecker::operator()(const ValidMapType& s) const {
         return;
     }
     const auto map_type = dom.get_map_type(s.map_fd_reg, context);
-    if (!map_type.has_value() || *map_type == 0) {
+    if (!map_type.has_value() || *map_type == 0 || *map_type >= 64) {
         return;
     }
     if ((s.allowed_map_types & (uint64_t{1} << *map_type)) == 0) {

--- a/src/crab/ebpf_checker.cpp
+++ b/src/crab/ebpf_checker.cpp
@@ -295,8 +295,11 @@ void EbpfChecker::operator()(const ValidMapType& s) const {
         return;
     }
     const auto map_type = dom.get_map_type(s.map_fd_reg, context);
-    if (!map_type.has_value() || *map_type == 0 || *map_type >= 64) {
+    if (!map_type.has_value() || *map_type == 0) {
         return;
+    }
+    if (*map_type >= 64) {
+        throw_fail("map type " + std::to_string(*map_type) + " is out of supported range for " + s.helper_name);
     }
     if ((s.allowed_map_types & (uint64_t{1} << *map_type)) == 0) {
         throw_fail("map type " + std::to_string(*map_type) + " is not allowed for " + s.helper_name);

--- a/src/ir/assertions.cpp
+++ b/src/ir/assertions.cpp
@@ -137,6 +137,9 @@ class AssertExtractor {
                 break;
             }
         }
+        if (map_fd_reg && resolved.contract.allowed_map_types != 0) {
+            res.emplace_back(ValidMapType{*map_fd_reg, resolved.contract.allowed_map_types, resolved.name});
+        }
         for (ArgPair arg : resolved.contract.pairs) {
             const auto group = arg.or_null ? TypeGroup::mem_or_num : TypeGroup::mem;
             const auto access_type =

--- a/src/ir/call_resolver.cpp
+++ b/src/ir/call_resolver.cpp
@@ -50,6 +50,7 @@ ResolvedCall resolve_helper(const Call& call, const ProgramInfo& info) {
     res.contract.reallocate_packet = proto.reallocate_packet;
     res.contract.is_map_lookup = proto.return_type == EBPF_RETURN_TYPE_PTR_TO_MAP_VALUE_OR_NULL;
     res.contract.zero_args_mask = proto.zero_args_mask;
+    res.contract.allowed_map_types = proto.allowed_map_types;
 
     const std::array<ebpf_argument_type_t, 7> args = {
         {EBPF_ARGUMENT_TYPE_DONTCARE, proto.argument_type[0], proto.argument_type[1], proto.argument_type[2],

--- a/src/ir/syntax.hpp
+++ b/src/ir/syntax.hpp
@@ -225,6 +225,7 @@ struct CallContract {
     bool reallocate_packet{};
     std::optional<Reg> alloc_size_reg{}; ///< Register holding allocation size (for T_ALLOC_MEM returns).
     uint8_t zero_args_mask{};            ///< Bitmask of arg positions (0-4 for R1-R5) that must be zero.
+    uint64_t allowed_map_types{};        ///< Bitmask of allowed map types for the MAP_FD argument (0 = any).
 };
 
 /// Resolved form of a Call: the key (via `call`) plus everything derivable
@@ -470,9 +471,18 @@ struct ValidArgZero {
     constexpr bool operator==(const ValidArgZero&) const = default;
 };
 
+/// Checks that the map type passed to a helper is in its allowed set.
+struct ValidMapType {
+    Reg map_fd_reg;
+    uint64_t allowed_map_types{};
+    std::string helper_name;
+    bool operator==(const ValidMapType&) const = default;
+};
+
 using Assertion =
     std::variant<Comparable, Addable, ValidDivisor, ValidAccess, ValidStore, ValidSize, ValidMapKeyValue,
-                 ValidCallbackTarget, TypeConstraint, FuncConstraint, ZeroCtxOffset, BoundedLoopCount, ValidArgZero>;
+                 ValidCallbackTarget, TypeConstraint, FuncConstraint, ZeroCtxOffset, BoundedLoopCount, ValidArgZero,
+                 ValidMapType>;
 
 std::ostream& operator<<(std::ostream& os, Instruction const& ins);
 std::string to_string(Instruction const& ins);

--- a/src/linux/gpl/spec_prototypes.cpp
+++ b/src/linux/gpl/spec_prototypes.cpp
@@ -4,6 +4,38 @@
 #include <string_view>
 
 namespace prevail {
+
+// Map-type bitmask constants for EbpfHelperPrototype::allowed_map_types.
+// Values match the BPF_MAP_TYPE_* enum in the kernel UAPI.
+namespace {
+constexpr uint64_t MT_PERF_EVENT_ARRAY = map_type_bit(4);
+constexpr uint64_t MT_STACK_TRACE = map_type_bit(7);
+constexpr uint64_t MT_CGROUP_ARRAY = map_type_bit(8);
+constexpr uint64_t MT_ARRAY_OF_MAPS = map_type_bit(12);
+constexpr uint64_t MT_HASH_OF_MAPS = map_type_bit(13);
+constexpr uint64_t MT_DEVMAP = map_type_bit(14);
+constexpr uint64_t MT_SOCKMAP = map_type_bit(15);
+constexpr uint64_t MT_CPUMAP = map_type_bit(16);
+constexpr uint64_t MT_XSKMAP = map_type_bit(17);
+constexpr uint64_t MT_SOCKHASH = map_type_bit(18);
+constexpr uint64_t MT_CGROUP_STORAGE = map_type_bit(19);
+constexpr uint64_t MT_REUSEPORT_SOCKARRAY = map_type_bit(20);
+constexpr uint64_t MT_PERCPU_CGROUP_STORAGE = map_type_bit(21);
+constexpr uint64_t MT_QUEUE = map_type_bit(22);
+constexpr uint64_t MT_STACK = map_type_bit(23);
+constexpr uint64_t MT_SK_STORAGE = map_type_bit(24);
+constexpr uint64_t MT_DEVMAP_HASH = map_type_bit(25);
+constexpr uint64_t MT_RINGBUF = map_type_bit(27);
+constexpr uint64_t MT_INODE_STORAGE = map_type_bit(28);
+constexpr uint64_t MT_TASK_STORAGE = map_type_bit(29);
+constexpr uint64_t MT_BLOOM_FILTER = map_type_bit(30);
+constexpr uint64_t MT_USER_RINGBUF = map_type_bit(31);
+constexpr uint64_t MT_CGRP_STORAGE = map_type_bit(32);
+constexpr uint64_t MT_PERCPU_ARRAY = map_type_bit(6);
+constexpr uint64_t MT_PERCPU_HASH = map_type_bit(5);
+constexpr uint64_t MT_LRU_PERCPU_HASH = map_type_bit(10);
+} // namespace
+
 // Most ABI return/argument type constants used below are first-class enum
 // members in spec/ebpf_base.h. Keep only compatibility aliases used by this
 // static prototype table.
@@ -116,6 +148,7 @@ static constexpr EbpfHelperPrototype bpf_perf_event_read_proto = {
             EBPF_ARGUMENT_TYPE_PTR_TO_MAP,
             EBPF_ARGUMENT_TYPE_ANYTHING,
         },
+    .allowed_map_types = MT_PERF_EVENT_ARRAY,
 };
 
 static constexpr EbpfHelperPrototype bpf_perf_event_read_value_proto = {
@@ -128,6 +161,7 @@ static constexpr EbpfHelperPrototype bpf_perf_event_read_value_proto = {
             EBPF_ARGUMENT_TYPE_PTR_TO_WRITABLE_MEM,
             EBPF_ARGUMENT_TYPE_CONST_SIZE,
         },
+    .allowed_map_types = MT_PERF_EVENT_ARRAY,
 };
 
 static constexpr EbpfHelperPrototype bpf_perf_event_output_proto = {
@@ -141,6 +175,7 @@ static constexpr EbpfHelperPrototype bpf_perf_event_output_proto = {
             EBPF_ARGUMENT_TYPE_PTR_TO_READABLE_MEM,
             EBPF_ARGUMENT_TYPE_CONST_SIZE_OR_ZERO,
         },
+    .allowed_map_types = MT_PERF_EVENT_ARRAY,
 };
 
 static constexpr EbpfHelperPrototype bpf_get_current_task_proto = {
@@ -156,6 +191,7 @@ static constexpr EbpfHelperPrototype bpf_current_task_under_cgroup_proto = {
             EBPF_ARGUMENT_TYPE_PTR_TO_MAP,
             EBPF_ARGUMENT_TYPE_ANYTHING,
         },
+    .allowed_map_types = MT_CGROUP_ARRAY,
 };
 
 static constexpr EbpfHelperPrototype bpf_perf_prog_read_value_proto = {
@@ -266,6 +302,7 @@ static constexpr EbpfHelperPrototype bpf_sock_map_update_proto = {
             EBPF_ARGUMENT_TYPE_DONTCARE,
         },
     .ctx_descriptor = &g_sock_ops_descr,
+    .allowed_map_types = MT_SOCKMAP,
 };
 
 static constexpr EbpfHelperPrototype bpf_sock_hash_update_proto = {
@@ -280,6 +317,7 @@ static constexpr EbpfHelperPrototype bpf_sock_hash_update_proto = {
             EBPF_ARGUMENT_TYPE_DONTCARE,
         },
     .ctx_descriptor = &g_sock_ops_descr,
+    .allowed_map_types = MT_SOCKHASH,
 };
 
 static constexpr EbpfHelperPrototype bpf_get_stackid_proto = {
@@ -291,6 +329,7 @@ static constexpr EbpfHelperPrototype bpf_get_stackid_proto = {
             EBPF_ARGUMENT_TYPE_PTR_TO_MAP,
             EBPF_ARGUMENT_TYPE_ANYTHING,
         },
+    .allowed_map_types = MT_STACK_TRACE,
 };
 
 static constexpr EbpfHelperPrototype bpf_get_stack_proto = {
@@ -447,6 +486,7 @@ static constexpr EbpfHelperPrototype bpf_sk_redirect_hash_proto = {
             EBPF_ARGUMENT_TYPE_ANYTHING,
         },
     .ctx_descriptor = &g_sk_buff,
+    .allowed_map_types = MT_SOCKHASH,
 };
 
 static constexpr EbpfHelperPrototype bpf_sk_redirect_map_proto = {
@@ -460,6 +500,7 @@ static constexpr EbpfHelperPrototype bpf_sk_redirect_map_proto = {
             EBPF_ARGUMENT_TYPE_ANYTHING,
         },
     .ctx_descriptor = &g_sk_buff,
+    .allowed_map_types = MT_SOCKMAP,
 };
 
 static constexpr EbpfHelperPrototype bpf_msg_redirect_hash_proto = {
@@ -473,6 +514,7 @@ static constexpr EbpfHelperPrototype bpf_msg_redirect_hash_proto = {
             EBPF_ARGUMENT_TYPE_ANYTHING,
         },
     .ctx_descriptor = &g_sk_msg_md,
+    .allowed_map_types = MT_SOCKHASH,
 };
 
 static constexpr EbpfHelperPrototype bpf_msg_redirect_map_proto = {
@@ -486,6 +528,7 @@ static constexpr EbpfHelperPrototype bpf_msg_redirect_map_proto = {
             EBPF_ARGUMENT_TYPE_ANYTHING,
         },
     .ctx_descriptor = &g_sk_msg_md,
+    .allowed_map_types = MT_SOCKMAP,
 };
 
 static constexpr EbpfHelperPrototype bpf_msg_apply_bytes_proto = {
@@ -766,6 +809,7 @@ static constexpr EbpfHelperPrototype bpf_skb_under_cgroup_proto = {
             EBPF_ARGUMENT_TYPE_ANYTHING,
         },
     .ctx_descriptor = &g_sk_buff,
+    .allowed_map_types = MT_CGROUP_ARRAY,
 };
 
 static constexpr EbpfHelperPrototype bpf_skb_cgroup_id_proto = {
@@ -957,6 +1001,7 @@ static constexpr EbpfHelperPrototype bpf_get_local_storage_proto = {
             EBPF_ARGUMENT_TYPE_ANYTHING,
         },
     .zero_args_mask = 1 << 1,
+    .allowed_map_types = MT_CGROUP_STORAGE | MT_PERCPU_CGROUP_STORAGE,
 };
 
 static constexpr EbpfHelperPrototype bpf_redirect_map_proto = {
@@ -968,6 +1013,7 @@ static constexpr EbpfHelperPrototype bpf_redirect_map_proto = {
             EBPF_ARGUMENT_TYPE_ANYTHING,
             EBPF_ARGUMENT_TYPE_ANYTHING,
         },
+    .allowed_map_types = MT_DEVMAP | MT_DEVMAP_HASH | MT_CPUMAP | MT_XSKMAP,
 };
 
 static constexpr EbpfHelperPrototype bpf_sk_select_reuseport_proto = {
@@ -979,6 +1025,7 @@ static constexpr EbpfHelperPrototype bpf_sk_select_reuseport_proto = {
         EBPF_ARGUMENT_TYPE_PTR_TO_MAP_KEY,
         EBPF_ARGUMENT_TYPE_ANYTHING,
     },
+    .allowed_map_types = MT_REUSEPORT_SOCKARRAY | MT_SOCKMAP | MT_SOCKHASH,
 };
 
 static constexpr EbpfHelperPrototype bpf_get_current_ancestor_cgroup_id_proto = {
@@ -1030,6 +1077,7 @@ static constexpr EbpfHelperPrototype bpf_map_push_elem_proto = {
         EBPF_ARGUMENT_TYPE_PTR_TO_MAP_VALUE,
         EBPF_ARGUMENT_TYPE_ANYTHING,
     },
+    .allowed_map_types = MT_QUEUE | MT_STACK | MT_BLOOM_FILTER,
 };
 
 static constexpr EbpfHelperPrototype bpf_map_pop_elem_proto = {
@@ -1039,6 +1087,7 @@ static constexpr EbpfHelperPrototype bpf_map_pop_elem_proto = {
         EBPF_ARGUMENT_TYPE_PTR_TO_MAP,
         EBPF_ARGUMENT_TYPE_PTR_TO_UNINIT_MAP_VALUE,
     },
+    .allowed_map_types = MT_QUEUE | MT_STACK,
 };
 
 static constexpr EbpfHelperPrototype bpf_map_peek_elem_proto = {
@@ -1048,6 +1097,7 @@ static constexpr EbpfHelperPrototype bpf_map_peek_elem_proto = {
         EBPF_ARGUMENT_TYPE_CONST_PTR_TO_MAP,
         EBPF_ARGUMENT_TYPE_PTR_TO_UNINIT_MAP_VALUE,
     },
+    .allowed_map_types = MT_QUEUE | MT_STACK | MT_BLOOM_FILTER,
 };
 
 static constexpr EbpfHelperPrototype bpf_msg_push_data_proto = {
@@ -1261,6 +1311,7 @@ static constexpr EbpfHelperPrototype bpf_sk_storage_get_proto = {
             EBPF_ARGUMENT_TYPE_PTR_TO_MAP_VALUE_OR_NULL,
             EBPF_ARGUMENT_TYPE_ANYTHING,
         },
+    .allowed_map_types = MT_SK_STORAGE,
 };
 
 static constexpr EbpfHelperPrototype bpf_sk_storage_delete_proto = {
@@ -1271,6 +1322,7 @@ static constexpr EbpfHelperPrototype bpf_sk_storage_delete_proto = {
             EBPF_ARGUMENT_TYPE_PTR_TO_MAP,
             EBPF_ARGUMENT_TYPE_PTR_TO_BTF_ID_SOCK_COMMON,
         },
+    .allowed_map_types = MT_SK_STORAGE,
 };
 
 static constexpr EbpfHelperPrototype bpf_send_signal_proto = {
@@ -1316,6 +1368,7 @@ static constexpr EbpfHelperPrototype bpf_skb_output_proto = {
             EBPF_ARGUMENT_TYPE_CONST_SIZE_OR_ZERO,
         },
     //.arg1_btf_id = &bpf_skb_output_btf_ids[0],
+    .allowed_map_types = MT_PERF_EVENT_ARRAY,
 };
 
 static constexpr EbpfHelperPrototype bpf_probe_read_user_proto = {
@@ -1409,6 +1462,7 @@ static constexpr EbpfHelperPrototype bpf_xdp_output_proto = {
             EBPF_ARGUMENT_TYPE_CONST_SIZE_OR_ZERO,
         },
     // .arg1_btf_id = &bpf_xdp_output_btf_ids[0],
+    .allowed_map_types = MT_PERF_EVENT_ARRAY,
 };
 
 static constexpr EbpfHelperPrototype bpf_sk_assign_proto = {
@@ -1480,6 +1534,7 @@ static constexpr EbpfHelperPrototype bpf_ringbuf_reserve_proto = {
             EBPF_ARGUMENT_TYPE_CONST_ALLOC_SIZE_OR_ZERO,
             EBPF_ARGUMENT_TYPE_ANYTHING,
         },
+    .allowed_map_types = MT_RINGBUF,
 };
 
 static constexpr EbpfHelperPrototype bpf_ringbuf_submit_proto = {
@@ -1512,6 +1567,7 @@ static constexpr EbpfHelperPrototype bpf_ringbuf_output_proto = {
             EBPF_ARGUMENT_TYPE_CONST_SIZE_OR_ZERO,
             EBPF_ARGUMENT_TYPE_ANYTHING,
         },
+    .allowed_map_types = MT_RINGBUF,
 };
 
 constexpr EbpfHelperPrototype bpf_ringbuf_query_proto = {
@@ -1522,6 +1578,7 @@ constexpr EbpfHelperPrototype bpf_ringbuf_query_proto = {
             EBPF_ARGUMENT_TYPE_CONST_PTR_TO_MAP,
             EBPF_ARGUMENT_TYPE_ANYTHING,
         },
+    .allowed_map_types = MT_RINGBUF,
 };
 
 static constexpr EbpfHelperPrototype bpf_csum_level_proto = {
@@ -1619,6 +1676,7 @@ static constexpr EbpfHelperPrototype bpf_inode_storage_get_proto = {
             EBPF_ARGUMENT_TYPE_ANYTHING,
         },
     //.arg2_btf_id = &bpf_inode_storage_btf_ids[0],
+    .allowed_map_types = MT_INODE_STORAGE,
 };
 
 static constexpr EbpfHelperPrototype bpf_inode_storage_delete_proto = {
@@ -1630,6 +1688,7 @@ static constexpr EbpfHelperPrototype bpf_inode_storage_delete_proto = {
             EBPF_ARGUMENT_TYPE_PTR_TO_BTF_ID,
         },
     //.arg2_btf_id = &bpf_inode_storage_btf_ids[0],
+    .allowed_map_types = MT_INODE_STORAGE,
 };
 
 static constexpr EbpfHelperPrototype bpf_d_path_proto = {
@@ -1745,6 +1804,7 @@ static constexpr EbpfHelperPrototype bpf_task_storage_get_proto = {
             EBPF_ARGUMENT_TYPE_ANYTHING,
         },
     // .arg2_btf_id = &bpf_task_storage_btf_ids[0],
+    .allowed_map_types = MT_TASK_STORAGE,
 };
 
 static constexpr EbpfHelperPrototype bpf_task_storage_delete_proto = {
@@ -1756,6 +1816,7 @@ static constexpr EbpfHelperPrototype bpf_task_storage_delete_proto = {
             EBPF_ARGUMENT_TYPE_PTR_TO_BTF_ID,
         },
     // .arg2_btf_id = &bpf_task_storage_btf_ids[0],
+    .allowed_map_types = MT_TASK_STORAGE,
 };
 
 static constexpr EbpfHelperPrototype bpf_get_current_task_btf_proto = {
@@ -2047,6 +2108,7 @@ static constexpr EbpfHelperPrototype bpf_map_lookup_percpu_elem_proto = {
             EBPF_ARGUMENT_TYPE_DONTCARE,
             EBPF_ARGUMENT_TYPE_DONTCARE,
         },
+    .allowed_map_types = MT_PERCPU_ARRAY | MT_PERCPU_HASH | MT_LRU_PERCPU_HASH,
 };
 
 // Time operations
@@ -2066,6 +2128,7 @@ static constexpr EbpfHelperPrototype bpf_ringbuf_reserve_dynptr_proto = {
             EBPF_ARGUMENT_TYPE_ANYTHING,
             EBPF_ARGUMENT_TYPE_ANYTHING,
         },
+    .allowed_map_types = MT_RINGBUF,
     .unsupported = true,
 };
 
@@ -2143,6 +2206,7 @@ static constexpr EbpfHelperPrototype bpf_user_ringbuf_drain_proto = {
             EBPF_ARGUMENT_TYPE_PTR_TO_STACK_OR_NULL,
             EBPF_ARGUMENT_TYPE_ANYTHING,
         },
+    .allowed_map_types = MT_USER_RINGBUF,
     .unsupported = true,
 };
 
@@ -2157,6 +2221,7 @@ static constexpr EbpfHelperPrototype bpf_cgrp_storage_get_proto = {
             EBPF_ARGUMENT_TYPE_PTR_TO_MAP_VALUE,
             EBPF_ARGUMENT_TYPE_ANYTHING,
         },
+    .allowed_map_types = MT_CGRP_STORAGE,
 };
 
 static constexpr EbpfHelperPrototype bpf_cgrp_storage_delete_proto = {
@@ -2167,6 +2232,7 @@ static constexpr EbpfHelperPrototype bpf_cgrp_storage_delete_proto = {
             EBPF_ARGUMENT_TYPE_PTR_TO_MAP,
             EBPF_ARGUMENT_TYPE_PTR_TO_BTF_ID,
         },
+    .allowed_map_types = MT_CGRP_STORAGE,
 };
 // Helper 83 - skb_ancestor_cgroup_id
 static constexpr EbpfHelperPrototype bpf_skb_ancestor_cgroup_id_proto = {

--- a/src/printing.cpp
+++ b/src/printing.cpp
@@ -420,6 +420,8 @@ struct AssertionPrinterVisitor {
 
     void operator()(ValidCallbackTarget const& a) { _os << "valid_callback_target(" << a.reg << ")"; }
 
+    void operator()(ValidMapType const& a) { _os << "valid_map_type(" << a.map_fd_reg << ", " << a.helper_name << ")"; }
+
     void operator()(ZeroCtxOffset const& a) { _os << variable_registry.reg(DataKind::ctx_offsets, a.reg.v) << " == 0"; }
 
     void operator()(Comparable const& a) {

--- a/src/result.cpp
+++ b/src/result.cpp
@@ -368,6 +368,8 @@ std::set<Reg> extract_assertion_registers(const Assertion& assertion) {
                 return {};
             } else if constexpr (std::is_same_v<T, ValidArgZero>) {
                 return {a.reg};
+            } else if constexpr (std::is_same_v<T, ValidMapType>) {
+                return {a.map_fd_reg};
             } else {
                 static_assert(always_false_v<T>, "Unhandled Assertion type in extract_assertion_registers");
             }

--- a/src/spec/function_prototypes.hpp
+++ b/src/spec/function_prototypes.hpp
@@ -2,9 +2,13 @@
 // SPDX-License-Identifier: MIT
 #pragma once
 
+#include <cstdint>
+
 #include "spec/ebpf_base.h"
 
 namespace prevail {
+
+constexpr uint64_t map_type_bit(uint32_t type) { return uint64_t{1} << type; }
 // A helper function's prototype is expressed by this struct.
 struct EbpfHelperPrototype {
     const char* name{};
@@ -26,6 +30,10 @@ struct EbpfHelperPrototype {
 
     // Whether this helper may sleep (forbidden in non-sleepable programs).
     bool might_sleep{};
+
+    // Bitmask of platform-specific map types that may be passed to this helper.
+    // Zero means any map type is accepted; bit N set means map type N is allowed.
+    uint64_t allowed_map_types{};
 
     bool unsupported = false;
 };

--- a/src/spec/function_prototypes.hpp
+++ b/src/spec/function_prototypes.hpp
@@ -8,7 +8,7 @@
 
 namespace prevail {
 
-constexpr uint64_t map_type_bit(uint32_t type) { return uint64_t{1} << type; }
+constexpr uint64_t map_type_bit(uint32_t type) { return type < 64 ? uint64_t{1} << type : 0; }
 // A helper function's prototype is expressed by this struct.
 struct EbpfHelperPrototype {
     const char* name{};


### PR DESCRIPTION
## Summary
- Add `allowed_map_types` bitmask to `EbpfHelperPrototype` and `CallContract`
- New `ValidMapType` assertion emitted when a helper with restricted map types receives a map fd argument
- Checker rejects mismatches at verification time
- Populated for 34 helpers matching the kernel v6.18 `check_map_func_compatibility` function→map direction

## Details

The kernel enforces bidirectional map-function compatibility: certain map types may only be used with specific helpers, and certain helpers may only receive specific map types. Prevail had no such check — any map type was accepted by any helper with a `PTR_TO_MAP` argument (except `tail_call`, which uses `PTR_TO_MAP_OF_PROGRAMS`).

This PR encodes the function→map direction. Map type UNSPEC (0) is treated as unknown and silently allowed to avoid false positives from incomplete ELF metadata. The reverse direction (map→function, e.g., "PERF_EVENT_ARRAY may not be passed to map_update_elem") is left for a follow-up.

## Test plan
- [x] Full test suite passes (1559 cases, 225 expected failures, 0 regressions)
- [x] New assertion visible in printed output for affected helpers (e.g., `valid_map_type(r1, ringbuf_output)`)

Closes #1123
Ref: #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)