### PR TITLE
Reject out-of-range section tables

### DIFF
--- a/src/io/elf_reader.cpp
+++ b/src/io/elf_reader.cpp
@@ -1,6 +1,7 @@
 // Copyright (c) Prevail Verifier contributors.
 // SPDX-License-Identifier: MIT
 #include <algorithm>
+#include <array>
 #include <cerrno>
 #include <concepts>
 #include <cstddef>
@@ -30,6 +31,29 @@ namespace prevail {
 // ---------------------------------------------------------------------------
 // Utility functions
 // ---------------------------------------------------------------------------
+
+static_assert(sizeof(ELFIO::Elf32_Ehdr) == 52);
+static_assert(offsetof(ELFIO::Elf32_Ehdr, e_shoff) == 32);
+static_assert(offsetof(ELFIO::Elf32_Ehdr, e_shentsize) == 46);
+static_assert(offsetof(ELFIO::Elf32_Ehdr, e_shnum) == 48);
+static_assert(sizeof(ELFIO::Elf64_Ehdr) == 64);
+static_assert(offsetof(ELFIO::Elf64_Ehdr, e_shoff) == 40);
+static_assert(offsetof(ELFIO::Elf64_Ehdr, e_shentsize) == 58);
+static_assert(offsetof(ELFIO::Elf64_Ehdr, e_shnum) == 60);
+static_assert(sizeof(ELFIO::Elf32_Shdr) == 40);
+static_assert(offsetof(ELFIO::Elf32_Shdr, sh_size) == 20);
+static_assert(sizeof(ELFIO::Elf64_Shdr) == 64);
+static_assert(offsetof(ELFIO::Elf64_Shdr, sh_size) == 32);
+static_assert(sizeof(ELFIO::Elf32_Rel) == 8);
+static_assert(offsetof(ELFIO::Elf32_Rel, r_offset) == 0);
+static_assert(offsetof(ELFIO::Elf32_Rel, r_info) == 4);
+static_assert(sizeof(ELFIO::Elf32_Rela) == 12);
+static_assert(offsetof(ELFIO::Elf32_Rela, r_addend) == 8);
+static_assert(sizeof(ELFIO::Elf64_Rel) == 16);
+static_assert(offsetof(ELFIO::Elf64_Rel, r_offset) == 0);
+static_assert(offsetof(ELFIO::Elf64_Rel, r_info) == 8);
+static_assert(sizeof(ELFIO::Elf64_Rela) == 24);
+static_assert(offsetof(ELFIO::Elf64_Rela, r_addend) == 16);
 
 std::pair<std::reference_wrapper<EbpfInst>, std::reference_wrapper<EbpfInst>>
 validate_and_get_lddw_pair(std::vector<EbpfInst>& instructions, const size_t location, const std::string& context) {
@@ -122,6 +146,9 @@ RelocationSectionLayout relocation_section_layout(const ELFIO::elfio& reader, co
 
     const size_t expected_entry_size = expected_relocation_entry_size(elf_class, section_type);
     const size_t entry_size = section.get_entry_size();
+    // ELFIO's relocation accessor silently treats zero entry size as no
+    // entries and then uses typed loads for non-zero entries. Validate the raw
+    // table first so every indexed byte read below is inside one complete entry.
     if (entry_size != expected_entry_size || section.get_data() == nullptr || section.get_size() % entry_size != 0) {
         throw UnmarshalError("Malformed relocation section " + section_name);
     }
@@ -337,7 +364,138 @@ static std::uintmax_t get_data_size(std::istream& input_stream, const std::strin
     return end_pos;
 }
 
+template <std::unsigned_integral T>
+static T read_uint(const unsigned char* bytes, const bool little_endian) {
+    T value = 0;
+    for (size_t i = 0; i < sizeof(T); ++i) {
+        const size_t byte_index = little_endian ? i : sizeof(T) - 1U - i;
+        value |= static_cast<T>(bytes[byte_index]) << (8U * i);
+    }
+    return value;
+}
+
+static std::streamsize read_stream_bytes_at(std::istream& input_stream, const std::uintmax_t offset,
+                                            unsigned char* output, const size_t size) {
+    input_stream.clear();
+    input_stream.seekg(gsl::narrow<std::streamoff>(offset));
+    input_stream.read(reinterpret_cast<char*>(output), gsl::narrow<std::streamsize>(size));
+    const auto bytes_read = input_stream.gcount();
+    input_stream.clear();
+    input_stream.seekg(0);
+    return bytes_read;
+}
+
+struct SectionHeaderTableLayout {
+    uint64_t offset{};
+    uint16_t entry_size{};
+    uint16_t count{};
+    size_t min_entry_size{};
+    size_t section_size_offset{};
+};
+
+static std::optional<SectionHeaderTableLayout>
+read_section_header_table_layout(const std::array<unsigned char, sizeof(ELFIO::Elf64_Ehdr)>& header,
+                                 const std::streamsize bytes_read, const unsigned char elf_class,
+                                 const bool little_endian) {
+    constexpr size_t elf64_header_size = sizeof(ELFIO::Elf64_Ehdr);
+    constexpr size_t elf32_section_header_size = sizeof(ELFIO::Elf32_Shdr);
+    constexpr size_t elf64_section_header_size = sizeof(ELFIO::Elf64_Shdr);
+    constexpr size_t elf32_section_size_offset = offsetof(ELFIO::Elf32_Shdr, sh_size);
+    constexpr size_t elf64_section_size_offset = offsetof(ELFIO::Elf64_Shdr, sh_size);
+
+    if (elf_class == ELFIO::ELFCLASS32) {
+        return SectionHeaderTableLayout{
+            .offset = read_uint<ELFIO::Elf32_Off>(header.data() + offsetof(ELFIO::Elf32_Ehdr, e_shoff), little_endian),
+            .entry_size =
+                read_uint<ELFIO::Elf_Half>(header.data() + offsetof(ELFIO::Elf32_Ehdr, e_shentsize), little_endian),
+            .count = read_uint<ELFIO::Elf_Half>(header.data() + offsetof(ELFIO::Elf32_Ehdr, e_shnum), little_endian),
+            .min_entry_size = elf32_section_header_size,
+            .section_size_offset = elf32_section_size_offset,
+        };
+    }
+
+    if (elf_class == ELFIO::ELFCLASS64 && bytes_read >= gsl::narrow<std::streamsize>(elf64_header_size)) {
+        return SectionHeaderTableLayout{
+            .offset = read_uint<ELFIO::Elf64_Off>(header.data() + offsetof(ELFIO::Elf64_Ehdr, e_shoff), little_endian),
+            .entry_size =
+                read_uint<ELFIO::Elf_Half>(header.data() + offsetof(ELFIO::Elf64_Ehdr, e_shentsize), little_endian),
+            .count = read_uint<ELFIO::Elf_Half>(header.data() + offsetof(ELFIO::Elf64_Ehdr, e_shnum), little_endian),
+            .min_entry_size = elf64_section_header_size,
+            .section_size_offset = elf64_section_size_offset,
+        };
+    }
+
+    return std::nullopt;
+}
+
+static void validate_section_header_table_bounds(std::istream& input_stream, const std::string& path,
+                                                 const std::uintmax_t data_size) {
+    // This pre-load check validates only the section header table extent.
+    // Individual section payload ranges are checked after ELFIO loads metadata.
+    constexpr size_t min_elf_header_size = sizeof(ELFIO::Elf32_Ehdr);
+    constexpr size_t elf64_header_size = sizeof(ELFIO::Elf64_Ehdr);
+    constexpr unsigned char elf_magic[] = {0x7f, 'E', 'L', 'F'};
+
+    std::array<unsigned char, elf64_header_size> header{};
+    const auto bytes_read = read_stream_bytes_at(input_stream, 0, header.data(), header.size());
+
+    if (bytes_read < gsl::narrow<std::streamsize>(min_elf_header_size) ||
+        !std::equal(std::begin(elf_magic), std::end(elf_magic), header.begin())) {
+        return;
+    }
+
+    const unsigned char elf_class = header[ELFIO::EI_CLASS];
+    const unsigned char elf_data = header[ELFIO::EI_DATA];
+    const bool little_endian = elf_data == ELFIO::ELFDATA2LSB;
+    if (elf_data != ELFIO::ELFDATA2LSB && elf_data != ELFIO::ELFDATA2MSB) {
+        return;
+    }
+
+    const std::optional<SectionHeaderTableLayout> layout =
+        read_section_header_table_layout(header, bytes_read, elf_class, little_endian);
+    if (!layout) {
+        return;
+    }
+    const SectionHeaderTableLayout table = *layout;
+
+    if (table.offset == 0 && table.count == 0) {
+        return;
+    }
+    if (table.entry_size < table.min_entry_size) {
+        throw UnmarshalError("ELF section header table in " + path + " has invalid entry size");
+    }
+    if (table.offset > data_size) {
+        throw UnmarshalError("ELF section header table in " + path + " is out of bounds");
+    }
+
+    const std::uintmax_t available = data_size - table.offset;
+    std::uintmax_t required_entries = table.count;
+    if (table.count == 0) {
+        if (available < table.min_entry_size) {
+            throw UnmarshalError("ELF section header table in " + path + " is out of bounds");
+        }
+
+        std::array<unsigned char, sizeof(ELFIO::Elf64_Shdr)> null_section_header{};
+        const auto null_section_bytes_read =
+            read_stream_bytes_at(input_stream, table.offset, null_section_header.data(), table.min_entry_size);
+        if (null_section_bytes_read < gsl::narrow<std::streamsize>(table.min_entry_size)) {
+            throw UnmarshalError("ELF section header table in " + path + " is out of bounds");
+        }
+
+        required_entries =
+            elf_class == ELFIO::ELFCLASS32
+                ? read_uint<ELFIO::Elf_Word>(null_section_header.data() + table.section_size_offset, little_endian)
+                : read_uint<ELFIO::Elf_Xword>(null_section_header.data() + table.section_size_offset, little_endian);
+    }
+    if (required_entries > available / table.entry_size) {
+        throw UnmarshalError("ELF section header table in " + path + " is out of bounds");
+    }
+}
+
 ELFIO::elfio load_elf(std::istream& input_stream, const std::string& path) {
+    const std::uintmax_t data_size = get_data_size(input_stream, path);
+    validate_section_header_table_bounds(input_stream, path, data_size);
+
     ELFIO::elfio reader;
     if (!reader.load(input_stream)) {
         throw UnmarshalError("Can't process ELF file " + path);
@@ -347,7 +505,6 @@ ELFIO::elfio load_elf(std::istream& input_stream, const std::string& path) {
         throw UnmarshalError("Unsupported ELF machine in file " + path + ": expected EM_BPF");
     }
 
-    const std::uintmax_t data_size = get_data_size(input_stream, path);
     for (const auto& section : reader.sections) {
         if (!section || section->get_type() == ELFIO::SHT_NOBITS) {
             continue;

--- a/src/test/test_elf_loader.cpp
+++ b/src/test/test_elf_loader.cpp
@@ -2,11 +2,14 @@
 // SPDX-License-Identifier: MIT
 
 #include <catch2/catch_all.hpp>
+#include <concepts>
 #include <cstddef>
 #include <cstdint>
+#include <cstring>
 #include <filesystem>
 #include <fstream>
 #include <iterator>
+#include <limits>
 #include <random>
 #include <sstream>
 #include <stdexcept>
@@ -14,7 +17,9 @@
 #include <string_view>
 #include <vector>
 
+#include <boost/endian/conversion.hpp>
 #include <elfio/elfio.hpp>
+#include <gsl/narrow>
 
 #include "config.hpp"
 #include "io/elf_loader.hpp"
@@ -44,52 +49,88 @@ void write_file_bytes(const std::filesystem::path& path, const std::vector<uint8
     }
 }
 
-uint32_t read_u32_le(const std::vector<uint8_t>& bytes, const size_t offset) {
-    if (offset + sizeof(uint32_t) > bytes.size()) {
-        throw std::runtime_error("u32 read out of bounds");
+template <std::unsigned_integral T>
+T read_uint(const std::vector<uint8_t>& bytes, const size_t offset, const bool little_endian) {
+    if (offset + sizeof(T) > bytes.size()) {
+        throw std::runtime_error("integer read out of bounds");
     }
-    return static_cast<uint32_t>(bytes[offset] | (static_cast<uint32_t>(bytes[offset + 1]) << 8U) |
-                                 (static_cast<uint32_t>(bytes[offset + 2]) << 16U) |
-                                 (static_cast<uint32_t>(bytes[offset + 3]) << 24U));
+
+    T encoded{};
+    std::memcpy(&encoded, bytes.data() + offset, sizeof(encoded));
+    return little_endian ? boost::endian::little_to_native(encoded) : boost::endian::big_to_native(encoded);
+}
+
+template <std::unsigned_integral T>
+void write_uint(std::vector<uint8_t>& bytes, const size_t offset, const T value, const bool little_endian) {
+    if (offset + sizeof(T) > bytes.size()) {
+        throw std::runtime_error("integer write out of bounds");
+    }
+
+    const T encoded = little_endian ? boost::endian::native_to_little(value) : boost::endian::native_to_big(value);
+    std::memcpy(bytes.data() + offset, &encoded, sizeof(encoded));
+}
+
+uint32_t read_u32_le(const std::vector<uint8_t>& bytes, const size_t offset) {
+    return read_uint<uint32_t>(bytes, offset, true);
 }
 
 uint64_t read_u64_le(const std::vector<uint8_t>& bytes, const size_t offset) {
-    if (offset + sizeof(uint64_t) > bytes.size()) {
-        throw std::runtime_error("u64 read out of bounds");
-    }
-
-    uint64_t value = 0;
-    for (size_t i = 0; i < sizeof(uint64_t); ++i) {
-        value |= static_cast<uint64_t>(bytes[offset + i]) << (8U * i);
-    }
-    return value;
+    return read_uint<uint64_t>(bytes, offset, true);
 }
 
 void write_u16_le(std::vector<uint8_t>& bytes, const size_t offset, const uint16_t value) {
-    if (offset + sizeof(uint16_t) > bytes.size()) {
-        throw std::runtime_error("u16 write out of bounds");
-    }
-    bytes[offset] = static_cast<uint8_t>(value & 0xffU);
-    bytes[offset + 1] = static_cast<uint8_t>((value >> 8U) & 0xffU);
+    write_uint<uint16_t>(bytes, offset, value, true);
 }
 
 void write_u32_le(std::vector<uint8_t>& bytes, const size_t offset, const uint32_t value) {
-    if (offset + sizeof(uint32_t) > bytes.size()) {
-        throw std::runtime_error("u32 write out of bounds");
-    }
-    bytes[offset] = static_cast<uint8_t>(value & 0xffU);
-    bytes[offset + 1] = static_cast<uint8_t>((value >> 8U) & 0xffU);
-    bytes[offset + 2] = static_cast<uint8_t>((value >> 16U) & 0xffU);
-    bytes[offset + 3] = static_cast<uint8_t>((value >> 24U) & 0xffU);
+    write_uint<uint32_t>(bytes, offset, value, true);
 }
 
 void write_u64_le(std::vector<uint8_t>& bytes, const size_t offset, const uint64_t value) {
-    if (offset + sizeof(uint64_t) > bytes.size()) {
-        throw std::runtime_error("u64 write out of bounds");
+    write_uint<uint64_t>(bytes, offset, value, true);
+}
+
+unsigned char get_elf_class(const std::vector<uint8_t>& bytes) {
+    if (bytes.size() <= ELFIO::EI_CLASS) {
+        throw std::runtime_error("ELF header is truncated");
     }
-    for (size_t i = 0; i < sizeof(uint64_t); ++i) {
-        bytes[offset + i] = static_cast<uint8_t>((value >> (8U * i)) & 0xffU);
+    if (bytes[ELFIO::EI_CLASS] != ELFIO::ELFCLASS32 && bytes[ELFIO::EI_CLASS] != ELFIO::ELFCLASS64) {
+        throw std::runtime_error("Unexpected ELF class");
     }
+    return bytes[ELFIO::EI_CLASS];
+}
+
+bool is_little_endian_elf(const std::vector<uint8_t>& bytes) {
+    if (bytes.size() <= ELFIO::EI_DATA) {
+        throw std::runtime_error("ELF header is truncated");
+    }
+    if (bytes[ELFIO::EI_DATA] == ELFIO::ELFDATA2LSB) {
+        return true;
+    }
+    if (bytes[ELFIO::EI_DATA] == ELFIO::ELFDATA2MSB) {
+        return false;
+    }
+    throw std::runtime_error("Unexpected ELF data encoding");
+}
+
+uint32_t read_elf_u32(const std::vector<uint8_t>& bytes, const size_t offset) {
+    return read_uint<uint32_t>(bytes, offset, is_little_endian_elf(bytes));
+}
+
+uint64_t read_elf_u64(const std::vector<uint8_t>& bytes, const size_t offset) {
+    return read_uint<uint64_t>(bytes, offset, is_little_endian_elf(bytes));
+}
+
+void write_elf_u16(std::vector<uint8_t>& bytes, const size_t offset, const uint16_t value) {
+    write_uint<uint16_t>(bytes, offset, value, is_little_endian_elf(bytes));
+}
+
+void write_elf_u32(std::vector<uint8_t>& bytes, const size_t offset, const uint32_t value) {
+    write_uint<uint32_t>(bytes, offset, value, is_little_endian_elf(bytes));
+}
+
+void write_elf_u64(std::vector<uint8_t>& bytes, const size_t offset, const uint64_t value) {
+    write_uint<uint64_t>(bytes, offset, value, is_little_endian_elf(bytes));
 }
 
 class TempElfFile {
@@ -151,8 +192,87 @@ SectionHeaderInfo get_section_header_info(const std::filesystem::path& path, con
 
 void patch_machine(const std::filesystem::path& path, const uint16_t machine) {
     auto bytes = read_file_bytes(path);
+    if (bytes.size() < offsetof(ELFIO::Elf32_Ehdr, e_machine) + sizeof(machine)) {
+        throw std::runtime_error("ELF header is truncated");
+    }
     // e_machine field in ELF header (both 32-bit and 64-bit).
     write_u16_le(bytes, offsetof(ELFIO::Elf32_Ehdr, e_machine), machine);
+    write_file_bytes(path, bytes);
+}
+
+void patch_elf_data_encoding(const std::filesystem::path& path, const unsigned char encoding) {
+    auto bytes = read_file_bytes(path);
+    if (bytes.size() <= ELFIO::EI_DATA) {
+        throw std::runtime_error("ELF header is truncated");
+    }
+    if (encoding != ELFIO::ELFDATA2LSB && encoding != ELFIO::ELFDATA2MSB) {
+        throw std::runtime_error("Unexpected ELF data encoding");
+    }
+    bytes[ELFIO::EI_DATA] = encoding;
+    write_file_bytes(path, bytes);
+}
+
+void patch_section_table_offset(const std::filesystem::path& path, const uint64_t offset) {
+    auto bytes = read_file_bytes(path);
+    const unsigned char elf_class = get_elf_class(bytes);
+    if (elf_class == ELFIO::ELFCLASS32) {
+        write_elf_u32(bytes, offsetof(ELFIO::Elf32_Ehdr, e_shoff), gsl::narrow<uint32_t>(offset));
+    } else if (elf_class == ELFIO::ELFCLASS64) {
+        write_elf_u64(bytes, offsetof(ELFIO::Elf64_Ehdr, e_shoff), offset);
+    } else {
+        throw std::runtime_error("Unexpected ELF class");
+    }
+    write_file_bytes(path, bytes);
+}
+
+void patch_section_table_entry_size(const std::filesystem::path& path, const uint16_t entry_size) {
+    auto bytes = read_file_bytes(path);
+    const unsigned char elf_class = get_elf_class(bytes);
+    if (elf_class == ELFIO::ELFCLASS32) {
+        write_elf_u16(bytes, offsetof(ELFIO::Elf32_Ehdr, e_shentsize), entry_size);
+    } else if (elf_class == ELFIO::ELFCLASS64) {
+        write_elf_u16(bytes, offsetof(ELFIO::Elf64_Ehdr, e_shentsize), entry_size);
+    } else {
+        throw std::runtime_error("Unexpected ELF class");
+    }
+    write_file_bytes(path, bytes);
+}
+
+void patch_section_table_count(const std::filesystem::path& path, const uint16_t count) {
+    auto bytes = read_file_bytes(path);
+    const unsigned char elf_class = get_elf_class(bytes);
+    if (elf_class == ELFIO::ELFCLASS32) {
+        write_elf_u16(bytes, offsetof(ELFIO::Elf32_Ehdr, e_shnum), count);
+    } else if (elf_class == ELFIO::ELFCLASS64) {
+        write_elf_u16(bytes, offsetof(ELFIO::Elf64_Ehdr, e_shnum), count);
+    } else {
+        throw std::runtime_error("Unexpected ELF class");
+    }
+    write_file_bytes(path, bytes);
+}
+
+size_t get_section_table_offset_from_header(const std::vector<uint8_t>& bytes) {
+    const unsigned char elf_class = get_elf_class(bytes);
+    if (elf_class == ELFIO::ELFCLASS32) {
+        return read_elf_u32(bytes, offsetof(ELFIO::Elf32_Ehdr, e_shoff));
+    }
+    if (elf_class == ELFIO::ELFCLASS64) {
+        return gsl::narrow<size_t>(read_elf_u64(bytes, offsetof(ELFIO::Elf64_Ehdr, e_shoff)));
+    }
+    throw std::runtime_error("Unexpected ELF class");
+}
+
+void patch_null_section_size(const std::filesystem::path& path, const uint64_t size) {
+    auto bytes = read_file_bytes(path);
+    const size_t section_table_offset = get_section_table_offset_from_header(bytes);
+    const unsigned char elf_class = get_elf_class(bytes);
+    if (elf_class == ELFIO::ELFCLASS32) {
+        write_elf_u32(bytes, section_table_offset + offsetof(ELFIO::Elf32_Shdr, sh_size), gsl::narrow<uint32_t>(size));
+    } else if (elf_class == ELFIO::ELFCLASS64) {
+        write_elf_u64(bytes, section_table_offset + offsetof(ELFIO::Elf64_Shdr, sh_size), size);
+    } else {
+        throw std::runtime_error("Unexpected ELF class");
+    }
     write_file_bytes(path, bytes);
 }
 
@@ -161,7 +281,7 @@ void patch_section_offset(const std::filesystem::path& path, const std::string& 
     auto bytes = read_file_bytes(path);
     if (info.elf_class == ELFIO::ELFCLASS32) {
         write_u32_le(bytes, info.section_header_offset + offsetof(ELFIO::Elf32_Shdr, sh_offset),
-                     static_cast<uint32_t>(offset));
+                     gsl::narrow<uint32_t>(offset));
     } else if (info.elf_class == ELFIO::ELFCLASS64) {
         write_u64_le(bytes, info.section_header_offset + offsetof(ELFIO::Elf64_Shdr, sh_offset), offset);
     } else {
@@ -175,7 +295,7 @@ void patch_section_size(const std::filesystem::path& path, const std::string& se
     auto bytes = read_file_bytes(path);
     if (info.elf_class == ELFIO::ELFCLASS32) {
         write_u32_le(bytes, info.section_header_offset + offsetof(ELFIO::Elf32_Shdr, sh_size),
-                     static_cast<uint32_t>(size));
+                     gsl::narrow<uint32_t>(size));
     } else if (info.elf_class == ELFIO::ELFCLASS64) {
         write_u64_le(bytes, info.section_header_offset + offsetof(ELFIO::Elf64_Shdr, sh_size), size);
     } else {
@@ -190,7 +310,7 @@ void patch_section_entry_size(const std::filesystem::path& path, const std::stri
     auto bytes = read_file_bytes(path);
     if (info.elf_class == ELFIO::ELFCLASS32) {
         write_u32_le(bytes, info.section_header_offset + offsetof(ELFIO::Elf32_Shdr, sh_entsize),
-                     static_cast<uint32_t>(entry_size));
+                     gsl::narrow<uint32_t>(entry_size));
     } else if (info.elf_class == ELFIO::ELFCLASS64) {
         write_u64_le(bytes, info.section_header_offset + offsetof(ELFIO::Elf64_Shdr, sh_entsize), entry_size);
     } else {
@@ -425,6 +545,53 @@ TEST_CASE("ELF loader rejects non-BPF e_machine", "[elf][hardening]") {
 
     REQUIRE_THROWS_WITH((ElfObject{elf.path().string(), {}, &g_ebpf_platform_linux}.get_programs(".text")),
                         Catch::Matchers::ContainsSubstring("Unsupported ELF machine"));
+}
+
+TEST_CASE("ELF loader accepts valid section header table metadata", "[elf][hardening]") {
+
+    TempElfFile elf{"ebpf-samples/build/twomaps.o", "good-section-table"};
+
+    const auto programs = ElfObject{elf.path().string(), {}, &g_ebpf_platform_linux}.get_programs(".text");
+    REQUIRE_FALSE(programs.empty());
+}
+
+TEST_CASE("ELF loader rejects out-of-range section header table", "[elf][hardening]") {
+
+    TempElfFile elf{"ebpf-samples/build/twomaps.o", "bad-section-table"};
+    patch_section_table_offset(elf.path(), std::numeric_limits<uint64_t>::max());
+
+    REQUIRE_THROWS_WITH((ElfObject{elf.path().string(), {}, &g_ebpf_platform_linux}.get_programs(".text")),
+                        Catch::Matchers::ContainsSubstring("section header table"));
+}
+
+TEST_CASE("ELF loader rejects undersized section header entries", "[elf][hardening]") {
+
+    TempElfFile elf{"ebpf-samples/build/twomaps.o", "bad-section-entry-size"};
+    patch_section_table_entry_size(elf.path(), 1);
+
+    REQUIRE_THROWS_WITH((ElfObject{elf.path().string(), {}, &g_ebpf_platform_linux}.get_programs(".text")),
+                        Catch::Matchers::ContainsSubstring("invalid entry size"));
+}
+
+TEST_CASE("ELF loader honors big-endian section header metadata", "[elf][hardening]") {
+
+    TempElfFile elf{"ebpf-samples/build/twomaps.o", "bad-big-endian-section-entry-size"};
+    patch_elf_data_encoding(elf.path(), ELFIO::ELFDATA2MSB);
+    patch_section_table_entry_size(elf.path(), 1);
+
+    REQUIRE_THROWS_WITH((ElfObject{elf.path().string(), {}, &g_ebpf_platform_linux}.get_programs(".text")),
+                        Catch::Matchers::ContainsSubstring("invalid entry size"));
+}
+
+TEST_CASE("ELF loader validates extended section header counts", "[elf][hardening]") {
+
+    TempElfFile elf{"ebpf-samples/build/twomaps.o", "bad-extended-section-count"};
+    const auto file_size = std::filesystem::file_size(elf.path());
+    patch_section_table_count(elf.path(), 0);
+    patch_null_section_size(elf.path(), file_size + 1);
+
+    REQUIRE_THROWS_WITH((ElfObject{elf.path().string(), {}, &g_ebpf_platform_linux}.get_programs(".text")),
+                        Catch::Matchers::ContainsSubstring("section header table"));
 }
 
 TEST_CASE("ELF loader rejects relocation sections with out-of-bounds file offsets", "[elf][hardening]") {


### PR DESCRIPTION
Fixes a bug where an ELF file with an impossible section header table offset could reach lower-level parser arithmetic before being rejected. The loader now checks the section table range from the ELF header before normal parsing.

Validation: `cmake --build build --target tests prevail-cli`; `bin/tests "[elf][hardening]"`; malformed local input now reports an out-of-bounds section table.