### PR TITLE
Fix weight-slot leak, clear_edges OOB, and vertex overflow in adapt_sgraph

### DIFF
--- a/src/crab/splitdbm/adapt_sgraph.hpp
+++ b/src/crab/splitdbm/adapt_sgraph.hpp
@@ -236,9 +236,12 @@ class AdaptGraph final {
             free_id.pop_back();
             is_free[v] = false;
         } else {
-            // static_cast<VertId>(_succs.size()) wraps to 0 at 65536 vertices,
-            // aliasing the reserved zero vertex; guard against the overflow.
-            assert(_succs.size() <= std::numeric_limits<VertId>::max());
+            // static_cast<VertId>(_succs.size()) wraps to 0 at 65536 vertices, aliasing the
+            // reserved zero vertex; and at size == max() the new vertex would make verts()'s
+            // one-past-end (65536) wrap to an empty range. Reject before either can happen.
+            // (An assert, not a hard check: an eBPF program's variable count is orders of
+            // magnitude below 65535, so this is a documented invariant, not a reachable path.)
+            assert(_succs.size() < std::numeric_limits<VertId>::max());
             v = static_cast<VertId>(_succs.size());
             is_free.push_back(false);
             _succs.emplace_back();

--- a/src/crab/splitdbm/adapt_sgraph.hpp
+++ b/src/crab/splitdbm/adapt_sgraph.hpp
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 
+#include <cassert>
+#include <limits>
 #include <ranges>
 #include <vector>
 
@@ -128,6 +130,9 @@ class AdaptGraph final {
 
     [[nodiscard]]
     auto verts() const {
+        // A vertex count of 65536 wraps to 0 through VertId (uint16_t), yielding an
+        // empty range; far beyond any eBPF program's variable count, but guard it.
+        assert(is_free.size() <= std::numeric_limits<VertId>::max());
         return std::views::iota(VertId{0}, static_cast<VertId>(is_free.size())) |
                std::views::filter([this](const VertId v) { return !is_free[v]; });
     }
@@ -231,6 +236,9 @@ class AdaptGraph final {
             free_id.pop_back();
             is_free[v] = false;
         } else {
+            // static_cast<VertId>(_succs.size()) wraps to 0 at 65536 vertices,
+            // aliasing the reserved zero vertex; guard against the overflow.
+            assert(_succs.size() <= std::numeric_limits<VertId>::max());
             v = static_cast<VertId>(_succs.size());
             is_free.push_back(false);
             _succs.emplace_back();
@@ -260,8 +268,12 @@ class AdaptGraph final {
         edge_count -= _succs[v].size();
         _succs[v].clear();
 
-        for (const TreeSMap::Key k : _preds[v].keys()) {
-            _succs[k].remove(v);
+        for (const auto& [key, val] : _preds[v]) {
+            // Recycle the weight slot of the in-edge key -> v. It is the same slot
+            // referenced from _succs[key], so it becomes unreferenced once removed
+            // below; failing to reclaim it leaks _ws slots monotonically.
+            free_widx.push_back(val);
+            _succs[key].remove(v);
         }
         edge_count -= _preds[v].size();
         _preds[v].clear();
@@ -272,6 +284,9 @@ class AdaptGraph final {
 
     void clear_edges() {
         _ws.clear();
+        // free_widx indexes into _ws; leaving stale indices after clearing _ws would
+        // make the next add_edge write _ws[idx] out of bounds.
+        free_widx.clear();
         for (const VertId v : verts()) {
             _succs[v].clear();
             _preds[v].clear();


### PR DESCRIPTION
Fixes #1168.

Three defects in `AdaptGraph` (`src/crab/splitdbm/adapt_sgraph.hpp`):

1. **`forget()` leaked in-edge weight slots.** Each edge `k -> v` owns one `_ws` slot referenced from both `_succs[k]` and `_preds[v]`. The in-edge loop removed `v` from `_succs[k]` without recycling that slot into `free_widx`, so `_ws` grew monotonically. Now iterate `_preds[v]` as key/value and push the slot to `free_widx`, mirroring the out-edge loop. (Self-loops are recycled once via the out-edge loop, so no double-free.)
2. **`clear_edges()` cleared `_ws` but left `free_widx` populated** → next `add_edge` writes `_ws[idx]` OOB. Clear `free_widx` too. (Currently no callers; fixed rather than left armed.)
3. **`verts()`/`new_vertex()` truncate the vertex count through `VertId` (uint16_t)** → wraps to 0 at 65536. Far beyond any eBPF program; added an assert.

## Verification
Domain / `[join]` / full non-slow `[samples]` suites pass (the writable-mem/havoc/forget path is exercised throughout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CsnGgfCt3qNBW1Wk8BPPjQ
