### PR TITLE
Migrate Windows CI to Visual Studio 2026 and bump yaml-cpp to 0.9.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,11 +63,11 @@ jobs:
         configurations: [Debug, Release]
         target: [tests, library]
       fail-fast: false
-    runs-on: windows-2025
+    runs-on: windows-latest
     env:
       MATRIX_TARGET: ${{ matrix.target }}
       BUILD_CONFIGURATION: ${{ matrix.configurations }}
-      CMAKE_GENERATOR: "Visual Studio 17 2022"
+      CMAKE_GENERATOR: "Visual Studio 18 2026"
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-2025]
+        os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:
       - uses: actions/checkout@v6
@@ -53,7 +53,7 @@ jobs:
         if: runner.os == 'Windows'
         shell: pwsh
         run: >
-          cmake -S . -B build -G "Visual Studio 17 2022"
+          cmake -S . -B build -G "Visual Studio 18 2026"
           -D prevail_ENABLE_TESTS=OFF
 
       # 3. Build

--- a/cmake/SetupYAMLCPP.cmake
+++ b/cmake/SetupYAMLCPP.cmake
@@ -19,7 +19,7 @@ if (NOT TARGET yaml-cpp::yaml-cpp)
 
     FetchContent_Declare(yaml-cpp
       GIT_REPOSITORY https://github.com/jbeder/yaml-cpp.git
-      GIT_TAG 0.8.0
+      GIT_TAG yaml-cpp-0.9.0
       GIT_SHALLOW TRUE
       FIND_PACKAGE_ARGS NAMES yaml-cpp
     )


### PR DESCRIPTION
## Problem

The Windows CI jobs fail at the CMake configure step:

```
CMake Error at CMakeLists.txt:12 (project):
  Generator

    Visual Studio 17 2022

  could not find any instance of Visual Studio.
```

GitHub migrated the `windows-2025` / `windows-latest` runner images to **Visual Studio 2026 (v18)** between 2026-06-08 and 2026-06-15, removing Visual Studio 2022 ([runner-images#14017](https://github.com/actions/runner-images/issues/14017)). The pinned `Visual Studio 17 2022` generator no longer matches any installed instance.

## Fix

- Use the `windows-latest` runner (now Windows Server 2025 + VS 2026) for the Windows jobs.
- Switch the CMake generator to `Visual Studio 18 2026`.

The `Visual Studio 18 2026` generator is supported since CMake 4.2; the VS 2026 image ships CMake 4.3.3, so no toolchain bump is required.

Applies the same change to both `build.yml` (CI) and `release.yaml` (release artifacts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)