### PR TITLE
Avoid undefined zero left shift

### DIFF
--- a/src/crab/finite_domain.cpp
+++ b/src/crab/finite_domain.cpp
@@ -1,5 +1,6 @@
 // Copyright (c) Prevail Verifier contributors.
 // SPDX-License-Identifier: MIT
+#include <cassert>
 #include <optional>
 #include <utility>
 
@@ -1001,6 +1002,11 @@ void FiniteDomain::shl_overflow(const Variable lhss, const Variable lhsu, const 
 }
 
 void FiniteDomain::shl(const Variable svalue, const Variable uvalue, const int imm, const int finite_width) {
+    // eBPF masks shift counts before this transfer function. Large operand
+    // values are valid; only the C++ shift count must be strictly below width.
+    assert((finite_width == 32 || finite_width == 64) && "unexpected finite-width shift domain");
+    assert(0 <= imm && imm < finite_width && "left shift count must be masked before FiniteDomain::shl");
+
     const auto uinterval = eval_interval(uvalue);
     if (!uinterval.finite_size()) {
         shl_overflow(svalue, uvalue, imm);
@@ -1009,7 +1015,10 @@ void FiniteDomain::shl(const Variable svalue, const Variable uvalue, const int i
     auto [lb_n, ub_n] = uinterval.pair<uint64_t>();
     const uint64_t uint_max = finite_width == 64 ? uint64_t{std::numeric_limits<uint64_t>::max()}
                                                  : uint64_t{std::numeric_limits<uint32_t>::max()};
-    if (lb_n >> (finite_width - imm) != ub_n >> (finite_width - imm)) {
+    const int unpreserved_bit_count = finite_width - imm;
+    const bool unpreserved_bits_differ =
+        unpreserved_bit_count < 64 && (lb_n >> unpreserved_bit_count) != (ub_n >> unpreserved_bit_count);
+    if (unpreserved_bits_differ) {
         // The bits that will be shifted out to the left are different,
         // which means all combinations of remaining bits are possible.
         lb_n = 0;

--- a/src/test/test_interval_bitwise.cpp
+++ b/src/test/test_interval_bitwise.cpp
@@ -5,7 +5,9 @@
 #include <cstdint>
 #include <limits>
 
+#include "crab/finite_domain.hpp"
 #include "crab/interval.hpp"
+#include "crab/type_to_num.hpp"
 
 using namespace prevail;
 
@@ -19,4 +21,45 @@ TEST_CASE("bitwise_and with non-singleton containing all-ones includes zero", "[
     const Interval left{5, 100};
     const Interval anomalous_right{-5, 5};
     REQUIRE(left.bitwise_and(anomalous_right) == Interval{0, 100});
+}
+
+TEST_CASE("finite domain left shift by zero preserves 64-bit interval", "[finite_domain][bitwise]") {
+    FiniteDomain::clear_thread_local_state();
+    const auto r1 = reg_pack(1);
+    FiniteDomain domain;
+    domain.set(r1.svalue, Interval{1, 5});
+    domain.set(r1.uvalue, Interval{1, 5});
+
+    domain.shl(r1.svalue, r1.uvalue, 0, 64);
+
+    REQUIRE(domain.eval_interval(r1.uvalue) == Interval{1, 5});
+    REQUIRE(domain.eval_interval(r1.svalue) == Interval{1, 5});
+}
+
+TEST_CASE("finite domain 32-bit left shift by zero widens when high operand bits differ", "[finite_domain][bitwise]") {
+    FiniteDomain::clear_thread_local_state();
+    const auto r2 = reg_pack(2);
+    FiniteDomain domain;
+    const Number uint32_max{std::numeric_limits<uint32_t>::max()};
+    domain.set(r2.svalue, Interval{uint32_max, uint32_max + 1});
+    domain.set(r2.uvalue, Interval{uint32_max, uint32_max + 1});
+
+    domain.shl(r2.svalue, r2.uvalue, 0, 32);
+
+    REQUIRE(domain.eval_interval(r2.uvalue) == Interval::top());
+    REQUIRE(domain.eval_interval(r2.svalue) == Interval::top());
+}
+
+TEST_CASE("finite domain left shift widens when high operand bits differ", "[finite_domain][bitwise]") {
+    FiniteDomain::clear_thread_local_state();
+    const auto r2 = reg_pack(2);
+    FiniteDomain domain;
+    const Number top_bit{uint64_t{1} << 63};
+    domain.set(r2.svalue, Interval{top_bit - 1, top_bit});
+    domain.set(r2.uvalue, Interval{top_bit - 1, top_bit});
+
+    domain.shl(r2.svalue, r2.uvalue, 1, 64);
+
+    REQUIRE(domain.eval_interval(r2.uvalue) == Interval{0, std::numeric_limits<uint64_t>::max() - 1});
+    REQUIRE(domain.eval_interval(r2.svalue) == Interval::top());
 }


### PR DESCRIPTION
Fixes a bug where shifting a 64-bit interval left by zero could evaluate an invalid 64-bit right shift while checking shifted-out bits. The zero-shift case now preserves the interval without that comparison.

Validation: `bin/tests "[finite_domain][bitwise]"`