### PR TITLE
Document writable helper output initialization contract

### DIFF
--- a/docs/instruction-semantics.md
+++ b/docs/instruction-semantics.md
@@ -327,6 +327,11 @@ void operator()(const Call& call) {
 
 Different helpers have different postconditions:
 
+Helper prototypes that declare a writable memory output, such as `PTR_TO_WRITABLE_MEM` and
+`PTR_TO_WRITABLE_MEM_OR_NULL`, must initialize the entire writable region described by the paired size argument
+unconditionally before returning. This includes failure returns. The verifier treats the declared region as initialized
+after the helper call, so a platform helper that only conditionally writes the region must use a different contract.
+
 ```cpp
 void apply_helper_contract(int func) {
     switch (func) {

--- a/src/spec/ebpf_base.h
+++ b/src/spec/ebpf_base.h
@@ -39,10 +39,12 @@ typedef enum _ebpf_argument_type {
     EBPF_ARGUMENT_TYPE_PTR_TO_MAP_VALUE = 8,
     EBPF_ARGUMENT_TYPE_PTR_TO_READABLE_MEM = 9, // Memory must have been initialized.
     EBPF_ARGUMENT_TYPE_PTR_TO_READABLE_MEM_OR_NULL = 10,
+    // Helper must initialize the full writable region described by the paired size argument on every return path.
     EBPF_ARGUMENT_TYPE_PTR_TO_WRITABLE_MEM = 11,
     EBPF_ARGUMENT_TYPE_PTR_TO_STACK = 12,
     EBPF_ARGUMENT_TYPE_PTR_TO_STACK_OR_NULL = 13,
     EBPF_ARGUMENT_TYPE_PTR_TO_CTX_OR_NULL = 14,
+    // Same as PTR_TO_WRITABLE_MEM, except the pointer may be null when the paired size is zero.
     EBPF_ARGUMENT_TYPE_PTR_TO_WRITABLE_MEM_OR_NULL = 15,
     EBPF_ARGUMENT_TYPE_PTR_TO_BTF_ID_SOCK_COMMON = 17,
     EBPF_ARGUMENT_TYPE_PTR_TO_SPIN_LOCK = 18,


### PR DESCRIPTION
Clarify the contract for helper arguments declared as writable memory outputs.

`EBPF_ARGUMENT_TYPE_PTR_TO_WRITABLE_MEM` and `_OR_NULL` require the helper to initialize the full writable region described by the paired size argument on every return path. This documents the verifier assumption that the region is initialized after the helper call, and makes clear that helpers with conditional writes need a different contract.

This is documentation only; no verifier behavior changes.