### PR TITLE
Fix width argument in weak type-store havoc

### DIFF
--- a/src/crab/array_domain.cpp
+++ b/src/crab/array_domain.cpp
@@ -635,8 +635,9 @@ std::optional<Variable> ArrayDomain::store_type(TypeDomain& inv, const Interval&
         if (!is_num && range.has_value()) {
             const auto [lb, ub] = *range;
             // A non-numeric value may overwrite previously numeric bytes,
-            // so conservatively mark the range as non-numeric.
-            num_bytes.havoc(lb, ub);
+            // so conservatively mark the range [lb, ub) as non-numeric. havoc's
+            // second argument is a width, not an upper bound.
+            num_bytes.havoc(lb, ub - lb);
         }
         // When is_num is true, the value being stored is numeric. Any byte
         // that gets written will still be numeric, and bytes not written

--- a/src/test/test_array_domain.cpp
+++ b/src/test/test_array_domain.cpp
@@ -27,3 +27,18 @@ TEST_CASE("weak type store outside the stack window is a no-op", "[array_domain]
     REQUIRE_NOTHROW((void)stack.store_type(types, Interval{16}, Interval{4}, false));
     REQUIRE(stack.all_num_width(Interval{0}, Interval{8}));
 }
+
+TEST_CASE("weak type store havoc spans the byte width, not the upper bound", "[array_domain]") {
+    ArrayDomain stack{64};
+    TypeDomain types;
+    stack.initialize_numbers(0, 64);
+
+    // Weak update (non-singleton index) of a non-numeric value over bytes
+    // [8, 20). Only that range must become non-numeric; the bug passed the
+    // upper bound (20) as the width and clobbered [8, 28) instead.
+    (void)stack.store_type(types, Interval{8, 16}, Interval{4}, /*is_num=*/false);
+
+    REQUIRE_FALSE(stack.all_num_width(Interval{8}, Interval{4}));   // [8, 12): targeted, non-numeric
+    REQUIRE(stack.all_num_width(Interval{20}, Interval{4}));        // [20, 24): untouched, still numeric
+    REQUIRE(stack.all_num_width(Interval{24}, Interval{4}));        // [24, 28): untouched, still numeric
+}


### PR DESCRIPTION
## Problem

`ArrayDomain::store_type`'s weak (non-constant index) update (`src/crab/array_domain.cpp`) called:

```cpp
const auto [lb, ub] = *range;   // range is [lb, ub)
num_bytes.havoc(lb, ub);
```

but `BitsetDomain::havoc(size_t lb, int width)`'s second argument is a **width**, not an upper bound. So it marked bytes `[lb, lb+ub)` non-numeric instead of `[lb, ub)` (clamped to the stack size). The correct sibling calls (`num_bytes.havoc(offset, size)`) pass a width.

Because `lb >= 0`, this only ever over-marks bytes as non-numeric, so it is conservative and cannot cause the verifier to accept an unsafe program — but it loses precision and can produce spurious rejections.

## Fix

Pass `ub - lb` as the width.

## Test

`test_array_domain.cpp` gains a case that does a weak non-numeric store over bytes `[8, 20)` and asserts bytes `[20, 28)` remain numeric (the bug clobbered `[8, 28)`).