### PR TITLE
Guard Exit assertion handler against a missing label

### DIFF
--- a/src/ir/assertions.cpp
+++ b/src/ir/assertions.cpp
@@ -65,7 +65,8 @@ class AssertExtractor {
 
     vector<Assertion> operator()(const Exit&) const {
         vector<Assertion> res;
-        if (current_label->stack_frame_prefix.empty()) {
+        // A missing label denotes the top-level frame, consistent with make_valid_access.
+        if (!current_label || current_label->stack_frame_prefix.empty()) {
             // Verify that Exit returns a number.
             res.emplace_back(TypeConstraint{Reg{R0_RETURN_VALUE}, TypeGroup::number});
         }


### PR DESCRIPTION
Fixes #1166.

## Problem
The `AssertExtractor` `Exit` handler dereferenced `current_label` (a `std::optional<Label>`) without checking `has_value()`. Latent today (the only `std::nullopt` call site passes a `Call`, not an `Exit`), but any future `get_assertions(Exit{}, ..., std::nullopt)` is UB in a security-critical file.

## Fix
Treat a missing label as the top-level frame, consistent with the sibling `make_valid_access` which already guards the same member.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CsnGgfCt3qNBW1Wk8BPPjQ
