### PR TITLE
Fix conformance-group selection in the CLI

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -104,7 +104,10 @@ int main(int argc, char** argv) {
         ->group("Features")
         ->check(CLI::Range(1, RuntimeConfig::MAX_PACKET_SIZE_LIMIT));
 
-    std::set<std::string> include_groups = get_conformance_group_names();
+    // Empty by default so that, absent --include_groups, only default_groups are
+    // enabled below (which is the documented intent: no callx or packet). Pre-seeding
+    // with every group name would OR all groups back in, overriding default_groups.
+    std::set<std::string> include_groups;
     app.add_option("--include_groups", include_groups, "Include conformance groups")
         ->group("Features")
         ->type_name("GROUPS")
@@ -156,7 +159,7 @@ int main(int argc, char** argv) {
         platform.supported_conformance_groups |= et_conformance_group_by_name(group_name).value();
     }
     for (const auto& group_name : exclude_groups) {
-        platform.supported_conformance_groups &= et_conformance_group_by_name(group_name).value();
+        platform.supported_conformance_groups &= ~et_conformance_group_by_name(group_name).value();
     }
 
     // Main program


### PR DESCRIPTION
Fixes #1164.

## Problem
Two defects in the CLI conformance-group handling (`src/main.cpp`):
1. `--exclude_groups` intersected instead of removing (`&= group` narrowed the supported set down to just `group`).
2. `include_groups` was pre-seeded with all eight names, so the default run ORed `callx`/`packet` back in, overriding `default_groups` and contradicting the adjacent comment.

## Fix
1. Use `&= ~group` (operator`~` already exists) to actually remove.
2. Initialize `include_groups` empty so the documented default (`default_groups`, no callx/packet) holds unless `--include_groups` is passed.

## Note (product decision, flagged in the issue)
(2) makes the CLI honor its own comment (no packet by default). The Linux *library* platform default is `default_groups | packet`; if the CLI should match that instead, seed `include_groups` with `{"packet"}`.

## Verification
With the CLI: excluding an unused group (`packet`) now PASSES a base program (previously collapsed the set to empty → failure), and excluding a needed group (`base32`/`base64`) correctly rejects with "requires conformance group base64".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CsnGgfCt3qNBW1Wk8BPPjQ
