### PR TITLE
Enforce get_local_storage flags argument must be zero

### DIFF
--- a/src/crab/ebpf_checker.cpp
+++ b/src/crab/ebpf_checker.cpp
@@ -46,6 +46,7 @@ class EbpfChecker final {
     void operator()(const ValidCallbackTarget&) const;
     void operator()(const ValidMapKeyValue&) const;
     void operator()(const ValidSize&) const;
+    void operator()(const ValidArgZero&) const;
     void operator()(const ValidStore&) const;
     void operator()(const ZeroCtxOffset&) const;
 
@@ -184,6 +185,12 @@ void EbpfChecker::operator()(const ValidSize& s) const {
     using namespace dsl_syntax;
     const auto r = reg_pack(s.reg);
     require_value(dom.state, s.can_be_zero ? r.svalue >= 0 : r.svalue > 0, "Invalid size");
+}
+
+void EbpfChecker::operator()(const ValidArgZero& s) const {
+    using namespace dsl_syntax;
+    const auto r = reg_pack(s.reg);
+    require_value(dom.state, r.svalue == 0, "Argument must be zero");
 }
 
 void EbpfChecker::operator()(const ValidCallbackTarget& s) const {

--- a/src/ir/assertions.cpp
+++ b/src/ir/assertions.cpp
@@ -147,6 +147,11 @@ class AssertExtractor {
             res.emplace_back(make_valid_access(arg.mem, 0, arg.size, arg.or_null, access_type));
             // TODO: reg is constant (or maybe it's not important)
         }
+        for (uint8_t i = 0; i < 5; ++i) {
+            if (resolved.contract.zero_args_mask & (1 << i)) {
+                res.emplace_back(ValidArgZero{Reg{static_cast<uint8_t>(i + 1)}});
+            }
+        }
         return res;
     }
 

--- a/src/ir/assertions.cpp
+++ b/src/ir/assertions.cpp
@@ -149,7 +149,9 @@ class AssertExtractor {
         }
         for (uint8_t i = 0; i < 5; ++i) {
             if (resolved.contract.zero_args_mask & (1 << i)) {
-                res.emplace_back(ValidArgZero{Reg{static_cast<uint8_t>(i + 1)}});
+                const Reg arg_reg{static_cast<uint8_t>(i + 1)};
+                res.emplace_back(TypeConstraint{arg_reg, TypeGroup::number});
+                res.emplace_back(ValidArgZero{arg_reg});
             }
         }
         return res;

--- a/src/ir/call_resolver.cpp
+++ b/src/ir/call_resolver.cpp
@@ -49,6 +49,7 @@ ResolvedCall resolve_helper(const Call& call, const ProgramInfo& info) {
     res.contract.return_nullable = return_info->pointer_nullable;
     res.contract.reallocate_packet = proto.reallocate_packet;
     res.contract.is_map_lookup = proto.return_type == EBPF_RETURN_TYPE_PTR_TO_MAP_VALUE_OR_NULL;
+    res.contract.zero_args_mask = proto.zero_args_mask;
 
     const std::array<ebpf_argument_type_t, 7> args = {
         {EBPF_ARGUMENT_TYPE_DONTCARE, proto.argument_type[0], proto.argument_type[1], proto.argument_type[2],

--- a/src/ir/syntax.hpp
+++ b/src/ir/syntax.hpp
@@ -224,6 +224,7 @@ struct CallContract {
     bool is_map_lookup{};
     bool reallocate_packet{};
     std::optional<Reg> alloc_size_reg{}; ///< Register holding allocation size (for T_ALLOC_MEM returns).
+    uint8_t zero_args_mask{};            ///< Bitmask of arg positions (0-4 for R1-R5) that must be zero.
 };
 
 /// Resolved form of a Call: the key (via `call`) plus everything derivable
@@ -463,8 +464,15 @@ struct BoundedLoopCount {
     static constexpr int limit = 100000;
 };
 
-using Assertion = std::variant<Comparable, Addable, ValidDivisor, ValidAccess, ValidStore, ValidSize, ValidMapKeyValue,
-                               ValidCallbackTarget, TypeConstraint, FuncConstraint, ZeroCtxOffset, BoundedLoopCount>;
+/// Checks that a register value is provably zero.
+struct ValidArgZero {
+    Reg reg;
+    constexpr bool operator==(const ValidArgZero&) const = default;
+};
+
+using Assertion =
+    std::variant<Comparable, Addable, ValidDivisor, ValidAccess, ValidStore, ValidSize, ValidMapKeyValue,
+                 ValidCallbackTarget, TypeConstraint, FuncConstraint, ZeroCtxOffset, BoundedLoopCount, ValidArgZero>;
 
 std::ostream& operator<<(std::ostream& os, Instruction const& ins);
 std::string to_string(Instruction const& ins);

--- a/src/linux/gpl/spec_prototypes.cpp
+++ b/src/linux/gpl/spec_prototypes.cpp
@@ -949,6 +949,7 @@ static constexpr EbpfHelperPrototype bpf_get_local_storage_proto = {
             EBPF_ARGUMENT_TYPE_PTR_TO_MAP,
             EBPF_ARGUMENT_TYPE_ANYTHING,
         },
+    .zero_args_mask = 1 << 1,
 };
 
 static constexpr EbpfHelperPrototype bpf_redirect_map_proto = {

--- a/src/printing.cpp
+++ b/src/printing.cpp
@@ -442,6 +442,8 @@ struct AssertionPrinterVisitor {
     }
 
     void operator()(FuncConstraint const& fc) { _os << variable_registry.type_reg(fc.reg.v) << " is helper"; }
+
+    void operator()(ValidArgZero const& a) { _os << a.reg << " == 0"; }
 };
 
 // ReSharper disable CppMemberFunctionMayBeConst

--- a/src/result.cpp
+++ b/src/result.cpp
@@ -366,6 +366,8 @@ std::set<Reg> extract_assertion_registers(const Assertion& assertion) {
             } else if constexpr (std::is_same_v<T, BoundedLoopCount>) {
                 // Loop counter, not a register
                 return {};
+            } else if constexpr (std::is_same_v<T, ValidArgZero>) {
+                return {a.reg};
             } else {
                 static_assert(always_false_v<T>, "Unhandled Assertion type in extract_assertion_registers");
             }

--- a/src/spec/function_prototypes.hpp
+++ b/src/spec/function_prototypes.hpp
@@ -21,6 +21,9 @@ struct EbpfHelperPrototype {
     // If R1 holds a context, then this holds a pointer to the context descriptor.
     const ebpf_ctx_descriptor_t* ctx_descriptor{};
 
+    // Bitmask of argument positions (0-4 for R1-R5) that must be provably zero.
+    uint8_t zero_args_mask{};
+
     bool unsupported = false;
 };
 } // namespace prevail


### PR DESCRIPTION
## Summary
- Add `zero_args_mask` field to `EbpfHelperPrototype` and `CallContract` for declaring per-argument zero constraints
- New `ValidArgZero` assertion type checks that marked arguments are provably zero
- Set `zero_args_mask = 1 << 1` on `get_local_storage` (R2/flags must be zero)

## Context

The kernel's `check_helper_call` (v6.18) explicitly checks:

```c
case BPF_FUNC_get_local_storage:
    if (!register_is_null(&regs[BPF_REG_2])) {
        verbose(env, "get_local_storage() doesn't support non-zero flags\n");
        return -EINVAL;
    }
```

The `zero_args_mask` mechanism is generic — it can be reused if other helpers gain similar requirements.

## Test plan
- [x] Full test suite passes (1559 cases, 225 expected failures, 0 regressions)

Closes #1124
Ref: #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)