### PR TITLE
Preserve boolean AND non-null implications

### DIFF
--- a/src/crab/ebpf_transformer.cpp
+++ b/src/crab/ebpf_transformer.cpp
@@ -3,6 +3,7 @@
 
 // This file is eBPF-specific, not derived from CRAB.
 
+#include <algorithm>
 #include <bitset>
 #include <cassert>
 #include <optional>
@@ -1176,6 +1177,48 @@ static int _movsx_bits(const Bin::Op op) {
     }
 }
 
+static void add_live_register_uvalue_upper_bounds(std::vector<Variable>& variables, const TypeToNumDomain& state,
+                                                  const Variable value, const Variable self) {
+    using namespace dsl_syntax;
+
+    for (int reg = R0_RETURN_VALUE; reg <= R10_STACK_POINTER; reg++) {
+        const Variable candidate = reg_pack(reg).uvalue;
+        if (candidate == self) {
+            continue;
+        }
+        if (state.values.entail(value <= candidate) && std::ranges::find(variables, candidate) == variables.end()) {
+            variables.push_back(candidate);
+        }
+    }
+}
+
+static std::vector<Variable> live_register_uvalue_upper_bounds_for_unsigned_and_lhs(const TypeToNumDomain& state,
+                                                                                    const Variable svalue,
+                                                                                    const Variable uvalue) {
+    using namespace dsl_syntax;
+
+    std::vector<Variable> result;
+    if (!(state.values.eval_interval(uvalue) <= Interval{0, 1}) || !state.values.entail(eq(svalue, uvalue))) {
+        return result;
+    }
+
+    add_live_register_uvalue_upper_bounds(result, state, uvalue, uvalue);
+    add_live_register_uvalue_upper_bounds(result, state, svalue, uvalue);
+    return result;
+}
+
+static void add_unsigned_and_result_bounds(TypeToNumDomain& state, const Variable result,
+                                           const std::vector<Variable>& old_upper_bounds) {
+    using namespace dsl_syntax;
+
+    for (const Variable upper_bound : old_upper_bounds) {
+        // For a boolean unsigned lhs, x & y <= x. If another live register's
+        // uvalue was an upper bound for the old lhs, keeping result <= that
+        // uvalue preserves non-null implications through boolean masks.
+        state.values.add_constraint(result <= upper_bound);
+    }
+}
+
 void EbpfTransformer::operator()(const Bin& bin) {
     if (dom.is_bottom()) {
         return;
@@ -1430,10 +1473,14 @@ void EbpfTransformer::operator()(const Bin& bin) {
             dom.state.values->bitwise_or(dst.svalue, dst.uvalue, src.uvalue, finite_width);
             dom.state.havoc_offsets(bin.dst);
             break;
-        case Bin::Op::AND:
+        case Bin::Op::AND: {
+            const auto old_upper_bounds =
+                live_register_uvalue_upper_bounds_for_unsigned_and_lhs(dom.state, dst.svalue, dst.uvalue);
             dom.state.values->bitwise_and(dst.svalue, dst.uvalue, src.uvalue, finite_width);
+            add_unsigned_and_result_bounds(dom.state, dst.uvalue, old_upper_bounds);
             dom.state.havoc_offsets(bin.dst);
             break;
+        }
         case Bin::Op::LSH:
             if (dom.state.is_in_group(src_reg, TS_NUM)) {
                 auto src_interval = dom.state.values.eval_interval(src.uvalue);

--- a/src/test/test_verify_cilium_core.cpp
+++ b/src/test/test_verify_cilium_core.cpp
@@ -32,6 +32,7 @@ TEST_PROGRAM("cilium-core", "bpf_lxc.o", "tc/tail", "tail_drop_notify", 30)
 TEST_PROGRAM("cilium-core", "bpf_lxc.o", "tc/tail", "tail_handle_arp", 30)
 TEST_PROGRAM("cilium-core", "bpf_lxc.o", "tc/tail", "tail_handle_ipv4", 30)
 TEST_PROGRAM("cilium-core", "bpf_lxc.o", "tc/tail", "tail_handle_ipv4_cont", 30)
+TEST_PROGRAM("cilium-core", "bpf_lxc.o", "tc/tail", "tail_handle_ipv6_cont", 30)
 TEST_PROGRAM("cilium-core", "bpf_lxc.o", "tc/tail", "tail_icmp6_handle_ns", 30)
 TEST_PROGRAM("cilium-core", "bpf_lxc.o", "tc/tail", "tail_icmp6_send_time_exceeded", 30)
 TEST_PROGRAM("cilium-core", "bpf_lxc.o", "tc/tail", "tail_ipv4_ct_egress", 30)
@@ -124,11 +125,6 @@ TEST_PROGRAM_FAIL("cilium-core", "bpf_host.o", "tc/tail", "tail_nodeport_nat_ing
                   verify_test::VerifyIssueKind::VerifierTypeTracking)
 // register type refinement is too imprecise in this control-flow pattern
 TEST_SECTION_FAIL("cilium-core", "bpf_lxc.o", ".text", verify_test::VerifyIssueKind::VerifierTypeTracking)
-// The type-kind soundness fix intentionally discards stale type-dependent
-// kind values. This exposes a false positive until the dependent boolean-AND
-// precision branch restores the needed non-null proof.
-TEST_PROGRAM_FAIL("cilium-core", "bpf_lxc.o", "tc/tail", "tail_handle_ipv6_cont", 30,
-                  verify_test::VerifyIssueKind::VerifierTypeTracking)
 // register type refinement is too imprecise in this control-flow pattern
 TEST_PROGRAM_FAIL("cilium-core", "bpf_lxc.o", "tc/tail", "tail_handle_ipv6", 30,
                   verify_test::VerifyIssueKind::VerifierTypeTracking)

--- a/test-data/bitop.yaml
+++ b/test-data/bitop.yaml
@@ -67,6 +67,29 @@ code:
 post: ["r1.type=number", "r1.svalue=-9223372036854775807", "r1.uvalue=9223372036854775809",
        "r2.type=number", "r2.svalue=-9223372036854775803", "r2.uvalue=9223372036854775813"]
 ---
+test-case: Bitwise AND preserves masked non-null implication
+
+pre: ["r1.type=number", "r1.svalue=[0, 1]", "r1.uvalue=r1.svalue",
+      "r2.type=number", "r2.svalue=[0, 1]", "r2.uvalue=r2.svalue",
+      "r3.type=shared", "r3.shared_offset=0", "r3.shared_region_size=4",
+      "r3.svalue=r1.uvalue", "r3.uvalue=r1.uvalue"]
+
+code:
+  <start>: |
+    r1 &= r2
+    r1 &= 1
+    if r1 == 0 goto <exit>
+    r0 = *(u32 *)(r3 + 0)
+  <exit>: |
+    r0 = 0
+    exit
+
+post: ["r0.type=number", "r0.svalue=0", "r0.uvalue=0",
+       "r1.type=number", "r1.svalue=[0, 1]", "r1.uvalue=r1.svalue",
+       "r2.type=number", "r2.svalue=[0, 1]", "r2.uvalue=r2.svalue",
+       "r3.type=shared", "r3.shared_offset=0", "r3.shared_region_size=4",
+       "r3.svalue=r1.svalue", "r3.uvalue=r1.svalue"]
+---
 test-case: Bitwise [-1, 1] AND 0 == 0
 
 pre: ["r1.type=number", "r1.svalue=[-1, 1]"]


### PR DESCRIPTION
## Summary

Stacked on #1156.

This restores the precision needed after the stale type-kind fix and the conservative socket-read model. Cilium carries non-null information through boolean masks such as `x &= y` and `x &= 1`; the existing register-AND transfer computed the numeric result but lost the relational implication that the boolean result remains below live registers that upper-bounded the original value.

For the narrow unsigned-boolean case where signed and unsigned views agree, this records live register `uvalue` upper bounds before register AND and re-applies them to the result afterward. That keeps the non-null proof without broadening the transfer function for arbitrary bitwise operations.

The PR also removes the temporary expected-failure annotation for `tail_handle_ipv6_cont`.

## Why

The stale type-dependent value fix made PREVAIL stop relying on invalid old facts. That is sound, but it exposed a real precision gap: after a masked boolean value is used to guard a nullable pointer path, the analyzer can lose the implication needed to prove the pointer non-null at a later dereference.

This change preserves only the implication that is valid for boolean unsigned AND: `x & y <= x`. If another live register was already an upper bound for the old boolean value, it remains an upper bound for the result.

Closes #1152.

## Tests

- `cmake --build build --target tests run_yaml prevail-cli --parallel`
- `./bin/run_yaml test-data/bitop.yaml`
- `./bin/tests "cilium-core/bpf_lxc.o tail_ipv4_policy" -r compact`
- `./bin/tests "cilium-core/bpf_lxc.o tail_handle_ipv6_cont" -r compact`
- `./bin/tests "[!shouldfail]" -r compact`
- `git diff --check`