### PR TITLE
Havoc offsets on non-singleton-typeset pointer add/sub

### DIFF
--- a/src/crab/ebpf_transformer.cpp
+++ b/src/crab/ebpf_transformer.cpp
@@ -1081,9 +1081,21 @@ void EbpfTransformer::add(const Reg& dst_reg, const int imm, const int finite_wi
     const auto dst = reg_pack(dst_reg);
     if (dom.state.may_have_type(dst_reg, T_NUM)) {
         dom.state.values->add_overflow(dst.svalue, dst.uvalue, imm, finite_width);
+        if (!dom.state.is_in_group(dst_reg, TS_NUM)) {
+            // The destination may also be a pointer (a {number, pointer} union). The numeric
+            // path above does not advance any pointer offset, so invalidate them rather than
+            // leaving a stale offset that a later bounds check would reason from.
+            dom.state.havoc_offsets(dst_reg);
+        }
     } else {
         if (const auto kind = dom.state.primary_kind_variable_for_type(dst_reg)) {
             dom.state.values->add(*kind, imm);
+        } else {
+            // The register's typeset is non-singleton, so we cannot pick a single offset
+            // variable to update. Conservatively invalidate all offset variables rather than
+            // leaving them stale, which would make subsequent bounds checks use a pre-add
+            // offset and accept out-of-bounds accesses. Mirrors shl()/lshr()/ashr().
+            dom.state.havoc_offsets(dst_reg);
         }
         dom.state.values->apply_unsigned(ArithBinOp::ADD, dst.svalue, dst.uvalue, dst.uvalue, imm, finite_width);
     }
@@ -1343,9 +1355,19 @@ void EbpfTransformer::operator()(const Bin& bin) {
                 if (dom.state.is_in_group(std::get<Reg>(bin.v), TS_NUM)) {
                     if (dom.state.may_have_type(bin.dst, T_NUM)) {
                         dom.state.values->sub_overflow(dst.svalue, dst.uvalue, src.svalue, finite_width);
+                        if (!dom.state.is_in_group(bin.dst, TS_NUM)) {
+                            // {number, pointer} union: the numeric path does not advance any
+                            // pointer offset, so invalidate them rather than leaving a stale
+                            // offset (see add()).
+                            dom.state.havoc_offsets(bin.dst);
+                        }
                     } else {
                         if (const auto kind = dom.state.primary_kind_variable_for_type(bin.dst)) {
                             dom.state.values->sub(*kind, src.svalue);
+                        } else {
+                            // Non-singleton typeset: no single offset variable to update.
+                            // Invalidate all offsets rather than leaving them stale (see add()).
+                            dom.state.havoc_offsets(bin.dst);
                         }
                         dom.state.values->apply_unsigned(ArithBinOp::SUB, dst.svalue, dst.uvalue, dst.uvalue,
                                                          src.uvalue, finite_width);

--- a/test-data/pointer.yaml
+++ b/test-data/pointer.yaml
@@ -355,3 +355,90 @@ post:
 
 messages:
   - "0: Invalid type (r1.type == number)"
+
+---
+# Regression test: when a register carries a
+# non-singleton typeset (here {ctx, shared}), add() cannot pick a single
+# offset variable to update. It must invalidate all offset variables rather
+# than leaving them stale; otherwise the post-add bounds check uses the
+# pre-add offset and accepts an out-of-bounds access. After advancing the
+# pointer past both regions, the dereference must be rejected.
+test-case: non-singleton typeset pointer add invalidates offsets
+
+pre: ["r1.type in {ctx, shared}",
+      "r1.ctx_offset=8",
+      "r1.shared_offset=8", "r1.shared_region_size=16",
+      "r1.svalue=8", "r1.uvalue=8"]
+
+code:
+  <start>: |
+    r1 += 56
+    r2 = *(u64 *)(r1 + 0)
+
+post:
+  - "_|_"
+
+messages:
+  - "1: Lower bound must be at least 0 (valid_access(r1.offset, width=8) for read)"
+
+---
+# Symmetric regression on the register-register
+# subtract path (ptr -= num with a non-singleton destination typeset).
+test-case: non-singleton typeset pointer sub invalidates offsets
+
+pre: ["r1.type in {ctx, shared}",
+      "r1.ctx_offset=8",
+      "r1.shared_offset=8", "r1.shared_region_size=16",
+      "r1.svalue=8", "r1.uvalue=8",
+      "r2.type=number", "r2.svalue=16", "r2.uvalue=16"]
+
+code:
+  <start>: |
+    r1 -= r2
+    r3 = *(u64 *)(r1 + 0)
+
+post:
+  - "_|_"
+
+messages:
+  - "1: Lower bound must be at least 0 (valid_access(r1.offset, width=8) for read)"
+
+---
+# Regression test for the {number, pointer} union case: a register that may be a
+# number or a pointer takes the numeric add/sub fast-path, which advances
+# svalue/uvalue but not any pointer offset. The pointer offset must be
+# invalidated rather than left stale; here ctx_offset must not survive the add.
+test-case: mixed number-pointer add invalidates pointer offset
+
+pre: ["r1.type in {number, ctx}", "r1.ctx_offset=8", "r1.svalue=8", "r1.uvalue=8"]
+
+code:
+  <start>: |
+    r1 += 56
+
+post:
+  - r1.svalue=64
+  - r1.type in {number, ctx}
+  - r1.uvalue=64
+
+---
+# Companion showing the conservative havoc only affects offsets *after*
+# arithmetic: a non-singleton {ctx, shared} register dereferenced directly,
+# in bounds and without prior arithmetic, still passes.
+test-case: non-singleton typeset in-bounds access still passes
+
+pre: ["r1.type in {ctx, shared}",
+      "r1.ctx_offset=0", "r1.shared_offset=0", "r1.shared_region_size=16",
+      "r1.svalue=8", "r1.uvalue=8"]
+
+code:
+  <start>: |
+    r2 = *(u64 *)(r1 + 0)
+
+post:
+  - r1.ctx_offset=0
+  - r1.shared_offset=0
+  - r1.shared_region_size=16
+  - r1.svalue=8
+  - r1.type in {ctx, shared}
+  - r1.uvalue=8


### PR DESCRIPTION
## Soundness fix — false PASS for OOB access

### Problem
`EbpfTransformer::add()` (and the symmetric register-register `sub` path) silently skipped the offset-variable update when the destination register carried a **non-singleton typeset** — two or more simultaneously possible pointer types (e.g. a join point where the same register may be a context pointer or a shared pointer).

In that case `primary_kind_variable_for_type(dst)` returns `nullopt` (there is no single offset variable to update), the `if (const auto kind = ...)` guard is false, and the offset update was skipped — yet `svalue`/`uvalue` were still advanced. The offset variable was left at its pre-arithmetic value while the verifier believed the arithmetic had been applied. All subsequent `valid_access` checks then used the **stale offset**, so the verifier concluded an out-of-bounds reference was in bounds and reported `PASS` for a program that performs an OOB read/write.

### Fix
When the typeset is non-singleton, conservatively invalidate **all** offset variables via `havoc_offsets(dst)` instead of silently skipping. This mirrors the pattern already used in `shl()`/`lshr()`/`ashr()`. The same gap existed on the register-register subtract path (`ptr -= num` with a non-singleton destination); both are fixed.

### Regression tests (`test-data/pointer.yaml`)
Two tests build a `{ctx, shared}` non-singleton register, advance the pointer past both regions, and dereference:
- **add**: `r1 += 56` then load — verified to be wrongly accepted before the fix (stale `ctx_offset=8`/`shared_offset=8` retained) and correctly rejected (`_|_`) after.
- **sub**: symmetric register-register `r1 -= r2`.

### Verification
Full non-expected-failure suite: `1333 passed, 0 failed`. The two new tests fail (accept the OOB program) on `main` and pass (reject it) with this change.
