### PR TITLE
Fix TypeDomain::is_subsumed_by for unsatisfied type-equality classes

### DIFF
--- a/src/crab/type_domain.cpp
+++ b/src/crab/type_domain.cpp
@@ -679,12 +679,10 @@ bool TypeDomain::State::is_subsumed_by(const State& other) const {
         }
         const auto id0 = var_ids.find_id(members[0]);
         if (!id0) {
-            for (size_t i = 1; i < members.size(); i++) {
-                if (var_ids.contains(members[i])) {
-                    return false;
-                }
-            }
-            continue;
+            // other requires type(members[0]) == type(members[i]), but members[0] is
+            // untracked in self and therefore an independent top -- self does not
+            // enforce this equality, so it is not subsumed by other.
+            return false;
         }
         const size_t rep0 = dsu.find_const(*id0);
         for (size_t i = 1; i < members.size(); i++) {

--- a/src/test/test_type_domain.cpp
+++ b/src/test/test_type_domain.cpp
@@ -229,6 +229,25 @@ TEST_CASE("restrict narrows the whole equivalence class", "[type_domain]") {
 }
 
 // ============================================================================
+// Subsumption (operator<=)
+// ============================================================================
+
+TEST_CASE("top is not subsumed by an unsatisfied type equality", "[type_domain][subsumption]") {
+    // Regression: is_subsumed_by treated a top-typeset equality class in `other`
+    // whose members are untracked in `self` as satisfied, inverting the order.
+    TypeDomain self; // top: tracks no type variables
+    TypeDomain other;
+    other.assume_eq(reg_type(r0), reg_type(r1)); // type(r0) == type(r1), typeset all()
+    REQUIRE(other.same_type(r0, r1));
+
+    // `self` (top) admits type(r0) != type(r1), which `other` forbids, so `self`
+    // is NOT subsumed by `other`.
+    REQUIRE(!(self <= other));
+    // Conversely, the constrained `other` is subsumed by top.
+    REQUIRE(other <= self);
+}
+
+// ============================================================================
 // Join
 // ============================================================================
 


### PR DESCRIPTION
Fixes #1163.

## Problem
`TypeDomain::State::is_subsumed_by` (backing `operator<=`) could report `self <= other` when false, inverting the lattice order. When `other` has a multi-member type-equality class whose first member is untracked in `self`, the code treated the equality as satisfied. But an untracked member is an independent top in `self`, so `self` does not enforce `other`'s equality — a fixpoint check relying on this can declare convergence prematurely and drop reachable states (unsound).

## Fix
Return `false` as soon as a nontrivial equality class in `other` has an untracked member in `self` (the conservative, correct side).

## Verification
Added a `TypeDomain`-level regression test (top is not subsumed by a top-typeset type equality) that **fails without the fix**; full `[subsumption]`/`[type_domain]`/`[join]` suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CsnGgfCt3qNBW1Wk8BPPjQ
