### PR TITLE
Sign-extend BPF_ST store immediates

### DIFF
--- a/src/ir/unmarshal.cpp
+++ b/src/ir/unmarshal.cpp
@@ -307,7 +307,7 @@ struct Unmarshaller {
                         .offset = inst.offset,
                     },
                 .value = isLoad  ? Value{Reg{inst.dst}}
-                         : isImm ? Value{Imm{zero_extend(inst.imm)}}
+                         : isImm ? Value{Imm{sign_extend(inst.imm)}}
                                  : Value{Reg{inst.src}},
                 .is_load = isLoad,
             };

--- a/src/test/test_marshal.cpp
+++ b/src/test/test_marshal.cpp
@@ -605,6 +605,26 @@ TEST_CASE("disasm_marshal_Mem", "[disasm][marshal]") {
     }
 }
 
+TEST_CASE("unmarshal ST sign-extends the immediate", "[disasm][marshal]") {
+    // A BPF_ST store assigns its signed 32-bit immediate to the target location.
+    // For a 64-bit (DW) store the kernel sign-extends, so -1 becomes
+    // 0xFFFFFFFFFFFFFFFF, not 0x00000000FFFFFFFF. Model it the same way, matching
+    // the ALU-immediate path (getBinValue).
+    const ProgramInfo info{.platform = &g_ebpf_platform_linux,
+                           .type = g_ebpf_platform_linux.get_program_type("unspec", "unspec")};
+    constexpr EbpfInst exit{.opcode = INST_OP_EXIT};
+    // *(u64*)(r10 - 8) = -1   ; opcode 0x7a = BPF_ST | BPF_MEM | BPF_DW
+    const EbpfInst store{.opcode = 0x7a, .dst = R10_STACK_POINTER, .src = 0, .offset = -8, .imm = -1};
+    const auto parsed = unmarshal(RawProgram{"", "", 0, "", {store, exit, exit}, info}, VerifierOptions{});
+    const auto* seq = std::get_if<InstructionSeq>(&parsed);
+    REQUIRE(seq != nullptr);
+    const auto* mem = std::get_if<Mem>(&std::get<1>((*seq)[0]));
+    REQUIRE(mem != nullptr);
+    const auto* imm = std::get_if<Imm>(&mem->value);
+    REQUIRE(imm != nullptr);
+    REQUIRE(imm->v == 0xFFFFFFFFFFFFFFFFULL);
+}
+
 TEST_CASE("unmarshal extension opcodes", "[disasm][marshal]") {
     // Merge (rX <<= 32; rX >>>= 32) into wX = rX.
     compare_unmarshal_marshal(EbpfInst{.opcode = INST_ALU_OP_LSH | INST_SRC_IMM | INST_CLS_ALU64, .dst = 1, .imm = 32},

--- a/src/test/test_marshal.cpp
+++ b/src/test/test_marshal.cpp
@@ -610,19 +610,30 @@ TEST_CASE("unmarshal ST sign-extends the immediate", "[disasm][marshal]") {
     // For a 64-bit (DW) store the kernel sign-extends, so -1 becomes
     // 0xFFFFFFFFFFFFFFFF, not 0x00000000FFFFFFFF. Model it the same way, matching
     // the ALU-immediate path (getBinValue).
+    //
+    // Unmarshal is width-agnostic here: it always sign-extends the s32 immediate to
+    // 64 bits regardless of store size. Narrowing to the access width (e.g. 0xFF for
+    // a byte store) is the abstract transformer's job, not the decoder's, so every
+    // width decodes to the same 0xFFFFFFFFFFFFFFFF immediate.
     const ProgramInfo info{.platform = &g_ebpf_platform_linux,
                            .type = g_ebpf_platform_linux.get_program_type("unspec", "unspec")};
     constexpr EbpfInst exit{.opcode = INST_OP_EXIT};
-    // *(u64*)(r10 - 8) = -1   ; opcode 0x7a = BPF_ST | BPF_MEM | BPF_DW
-    const EbpfInst store{.opcode = 0x7a, .dst = R10_STACK_POINTER, .src = 0, .offset = -8, .imm = -1};
-    const auto parsed = unmarshal(RawProgram{"", "", 0, "", {store, exit, exit}, info}, VerifierOptions{});
-    const auto* seq = std::get_if<InstructionSeq>(&parsed);
-    REQUIRE(seq != nullptr);
-    const auto* mem = std::get_if<Mem>(&std::get<1>((*seq)[0]));
-    REQUIRE(mem != nullptr);
-    const auto* imm = std::get_if<Imm>(&mem->value);
-    REQUIRE(imm != nullptr);
-    REQUIRE(imm->v == 0xFFFFFFFFFFFFFFFFULL);
+
+    const std::array widths{INST_SIZE_B, INST_SIZE_H, INST_SIZE_W, INST_SIZE_DW};
+    for (const auto size : widths) {
+        // BPF_ST | BPF_MEM | <size>; e.g. INST_SIZE_DW yields opcode 0x7a.
+        const auto opcode = gsl::narrow<uint8_t>(INST_CLS_ST | INST_MODE_MEM | size);
+        // *(uN*)(r10 - 8) = -1
+        const EbpfInst store{.opcode = opcode, .dst = R10_STACK_POINTER, .src = 0, .offset = -8, .imm = -1};
+        const auto parsed = unmarshal(RawProgram{"", "", 0, "", {store, exit, exit}, info}, VerifierOptions{});
+        const auto* seq = std::get_if<InstructionSeq>(&parsed);
+        REQUIRE(seq != nullptr);
+        const auto* mem = std::get_if<Mem>(&std::get<1>((*seq)[0]));
+        REQUIRE(mem != nullptr);
+        const auto* imm = std::get_if<Imm>(&mem->value);
+        REQUIRE(imm != nullptr);
+        REQUIRE(imm->v == 0xFFFFFFFFFFFFFFFFULL);
+    }
 }
 
 TEST_CASE("unmarshal extension opcodes", "[disasm][marshal]") {


### PR DESCRIPTION
## Problem

`src/ir/unmarshal.cpp` decoded the immediate of a `BPF_ST` store with `zero_extend`. For a 64-bit (`BPF_DW`) store this drops the sign:

- `*(u64*)(r10-8) = -1` was modeled with value `0x00000000FFFFFFFF` (4294967295), but the Linux kernel assigns the `s32` immediate to a `u64` location, i.e. sign-extends to `0xFFFFFFFFFFFFFFFF`.

A later load of that cell then hands the analyzer a small positive scalar where the runtime value is negative/huge, which can under-approximate the value's range. Every other immediate path already uses `sign_extend` (the ALU path one screen up even documents it), and the marshaller round-trips through `int32_t`, so a sign-extended value is what actually re-marshals cleanly.

## Fix

Decode the `BPF_ST` immediate with `sign_extend`. Narrower stores (`B`/`H`/`W`) are unaffected because the transformer masks the stored value to the access width.

## Test

`test_marshal.cpp` gains a case that unmarshals `*(u64*)(r10-8) = -1` and asserts the decoded `Imm` value is `0xFFFFFFFFFFFFFFFF`.