### PR TITLE
Fix unsound signed-division interval abstraction

### DIFF
--- a/src/crab/interval.cpp
+++ b/src/crab/interval.cpp
@@ -7,6 +7,10 @@
 
 namespace prevail {
 
+// Unsigned division (udiv) operand-box adjustment. Only udiv relies on this;
+// signed division (sdiv / operator/) divides the original corners directly,
+// because truncated signed division is monotone per argument on a
+// sign-consistent box.
 static Interval make_dividend_when_both_nonzero(const Interval& dividend, const Interval& divisor) {
     if (dividend.ub() >= 0) {
         return dividend;
@@ -67,13 +71,15 @@ Interval Interval::operator/(const Interval& x) const {
         const Interval u{1, _ub};
         return (l / x) | (u / x) | Interval{0};
     } else {
-        // Neither the dividend nor the divisor contains 0
-        const Interval a = make_dividend_when_both_nonzero(*this, x);
+        // Neither the dividend nor the divisor contains 0. eBPF signed division
+        // truncates toward zero (matching Number::operator/), and truncated
+        // division is monotone in each argument on a sign-consistent box, so the
+        // extreme quotients are attained at the corners of the operand box.
         const auto [clb, cub] = std::minmax({
-            a._lb / x._lb,
-            a._lb / x._ub,
-            a._ub / x._lb,
-            a._ub / x._ub,
+            _lb / x._lb,
+            _lb / x._ub,
+            _ub / x._lb,
+            _ub / x._ub,
         });
         return Interval{clb, cub};
     }
@@ -113,13 +119,15 @@ Interval Interval::sdiv(const Interval& x) const {
         const Interval u{1, _ub};
         return l.sdiv(x) | u.sdiv(x) | Interval{0};
     } else {
-        // Neither the dividend nor the divisor contains 0
-        const Interval a = make_dividend_when_both_nonzero(*this, x);
+        // Neither the dividend nor the divisor contains 0. eBPF signed division
+        // truncates toward zero (matching Number::operator/), and truncated
+        // division is monotone in each argument on a sign-consistent box, so the
+        // extreme quotients are attained at the corners of the operand box.
         const auto [clb, cub] = std::minmax({
-            a._lb / x._lb,
-            a._lb / x._ub,
-            a._ub / x._lb,
-            a._ub / x._ub,
+            _lb / x._lb,
+            _lb / x._ub,
+            _ub / x._lb,
+            _ub / x._ub,
         });
         return Interval{clb, cub};
     }

--- a/src/test/test_interval_bitwise.cpp
+++ b/src/test/test_interval_bitwise.cpp
@@ -30,6 +30,25 @@ TEST_CASE("signed division by a negative singleton preserves interval order", "[
     REQUIRE((Interval::top() / Interval{-1}) == Interval::top());
 }
 
+TEST_CASE("signed division by a non-singleton divisor over-approximates truncated quotients",
+          "[interval][arithmetic]") {
+    // Regression test: the abstract result must CONTAIN every concrete eBPF SDIV
+    // result (truncation toward zero). A previous dividend adjustment produced a
+    // floored-division hull that was disjoint from the true set for negative
+    // dividends, letting the verifier prune reachable paths.
+
+    // -8 s/ 5 = -1 and -8 s/ 6 = -1  (both truncate toward zero to -1).
+    REQUIRE(Interval{-8, -8}.sdiv(Interval{5, 6}) == Interval{-1, -1});
+    REQUIRE((Interval{-8, -8} / Interval{5, 6}) == Interval{-1, -1});
+
+    // -7 s/ 2 = -3, -7 s/ 3 = -2, -5 s/ 2 = -2, -5 s/ 3 = -1  ->  [-3, -1].
+    REQUIRE(Interval{-7, -5}.sdiv(Interval{2, 3}) == Interval{-3, -1});
+
+    // Positive and negative/negative boxes were already exact and stay so.
+    REQUIRE(Interval{7, 8}.sdiv(Interval{2, 3}) == Interval{2, 4});
+    REQUIRE(Interval{-8, -6}.sdiv(Interval{-3, -2}) == Interval{2, 4});
+}
+
 TEST_CASE("finite domain left shift by zero preserves 64-bit interval", "[finite_domain][bitwise]") {
     FiniteDomain::clear_thread_local_state();
     const auto r1 = reg_pack(1);

--- a/src/test/test_interval_bitwise.cpp
+++ b/src/test/test_interval_bitwise.cpp
@@ -44,6 +44,10 @@ TEST_CASE("signed division by a non-singleton divisor over-approximates truncate
     // -7 s/ 2 = -3, -7 s/ 3 = -2, -5 s/ 2 = -2, -5 s/ 3 = -1  ->  [-3, -1].
     REQUIRE(Interval{-7, -5}.sdiv(Interval{2, 3}) == Interval{-3, -1});
 
+    // Positive dividend over negative divisor: 6/-3=-2, 6/-2=-3, 8/-3=-2, 8/-2=-4 -> [-4, -2].
+    REQUIRE(Interval{6, 8}.sdiv(Interval{-3, -2}) == Interval{-4, -2});
+    REQUIRE((Interval{6, 8} / Interval{-3, -2}) == Interval{-4, -2});
+
     // Positive and negative/negative boxes were already exact and stay so.
     REQUIRE(Interval{7, 8}.sdiv(Interval{2, 3}) == Interval{2, 4});
     REQUIRE(Interval{-8, -6}.sdiv(Interval{-3, -2}) == Interval{2, 4});


### PR DESCRIPTION
## Problem

`Interval::sdiv` and `Interval::operator/` (`src/crab/interval.cpp`), in the branch where neither operand contains zero, first adjusted the dividend via `make_dividend_when_both_nonzero` (`dividend + 1 - divisor`, or `dividend + divisor + 1`) before dividing the box corners.

`Number::operator/` truncates toward zero (native `Int128 a / b`), which matches eBPF `SDIV`. On a sign-consistent box (neither operand crosses 0), truncated division is monotone in each argument, so the plain corner division is already exact. The adjustment instead turned the result into a *floored*-division hull that can be **disjoint from the true quotient set** for a negative dividend and a non-singleton divisor:

- `-8 s/ [5,6]` was modeled as `[-2, -2]`, but both `-8 s/ 5` and `-8 s/ 6` truncate to `-1`.

Because the abstract interval excluded the real value, a following branch such as `if r1 == -1 goto <unsafe>` was judged infeasible and its **reachable** path went unverified — a soundness hole. It is reachable from a single instruction: `r1 = -8; r2 &= 1; r2 += 5; r1 s/= r2` (`ebpf_transformer.cpp` → `finite_domain.cpp` → `Interval::sdiv` with a non-singleton divisor).

## Fix

Drop the adjustment and divide the original operand-box corners directly. Positive and negative/negative boxes were already exact and are unchanged; negative-dividend boxes are now sound (and exact).

## Test

`test_interval_bitwise.cpp` gains a case asserting the truncated-quotient results for negative, positive, and negative/negative boxes, including the `-8 s/ [5,6] == [-1,-1]` regression.

Note: an unrelated latent issue in `ExtendedNumber::AbsDiv` (infinity sign ignores divisor sign) is filed separately; it is not reachable from the eBPF SDIV path (division callers pass finite width-limited intervals) and is orthogonal to this change.