### PR TITLE
Flip infinite bound sign in ExtendedNumber signed division

### DIFF
--- a/src/arith/num_extended.hpp
+++ b/src/arith/num_extended.hpp
@@ -123,7 +123,8 @@ class ExtendedNumber final {
     ExtendedNumber& operator*=(const ExtendedNumber& x) { return operator=(operator*(x)); }
 
   private:
-    ExtendedNumber AbsDiv(const ExtendedNumber& x, ExtendedNumber (*f)(const Number&, const Number&)) const {
+    ExtendedNumber AbsDiv(const ExtendedNumber& x, ExtendedNumber (*f)(const Number&, const Number&),
+                          const bool flip_infinite_by_divisor_sign = false) const {
         if (x._n == 0) {
             CRAB_ERROR("Bound: division by zero");
         }
@@ -134,15 +135,20 @@ class ExtendedNumber final {
             return Number{0};
         }
         if (is_infinite()) {
-            return *this;
+            // Dividing an infinite bound by a negative divisor flips its sign
+            // (e.g. -oo / negative == +oo). Only signed division applies this;
+            // modulo keeps the dividend's infinity and the unsigned ops treat
+            // the divisor as unsigned (never negative).
+            return flip_infinite_by_divisor_sign && x._n < 0 ? -*this : *this;
         }
         return f(_n, x._n);
     }
 
   public:
     ExtendedNumber operator/(const ExtendedNumber& x) const {
-        return AbsDiv(x,
-                      [](const Number& dividend, const Number& divisor) { return ExtendedNumber{dividend / divisor}; });
+        return AbsDiv(
+            x, [](const Number& dividend, const Number& divisor) { return ExtendedNumber{dividend / divisor}; },
+            /*flip_infinite_by_divisor_sign=*/true);
     }
 
     ExtendedNumber operator%(const ExtendedNumber& x) const {

--- a/src/test/test_interval_bitwise.cpp
+++ b/src/test/test_interval_bitwise.cpp
@@ -23,6 +23,23 @@ TEST_CASE("bitwise_and with non-singleton containing all-ones includes zero", "[
     REQUIRE(left.bitwise_and(anomalous_right) == Interval{0, 100});
 }
 
+TEST_CASE("ExtendedNumber division flips an infinite bound for a negative divisor", "[extended_number][arithmetic]") {
+    const auto pos_inf = ExtendedNumber::plus_infinity();
+    const auto neg_inf = ExtendedNumber::minus_infinity();
+    const ExtendedNumber neg{-2};
+    const ExtendedNumber pos{2};
+
+    // Signed division flips the sign of an infinite dividend when the divisor is negative.
+    REQUIRE((neg_inf / neg) == pos_inf);
+    REQUIRE((pos_inf / neg) == neg_inf);
+    REQUIRE((neg_inf / pos) == neg_inf);
+    REQUIRE((pos_inf / pos) == pos_inf);
+
+    // Modulo keeps the dividend's infinity regardless of the divisor sign.
+    REQUIRE((pos_inf % neg) == pos_inf);
+    REQUIRE((neg_inf % neg) == neg_inf);
+}
+
 TEST_CASE("signed division by a negative singleton preserves interval order", "[interval][arithmetic]") {
     REQUIRE(Interval{-8, -4}.sdiv(Interval{-1}) == Interval{4, 8});
     REQUIRE(Interval{4, 8}.sdiv(Interval{-2}) == Interval{-4, -2});


### PR DESCRIPTION
Fixes #1165.

## Problem
`ExtendedNumber::AbsDiv` returned the dividend's own infinity unchanged when dividing an infinite bound by a finite divisor, so `-oo / (negative)` yielded `-oo` instead of `+oo`.

## Fix
Thread a flag so only signed `operator/` flips the infinity sign by the divisor sign. Modulo keeps the dividend's infinity (magnitude is bounded, so the sign is the conservative choice) and the unsigned `udiv`/`urem` treat the divisor as unsigned (never negative), so those are deliberately unchanged.

## Verification
Added a direct `ExtendedNumber` test covering both division sign flips and the unchanged modulo convention; `[arithmetic]` suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CsnGgfCt3qNBW1Wk8BPPjQ
