### PR TITLE
Forget the truncated result of ALU32 pointer arithmetic

### DIFF
--- a/src/crab/ebpf_transformer.cpp
+++ b/src/crab/ebpf_transformer.cpp
@@ -1496,7 +1496,22 @@ void EbpfTransformer::operator()(const Bin& bin) {
         }
     }
     if (!bin.is64) {
-        dom.state.values->bitwise_and(dst.svalue, dst.uvalue, std::numeric_limits<uint32_t>::max());
+        if (dom.state.is_in_group(bin.dst, TS_NUM)) {
+            // A genuine scalar: the 32-bit result is zero-extended, so masking off the upper
+            // half models it precisely.
+            dom.state.values->bitwise_and(dst.svalue, dst.uvalue, std::numeric_limits<uint32_t>::max());
+        } else {
+            // The input may be a pointer, so a 32-bit op yields the low 32 bits of a (possibly
+            // kernel) address. That value is neither a usable pointer (the upper half is gone)
+            // nor a safe-to-leak scalar (it carries pointer bits), and this type model has no
+            // "tainted scalar". Retyping it as T_NUM would launder the address into a number
+            // that could be stored or returned, leaking kernel addresses; keeping it a pointer
+            // would let a later dereference pass. So forget it entirely (unknown type): a later
+            // dereference then fails as a non-pointer and a later leak fails as a non-number,
+            // matching the kernel, which forbids the operation outright. Mirrors the immediate
+            // ADD/SUB and MOV paths.
+            dom.state.havoc_register(bin.dst);
+        }
     }
 }
 

--- a/test-data/pointer.yaml
+++ b/test-data/pointer.yaml
@@ -442,3 +442,85 @@ post:
   - r1.svalue=8
   - r1.type in {ctx, shared}
   - r1.uvalue=8
+
+---
+# Regression test: 32-bit (ALU32) ADD/SUB on a pointer register. ALU32
+# zero-extends its 32-bit result, destroying the upper half of a live pointer,
+# so the result cannot be a usable pointer. The immediate forms above were
+# already caught, but the register-register form kept the pointer type: r1
+# stayed ctx and the following load synthesized a fresh valid packet pointer.
+# The result is now retyped as the scalar it is, so the dereference is rejected.
+test-case: 32-bit pointer truncation - register addition
+
+pre:
+  - "r1.ctx_offset=0"
+  - "r1.svalue=[0, 4294967295]"
+  - "r1.uvalue=r1.svalue"
+  - "r1.type=ctx"
+  - "r1.uvalue=[0, 4294967295]"
+  - "r2.type=number"
+  - "r2.svalue=0"
+  - "r2.uvalue=0"
+
+code:
+  <start>: |
+    w1 += w2
+    r3 = *(u32 *)(r1 + 0)
+
+post:
+  - "_|_"
+
+messages:
+  - "1: Invalid type (r1.type in {ctx, stack, packet, shared})"
+
+---
+test-case: 32-bit pointer truncation - register subtraction
+
+pre:
+  - "r1.ctx_offset=0"
+  - "r1.svalue=[0, 4294967295]"
+  - "r1.uvalue=r1.svalue"
+  - "r1.type=ctx"
+  - "r1.uvalue=[0, 4294967295]"
+  - "r2.type=number"
+  - "r2.svalue=0"
+  - "r2.uvalue=0"
+
+code:
+  <start>: |
+    w1 -= w2
+    r3 = *(u32 *)(r1 + 0)
+
+post:
+  - "_|_"
+
+messages:
+  - "1: Invalid type (r1.type in {ctx, stack, packet, shared})"
+
+---
+# The low 32 bits of a pointer produced by a 32-bit op must not be usable as a
+# scalar: doing so would launder a (possibly kernel) address into a number that
+# can be returned or stored, leaking it. The forgotten result is not provably a
+# number, so returning it is rejected -- the pointer cannot be leaked this way.
+test-case: 32-bit pointer truncation - result is not leakable
+
+pre:
+  - "r1.type=ctx"
+  - "r1.ctx_offset=0"
+  - "r1.svalue=8"
+  - "r1.uvalue=8"
+  - "r2.type=number"
+  - "r2.svalue=0"
+  - "r2.uvalue=0"
+
+code:
+  <start>: |
+    w1 += w2
+    r0 = r1
+    exit
+
+post:
+  - "_|_"
+
+messages:
+  - "2: Invalid type (r0.type == number)"


### PR DESCRIPTION
## Soundness fix: false PASS for ALU32 pointer corruption

### Problem
A 32-bit (ALU32) `ADD`/`SUB` whose destination is a pointer is accepted with the destination still typed as a usable pointer. ALU32 zero-extends its result, destroying the upper half of the pointer at runtime, so a subsequent load through it dereferences a corrupted address while verification reports `PASS`. For example, `w1 += w2` on a `ctx` register followed by `r3 = *(u32*)(r1 + 0)` is accepted and `r3` becomes a fresh packet pointer.

### Fix
At the shared truncation point for binary register operations, forget the destination register whenever the 32-bit result is not provably a number.

The result of an ALU32 op on a pointer is the low half of a (possibly kernel) address: it is neither a usable pointer (the upper half is gone) nor a scalar that is safe to expose (it still carries address bits), and the type model has no representation for such a tainted scalar. Forgetting the register makes a later dereference fail as a non-pointer and a later store or return fail as a non-number, so the value can be neither followed nor leaked. A genuine scalar operand instead keeps its precise value, masked to 32 bits.

Same-region pointer subtraction (e.g. `data_end - data`) is a separate case: it yields a scalar length and is already typed as a number before this point, so its result is kept and the computation is accepted.

### Tests (`pointer.yaml`)
- Register-register `ADD`/`SUB` on a pointer followed by a load: rejected (`_|_`).
- `result is not leakable`: `w1 += w2` on a `ctx` pointer then `r0 = r1; exit` is rejected — the truncated value is not a number, so it cannot be returned.

### Completeness note
A 32-bit op on a pointer whose result is never used is accepted, though the kernel rejects all non-64-bit pointer arithmetic. This is sound (no dereference, no leak); matching the kernel exactly would require rejecting based on the destination being a provably singleton pointer, a separate change.

### Verification
Full suite: 1334 passed, 0 failures (225 failed-as-expected unchanged); cilium-core samples pass.
