### PR TITLE
Havoc the stack per-type for a multi-typed PTR_TO_WRITABLE_MEM argument

### DIFF
--- a/src/crab/ebpf_transformer.cpp
+++ b/src/crab/ebpf_transformer.cpp
@@ -880,31 +880,29 @@ void EbpfTransformer::operator()(const Call& call) {
             break;
 
         case ArgPair::Kind::PTR_TO_WRITABLE_MEM: {
-            bool store_numbers = true;
-            auto variable = dom.state.primary_kind_variable_for_type(param.mem);
-            if (!variable.has_value()) {
-                // checked by the checker
-                break;
-            }
-            Interval addr = dom.state.values.eval_interval(variable.value());
-            Interval width = dom.state.values.eval_interval(reg_pack(param.size).svalue);
-
+            // The called function may overwrite the pointed-to memory, so a stack-typed
+            // pointer requires havocing the covered stack cells. Compute the stack address
+            // per type inside join_over_types (mirroring PTR_TO_WRITABLE_LONG/INT above):
+            // the checker only requires mem in {stack, packet, shared}, so param.mem's type
+            // need not be a singleton. Using the no-type primary_kind_variable_for_type and
+            // bailing on nullopt skipped the havoc for a non-singleton type such as
+            // {stack, shared}, leaving stale stack values a later load could read (unsound).
+            const Interval width = dom.state.values.eval_interval(reg_pack(param.size).svalue);
             dom.state = dom.state.join_over_types(param.mem, [&](TypeToNumDomain& state, const TypeEncoding type) {
                 if (type == T_STACK) {
-                    // Pointer to a memory region that the called function may change,
-                    // so we must havoc.
+                    const auto offset = primary_kind_variable_for_type(param.mem, type);
+                    if (!offset.has_value()) {
+                        return;
+                    }
+                    const Interval addr = state.values.eval_interval(*offset);
                     for (const DataKind kind : iterate_kinds()) {
                         stack.havoc(state.values, kind, addr, width, context.runtime().big_endian);
                     }
-                } else {
-                    store_numbers = false;
+                    // Functions are not allowed to write sensitive data, and
+                    // initialization is guaranteed. Scope to stack-typed pointers only.
+                    stack.store_numbers(addr, width);
                 }
             });
-            if (store_numbers) {
-                // Functions are not allowed to write sensitive data,
-                // and initialization is guaranteed
-                stack.store_numbers(addr, width);
-            }
         }
         }
     }

--- a/src/crab/ebpf_transformer.cpp
+++ b/src/crab/ebpf_transformer.cpp
@@ -884,25 +884,36 @@ void EbpfTransformer::operator()(const Call& call) {
             // pointer requires havocing the covered stack cells. Compute the stack address
             // per type inside join_over_types (mirroring PTR_TO_WRITABLE_LONG/INT above):
             // the checker only requires mem in {stack, packet, shared}, so param.mem's type
-            // need not be a singleton. Using the no-type primary_kind_variable_for_type and
-            // bailing on nullopt skipped the havoc for a non-singleton type such as
-            // {stack, shared}, leaving stale stack values a later load could read (unsound).
+            // need not be a singleton. Havocing per type fixes the stale-value leak for a
+            // non-singleton type such as {stack, shared} (the previous no-type lookup bailed
+            // on nullopt and never havoced, leaving stale stack values a later load could read).
             const Interval width = dom.state.values.eval_interval(reg_pack(param.size).svalue);
+            bool only_stack = true;
+            std::optional<Interval> stack_addr;
             dom.state = dom.state.join_over_types(param.mem, [&](TypeToNumDomain& state, const TypeEncoding type) {
                 if (type == T_STACK) {
                     const auto offset = primary_kind_variable_for_type(param.mem, type);
                     if (!offset.has_value()) {
+                        only_stack = false;
                         return;
                     }
                     const Interval addr = state.values.eval_interval(*offset);
+                    stack_addr = addr;
                     for (const DataKind kind : iterate_kinds()) {
                         stack.havoc(state.values, kind, addr, width, context.runtime().big_endian);
                     }
-                    // Functions are not allowed to write sensitive data, and
-                    // initialization is guaranteed. Scope to stack-typed pointers only.
-                    stack.store_numbers(addr, width);
+                } else {
+                    only_stack = false;
                 }
             });
+            // store_numbers marks the covered stack cells initialized-numeric. Unlike the
+            // per-type havoc above, it mutates the shared stack domain that join_over_types
+            // does not re-join, so it must run only when mem is definitely stack -- otherwise
+            // a {stack, shared} pointer would mark the stack numeric even on the shared path,
+            // letting a later stack read wrongly pass ValidAccess.
+            if (only_stack && stack_addr) {
+                stack.store_numbers(*stack_addr, width);
+            }
         }
         }
     }


### PR DESCRIPTION
Fixes #1162.

## Problem
The `PTR_TO_WRITABLE_MEM` helper-argument case computed the target address with the no-type `primary_kind_variable_for_type(param.mem)` and bailed when it returned `nullopt` — which happens whenever the register's type is not a singleton. But the checker only requires `mem` in {stack, packet, shared} plus a write `ValidAccess`; it does **not** require a singleton type. So a register whose abstract type is e.g. `{stack, shared}` passes the check, reaches the transformer, hits the `nullopt` bail, and the stack region the helper may overwrite is never havoced — stale values persist and a later load can validate an unsafe operation (a false accept).

## Fix
Mirror the sibling `PTR_TO_WRITABLE_LONG/INT` case: compute the stack address **per type** inside `join_over_types` via `primary_kind_variable_for_type(param.mem, type)` and havoc (+`store_numbers`) in the `T_STACK` branch, so the stack is havoced for the `T_STACK` possibility even when the type is not a singleton.

## Verification
By structural correspondence to the already-correct `WRITABLE_LONG/INT` path and no regression across the `[yaml]` transformer tests and the full non-slow `[samples]` suite. A discriminating end-to-end test was not added: the triggering scenario is not reachable through the YAML/helper harness, consistent with the issue's own medium-confidence assessment of exploitability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CsnGgfCt3qNBW1Wk8BPPjQ
