### PR TITLE
Model direct socket reads conservatively

### DIFF
--- a/src/crab/ebpf_checker.cpp
+++ b/src/crab/ebpf_checker.cpp
@@ -3,6 +3,7 @@
 
 // This file is eBPF-specific, not derived from CRAB.
 
+#include <array>
 #include <bitset>
 #include <optional>
 #include <utility>
@@ -27,6 +28,60 @@ namespace {
 struct VerificationFailureSignal final : std::runtime_error {
     using std::runtime_error::runtime_error;
 };
+
+bool is_power_of_two(const int size) { return size > 0 && (size & (size - 1)) == 0; }
+
+bool field_is_present(const EbpfStructFieldDescriptor& field) { return field.offset >= 0 && field.span > 0; }
+
+bool field_allows_access(const EbpfStructFieldDescriptor& field, const int offset, const int size,
+                         const AccessType access_type) {
+    if (!field_is_present(field)) {
+        return false;
+    }
+    if (access_type == AccessType::write && field.permission == EbpfStructFieldPermission::read_only) {
+        return false;
+    }
+    if (field.allow_narrow_access) {
+        if (size <= field.max_access_width && is_power_of_two(size) && offset >= field.offset &&
+            offset + size <= field.offset + field.span) {
+            return true;
+        }
+    } else if (offset == field.offset && size == field.max_access_width) {
+        return true;
+    }
+    return access_type == AccessType::read && field.extra_read_width_at_start > 0 &&
+           size == field.extra_read_width_at_start && is_power_of_two(size) && offset == field.offset;
+}
+
+bool is_valid_struct_access(const EbpfStructDescriptor& descriptor, const int offset, const int size,
+                            const AccessType access_type) {
+    if (!descriptor.fields || size <= 0 || offset < 0 || offset >= descriptor.size || offset + size > descriptor.size ||
+        offset % size != 0) {
+        return false;
+    }
+    for (size_t i = 0; i < descriptor.field_count; ++i) {
+        if (field_allows_access(descriptor.fields[i], offset, size, access_type)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+template <size_t N>
+bool write_may_touch_readonly_field(const NumAbsDomain& values, const LinearExpression& lb, const LinearExpression& ub,
+                                    const std::array<EbpfStructFieldDescriptor, N>& fields) {
+    using namespace dsl_syntax;
+    for (const EbpfStructFieldDescriptor& field : fields) {
+        if (!field_is_present(field) || field.permission != EbpfStructFieldPermission::read_only) {
+            continue;
+        }
+        if (values.intersect(ub > LinearExpression{field.offset}) &&
+            values.intersect(lb < LinearExpression{field.offset + field.span})) {
+            return true;
+        }
+    }
+    return false;
+}
 } // namespace
 
 class EbpfChecker final {
@@ -353,34 +408,25 @@ void EbpfChecker::operator()(const ValidAccess& s) const {
             const auto* desc = context.program_info().type.ctx_descriptor;
             const auto [lb, ub] = lb_ub_access_pair(s, reg.ctx_offset);
             if (s.access_type == AccessType::write && desc->end >= 0) {
-                // The data/data_end/meta fields are read-only pointer slots: a *load* of those
-                // offsets synthesizes a typed packet pointer (see do_load_ctx). Writes are not
-                // tracked by the abstract transformer (do_mem_store models only stack stores),
-                // so an accepted write to e.g. ctx->data followed by a reload would hand out a
-                // fresh "valid" packet pointer for a field the program corrupted at runtime,
-                // a false PASS for an out-of-bounds dereference. Writes to other (scalar)
-                // context fields are sound, since their loads are havoced to numbers, and real
-                // programs do write them; so reject only writes that may overlap a pointer
-                // slot. A write of [lb, ub) overlaps slot [f, f + field_width) unless we can
-                // prove it lies entirely before (ub <= f) or entirely after (lb >= f + width).
-                //
-                // field_width is the size of a pointer slot, taken as end - data: this is the
-                // data/data_end adjacency that do_load_ctx also relies on. If a descriptor ever
-                // violated it (non-positive width), the overlap math would be meaningless, so
-                // fall back to rejecting the write outright rather than reasoning from a bogus
-                // slot width.
                 const int field_width = desc->end - desc->data;
                 if (field_width <= 0) {
                     throw_fail("Cannot write to context with unexpected pointer-field layout");
                 }
-                const auto may_overlap = [&](const int field_offset) {
-                    if (field_offset < 0) {
-                        return false;
-                    }
-                    return dom.state.values.intersect(ub > LinearExpression{field_offset}) &&
-                           dom.state.values.intersect(lb < LinearExpression{field_offset + field_width});
+                const std::array packet_pointer_fields{
+                    EbpfStructFieldDescriptor{.offset = desc->data,
+                                              .span = field_width,
+                                              .permission = EbpfStructFieldPermission::read_only,
+                                              .max_access_width = field_width},
+                    EbpfStructFieldDescriptor{.offset = desc->end,
+                                              .span = field_width,
+                                              .permission = EbpfStructFieldPermission::read_only,
+                                              .max_access_width = field_width},
+                    EbpfStructFieldDescriptor{.offset = desc->meta,
+                                              .span = field_width,
+                                              .permission = EbpfStructFieldPermission::read_only,
+                                              .max_access_width = field_width},
                 };
-                if (may_overlap(desc->data) || may_overlap(desc->end) || may_overlap(desc->meta)) {
+                if (write_may_touch_readonly_field(dom.state.values, lb, ub, packet_pointer_fields)) {
                     throw_fail("Cannot write to context pointer field");
                 }
             }
@@ -413,6 +459,38 @@ void EbpfChecker::operator()(const ValidAccess& s) const {
                                 "Upper bound must be at most " + variable_registry.name(reg.shared_region_size));
             if (!is_comparison_check && !s.or_null) {
                 require_value(dom.state, reg.uvalue > 0, "Possible null access");
+            }
+            break;
+        }
+        case T_SOCKET: {
+            const ebpf_platform_t* platform = context.program_info().platform;
+            if (!platform || !platform->sock_common_layout) {
+                throw_fail("Socket layout is unavailable");
+            }
+            const EbpfStructDescriptor& socket_layout = *platform->sock_common_layout;
+            const auto [lb, ub] = lb_ub_access_pair(s, reg.socket_offset);
+            require_lower_bound(lb, LinearExpression{0}, "Lower bound must be at least 0");
+            require_upper_bound(ub, LinearExpression{socket_layout.size},
+                                "Upper bound must be at most " + std::to_string(socket_layout.size));
+            if (!is_comparison_check) {
+                if (s.access_type == AccessType::write) {
+                    throw_fail("Socket memory is read-only");
+                }
+                if (!std::holds_alternative<Imm>(s.width)) {
+                    throw_fail("Socket access size must be constant");
+                }
+                const Interval offset = dom.state.values.eval_interval(lb);
+                const auto exact_offset = offset.singleton();
+                if (!exact_offset || !exact_offset->fits_cast_to<int32_t>()) {
+                    throw_fail("Socket access offset must be precise");
+                }
+                const auto width = static_cast<int>(std::get<Imm>(s.width).v);
+                if (!is_valid_struct_access(socket_layout, exact_offset->cast_to<int32_t>(), width, s.access_type)) {
+                    throw_fail("Invalid socket access");
+                }
+                if (!s.or_null) {
+                    require_value(dom.state, reg.uvalue > 0, "Possible null access");
+                }
             }
             break;
         }
@@ -450,7 +528,6 @@ void EbpfChecker::operator()(const ValidAccess& s) const {
                 throw_fail("FDs cannot be dereferenced directly");
             }
             break;
-        case T_SOCKET: [[fallthrough]];
         case T_BTF_ID:
             // TODO: implement proper access checks for these pointer types.
             if (!is_comparison_check) {

--- a/src/crab/ebpf_transformer.cpp
+++ b/src/crab/ebpf_transformer.cpp
@@ -591,11 +591,11 @@ void EbpfTransformer::do_load(const Mem& b, const Reg& target_reg) {
         case T_SOCKET:
         case T_BTF_ID:
             // Loadable but contents are not tracked: havoc the destination.
-            // T_SOCKET/T_BTF_ID dereferences are rejected by the checker
-            // (see ebpf_checker.cpp ValidAccess), so reaching this branch
-            // for those types means the checker was bypassed; havoc is the
-            // sound fallback. T_ALLOC_MEM remains a TODO for proper load
-            // semantics (offset-tracked content).
+            // T_BTF_ID dereferences are rejected by the checker (see
+            // ebpf_checker.cpp ValidAccess), so reaching that type here means
+            // the checker was bypassed; havoc is the sound fallback.
+            // T_ALLOC_MEM remains a TODO for proper load semantics
+            // (offset-tracked content).
             do_load_packet_or_shared(state, target_reg, width, b.is_signed);
             break;
         case T_UNINIT:
@@ -771,12 +771,12 @@ void EbpfTransformer::operator()(const Atomic& a) {
     if (dom.is_bottom()) {
         return;
     }
-    if (!dom.state.is_in_group(a.access.basereg, TS_POINTER) || !dom.state.is_in_group(a.valreg, TS_NUM)) {
+    if (!dom.state.is_in_group(a.access.basereg, TS_DEREFERENCEABLE) || !dom.state.is_in_group(a.valreg, TS_NUM)) {
         return;
     }
     if (!dom.state.may_have_type(a.access.basereg, T_STACK)) {
-        // Shared memory regions are volatile so we can just havoc
-        // any register that will be updated.
+        // Non-stack memory contents are not tracked here. A fetch/CMPXCHG
+        // therefore reads an unknown old value into the result register.
         if (a.op == Atomic::Op::CMPXCHG) {
             dom.state.havoc_register_except_type(Reg{R0_RETURN_VALUE});
         } else if (a.fetch) {
@@ -968,6 +968,8 @@ void EbpfTransformer::operator()(const Call& call) {
             dom.state.values.assign(r0_pack.alloc_mem_offset, 0);
             const auto size_value = dom.state.values.eval_interval(reg_pack(*resolved.contract.alloc_size_reg).uvalue);
             dom.state.values.set(r0_pack.alloc_mem_size, size_value);
+        } else if (*resolved.contract.return_ptr_type == T_SOCKET) {
+            dom.state.values.assign(r0_pack.socket_offset, 0);
         } else {
             dom.state.havoc_offsets(r0_reg);
         }

--- a/src/crab/region_semantics.hpp
+++ b/src/crab/region_semantics.hpp
@@ -11,14 +11,15 @@
 namespace prevail {
 
 /// True for pointer types whose in-region accesses are bounds-checked. Other
-/// pointer types (T_SOCKET, T_BTF_ID, T_MAP, T_MAP_PROGRAMS, T_FUNC) are not
-/// directly dereferenceable in this verifier.
-inline constexpr bool is_region_access_type(const TypeEncoding type) {
+/// pointer types (T_BTF_ID, T_MAP, T_MAP_PROGRAMS, T_FUNC) are not directly
+/// dereferenceable in this verifier.
+constexpr bool is_region_access_type(const TypeEncoding type) {
     switch (type) {
     case T_STACK:
     case T_CTX:
     case T_PACKET:
     case T_SHARED:
+    case T_SOCKET:
     case T_ALLOC_MEM: return true;
     default: return false;
     }

--- a/src/crab/type_domain.cpp
+++ b/src/crab/type_domain.cpp
@@ -50,6 +50,7 @@ const TypeSet TS_MAP{T_MAP};
 const TypeSet TS_POINTER{T_CTX, T_PACKET, T_STACK, T_SHARED};
 const TypeSet TS_SINGLETON_PTR{T_CTX, T_PACKET, T_STACK};
 const TypeSet TS_MEM{T_PACKET, T_STACK, T_SHARED};
+const TypeSet TS_DEREFERENCEABLE{T_CTX, T_PACKET, T_STACK, T_SHARED, T_SOCKET, T_ALLOC_MEM};
 const TypeSet TS_SOCKET{T_SOCKET};
 const TypeSet TS_BTF_ID{T_BTF_ID};
 const TypeSet TS_ALLOC_MEM{T_ALLOC_MEM};
@@ -232,6 +233,7 @@ TypeSet to_typeset(const TypeGroup group) {
     case TypeGroup::stack_or_num: return TypeSet{T_NUM, T_STACK};
     case TypeGroup::mem: return TS_MEM;
     case TypeGroup::mem_or_num: return TS_MEM | TS_NUM;
+    case TypeGroup::dereferenceable: return TS_DEREFERENCEABLE;
     case TypeGroup::pointer: return TS_POINTER;
     case TypeGroup::ptr_or_num: return TS_POINTER | TS_NUM;
     case TypeGroup::stack_or_packet: return TypeSet{T_STACK, T_PACKET};
@@ -279,6 +281,7 @@ std::ostream& operator<<(std::ostream& os, const TypeGroup ts) {
         {TypeGroup::alloc_mem, S_ALLOC_MEM},
         {TypeGroup::func, S_FUNC},
         {TypeGroup::mem, typeset_to_string({T_STACK, T_PACKET, T_SHARED})},
+        {TypeGroup::dereferenceable, typeset_to_string({T_CTX, T_STACK, T_PACKET, T_SHARED, T_SOCKET, T_ALLOC_MEM})},
         {TypeGroup::pointer, typeset_to_string({T_CTX, T_STACK, T_PACKET, T_SHARED})},
         {TypeGroup::ptr_or_num, typeset_to_string({T_NUM, T_CTX, T_STACK, T_PACKET, T_SHARED})},
         {TypeGroup::stack_or_packet, typeset_to_string({T_STACK, T_PACKET})},

--- a/src/crab/type_encoding.hpp
+++ b/src/crab/type_encoding.hpp
@@ -162,6 +162,7 @@ extern const TypeSet TS_MAP;
 extern const TypeSet TS_POINTER;
 extern const TypeSet TS_SINGLETON_PTR;
 extern const TypeSet TS_MEM;
+extern const TypeSet TS_DEREFERENCEABLE;
 extern const TypeSet TS_SOCKET;
 extern const TypeSet TS_BTF_ID;
 extern const TypeSet TS_ALLOC_MEM;
@@ -182,7 +183,8 @@ enum class TypeGroup {
     map_fd_programs, ///< reg == T_MAP_PROGRAMS
     mem,             ///< shared | stack | packet
     mem_or_num,      ///< mem | number
-    pointer,         ///< any pointer type (ctx | packet | stack | shared | socket | btf_id | alloc_mem)
+    dereferenceable, ///< types whose direct load/store access is modeled
+    pointer,         ///< region pointers with modeled arithmetic (ctx | packet | stack | shared)
     ptr_or_num,      ///< pointer | number
     stack_or_packet, ///< stack | packet
     singleton_ptr,   ///< ctx | packet | stack: uniquely identifiable regions. Unrelated to is_singleton_type.

--- a/src/ir/assertions.cpp
+++ b/src/ir/assertions.cpp
@@ -259,7 +259,7 @@ class AssertExtractor {
                 // res.emplace_back(make_valid_access(basereg, offset, width, false, AccessType::read));
             }
         } else {
-            res.emplace_back(TypeConstraint{basereg, TypeGroup::pointer});
+            res.emplace_back(TypeConstraint{basereg, TypeGroup::dereferenceable});
             res.emplace_back(
                 make_valid_access(basereg, offset, width, false, ins.is_load ? AccessType::read : AccessType::write));
             if (!info.type.is_privileged && !ins.is_load) {
@@ -282,7 +282,7 @@ class AssertExtractor {
         // access_type would let an atomic corrupt e.g. ctx->data unchecked).
         return {
             Assertion{TypeConstraint{ins.valreg, TypeGroup::number}},
-            Assertion{TypeConstraint{ins.access.basereg, TypeGroup::pointer}},
+            Assertion{TypeConstraint{ins.access.basereg, TypeGroup::dereferenceable}},
             Assertion{make_valid_access(ins.access.basereg, ins.access.offset,
                                         Imm{static_cast<uint32_t>(ins.access.width)}, false, AccessType::write)},
         };

--- a/src/linux/gpl/spec_type_descriptors.hpp
+++ b/src/linux/gpl/spec_type_descriptors.hpp
@@ -1,5 +1,8 @@
 #pragma once
-#include "spec/ebpf_base.h"
+
+#include <array>
+
+#include "spec/type_descriptors.hpp"
 
 namespace prevail {
 constexpr int NMAPS = 64;
@@ -33,6 +36,72 @@ constexpr int lirc_mode2_regions = 4;
 constexpr int netfilter_regions = 2 * 8;
 // Syscall: context is user-supplied buffer, kernel allows up to U16_MAX.
 constexpr int syscall_regions = 65535;
+
+constexpr int bpf_sock_bound_dev_if_offset = 0;
+constexpr int bpf_sock_family_offset = 4;
+constexpr int bpf_sock_src_ip4_offset = 24;
+constexpr int bpf_sock_src_ip6_offset = 28;
+constexpr int bpf_sock_src_ip6_end = 44;
+constexpr int bpf_sock_src_port_offset = 44;
+constexpr int bpf_sock_dst_port_offset = 48;
+constexpr int bpf_sock_dst_port_end = 50;
+constexpr int bpf_sock_dst_ip4_offset = 52;
+constexpr int bpf_sock_dst_ip6_offset = 56;
+constexpr int bpf_sock_dst_ip6_end = 72;
+constexpr int bpf_sock_state_offset = 72;
+constexpr int bpf_sock_rx_queue_mapping_offset = 76;
+constexpr int bpf_sock_u32_field_size = 4;
+
+constexpr EbpfStructFieldDescriptor readonly_bpf_sock_u32_field(const int offset) {
+    return EbpfStructFieldDescriptor{.offset = offset,
+                                     .span = bpf_sock_u32_field_size,
+                                     .permission = EbpfStructFieldPermission::read_only,
+                                     .max_access_width = bpf_sock_u32_field_size,
+                                     .allow_narrow_access = true};
+}
+
+// Prevail currently collapses Linux's PTR_TO_SOCK_COMMON and PTR_TO_SOCKET into
+// one T_SOCKET, so direct socket access uses this common safe field subset. The
+// table intentionally excludes the type..priority range and padding bytes.
+inline constexpr std::array bpf_sock_common_fields{
+    // Unlike the other u32 fields, bound_dev_if does not opt into narrow
+    // sub-field reads: it is accepted only at its exact 32-bit width. Narrow
+    // access here is intentionally left out of the verified-safe subset, which
+    // is conservative (stricter than the kernel only rejects valid programs; it
+    // never accepts invalid ones). Widen this to allow_narrow_access if a real
+    // program needs sub-word bound_dev_if reads.
+    EbpfStructFieldDescriptor{.offset = bpf_sock_bound_dev_if_offset,
+                              .span = bpf_sock_u32_field_size,
+                              .permission = EbpfStructFieldPermission::read_only,
+                              .max_access_width = bpf_sock_u32_field_size},
+    readonly_bpf_sock_u32_field(bpf_sock_family_offset),
+    readonly_bpf_sock_u32_field(bpf_sock_src_ip4_offset),
+    EbpfStructFieldDescriptor{.offset = bpf_sock_src_ip6_offset,
+                              .span = bpf_sock_src_ip6_end - bpf_sock_src_ip6_offset,
+                              .permission = EbpfStructFieldPermission::read_only,
+                              .max_access_width = bpf_sock_u32_field_size,
+                              .allow_narrow_access = true},
+    readonly_bpf_sock_u32_field(bpf_sock_src_port_offset),
+    EbpfStructFieldDescriptor{.offset = bpf_sock_dst_port_offset,
+                              .span = bpf_sock_dst_port_end - bpf_sock_dst_port_offset,
+                              .permission = EbpfStructFieldPermission::read_only,
+                              .max_access_width = bpf_sock_dst_port_end - bpf_sock_dst_port_offset,
+                              .allow_narrow_access = true,
+                              // The kernel permits a 32-bit read starting at
+                              // dst_port although the logical field is 16 bits.
+                              .extra_read_width_at_start = bpf_sock_u32_field_size},
+    readonly_bpf_sock_u32_field(bpf_sock_dst_ip4_offset),
+    EbpfStructFieldDescriptor{.offset = bpf_sock_dst_ip6_offset,
+                              .span = bpf_sock_dst_ip6_end - bpf_sock_dst_ip6_offset,
+                              .permission = EbpfStructFieldPermission::read_only,
+                              .max_access_width = bpf_sock_u32_field_size,
+                              .allow_narrow_access = true},
+    readonly_bpf_sock_u32_field(bpf_sock_state_offset),
+    readonly_bpf_sock_u32_field(bpf_sock_rx_queue_mapping_offset),
+};
+
+inline constexpr EbpfStructDescriptor bpf_sock_common_layout{
+    .size = cgroup_sock_regions, .fields = bpf_sock_common_fields.data(), .field_count = bpf_sock_common_fields.size()};
 
 constexpr ebpf_ctx_descriptor_t sk_buff = {sk_skb_regions, 76, 80, 140}; // data/data_end/data_meta
 constexpr ebpf_ctx_descriptor_t xdp_md = {xdp_regions, 0, 4, 8};         // data/data_end/data_meta

--- a/src/linux/linux_platform.cpp
+++ b/src/linux/linux_platform.cpp
@@ -496,6 +496,7 @@ const ebpf_platform_t g_ebpf_platform_linux = {
     .get_map_descriptor = get_map_descriptor_linux,
     .get_map_type = get_map_type_linux,
     .resolve_inner_map_references = resolve_inner_map_references_linux,
+    .sock_common_layout = &bpf_sock_common_layout,
     .supported_conformance_groups = bpf_conformance_groups_t::default_groups | bpf_conformance_groups_t::packet,
 };
 } // namespace prevail

--- a/src/platform.hpp
+++ b/src/platform.hpp
@@ -71,6 +71,7 @@ struct ebpf_platform_t {
     ebpf_get_map_descriptor_fn get_map_descriptor;
     ebpf_get_map_type_fn get_map_type;
     ebpf_resolve_inner_map_references_fn resolve_inner_map_references;
+    const EbpfStructDescriptor* sock_common_layout;
     bpf_conformance_groups_t supported_conformance_groups;
 
     bool supports_group(const bpf_conformance_groups_t group) const {

--- a/src/spec/type_descriptors.hpp
+++ b/src/spec/type_descriptors.hpp
@@ -42,6 +42,26 @@ struct EbpfProgramType {
     bool is_sleepable{};
 };
 
+enum class EbpfStructFieldPermission { read_only, read_write };
+
+struct EbpfStructFieldDescriptor {
+    int offset{};
+    int span{};
+    // Default read_only so a descriptor that omits an explicit permission fails
+    // closed (rejects writes); writable fields must opt in with read_write.
+    EbpfStructFieldPermission permission{EbpfStructFieldPermission::read_only};
+    int max_access_width{};
+    bool allow_narrow_access{};
+    // Additional exact-width read allowed only at the field start.
+    int extra_read_width_at_start{};
+};
+
+struct EbpfStructDescriptor {
+    int size{};
+    const EbpfStructFieldDescriptor* fields{};
+    size_t field_count{};
+};
+
 // Represents the key characteristics that determine equivalence between eBPF maps.
 // Used to cache and compare map configurations across the program.
 struct EquivalenceKey {

--- a/src/test/ebpf_yaml.cpp
+++ b/src/test/ebpf_yaml.cpp
@@ -104,6 +104,7 @@ ebpf_platform_t g_platform_test = {.get_program_type = ebpf_get_program_type,
                                    .parse_maps_section = ebpf_parse_maps_section,
                                    .get_map_descriptor = ebpf_get_map_descriptor,
                                    .get_map_type = ebpf_get_map_type,
+                                   .sock_common_layout = g_ebpf_platform_linux.sock_common_layout,
                                    .supported_conformance_groups = bpf_conformance_groups_t::default_groups |
                                                                    bpf_conformance_groups_t::packet |
                                                                    bpf_conformance_groups_t::callx};

--- a/src/test/test_type_domain.cpp
+++ b/src/test/test_type_domain.cpp
@@ -133,6 +133,15 @@ TEST_CASE("type query predicates", "[type_domain]") {
     REQUIRE(td.may_have_type(r0, T_NUM));
 }
 
+TEST_CASE("socket is dereferenceable but not helper memory", "[type_domain]") {
+    TypeDomain td;
+    td.assign_type(r0, T_SOCKET);
+
+    REQUIRE(td.is_in_group(r0, TS_DEREFERENCEABLE));
+    REQUIRE(!td.is_in_group(r0, TS_MEM));
+    REQUIRE(!td.is_in_group(r0, TS_POINTER));
+}
+
 // ============================================================================
 // Constraint handling
 // ============================================================================

--- a/src/test/test_verify_cilium_core.cpp
+++ b/src/test/test_verify_cilium_core.cpp
@@ -31,11 +31,13 @@ TEST_PROGRAM("cilium-core", "bpf_lxc.o", "tc/entry", "cil_to_container", 4)
 TEST_PROGRAM("cilium-core", "bpf_lxc.o", "tc/tail", "tail_drop_notify", 30)
 TEST_PROGRAM("cilium-core", "bpf_lxc.o", "tc/tail", "tail_handle_arp", 30)
 TEST_PROGRAM("cilium-core", "bpf_lxc.o", "tc/tail", "tail_handle_ipv4", 30)
+TEST_PROGRAM("cilium-core", "bpf_lxc.o", "tc/tail", "tail_handle_ipv4_cont", 30)
 TEST_PROGRAM("cilium-core", "bpf_lxc.o", "tc/tail", "tail_icmp6_handle_ns", 30)
 TEST_PROGRAM("cilium-core", "bpf_lxc.o", "tc/tail", "tail_icmp6_send_time_exceeded", 30)
 TEST_PROGRAM("cilium-core", "bpf_lxc.o", "tc/tail", "tail_ipv4_ct_egress", 30)
 TEST_PROGRAM("cilium-core", "bpf_lxc.o", "tc/tail", "tail_ipv4_ct_ingress", 30)
 TEST_PROGRAM("cilium-core", "bpf_lxc.o", "tc/tail", "tail_ipv4_ct_ingress_policy_only", 30)
+TEST_PROGRAM("cilium-core", "bpf_lxc.o", "tc/tail", "tail_ipv4_policy", 30)
 TEST_PROGRAM("cilium-core", "bpf_lxc.o", "tc/tail", "tail_ipv4_to_endpoint", 30)
 TEST_PROGRAM("cilium-core", "bpf_lxc.o", "tc/tail", "tail_ipv6_ct_egress", 30)
 TEST_PROGRAM("cilium-core", "bpf_lxc.o", "tc/tail", "tail_ipv6_ct_ingress", 30)
@@ -122,19 +124,9 @@ TEST_PROGRAM_FAIL("cilium-core", "bpf_host.o", "tc/tail", "tail_nodeport_nat_ing
                   verify_test::VerifyIssueKind::VerifierTypeTracking)
 // register type refinement is too imprecise in this control-flow pattern
 TEST_SECTION_FAIL("cilium-core", "bpf_lxc.o", ".text", verify_test::VerifyIssueKind::VerifierTypeTracking)
-// register type refinement is too imprecise in this control-flow pattern
-TEST_PROGRAM_FAIL("cilium-core", "bpf_lxc.o", "tc/tail", "tail_handle_ipv4_cont", 30,
-                  verify_test::VerifyIssueKind::VerifierTypeTracking)
-// register type refinement is too imprecise in this control-flow pattern
 // The type-kind soundness fix intentionally discards stale type-dependent
-// kind values. This exposes a false positive until the dependent T_SOCKET
-// precision branch models direct socket reads.
-TEST_PROGRAM_FAIL("cilium-core", "bpf_lxc.o", "tc/tail", "tail_ipv4_policy", 30,
-                  verify_test::VerifyIssueKind::VerifierTypeTracking)
-// register type refinement is too imprecise in this control-flow pattern
-// The type-kind soundness fix intentionally discards stale type-dependent
-// kind values. This exposes a false positive until the dependent T_SOCKET and
-// boolean-AND precision branches restore the needed non-null proof.
+// kind values. This exposes a false positive until the dependent boolean-AND
+// precision branch restores the needed non-null proof.
 TEST_PROGRAM_FAIL("cilium-core", "bpf_lxc.o", "tc/tail", "tail_handle_ipv6_cont", 30,
                   verify_test::VerifyIssueKind::VerifierTypeTracking)
 // register type refinement is too imprecise in this control-flow pattern

--- a/src/test/test_verify_cilium_examples.cpp
+++ b/src/test/test_verify_cilium_examples.cpp
@@ -12,6 +12,7 @@ TEST_PROGRAM("cilium-examples", "tcx_bpf_bpfel.o", "tc", "egress_prog_func", 2)
 TEST_PROGRAM("cilium-examples", "tcx_bpf_bpfel.o", "tc", "ingress_prog_func", 2)
 TEST_SECTION("cilium-examples", "tracepoint_in_c_bpf_bpfel.o", "tracepoint/kmem/mm_page_alloc")
 TEST_SECTION("cilium-examples", "xdp_bpf_bpfel.o", "xdp")
+TEST_SECTION("cilium-examples", "tcprtt_sockops_bpf_bpfel.o", "sockops")
 
 // VerifierTypeTracking:
 // register type refinement is too imprecise in this control-flow pattern
@@ -27,7 +28,4 @@ TEST_SECTION_FAIL("cilium-examples", "fentry_bpf_bpfel.o", "fentry/tcp_connect",
                   verify_test::VerifyIssueKind::VerifierBoundsTracking)
 // interval/bounds refinement loses precision for this memory-access proof
 TEST_SECTION_FAIL("cilium-examples", "tcprtt_bpf_bpfel.o", "fentry/tcp_close",
-                  verify_test::VerifyIssueKind::VerifierBoundsTracking)
-// interval/bounds refinement loses precision for this memory-access proof
-TEST_SECTION_FAIL("cilium-examples", "tcprtt_sockops_bpf_bpfel.o", "sockops",
                   verify_test::VerifyIssueKind::VerifierBoundsTracking)

--- a/test-data/atomic.yaml
+++ b/test-data/atomic.yaml
@@ -260,6 +260,65 @@ post:
 messages:
   - "0: Upper bound must be at most r2.shared_region_size (valid_access(r2.offset+4, width=4) for write)"
 ---
+test-case: atomic fetch from alloc_mem havocs result register
+
+pre: ["r1.type=map_fd", "r1.map_fd=27",
+      "r2.type=number", "r2.svalue=8", "r2.uvalue=8",
+      "r3.type=number", "r3.svalue=0", "r3.uvalue=0"]
+
+code:
+  <start>: |
+    call 131; bpf_ringbuf_reserve
+    assume r0 != 0
+    r6 = 2
+    lock *(u32 *)(r0 + 0) += r6 fetch
+    if r6 != 2 goto <havoced>
+    r0 = 0
+    exit
+  <havoced>: |
+    r0 = 1
+    exit
+
+post:
+  - r0.type=number
+  - r0.svalue=[0, 1]
+  - r0.uvalue=r0.svalue
+  - r6.type=number
+---
+test-case: atomic cmpxchg from alloc_mem havocs r0
+
+pre: ["r1.type=map_fd", "r1.map_fd=27",
+      "r2.type=number", "r2.svalue=8", "r2.uvalue=8",
+      "r3.type=number", "r3.svalue=0", "r3.uvalue=0"]
+
+code:
+  <start>: |
+    call 131; bpf_ringbuf_reserve
+    assume r0 != 0
+    r7 = r0
+    r0 = 1
+    r6 = 2
+    lock *(u32 *)(r7 + 0) cx= r6
+    if r0 != 1 goto <havoced>
+    r7 = 0
+    r0 = 0
+    exit
+  <havoced>: |
+    r7 = 0
+    r0 = 1
+    exit
+
+post:
+  - r0.type=number
+  - r0.svalue=[0, 1]
+  - r0.uvalue=r0.svalue
+  - r6.type=number
+  - r6.svalue=2
+  - r6.uvalue=2
+  - r7.type=number
+  - r7.svalue=0
+  - r7.uvalue=0
+---
 test-case: atomic 32-bit ADD stack
 
 pre: ["r1.type=number", "r1.svalue=2", "r1.uvalue=2",
@@ -597,7 +656,7 @@ post:
   - "_|_"
 
 messages:
-  - "0: Invalid type (r2.type in {ctx, stack, packet, shared})"
+  - "0: Invalid type (r2.type in {ctx, stack, packet, shared, socket, alloc_mem})"
 ---
 test-case: atomic 64-bit CMPXCHG comparing against non-number
 

--- a/test-data/call.yaml
+++ b/test-data/call.yaml
@@ -67,6 +67,169 @@ post:
 messages:
   - "5: Invalid type (r1.type == map_fd)"
 ---
+test-case: skc_lookup_tcp checked socket can read common state field
+
+pre: ["r1.type=ctx", "r1.ctx_offset=0",
+      "r10.type=stack", "r10.stack_offset=512",
+      "r2.type=stack", "r2.stack_offset=496",
+      "r3.type=number", "r3.svalue=12", "r3.uvalue=12",
+      "r4.type=number", "r4.svalue=0", "r4.uvalue=0",
+      "r5.type=number", "r5.svalue=0", "r5.uvalue=0",
+      "s[496...507].type=number"]
+
+code:
+  <start>: |
+    call 99; bpf_skc_lookup_tcp
+    if r0 == 0 goto <exit>
+    r1 = *(u32 *)(r0 + 72)
+  <exit>: |
+    r0 = 0
+    exit
+
+post:
+  - r0.type=number
+  - r0.svalue=0
+  - r0.uvalue=0
+  - r10.type=stack
+  - r10.stack_offset=512
+  - s[496...507].type=number
+---
+test-case: skc_lookup_tcp checked socket can read narrow common fields
+
+pre: ["r1.type=ctx", "r1.ctx_offset=0",
+      "r10.type=stack", "r10.stack_offset=512",
+      "r2.type=stack", "r2.stack_offset=496",
+      "r3.type=number", "r3.svalue=12", "r3.uvalue=12",
+      "r4.type=number", "r4.svalue=0", "r4.uvalue=0",
+      "r5.type=number", "r5.svalue=0", "r5.uvalue=0",
+      "s[496...507].type=number"]
+
+code:
+  <start>: |
+    call 99; bpf_skc_lookup_tcp
+    assume r0 != 0
+    r1 = *(u8 *)(r0 + 25)
+    r2 = *(u16 *)(r0 + 42)
+    r3 = *(u8 *)(r0 + 49)
+    r0 = 0
+    exit
+
+post:
+  - r0.type=number
+  - r0.svalue=0
+  - r0.uvalue=0
+  - r1.type=number
+  - r1.svalue=[0, 255]
+  - r1.uvalue=[0, 255]
+  - r2.type=number
+  - r2.svalue=[0, 65535]
+  - r2.uvalue=[0, 65535]
+  - r3.type=number
+  - r3.svalue=[0, 255]
+  - r3.uvalue=[0, 255]
+  - r10.type=stack
+  - r10.stack_offset=512
+  - s[496...507].type=number
+---
+test-case: skc_lookup_tcp checked socket can read dst_port as u32
+
+pre: ["r1.type=ctx", "r1.ctx_offset=0",
+      "r10.type=stack", "r10.stack_offset=512",
+      "r2.type=stack", "r2.stack_offset=496",
+      "r3.type=number", "r3.svalue=12", "r3.uvalue=12",
+      "r4.type=number", "r4.svalue=0", "r4.uvalue=0",
+      "r5.type=number", "r5.svalue=0", "r5.uvalue=0",
+      "s[496...507].type=number"]
+
+code:
+  <start>: |
+    call 99; bpf_skc_lookup_tcp
+    assume r0 != 0
+    r1 = *(u32 *)(r0 + 48)
+    r0 = 0
+    exit
+
+post:
+  - r0.type=number
+  - r0.svalue=0
+  - r0.uvalue=0
+  - r1.type=number
+  - r10.type=stack
+  - r10.stack_offset=512
+  - s[496...507].type=number
+---
+test-case: skc_lookup_tcp rejects socket type-priority access
+
+pre: ["r1.type=ctx", "r1.ctx_offset=0",
+      "r10.type=stack", "r10.stack_offset=512",
+      "r2.type=stack", "r2.stack_offset=496",
+      "r3.type=number", "r3.svalue=12", "r3.uvalue=12",
+      "r4.type=number", "r4.svalue=0", "r4.uvalue=0",
+      "r5.type=number", "r5.svalue=0", "r5.uvalue=0",
+      "s[496...507].type=number"]
+
+code:
+  <start>: |
+    call 99; bpf_skc_lookup_tcp
+    assume r0 != 0
+    r1 = *(u32 *)(r0 + 8)
+    r0 = 0
+    exit
+
+post:
+  - "_|_"
+
+messages:
+  - "2: Invalid socket access (valid_access(r0.offset+8, width=4) for read)"
+---
+test-case: skc_lookup_tcp rejects socket padding access
+
+pre: ["r1.type=ctx", "r1.ctx_offset=0",
+      "r10.type=stack", "r10.stack_offset=512",
+      "r2.type=stack", "r2.stack_offset=496",
+      "r3.type=number", "r3.svalue=12", "r3.uvalue=12",
+      "r4.type=number", "r4.svalue=0", "r4.uvalue=0",
+      "r5.type=number", "r5.svalue=0", "r5.uvalue=0",
+      "s[496...507].type=number"]
+
+code:
+  <start>: |
+    call 99; bpf_skc_lookup_tcp
+    assume r0 != 0
+    r1 = *(u8 *)(r0 + 50)
+    r0 = 0
+    exit
+
+post:
+  - "_|_"
+
+messages:
+  - "2: Invalid socket access (valid_access(r0.offset+50, width=1) for read)"
+---
+test-case: skc_lookup_tcp rejects narrow bound_dev_if access
+
+pre: ["r1.type=ctx", "r1.ctx_offset=0",
+      "r10.type=stack", "r10.stack_offset=512",
+      "r2.type=stack", "r2.stack_offset=496",
+      "r3.type=number", "r3.svalue=12", "r3.uvalue=12",
+      "r4.type=number", "r4.svalue=0", "r4.uvalue=0",
+      "r5.type=number", "r5.svalue=0", "r5.uvalue=0",
+      "s[496...507].type=number"]
+
+code:
+  <start>: |
+    call 99; bpf_skc_lookup_tcp
+    assume r0 != 0
+    r1 = *(u8 *)(r0 + 0)
+    r0 = 0
+    exit
+
+post:
+  - "_|_"
+
+messages:
+  - "2: Invalid socket access (valid_access(r0.offset, width=1) for read)"
+---
 test-case: bpf_map_lookup_elem shared key
 
 pre: ["r1.type=map_fd", "r1.map_fd=1",

--- a/test-data/pointer.yaml
+++ b/test-data/pointer.yaml
@@ -20,7 +20,7 @@ post:
   - "_|_"
 
 messages:
-  - "1: Invalid type (r1.type in {ctx, stack, packet, shared})"
+  - "1: Invalid type (r1.type in {ctx, stack, packet, shared, socket, alloc_mem})"
 
 ---
 test-case: 32-bit pointer truncation - subtraction
@@ -42,7 +42,7 @@ post:
   - "_|_"
 
 messages:
-  - "1: Invalid type (r1.type in {ctx, stack, packet, shared})"
+  - "1: Invalid type (r1.type in {ctx, stack, packet, shared, socket, alloc_mem})"
 
 ---
 test-case: 32-bit pointer truncation - multiplication
@@ -471,7 +471,7 @@ post:
   - "_|_"
 
 messages:
-  - "1: Invalid type (r1.type in {ctx, stack, packet, shared})"
+  - "1: Invalid type (r1.type in {ctx, stack, packet, shared, socket, alloc_mem})"
 
 ---
 test-case: 32-bit pointer truncation - register subtraction
@@ -495,7 +495,7 @@ post:
   - "_|_"
 
 messages:
-  - "1: Invalid type (r1.type in {ctx, stack, packet, shared})"
+  - "1: Invalid type (r1.type in {ctx, stack, packet, shared, socket, alloc_mem})"
 
 ---
 # The low 32 bits of a pointer produced by a 32-bit op must not be usable as a


### PR DESCRIPTION
## Summary

This is the T_SOCKET follow-up to the stale type-kind fix. It makes helper-returned socket values directly readable where the kernel permits reads from the common `bpf_sock` layout, instead of rejecting all `T_SOCKET` dereferences up front.

The checker now validates socket reads with an explicit conservative rule set:

- socket memory remains read-only
- bounds and alignment are checked against the `bpf_sock` layout
- `type..priority` is rejected to match the stricter socket-common subset used by PREVAIL's collapsed socket type
- padding is rejected explicitly
- narrow reads are allowed only where modeled safely

The transformer also initializes `socket_offset` for socket-returning helpers so later access checks do not depend on stale or absent kind facts.

## Why

After stale type-dependent numeric facts are discarded, previously hidden paths reach socket-returning helpers such as `skc_lookup_tcp()`. Those helpers can produce a non-null `T_SOCKET`, and real accepted programs read fields such as `state` from that socket value.

Before this change, the checker required dereference sources to be `{ctx, stack, packet, shared}`, so a valid socket read was rejected as a type error. This PR gives `T_SOCKET` its own direct-access rule instead of pretending it is one of the existing pointer kinds.

This is part of the #1152 stack, but it does not close #1152 by itself; `tail_handle_ipv6_cont` still needs the dependent boolean/null precision follow-up.

## Tests

- `cmake --build build --target tests run_yaml prevail-cli --parallel`
- `./bin/tests "[type_domain]" -r compact`
- `./bin/run_yaml test-data/call.yaml`
- `./bin/run_yaml test-data/pointer.yaml`
- `./bin/run_yaml test-data/atomic.yaml`
- `./bin/tests "cilium-core/bpf_lxc.o tail_ipv4_policy" -r compact`
- `./bin/tests "cilium-core/bpf_lxc.o tail_handle_ipv6_cont" -r compact`