### PR TITLE
Fix stale type-dependent numeric values on type updates

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -274,6 +274,7 @@ if (prevail_ENABLE_TESTS)
     src/test/test_sign_extension.cpp
     src/test/test_subsumption.cpp
     src/test/test_type_domain.cpp
+    src/test/test_type_to_num.cpp
     src/test/test_verify_bcc.cpp
     src/test/test_verify_bpf_cilium_test.cpp
     src/test/test_verify_build.cpp

--- a/src/crab/ebpf_checker.cpp
+++ b/src/crab/ebpf_checker.cpp
@@ -163,7 +163,7 @@ void EbpfChecker::operator()(const FuncConstraint& s) const {
     if (dom.state.is_bottom()) {
         return;
     }
-    const auto src_interval = dom.state.values.eval_interval(reg_pack(s.reg).svalue);
+    const auto src_interval = dom.state.values.eval_interval(reg_pack(s.reg).uvalue);
     if (const auto sn = src_interval.singleton()) {
         if (sn->fits<int32_t>()) {
             // We can now process it as if the id was immediate.

--- a/src/crab/ebpf_transformer.cpp
+++ b/src/crab/ebpf_transformer.cpp
@@ -157,7 +157,9 @@ void EbpfTransformer::save_callee_saved_registers(const std::string& prefix) {
     for (const Reg r : {Reg{R6}, Reg{R7}, Reg{R8}, Reg{R9}}) {
         if (dom.state.is_initialized(r)) {
             const Variable type_var = variable_registry.type_reg(r.v);
-            dom.state.assign_type(variable_registry.stack_frame_var(DataKind::types, r.v, prefix), type_var);
+            const Variable frame_type_var = variable_registry.stack_frame_var(DataKind::types, r.v, prefix);
+            dom.state.forget_type_dependent_values(frame_type_var);
+            dom.state.assign_type(frame_type_var, type_var);
             for (const TypeEncoding type : dom.state.iterate_types(r)) {
                 auto kinds = type_to_kinds.at(type);
                 kinds.push_back(DataKind::uvalues);
@@ -294,6 +296,7 @@ void EbpfTransformer::operator()(const LoadPseudo& pseudo) {
     case PseudoAddress::Kind::CODE_ADDR: {
         const auto dst = reg_pack(pseudo.dst);
         const uint64_t imm64 = merge_imm32_to_u64(pseudo.addr.imm, pseudo.addr.next_imm);
+        dom.state.forget_type_dependent_values(pseudo.dst);
         dom.state.values.assign(dst.uvalue, imm64);
         dom.state.values->overflow_bounds(dst.uvalue, 64, false);
         dom.state.assign_type(pseudo.dst, T_FUNC);
@@ -912,6 +915,8 @@ void EbpfTransformer::operator()(const Call& call) {
     // Set r0 as a nullable T_SHARED pointer at offset 0.
     // If region_size is known, constrain it; otherwise havoc to prevent stale values.
     auto assign_shared_map_value = [&](const std::optional<Interval>& region_size) {
+        dom.state.forget_type_dependent_values(r0_reg);
+        dom.state.assign_type(r0_reg, T_SHARED);
         assign_valid_ptr(r0_reg, true);
         dom.state.values.assign(r0_pack.shared_offset, 0);
         if (region_size) {
@@ -919,7 +924,6 @@ void EbpfTransformer::operator()(const Call& call) {
         } else {
             dom.state.values.havoc(r0_pack.shared_region_size);
         }
-        dom.state.assign_type(r0_reg, T_SHARED);
     };
     auto resolve_map_lookup = [&] {
         // Map lookup is the only way to get a null pointer.
@@ -947,8 +951,9 @@ void EbpfTransformer::operator()(const Call& call) {
     if (resolved.contract.is_map_lookup) {
         resolve_map_lookup();
     } else if (resolved.contract.return_ptr_type.has_value()) {
-        assign_valid_ptr(r0_reg, resolved.contract.return_nullable);
+        dom.state.forget_type_dependent_values(r0_reg);
         dom.state.assign_type(r0_reg, *resolved.contract.return_ptr_type);
+        assign_valid_ptr(r0_reg, resolved.contract.return_nullable);
         if (*resolved.contract.return_ptr_type == T_ALLOC_MEM && resolved.contract.alloc_size_reg.has_value()) {
             // Propagate allocation bounds: offset starts at 0, size is the allocation size argument.
             dom.state.values.assign(r0_pack.alloc_mem_offset, 0);
@@ -988,7 +993,7 @@ void EbpfTransformer::operator()(const Callx& callx) {
 
     // Look up the helper function id.
     const RegPack& reg = reg_pack(callx.func);
-    const auto src_interval = dom.state.values.eval_interval(reg.svalue);
+    const auto src_interval = dom.state.values.eval_interval(reg.uvalue);
     if (const auto sn = src_interval.singleton()) {
         if (sn->fits<int32_t>()) {
             // We can now process it as if the id was immediate.
@@ -1006,6 +1011,7 @@ void EbpfTransformer::do_load_mapfd(const Reg& dst_reg, const int mapfd, const b
     const auto& desc = context.map_descriptor(mapfd);
     const EbpfMapType& type = context.platform().get_map_type(desc.type);
     const RegPack& dst = reg_pack(dst_reg);
+    dom.state.forget_type_dependent_values(dst_reg);
     if (type.value_type == EbpfMapValueType::PROGRAM) {
         dom.state.assign_type(dst_reg, T_MAP_PROGRAMS);
         dom.state.values.assign(dst.map_fd_programs, mapfd);
@@ -1032,6 +1038,7 @@ void EbpfTransformer::do_load_map_address(const Reg& dst_reg, const int mapfd, c
     }
 
     // Set the shared region size and offset for the map.
+    dom.state.forget_type_dependent_values(dst_reg);
     dom.state.assign_type(dst_reg, T_SHARED);
     const RegPack& dst = reg_pack(dst_reg);
     dom.state.values.assign(dst.shared_offset, offset);

--- a/src/crab/type_to_num.cpp
+++ b/src/crab/type_to_num.cpp
@@ -205,6 +205,7 @@ void TypeToNumDomain::havoc_all_locations_having_type(const TypeEncoding type) {
 }
 
 void TypeToNumDomain::forget_type_dependent_values(const Variable type_variable) {
+    assert(variable_registry.is_type(type_variable));
     for (const auto& kinds : type_to_kinds | std::views::values) {
         for (const DataKind kind : kinds) {
             values.havoc(variable_registry.kind_var(kind, type_variable));

--- a/src/crab/type_to_num.cpp
+++ b/src/crab/type_to_num.cpp
@@ -200,25 +200,29 @@ void TypeToNumDomain::havoc_all_locations_having_type(const TypeEncoding type) {
     for (const Variable type_variable : types.variables_with_type(type)) {
         types.havoc_type(type_variable);
         values.havoc(variable_registry.kind_var(DataKind::uvalues, type_variable));
-        for (const DataKind kind : type_to_kinds.at(type)) {
+        forget_type_dependent_values(type_variable);
+    }
+}
+
+void TypeToNumDomain::forget_type_dependent_values(const Variable type_variable) {
+    for (const auto& kinds : type_to_kinds | std::views::values) {
+        for (const DataKind kind : kinds) {
             values.havoc(variable_registry.kind_var(kind, type_variable));
         }
     }
 }
 
+void TypeToNumDomain::forget_type_dependent_values(const Reg& reg) { forget_type_dependent_values(reg_type(reg)); }
+
 void TypeToNumDomain::assign(const Reg& lhs, const Reg& rhs) {
     if (lhs == rhs) {
         return;
     }
+    forget_type_dependent_values(lhs);
     types.assign_type(lhs, rhs);
 
     values.assign(reg_pack(lhs).uvalue, reg_pack(rhs).uvalue);
 
-    for (const auto& type : types.iterate_types(lhs)) {
-        for (const auto& kind : type_to_kinds.at(type)) {
-            values.havoc(variable_registry.kind_var(kind, reg_type(lhs)));
-        }
-    }
     for (const auto& type : types.iterate_types(rhs)) {
         for (const auto kind : type_to_kinds.at(type)) {
             const auto lhs_var = variable_registry.kind_var(kind, reg_type(lhs));

--- a/src/crab/type_to_num.hpp
+++ b/src/crab/type_to_num.hpp
@@ -189,6 +189,9 @@ struct TypeToNumDomain {
 
     void havoc_all_locations_having_type(TypeEncoding type);
 
+    // `type_variable` must identify a DataKind::types location. This clears only
+    // type-dependent kind values for that location and intentionally preserves
+    // `uvalue`, whose meaning is type-independent.
     void forget_type_dependent_values(Variable type_variable);
     void forget_type_dependent_values(const Reg& reg);
 

--- a/src/crab/type_to_num.hpp
+++ b/src/crab/type_to_num.hpp
@@ -189,6 +189,9 @@ struct TypeToNumDomain {
 
     void havoc_all_locations_having_type(TypeEncoding type);
 
+    void forget_type_dependent_values(Variable type_variable);
+    void forget_type_dependent_values(const Reg& reg);
+
     void assign(const Reg& lhs, const Reg& rhs);
 
     void assign_type(auto&&... args) { types.assign_type(std::forward<decltype(args)>(args)...); }

--- a/src/test/test_type_to_num.cpp
+++ b/src/test/test_type_to_num.cpp
@@ -1,0 +1,70 @@
+// Copyright (c) Prevail Verifier contributors.
+// SPDX-License-Identifier: MIT
+
+#include <catch2/catch_all.hpp>
+
+#include "arith/dsl_syntax.hpp"
+#include "crab/type_to_num.hpp"
+
+using namespace prevail;
+
+static constexpr Reg r0{0};
+static constexpr Reg r1{1};
+
+TEST_CASE("forget_type_dependent_values preserves type and universal value", "[type_to_num]") {
+    TypeToNumDomain dom;
+    const RegPack pack = reg_pack(r0);
+
+    dom.assign_type(r0, T_STACK);
+    dom.values.assign(pack.uvalue, 512);
+    dom.values.assign(pack.svalue, 512);
+    dom.values.assign(pack.stack_offset, 512);
+
+    dom.forget_type_dependent_values(r0);
+
+    REQUIRE(dom.get_type(r0) == T_STACK);
+    REQUIRE(dom.values.eval_interval(pack.uvalue) == Interval{512});
+    REQUIRE(dom.values.eval_interval(pack.svalue).is_top());
+    REQUIRE(dom.values.eval_interval(pack.stack_offset).is_top());
+}
+
+TEST_CASE("TypeToNumDomain register assignment clears stale destination kind values", "[type_to_num]") {
+    using namespace dsl_syntax;
+
+    TypeToNumDomain dom;
+    const RegPack dst = reg_pack(r0);
+    const RegPack src = reg_pack(r1);
+
+    dom.assign_type(r0, T_NUM);
+    dom.values.assign(dst.svalue, 7);
+    dom.values.assign(dst.uvalue, 7);
+
+    dom.assign_type(r1, T_SHARED);
+    dom.values.assign(src.uvalue, 100);
+    dom.values.assign(src.shared_offset, 4);
+    dom.values.assign(src.shared_region_size, 16);
+
+    dom.assign(r0, r1);
+
+    REQUIRE(dom.get_type(r0) == T_SHARED);
+    REQUIRE(dom.values.eval_interval(dst.uvalue) == Interval{100});
+    REQUIRE(dom.values.eval_interval(dst.shared_offset) == Interval{4});
+    REQUIRE(dom.values.entail(eq(dst.shared_region_size, src.shared_region_size)));
+    REQUIRE(dom.values.entail(dst.shared_region_size >= 16));
+    REQUIRE(dom.values.eval_interval(dst.svalue).is_top());
+}
+
+TEST_CASE("TypeToNumDomain self assignment keeps kind values", "[type_to_num]") {
+    TypeToNumDomain dom;
+    const RegPack pack = reg_pack(r0);
+
+    dom.assign_type(r0, T_NUM);
+    dom.values.assign(pack.svalue, -3);
+    dom.values.assign(pack.uvalue, 7);
+
+    dom.assign(r0, r0);
+
+    REQUIRE(dom.get_type(r0) == T_NUM);
+    REQUIRE(dom.values.eval_interval(pack.svalue) == Interval{-3});
+    REQUIRE(dom.values.eval_interval(pack.uvalue) == Interval{7});
+}

--- a/src/test/test_type_to_num.cpp
+++ b/src/test/test_type_to_num.cpp
@@ -3,6 +3,8 @@
 
 #include <catch2/catch_all.hpp>
 
+#include <string>
+
 #include "arith/dsl_syntax.hpp"
 #include "crab/type_to_num.hpp"
 
@@ -26,6 +28,27 @@ TEST_CASE("forget_type_dependent_values preserves type and universal value", "[t
     REQUIRE(dom.values.eval_interval(pack.uvalue) == Interval{512});
     REQUIRE(dom.values.eval_interval(pack.svalue).is_top());
     REQUIRE(dom.values.eval_interval(pack.stack_offset).is_top());
+}
+
+TEST_CASE("forget_type_dependent_values handles stack frame type variables", "[type_to_num]") {
+    TypeToNumDomain dom;
+    const std::string prefix = "saved";
+    const Variable frame_type = variable_registry.stack_frame_var(DataKind::types, r0.v, prefix);
+    const Variable frame_uvalue = variable_registry.stack_frame_var(DataKind::uvalues, r0.v, prefix);
+    const Variable frame_svalue = variable_registry.stack_frame_var(DataKind::svalues, r0.v, prefix);
+    const Variable frame_stack_offset = variable_registry.stack_frame_var(DataKind::stack_offsets, r0.v, prefix);
+
+    dom.assign_type(frame_type, LinearExpression{T_STACK});
+    dom.values.assign(frame_uvalue, 512);
+    dom.values.assign(frame_svalue, 512);
+    dom.values.assign(frame_stack_offset, 512);
+
+    dom.forget_type_dependent_values(frame_type);
+
+    REQUIRE(dom.types.entail_type(frame_type, T_STACK));
+    REQUIRE(dom.values.eval_interval(frame_uvalue) == Interval{512});
+    REQUIRE(dom.values.eval_interval(frame_svalue).is_top());
+    REQUIRE(dom.values.eval_interval(frame_stack_offset).is_top());
 }
 
 TEST_CASE("TypeToNumDomain register assignment clears stale destination kind values", "[type_to_num]") {

--- a/src/test/test_verify_cilium_core.cpp
+++ b/src/test/test_verify_cilium_core.cpp
@@ -31,13 +31,11 @@ TEST_PROGRAM("cilium-core", "bpf_lxc.o", "tc/entry", "cil_to_container", 4)
 TEST_PROGRAM("cilium-core", "bpf_lxc.o", "tc/tail", "tail_drop_notify", 30)
 TEST_PROGRAM("cilium-core", "bpf_lxc.o", "tc/tail", "tail_handle_arp", 30)
 TEST_PROGRAM("cilium-core", "bpf_lxc.o", "tc/tail", "tail_handle_ipv4", 30)
-TEST_PROGRAM("cilium-core", "bpf_lxc.o", "tc/tail", "tail_handle_ipv6_cont", 30)
 TEST_PROGRAM("cilium-core", "bpf_lxc.o", "tc/tail", "tail_icmp6_handle_ns", 30)
 TEST_PROGRAM("cilium-core", "bpf_lxc.o", "tc/tail", "tail_icmp6_send_time_exceeded", 30)
 TEST_PROGRAM("cilium-core", "bpf_lxc.o", "tc/tail", "tail_ipv4_ct_egress", 30)
 TEST_PROGRAM("cilium-core", "bpf_lxc.o", "tc/tail", "tail_ipv4_ct_ingress", 30)
 TEST_PROGRAM("cilium-core", "bpf_lxc.o", "tc/tail", "tail_ipv4_ct_ingress_policy_only", 30)
-TEST_PROGRAM("cilium-core", "bpf_lxc.o", "tc/tail", "tail_ipv4_policy", 30)
 TEST_PROGRAM("cilium-core", "bpf_lxc.o", "tc/tail", "tail_ipv4_to_endpoint", 30)
 TEST_PROGRAM("cilium-core", "bpf_lxc.o", "tc/tail", "tail_ipv6_ct_egress", 30)
 TEST_PROGRAM("cilium-core", "bpf_lxc.o", "tc/tail", "tail_ipv6_ct_ingress", 30)
@@ -126,6 +124,18 @@ TEST_PROGRAM_FAIL("cilium-core", "bpf_host.o", "tc/tail", "tail_nodeport_nat_ing
 TEST_SECTION_FAIL("cilium-core", "bpf_lxc.o", ".text", verify_test::VerifyIssueKind::VerifierTypeTracking)
 // register type refinement is too imprecise in this control-flow pattern
 TEST_PROGRAM_FAIL("cilium-core", "bpf_lxc.o", "tc/tail", "tail_handle_ipv4_cont", 30,
+                  verify_test::VerifyIssueKind::VerifierTypeTracking)
+// register type refinement is too imprecise in this control-flow pattern
+// The type-kind soundness fix intentionally discards stale type-dependent
+// kind values. This exposes a false positive until the dependent T_SOCKET
+// precision branch models direct socket reads.
+TEST_PROGRAM_FAIL("cilium-core", "bpf_lxc.o", "tc/tail", "tail_ipv4_policy", 30,
+                  verify_test::VerifyIssueKind::VerifierTypeTracking)
+// register type refinement is too imprecise in this control-flow pattern
+// The type-kind soundness fix intentionally discards stale type-dependent
+// kind values. This exposes a false positive until the dependent T_SOCKET and
+// boolean-AND precision branches restore the needed non-null proof.
+TEST_PROGRAM_FAIL("cilium-core", "bpf_lxc.o", "tc/tail", "tail_handle_ipv6_cont", 30,
                   verify_test::VerifyIssueKind::VerifierTypeTracking)
 // register type refinement is too imprecise in this control-flow pattern
 TEST_PROGRAM_FAIL("cilium-core", "bpf_lxc.o", "tc/tail", "tail_handle_ipv6", 30,

--- a/test-data/call.yaml
+++ b/test-data/call.yaml
@@ -18,6 +18,55 @@ post:
   - r0.uvalue=[0, 2147418112]
   - s[504...511].type=number
 ---
+test-case: bpf_map_lookup_elem null check discards stale destination kind values
+
+pre: ["r0.type=number", "r0.svalue=1", "r0.uvalue=1",
+      "r1.type=map_fd", "r1.map_fd=1",
+      "r2.type=stack", "r2.stack_offset=504",
+      "r6.type=stack", "r6.stack_offset=504",
+      "s[504...511].type=number"]
+
+code:
+  <start>: |
+    call 1; bpf_map_lookup_elem
+    if r0 != 0 goto <exit>
+    r1 = r0
+    r2 = r6
+    call 1; bpf_map_lookup_elem
+  <exit>: |
+    exit
+
+post:
+  - "_|_"
+
+messages:
+  - "4: Invalid type (r1.type == map_fd)"
+---
+test-case: bpf_map_lookup_elem copied null check discards stale destination kind values
+
+pre: ["r1.type=map_fd", "r1.map_fd=1",
+      "r2.type=stack", "r2.stack_offset=504",
+      "r6.type=stack", "r6.stack_offset=504",
+      "r7.type=number", "r7.svalue=-1",
+      "s[504...511].type=number"]
+
+code:
+  <start>: |
+    call 1; bpf_map_lookup_elem
+    r7 = r0
+    if r7 == 0 goto <exit>
+    r1 = r7
+    r2 = r6
+    call 1; bpf_map_lookup_elem
+  <exit>: |
+    exit
+
+post:
+  - "_|_"
+
+messages:
+  - "5: Invalid type (r1.type == map_fd)"
+---
 test-case: bpf_map_lookup_elem shared key
 
 pre: ["r1.type=map_fd", "r1.map_fd=1",

--- a/test-data/callx.yaml
+++ b/test-data/callx.yaml
@@ -157,6 +157,23 @@ post:
 messages:
   - "0: callx helper function id is not a valid singleton (r8.type is helper)"
 ---
+test-case: callx validation and dispatch use the same helper id
+
+pre: ["r1.type=map_fd", "r1.map_fd=1",
+      "r2.type=stack", "r2.stack_offset=504",
+      "r8.type=number", "r8.svalue=1", "r8.uvalue=2",
+      "s[504...511].type=number"]
+
+code:
+  <start>: |
+    callx r8; bpf_map_update_elem
+
+post:
+  - "_|_"
+
+messages:
+  - "0: Invalid type (r3.type in {stack, packet, shared})"
+---
 test-case: callx bpf_map_lookup_elem with non-numeric stack key
 
 pre: ["r1.type=map_fd", "r1.map_fd=1",


### PR DESCRIPTION
This fixes the stale `svalue` / type-kind soundness bug by treating `svalue` as what it is in the abstract domain: the numeric kind for `T_NUM`, not a universal register value.

When a register or frame slot changes type, any numeric facts whose meaning depends on the old type must be discarded before installing the new type. That includes `svalue`, but also pointer offsets, region sizes, socket offsets, and other type-specific kind variables. `uvalue` is preserved because it is the type-independent register value.

### Why this is needed instead of #1151

The simpler #1151-style fix special-cases `svalue`. That fixes one symptom, but not the domain invariant.

The real invariant is:

> For a type variable, kind variables are meaningful only for the currently possible types of that variable.

If we only clear `svalue`, stale pointer-kind facts can still leak across a type reassignment. If we only clear it at one call site, stale facts can still leak through helper returns, pseudo loads, map fd/address loads, callee-saved frame slots, or ordinary register assignment.

This PR centralizes the operation as `forget_type_dependent_values(...)` and uses it at type reassignment points, including `TypeToNumDomain::assign`. Self-assignment remains a no-op to avoid unnecessary precision loss.

`Callx` now reads helper IDs from `uvalue`, since helper IDs are scalar values independent of whether the register is currently typed as `T_NUM`.

## Tests

Added focused coverage for:

- preserving `uvalue` while forgetting type-dependent values
- clearing stale destination kind values on register assignment
- keeping self-assignment precise
- rejecting stale map-lookup/null-check paths that previously reused old kind facts unsoundly

This PR intentionally marks two Cilium cases as expected failures. They are soundness-related precision fallout from dropping stale facts and should be handled in follow-up work.