### PR TITLE
Make WTO consumers iterative to avoid stack overflow on crafted CFGs

### DIFF
--- a/src/cfg/wto.cpp
+++ b/src/cfg/wto.cpp
@@ -3,6 +3,7 @@
 #include <map>
 #include <ranges>
 #include <variant>
+#include <vector>
 
 #include "cfg/cfg.hpp"
 #include "cfg/label.hpp"
@@ -17,16 +18,24 @@
 namespace prevail {
 
 bool is_component_member(const Label& label, const CycleOrLabel& component) {
-    if (const auto plabel = std::get_if<Label>(&component)) {
-        return *plabel == label;
-    }
-    const auto cycle = std::get<std::shared_ptr<WtoCycle>>(component);
-    if (cycle->head() == label) {
-        return true;
-    }
-    for (const auto& sub_component : *cycle) {
-        if (is_component_member(label, sub_component)) {
+    // Iterative (explicit work-stack) rather than recursive on cycle-nesting depth:
+    // a crafted CFG can nest ~N/2 components and overflow the C++ stack.
+    std::vector<const CycleOrLabel*> stack{&component};
+    while (!stack.empty()) {
+        const CycleOrLabel* const current = stack.back();
+        stack.pop_back();
+        if (const auto plabel = std::get_if<Label>(current)) {
+            if (*plabel == label) {
+                return true;
+            }
+            continue;
+        }
+        const auto& cycle = std::get<std::shared_ptr<WtoCycle>>(*current);
+        if (cycle->head() == label) {
             return true;
+        }
+        for (const auto& sub_component : *cycle) {
+            stack.push_back(&sub_component);
         }
     }
     return false;

--- a/src/cfg/wto.hpp
+++ b/src/cfg/wto.hpp
@@ -64,6 +64,14 @@ class WtoNesting final {
 using CycleOrLabel = std::variant<std::shared_ptr<class WtoCycle>, Label>;
 using WtoPartition = std::vector<CycleOrLabel>;
 
+namespace detail {
+// Shared iterative traversal backing Wto::for_each_loop_head and
+// WtoCycle::for_each_loop_head, so the (soundness-relevant) traversal invariant lives in
+// one place. Forward-declared here and defined once WtoCycle is complete (below).
+template <typename Range, typename F>
+void wto_for_each_loop_head(const Range& top_level, F&& f);
+} // namespace detail
+
 // Bourdoncle, "Efficient chaotic iteration strategies with widenings", 1993
 // section 3 uses the term "nested component" to refer to what WtoCycle implements.
 class WtoCycle final {
@@ -104,27 +112,33 @@ class WtoCycle final {
         return _components.crend();
     }
 
-    void for_each_loop_head(auto&& f) const {
-        // Iterative (explicit work-stack) rather than recursive on cycle-nesting
-        // depth, which a crafted CFG could drive deep enough to overflow the stack.
-        std::vector<const WtoCycle*> stack;
-        for (const auto& component : *this) {
+    void for_each_loop_head(auto&& f) const { detail::wto_for_each_loop_head(*this, f); }
+};
+
+namespace detail {
+template <typename Range, typename F>
+void wto_for_each_loop_head(const Range& top_level, F&& f) {
+    // Iterative (explicit work-stack) rather than recursive on cycle-nesting depth, which a
+    // crafted CFG could drive deep enough to overflow the stack. Seeds from the given
+    // top-level components (a Wto or a WtoCycle) and visits every nested cycle head once.
+    std::vector<const WtoCycle*> stack;
+    for (const auto& component : top_level) {
+        if (const auto pc = std::get_if<std::shared_ptr<WtoCycle>>(&component)) {
+            stack.push_back(pc->get());
+        }
+    }
+    while (!stack.empty()) {
+        const WtoCycle* const cycle = stack.back();
+        stack.pop_back();
+        f(cycle->head());
+        for (const auto& component : *cycle) {
             if (const auto pc = std::get_if<std::shared_ptr<WtoCycle>>(&component)) {
                 stack.push_back(pc->get());
             }
         }
-        while (!stack.empty()) {
-            const WtoCycle* const cycle = stack.back();
-            stack.pop_back();
-            f(cycle->head());
-            for (const auto& component : *cycle) {
-                if (const auto pc = std::get_if<std::shared_ptr<WtoCycle>>(&component)) {
-                    stack.push_back(pc->get());
-                }
-            }
-        }
     }
-};
+}
+} // namespace detail
 
 // Check if node is a member of the wto component.
 bool is_component_member(const Label& label, const CycleOrLabel& component);
@@ -170,25 +184,6 @@ class Wto final {
      *
      * The order in which the heads are visited is not specified.
      */
-    void for_each_loop_head(auto&& f) const {
-        // Iterative (explicit work-stack) rather than recursive on cycle-nesting
-        // depth, which a crafted CFG could drive deep enough to overflow the stack.
-        std::vector<const WtoCycle*> stack;
-        for (const auto& component : *this) {
-            if (const auto pc = std::get_if<std::shared_ptr<WtoCycle>>(&component)) {
-                stack.push_back(pc->get());
-            }
-        }
-        while (!stack.empty()) {
-            const WtoCycle* const cycle = stack.back();
-            stack.pop_back();
-            f(cycle->head());
-            for (const auto& component : *cycle) {
-                if (const auto pc = std::get_if<std::shared_ptr<WtoCycle>>(&component)) {
-                    stack.push_back(pc->get());
-                }
-            }
-        }
-    }
+    void for_each_loop_head(auto&& f) const { detail::wto_for_each_loop_head(*this, f); }
 };
 } // namespace prevail

--- a/src/cfg/wto.hpp
+++ b/src/cfg/wto.hpp
@@ -105,10 +105,22 @@ class WtoCycle final {
     }
 
     void for_each_loop_head(auto&& f) const {
+        // Iterative (explicit work-stack) rather than recursive on cycle-nesting
+        // depth, which a crafted CFG could drive deep enough to overflow the stack.
+        std::vector<const WtoCycle*> stack;
         for (const auto& component : *this) {
             if (const auto pc = std::get_if<std::shared_ptr<WtoCycle>>(&component)) {
-                f((*pc)->head());
-                (*pc)->for_each_loop_head(f);
+                stack.push_back(pc->get());
+            }
+        }
+        while (!stack.empty()) {
+            const WtoCycle* const cycle = stack.back();
+            stack.pop_back();
+            f(cycle->head());
+            for (const auto& component : *cycle) {
+                if (const auto pc = std::get_if<std::shared_ptr<WtoCycle>>(&component)) {
+                    stack.push_back(pc->get());
+                }
             }
         }
     }
@@ -159,10 +171,22 @@ class Wto final {
      * The order in which the heads are visited is not specified.
      */
     void for_each_loop_head(auto&& f) const {
+        // Iterative (explicit work-stack) rather than recursive on cycle-nesting
+        // depth, which a crafted CFG could drive deep enough to overflow the stack.
+        std::vector<const WtoCycle*> stack;
         for (const auto& component : *this) {
             if (const auto pc = std::get_if<std::shared_ptr<WtoCycle>>(&component)) {
-                f((*pc)->head());
-                (*pc)->for_each_loop_head(f);
+                stack.push_back(pc->get());
+            }
+        }
+        while (!stack.empty()) {
+            const WtoCycle* const cycle = stack.back();
+            stack.pop_back();
+            f(cycle->head());
+            for (const auto& component : *cycle) {
+                if (const auto pc = std::get_if<std::shared_ptr<WtoCycle>>(&component)) {
+                    stack.push_back(pc->get());
+                }
             }
         }
     }

--- a/src/ir/cfg_builder.cpp
+++ b/src/ir/cfg_builder.cpp
@@ -625,12 +625,20 @@ static bool is_tail_call_site(const Instruction& ins, const ebpf_platform_t& pla
 }
 
 static void collect_wto_labels(const CycleOrLabel& component, std::set<Label>& labels) {
-    if (const auto plabel = std::get_if<Label>(&component)) {
-        labels.insert(*plabel);
-        return;
-    }
-    for (const auto& nested_component : *std::get<std::shared_ptr<WtoCycle>>(component)) {
-        collect_wto_labels(nested_component, labels);
+    // Iterative (explicit work-stack) rather than recursive on cycle-nesting depth.
+    // This runs unconditionally for every program via pass_validate_tail_call_depth,
+    // so a crafted deeply-nested CFG must not be able to overflow the C++ stack here.
+    std::vector<const CycleOrLabel*> stack{&component};
+    while (!stack.empty()) {
+        const CycleOrLabel* const current = stack.back();
+        stack.pop_back();
+        if (const auto plabel = std::get_if<Label>(current)) {
+            labels.insert(*plabel);
+            continue;
+        }
+        for (const auto& nested_component : *std::get<std::shared_ptr<WtoCycle>>(*current)) {
+            stack.push_back(&nested_component);
+        }
     }
 }
 


### PR DESCRIPTION
Fixes #1167.

## Problem
The WTO builder is deliberately iterative, but three consumers recursed on cycle-nesting depth:
- `is_component_member` (`src/cfg/wto.cpp`)
- `Wto`/`WtoCycle::for_each_loop_head` (`src/cfg/wto.hpp`, used by `pass_insert_termination_counters`)
- `collect_wto_labels` (`src/ir/cfg_builder.cpp`), invoked **unconditionally** by `pass_validate_tail_call_depth` for every program.

A crafted program (~1M instructions) with ~N/2 nested SCCs drives recursion depth O(N); on the mandatory `collect_wto_labels` path that can exhaust the C++ stack and crash — a DoS on untrusted bytecode.

## Fix
Convert all three to explicit work-stacks, mirroring the builder. Traversal semantics are unchanged (order is unspecified for `for_each_loop_head`; the label sets are identical).

## Verification
No regression across `[yaml]` and the full non-slow `[samples]` suite, which drive WTO ordering through every analysis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CsnGgfCt3qNBW1Wk8BPPjQ
