### PR TITLE
Add missing reallocate_packet flags for 8 helpers

### DIFF
--- a/src/linux/gpl/spec_prototypes.cpp
+++ b/src/linux/gpl/spec_prototypes.cpp
@@ -370,6 +370,7 @@ static constexpr EbpfHelperPrototype bpf_l3_csum_replace_proto = {
             EBPF_ARGUMENT_TYPE_ANYTHING,
             EBPF_ARGUMENT_TYPE_ANYTHING,
         },
+    .reallocate_packet = true,
     .ctx_descriptor = &g_sk_buff,
 };
 
@@ -384,6 +385,7 @@ static constexpr EbpfHelperPrototype bpf_l4_csum_replace_proto = {
             EBPF_ARGUMENT_TYPE_ANYTHING,
             EBPF_ARGUMENT_TYPE_ANYTHING,
         },
+    .reallocate_packet = true,
     .ctx_descriptor = &g_sk_buff,
 };
 
@@ -420,6 +422,7 @@ static constexpr EbpfHelperPrototype bpf_clone_redirect_proto = {
             EBPF_ARGUMENT_TYPE_ANYTHING,
             EBPF_ARGUMENT_TYPE_ANYTHING,
         },
+    .reallocate_packet = true,
     .ctx_descriptor = &g_sk_buff,
 };
 
@@ -517,6 +520,7 @@ static constexpr EbpfHelperPrototype bpf_msg_pull_data_proto = {
             EBPF_ARGUMENT_TYPE_ANYTHING,
             EBPF_ARGUMENT_TYPE_ANYTHING,
         },
+    .reallocate_packet = true,
     .ctx_descriptor = &g_sk_msg_md,
 };
 static constexpr EbpfHelperPrototype bpf_get_cgroup_classid_proto = {
@@ -878,6 +882,7 @@ static constexpr EbpfHelperPrototype bpf_lwt_push_encap_proto = {
             EBPF_ARGUMENT_TYPE_PTR_TO_READABLE_MEM,
             EBPF_ARGUMENT_TYPE_CONST_SIZE,
         },
+    .reallocate_packet = true,
     .ctx_descriptor = &g_sk_buff,
 };
 
@@ -891,6 +896,7 @@ static constexpr EbpfHelperPrototype bpf_lwt_seg6_store_bytes_proto = {
             EBPF_ARGUMENT_TYPE_PTR_TO_READABLE_MEM,
             EBPF_ARGUMENT_TYPE_CONST_SIZE,
         },
+    .reallocate_packet = true,
     .ctx_descriptor = &g_sk_buff,
 };
 
@@ -904,6 +910,7 @@ static constexpr EbpfHelperPrototype bpf_lwt_seg6_action_proto = {
             EBPF_ARGUMENT_TYPE_PTR_TO_READABLE_MEM,
             EBPF_ARGUMENT_TYPE_CONST_SIZE,
         },
+    .reallocate_packet = true,
     .ctx_descriptor = &g_sk_buff,
 };
 
@@ -2203,6 +2210,7 @@ static constexpr EbpfHelperPrototype bpf_store_hdr_opt_proto = {
             EBPF_ARGUMENT_TYPE_CONST_SIZE,          // len
             EBPF_ARGUMENT_TYPE_ANYTHING,            // flags
         },
+    .reallocate_packet = true,
     .ctx_descriptor = &g_sock_ops_descr,
 };
 


### PR DESCRIPTION
## Summary
- Add `reallocate_packet = true` to 8 helper prototypes that the kernel's `bpf_helper_changes_pkt_data()` marks as modifying packet data

## Affected helpers
`clone_redirect`, `l3_csum_replace`, `l4_csum_replace`, `lwt_push_encap`, `lwt_seg6_action`, `lwt_seg6_store_bytes`, `msg_pull_data`, `store_hdr_opt`

Without this flag, packet pointers are not invalidated after these calls, which could allow stale packet pointer access after packet data modification.

Note: the kernel also marks `tail_call`, but in prevail's model the callee is verified separately — when tail_call returns (fails), no packet data was changed.

## Test plan
- [x] Full test suite passes (1559 cases, 225 expected failures, 0 regressions)

Closes #1125
Ref: #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)