### PR TITLE
Handle out-of-window numeric byte ranges

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -260,6 +260,7 @@ if (prevail_ENABLE_TESTS)
   add_executable(run_yaml "${prevail_source_dir}/src/test/run_yaml.cpp")
 
   set(prevail_TEST_SRC
+    src/test/test_array_domain.cpp
     src/test/test_cfg_builder_passes.cpp
     src/test/test_conformance.cpp
     src/test/test_elf_loader.cpp

--- a/src/crab/array_domain.cpp
+++ b/src/crab/array_domain.cpp
@@ -358,21 +358,42 @@ static std::optional<std::pair<offset_t, unsigned>> kill_and_find_var(StackCellR
     }
     return res;
 }
-static std::tuple<int, int> as_numbytes_range(const Interval& index, const Interval& width, const int stack_size) {
-    return (index | (index + width)).bound(0, stack_size);
+static std::optional<std::tuple<int, int>> as_numbytes_range(const Interval& range, const int stack_size) {
+    const Interval bounded_range = Interval{0, stack_size} & range;
+    if (bounded_range.is_bottom()) {
+        return {};
+    }
+    const auto bounds = bounded_range.pair<int>();
+    const auto [lb, ub] = bounds;
+    if (lb >= ub) {
+        return {};
+    }
+    return bounds;
+}
+
+static std::optional<std::tuple<int, int>> as_numbytes_range(const Interval& index, const Interval& width,
+                                                             const int stack_size) {
+    const Interval range = index | (index + width);
+    return as_numbytes_range(range, stack_size);
 }
 
 bool ArrayDomain::all_num_lb_ub(const Interval& lb, const Interval& ub) const {
-    const auto [min_lb, max_ub] = (lb | ub).bound(0, total_stack_size());
-    if (min_lb > max_ub) {
+    const auto range = as_numbytes_range(lb | ub, total_stack_size());
+    if (!range.has_value()) {
         return false;
     }
+    const auto [min_lb, max_ub] = *range;
+    assert(min_lb < max_ub);
     return this->num_bytes.all_num(min_lb, max_ub);
 }
 
 bool ArrayDomain::all_num_width(const Interval& index, const Interval& width) const {
-    const auto [min_lb, max_ub] = as_numbytes_range(index, width, total_stack_size());
-    assert(min_lb <= max_ub);
+    const auto range = as_numbytes_range(index, width, total_stack_size());
+    if (!range.has_value()) {
+        return false;
+    }
+    const auto [min_lb, max_ub] = *range;
+    assert(min_lb < max_ub);
     return this->num_bytes.all_num(min_lb, max_ub);
 }
 
@@ -610,8 +631,9 @@ std::optional<Variable> ArrayDomain::store_type(TypeDomain& inv, const Interval&
         using namespace dsl_syntax;
         // Weak update: cannot perform a strong update because the index is
         // not a singleton. Havoc the type cells in the range.
-        const auto [lb, ub] = as_numbytes_range(idx, width, total_stack_size());
-        if (!is_num) {
+        const auto range = as_numbytes_range(idx, width, total_stack_size());
+        if (!is_num && range.has_value()) {
+            const auto [lb, ub] = *range;
             // A non-numeric value may overwrite previously numeric bytes,
             // so conservatively mark the range as non-numeric.
             num_bytes.havoc(lb, ub);

--- a/src/test/test_array_domain.cpp
+++ b/src/test/test_array_domain.cpp
@@ -1,0 +1,29 @@
+// Copyright (c) Prevail Verifier contributors.
+// SPDX-License-Identifier: MIT
+#include <catch2/catch_all.hpp>
+
+#include "crab/array_domain.hpp"
+
+using namespace prevail;
+
+TEST_CASE("numeric byte queries outside the stack window fail closed", "[array_domain]") {
+    ArrayDomain stack{8};
+    stack.initialize_numbers(0, 8);
+
+    REQUIRE(stack.all_num_width(Interval{0}, Interval{8}));
+    REQUIRE_FALSE(stack.all_num_width(Interval{8}, Interval{4}));
+    REQUIRE_FALSE(stack.all_num_width(Interval{16}, Interval{4}));
+    REQUIRE_FALSE(stack.all_num_width(Interval{-8}, Interval{4}));
+    REQUIRE_FALSE(stack.all_num_lb_ub(Interval{8}, Interval{12}));
+    REQUIRE_FALSE(stack.all_num_lb_ub(Interval{16}, Interval{20}));
+    REQUIRE_FALSE(stack.all_num_lb_ub(Interval{-8}, Interval{-4}));
+}
+
+TEST_CASE("weak type store outside the stack window is a no-op", "[array_domain]") {
+    ArrayDomain stack{8};
+    TypeDomain types;
+    stack.initialize_numbers(0, 8);
+
+    REQUIRE_NOTHROW((void)stack.store_type(types, Interval{16}, Interval{4}, false));
+    REQUIRE(stack.all_num_width(Interval{0}, Interval{8}));
+}


### PR DESCRIPTION
Fixes a bug where byte-range numericness checks could turn an out-of-window range into an internal error. Empty intersections with the tracked stack byte window now produce a normal negative query result, and weak updates outside that window are ignored.

Validation: `cmake --build build --target tests`; `bin/tests "[array_domain]"`