### PR TITLE
Reject writes to read-only context pointer fields

### DIFF
--- a/src/crab/ebpf_checker.cpp
+++ b/src/crab/ebpf_checker.cpp
@@ -344,8 +344,41 @@ void EbpfChecker::operator()(const ValidAccess& s) const {
             break;
         }
         case T_CTX: {
-            const auto ctx_size = context.program_info().type.ctx_descriptor->size;
+            const auto* desc = context.program_info().type.ctx_descriptor;
             const auto [lb, ub] = lb_ub_access_pair(s, reg.ctx_offset);
+            if (s.access_type == AccessType::write && desc->end >= 0) {
+                // The data/data_end/meta fields are read-only pointer slots: a *load* of those
+                // offsets synthesizes a typed packet pointer (see do_load_ctx). Writes are not
+                // tracked by the abstract transformer (do_mem_store models only stack stores),
+                // so an accepted write to e.g. ctx->data followed by a reload would hand out a
+                // fresh "valid" packet pointer for a field the program corrupted at runtime,
+                // a false PASS for an out-of-bounds dereference. Writes to other (scalar)
+                // context fields are sound, since their loads are havoced to numbers, and real
+                // programs do write them; so reject only writes that may overlap a pointer
+                // slot. A write of [lb, ub) overlaps slot [f, f + field_width) unless we can
+                // prove it lies entirely before (ub <= f) or entirely after (lb >= f + width).
+                //
+                // field_width is the size of a pointer slot, taken as end - data: this is the
+                // data/data_end adjacency that do_load_ctx also relies on. If a descriptor ever
+                // violated it (non-positive width), the overlap math would be meaningless, so
+                // fall back to rejecting the write outright rather than reasoning from a bogus
+                // slot width.
+                const int field_width = desc->end - desc->data;
+                if (field_width <= 0) {
+                    throw_fail("Cannot write to context with unexpected pointer-field layout");
+                }
+                const auto may_overlap = [&](const int field_offset) {
+                    if (field_offset < 0) {
+                        return false;
+                    }
+                    return dom.state.values.intersect(ub > LinearExpression{field_offset}) &&
+                           dom.state.values.intersect(lb < LinearExpression{field_offset + field_width});
+                };
+                if (may_overlap(desc->data) || may_overlap(desc->end) || may_overlap(desc->meta)) {
+                    throw_fail("Cannot write to context pointer field");
+                }
+            }
+            const auto ctx_size = desc->size;
             require_lower_bound(lb, LinearExpression{0}, "Lower bound must be at least 0");
             require_upper_bound(ub, LinearExpression{ctx_size},
                                 "Upper bound must be at most " + std::to_string(ctx_size));

--- a/src/ir/assertions.cpp
+++ b/src/ir/assertions.cpp
@@ -276,11 +276,14 @@ class AssertExtractor {
 
     vector<Assertion> operator()(const Atomic& ins) const {
 
+        // An atomic is a read-modify-write: model it as a write so that, like a plain
+        // store, it is rejected against read-only context pointer fields (a non-write
+        // access_type would let an atomic corrupt e.g. ctx->data unchecked).
         return {
             Assertion{TypeConstraint{ins.valreg, TypeGroup::number}},
             Assertion{TypeConstraint{ins.access.basereg, TypeGroup::pointer}},
             Assertion{make_valid_access(ins.access.basereg, ins.access.offset,
-                                        Imm{static_cast<uint32_t>(ins.access.width)}, false)},
+                                        Imm{static_cast<uint32_t>(ins.access.width)}, false, AccessType::write)},
         };
     }
 

--- a/src/test/test_yaml.cpp
+++ b/src/test/test_yaml.cpp
@@ -21,6 +21,7 @@
 
 YAML_CASE("test-data/add.yaml")
 YAML_CASE("test-data/assign.yaml")
+YAML_CASE("test-data/ctx.yaml")
 YAML_CASE("test-data/atomic.yaml")
 YAML_CASE("test-data/bitop.yaml")
 YAML_CASE("test-data/observe.yaml")

--- a/test-data/ctx.yaml
+++ b/test-data/ctx.yaml
@@ -1,0 +1,124 @@
+# Copyright (c) Prevail Verifier contributors.
+# SPDX-License-Identifier: MIT
+#
+# Regression tests for writes through a context pointer.
+#
+# The context descriptor used by the YAML test harness is {size=64, data=0,
+# end=4, meta=-1}: the data and data_end pointer slots occupy bytes [0,4) and
+# [4,8). A *load* of those slots synthesizes a typed packet pointer
+# (do_load_ctx), but writes are not tracked by the abstract transformer. A write
+# to e.g. ctx->data that is accepted as a silent no-op, followed by a reload,
+# would hand the program a fresh "valid" packet pointer for a field it corrupted
+# at runtime -- a false PASS for an out-of-bounds dereference. Writes that may
+# overlap a pointer slot must therefore be rejected, regardless of the stored
+# value. Writes to other (scalar) context fields remain allowed.
+---
+test-case: store number to ctx data pointer slot is rejected
+
+pre: ["r1.type=ctx", "r1.ctx_offset=0",
+      "r2.type=number", "r2.svalue=0", "r2.uvalue=0"]
+
+code:
+  <start>: |
+    *(u32 *)(r1 + 0) = r2
+
+post:
+  - "_|_"
+
+messages:
+  - "0: Cannot write to context pointer field (valid_access(r1.offset, width=4) for write)"
+
+---
+test-case: store number to ctx data_end pointer slot is rejected
+
+pre: ["r1.type=ctx", "r1.ctx_offset=0",
+      "r2.type=number", "r2.svalue=0", "r2.uvalue=0"]
+
+code:
+  <start>: |
+    *(u32 *)(r1 + 4) = r2
+
+post:
+  - "_|_"
+
+messages:
+  - "0: Cannot write to context pointer field (valid_access(r1.offset+4, width=4) for write)"
+
+---
+# A wide store starting before a pointer slot still overlaps it and must be rejected.
+test-case: store overlapping ctx data pointer slot is rejected
+
+pre: ["r1.type=ctx", "r1.ctx_offset=0",
+      "r2.type=number", "r2.svalue=0", "r2.uvalue=0"]
+
+code:
+  <start>: |
+    *(u64 *)(r1 + 0) = r2
+
+post:
+  - "_|_"
+
+messages:
+  - "0: Cannot write to context pointer field (valid_access(r1.offset, width=8) for write)"
+
+---
+# Full exploit shape: overwrite ctx->data, reload it as a packet pointer, then
+# dereference. Verification must stop at the write rather than reporting PASS.
+test-case: overwrite ctx data then reload and deref is rejected
+
+pre: ["r1.type=ctx", "r1.ctx_offset=0",
+      "r2.type=number", "r2.svalue=0", "r2.uvalue=0"]
+
+code:
+  <start>: |
+    *(u32 *)(r1 + 0) = r2
+    r3 = *(u32 *)(r1 + 0)
+    r4 = *(u8 *)(r3 + 0)
+
+post:
+  - "_|_"
+
+messages:
+  - "0: Cannot write to context pointer field (valid_access(r1.offset, width=4) for write)"
+
+---
+# An atomic read-modify-write also modifies the field and must be rejected on a
+# pointer slot, even with a number value register (the value-type check alone
+# would let it through).
+test-case: atomic to ctx data pointer slot is rejected
+
+pre: ["r1.type=ctx", "r1.ctx_offset=0",
+      "r5.type=number", "r5.svalue=1", "r5.uvalue=1"]
+
+code:
+  <start>: |
+    lock *(u64 *)(r1 + 0) += r5
+
+post:
+  - "_|_"
+
+messages:
+  - "0: Cannot write to context pointer field (valid_access(r1.offset, width=8) for write)"
+
+---
+# Writes to scalar context fields (outside any pointer slot) remain allowed.
+test-case: store number to ctx scalar field is allowed
+
+pre: ["r1.type=ctx", "r1.ctx_offset=0",
+      "r2.type=number", "r2.svalue=0", "r2.uvalue=0"]
+
+code:
+  <start>: |
+    *(u32 *)(r1 + 8) = r2
+    r0 = 0
+    exit
+
+post:
+  - r0.svalue=0
+  - r0.type=number
+  - r0.uvalue=0
+  - r1.ctx_offset=0
+  - r1.type=ctx
+  - r2.svalue=0
+  - r2.type=number
+  - r2.uvalue=0

--- a/test-data/uninit.yaml
+++ b/test-data/uninit.yaml
@@ -302,6 +302,10 @@ code:
 
 post: []
 
+# These stores target a scalar context field (offset 8), not a data/data_end/meta
+# pointer slot, so they reach the value-type check that rejects storing a
+# non-number to an externally-visible region. (Writes that overlap a pointer slot
+# are rejected earlier regardless of value; see test-data/ctx.yaml.)
 ---
 test-case: Store uninitialized register to context - 8 bytes
 
@@ -311,7 +315,7 @@ pre:
 
 code:
   <start>: |
-    *(u64 *)(r1 + 0) = r0
+    *(u64 *)(r1 + 8) = r0
 
 post:
   - "_|_"
@@ -328,7 +332,7 @@ pre:
 
 code:
   <start>: |
-    *(u32 *)(r1 + 0) = r0
+    *(u32 *)(r1 + 8) = r0
 
 post:
   - "_|_"
@@ -345,7 +349,7 @@ pre:
 
 code:
   <start>: |
-    *(u16 *)(r1 + 0) = r0
+    *(u16 *)(r1 + 8) = r0
 
 post:
   - "_|_"
@@ -362,7 +366,7 @@ pre:
 
 code:
   <start>: |
-    *(u8 *)(r1 + 0) = r0
+    *(u8 *)(r1 + 8) = r0
 
 post:
   - "_|_"
@@ -379,7 +383,7 @@ pre:
 
 code:
   <start>: |
-    lock *(u64 *)(r1 + 0) += r5
+    lock *(u64 *)(r1 + 8) += r5
 
 post:
   - "_|_"
@@ -396,7 +400,7 @@ pre:
 
 code:
   <start>: |
-    lock *(u64 *)(r1 + 0) &= r5
+    lock *(u64 *)(r1 + 8) &= r5
 
 post:
   - "_|_"
@@ -413,7 +417,7 @@ pre:
 
 code:
   <start>: |
-    lock *(u64 *)(r1 + 0) |= r5
+    lock *(u64 *)(r1 + 8) |= r5
 
 post:
   - "_|_"
@@ -430,7 +434,7 @@ pre:
 
 code:
   <start>: |
-    lock *(u64 *)(r1 + 0) |= r5
+    lock *(u64 *)(r1 + 8) ^= r5
 
 post:
   - "_|_"
@@ -447,7 +451,7 @@ pre:
 
 code:
   <start>: |
-    lock *(u64 *)(r1 + 0) x= r5
+    lock *(u64 *)(r1 + 8) x= r5
 
 post:
   - "_|_"
@@ -464,7 +468,7 @@ pre:
 
 code:
   <start>: |
-    lock *(u64 *)(r1 + 0) x= r5
+    lock *(u64 *)(r1 + 8) x= r5
 
 post:
   - "_|_"


### PR DESCRIPTION
## Soundness fix — false PASS for context-write type confusion

### Problem
A write through a `T_CTX`-typed base register was silently accepted:
- `do_mem_store` models only `T_STACK` stores (`// do nothing for any other type`), so a context write left the abstract state unchanged, and
- the checker's `T_CTX` arm of `check_valid_access` enforced bounds but never inspected `s.access_type`.

Because a *load* of the `data`/`data_end`/`meta` context fields synthesizes a typed packet pointer (`do_load_ctx`), a program could overwrite e.g. `ctx->data`, reload it as a `T_PACKET` pointer, and dereference an attacker-controlled address — while prevail reported `PASS`.

### Why not just reject all context writes
The context descriptor (`{size, data, end, meta}`) carries no per-field writability information. The `data`/`data_end`/`meta` slots must stay read-only for soundness, but **real programs legitimately write scalar context fields** (e.g. `__sk_buff` fields written by Cilium). A blanket rejection regressed 179 tests including `cilium-core/bpf_lxc.o`.

### Fix
The `T_CTX` arm now rejects a write only when its byte range `[lb, ub)` **may overlap** a pointer slot `[f, f + field_width)` — i.e. when we cannot prove it lies entirely before (`ub <= f`) or entirely after (`lb >= f + width`), evaluated against the abstract state. Writes to other (scalar) fields are allowed; their loads are havoced to numbers, so the untracked store is sound.

The same hole existed on the **atomic** path: an atomic is a read-modify-write, but its `ValidAccess` used the default `compare` access type, so an atomic RMW could corrupt a context pointer field unchecked. Atomics now assert a `write` access (a related, previously-unreported variant of the same bug).

### Tests
- New `test-data/ctx.yaml`: rejection of stores/atomics overlapping a pointer slot (including the full overwrite→reload→deref case) and **acceptance** of scalar context writes. Verified to be accepted on `main` (false PASS) and rejected with this change.
- Existing `uninit.yaml` context stores/atomics targeted offset 0; they are moved to a scalar offset so they keep exercising the value-type check they were written for (their verdict and messages are unchanged).

### Verification
Full non-expected-failure suite: `1334 passed, 0 failed` (Cilium and other real-program tests unaffected).
