### PR TITLE
Fix signed division by negative singleton

### DIFF
--- a/src/crab/interval.cpp
+++ b/src/crab/interval.cpp
@@ -17,6 +17,11 @@ static Interval make_dividend_when_both_nonzero(const Interval& dividend, const 
     return dividend + Interval{1} - divisor;
 }
 
+static ExtendedNumber divide_bound_by_negative_singleton(const ExtendedNumber& bound, const Number& divisor) {
+    assert(divisor < 0);
+    return bound.is_infinite() ? -bound : bound / divisor;
+}
+
 Interval Interval::operator*(const Interval& x) const {
     if (is_bottom() || x.is_bottom()) {
         return bottom();
@@ -45,7 +50,7 @@ Interval Interval::operator/(const Interval& x) const {
         } else if (c > 0) {
             return Interval{_lb / c, _ub / c};
         } else if (c < 0) {
-            return Interval{_ub / c, _lb / c};
+            return Interval{divide_bound_by_negative_singleton(_ub, c), divide_bound_by_negative_singleton(_lb, c)};
         } else {
             // The eBPF ISA defines division by 0 as resulting in 0.
             return Interval{0};
@@ -87,8 +92,10 @@ Interval Interval::sdiv(const Interval& x) const {
             const Number c{n->cast_to<int64_t>()};
             if (c == 1) {
                 return *this;
-            } else if (c != 0) {
+            } else if (c > 0) {
                 return Interval{_lb / c, _ub / c};
+            } else if (c < 0) {
+                return Interval{divide_bound_by_negative_singleton(_ub, c), divide_bound_by_negative_singleton(_lb, c)};
             } else {
                 // The eBPF ISA defines division by 0 as resulting in 0.
                 return Interval{0};

--- a/src/test/test_interval_bitwise.cpp
+++ b/src/test/test_interval_bitwise.cpp
@@ -23,6 +23,13 @@ TEST_CASE("bitwise_and with non-singleton containing all-ones includes zero", "[
     REQUIRE(left.bitwise_and(anomalous_right) == Interval{0, 100});
 }
 
+TEST_CASE("signed division by a negative singleton preserves interval order", "[interval][arithmetic]") {
+    REQUIRE(Interval{-8, -4}.sdiv(Interval{-1}) == Interval{4, 8});
+    REQUIRE(Interval{4, 8}.sdiv(Interval{-2}) == Interval{-4, -2});
+    REQUIRE(Interval::top().sdiv(Interval{-1}) == Interval::top());
+    REQUIRE((Interval::top() / Interval{-1}) == Interval::top());
+}
+
 TEST_CASE("finite domain left shift by zero preserves 64-bit interval", "[finite_domain][bitwise]") {
     FiniteDomain::clear_thread_local_state();
     const auto r1 = reg_pack(1);

--- a/test-data/sdivmod.yaml
+++ b/test-data/sdivmod.yaml
@@ -29,6 +29,21 @@ post:
   - r1.svalue=0
   - r1.uvalue=0
 ---
+test-case: non-singleton interval divided by negative singleton immediate
+
+pre:
+  - "r1.type=number"
+  - "r1.svalue=[-8, -4]"
+
+code:
+  <start>: |
+    r1 s/= -1
+
+post:
+  - r1.type=number
+  - r1.svalue=[4, 8]
+  - r1.uvalue=r1.svalue
+---
 test-case: zero divided by zero immediate
 
 pre: ["r1.type=number", "r1.svalue=0", "r1.uvalue=0"]


### PR DESCRIPTION
Signed interval division now preserves bound ordering when the divisor is a negative singleton. The singleton fast path mirrors the existing positive/negative divisor split used by generic signed division, avoiding an inverted interval for cases like `[-8, -4] / -1`.

Validation:
- `bin/tests "[interval][arithmetic]"`
- `bin/tests "YAML suite: test-data/sdivmod.yaml"`