### PR TITLE
Fix test-generation/inventory script correctness gaps

### DIFF
--- a/scripts/audit_verify_reasons.py
+++ b/scripts/audit_verify_reasons.py
@@ -81,7 +81,8 @@ def main() -> int:
     }
 
     output_path = Path(args.output)
-    output_path.write_text(json.dumps(audit, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    with open(output_path, "w", encoding="utf-8", newline="\n") as handle:
+        handle.write(json.dumps(audit, indent=2, sort_keys=True) + "\n")
     print(f"Wrote {output_path}")
     return 0
 

--- a/scripts/check_conformance_list.py
+++ b/scripts/check_conformance_list.py
@@ -15,7 +15,15 @@ MACRO_RE = re.compile(
 DATA_DIR = pathlib.Path("external/bpf_conformance/tests")
 CONFORMANCE_TEST_FILE = pathlib.Path("src/test/test_conformance.cpp")
 
-txt = CONFORMANCE_TEST_FILE.read_text(encoding="utf-8", errors="ignore")
+
+def strip_comments(text: str) -> str:
+    """Remove C/C++ comments so a commented-out TEST_CONFORMANCE does not count as listed."""
+    text = re.sub(r"/\*.*?\*/", "", text, flags=re.DOTALL)
+    text = re.sub(r"//[^\n]*", "", text)
+    return text
+
+
+txt = strip_comments(CONFORMANCE_TEST_FILE.read_text(encoding="utf-8", errors="ignore"))
 listed = {m.group(2) for m in MACRO_RE.finditer(txt)}
 on_disk = {p.name for p in DATA_DIR.glob("*.data") if p.is_file()}
 

--- a/scripts/generate_elf_inventory.py
+++ b/scripts/generate_elf_inventory.py
@@ -153,6 +153,32 @@ def merge_existing_overrides(inventory: dict, existing: dict) -> None:
                 odata["test_overrides"] = overrides
 
 
+def preserve_timed_out_sections(inventory: dict, existing: dict) -> None:
+    """Reuse the previous inventory's section listing for an object whose `prevail -l`
+    timed out this run.
+
+    A timeout yields an empty `sections` map; generate_verify_project_tests.py emits tests
+    only by iterating `sections`, so writing the empty map would delete every generated
+    verify test for that object on a transient timeout. Carry forward the prior listing
+    (keeping the `timeout` flag/diagnostic so the staleness is visible).
+    """
+    existing_projects = existing.get("projects", {})
+    for project, pdata in inventory.get("projects", {}).items():
+        existing_objects = existing_projects.get(project, {}).get("objects", {})
+        for object_name, odata in pdata.get("objects", {}).items():
+            if not odata.get("timeout") or odata.get("sections"):
+                continue
+            prev = existing_objects.get(object_name)
+            prev_sections = prev.get("sections") if prev else None
+            if not prev_sections:
+                continue
+            odata["sections"] = prev_sections
+            odata["section_count"] = prev.get("section_count", len(prev_sections))
+            odata["program_count"] = prev.get(
+                "program_count", sum(len(programs) for programs in prev_sections.values())
+            )
+
+
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description="Generate a complete project/object/section/program inventory from ebpf-samples."
@@ -200,6 +226,7 @@ def main() -> int:
         if output_path.exists():
             existing = json.loads(output_path.read_text(encoding="utf-8"))
             merge_existing_overrides(inventory, existing)
+            preserve_timed_out_sections(inventory, existing)
 
     rendered = json.dumps(inventory, indent=2, sort_keys=True)
 

--- a/scripts/generate_elf_inventory.py
+++ b/scripts/generate_elf_inventory.py
@@ -63,8 +63,22 @@ def parse_check_output(output_lines: list[str]) -> tuple[dict[str, list[dict[str
 
 def inspect_object(check_bin: Path, root: Path, elf_path: Path, timeout_seconds: int) -> tuple[str, str, dict]:
     rel = elf_path.relative_to(root)
+    project = rel.parts[0] if len(rel.parts) >= 2 else "_root"
+    object_name = Path(*rel.parts[1:]).as_posix() if len(rel.parts) >= 2 else rel.as_posix()
+
     cmd = [str(check_bin), "-l", str(elf_path)]
-    completed = subprocess.run(cmd, capture_output=True, text=True, errors="replace", timeout=timeout_seconds)
+    try:
+        completed = subprocess.run(cmd, capture_output=True, text=True, errors="replace", timeout=timeout_seconds)
+    except subprocess.TimeoutExpired:
+        # A single slow ELF must not abort the whole inventory; record the timeout and move on.
+        return project, object_name, {
+            "exit_code": None,
+            "section_count": 0,
+            "program_count": 0,
+            "sections": {},
+            "diagnostics": [f"inventory scan timed out after {timeout_seconds}s"],
+            "timeout": True,
+        }
 
     combined_lines = []
     combined_lines.extend(completed.stdout.splitlines())
@@ -73,9 +87,6 @@ def inspect_object(check_bin: Path, root: Path, elf_path: Path, timeout_seconds:
 
     section_names = sorted(sections.keys())
     program_count = sum(len(programs) for programs in sections.values())
-
-    project = rel.parts[0] if len(rel.parts) >= 2 else "_root"
-    object_name = Path(*rel.parts[1:]).as_posix() if len(rel.parts) >= 2 else rel.as_posix()
 
     return project, object_name, {
         "exit_code": completed.returncode,
@@ -127,6 +138,21 @@ def build_inventory(samples_root: Path, check_bin: Path, jobs: int, timeout_seco
     }
 
 
+def merge_existing_overrides(inventory: dict, existing: dict) -> None:
+    """Carry hand-curated test_overrides from a previous inventory into the regenerated one.
+
+    The scan rebuilds the inventory from scratch and does not know about curated reasons or
+    kinds, so without this merge every regeneration would discard them.
+    """
+    existing_projects = existing.get("projects", {})
+    for project, pdata in inventory.get("projects", {}).items():
+        existing_objects = existing_projects.get(project, {}).get("objects", {})
+        for object_name, odata in pdata.get("objects", {}).items():
+            overrides = existing_objects.get(object_name, {}).get("test_overrides")
+            if overrides:
+                odata["test_overrides"] = overrides
+
+
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description="Generate a complete project/object/section/program inventory from ebpf-samples."
@@ -168,13 +194,21 @@ def main() -> int:
         return 2
 
     inventory = build_inventory(samples_root, check_bin, args.jobs, args.timeout_seconds)
+
+    if args.output != "-":
+        output_path = Path(args.output)
+        if output_path.exists():
+            existing = json.loads(output_path.read_text(encoding="utf-8"))
+            merge_existing_overrides(inventory, existing)
+
     rendered = json.dumps(inventory, indent=2, sort_keys=True)
 
     if args.output == "-":
         print(rendered)
     else:
         output_path = Path(args.output)
-        output_path.write_text(rendered + "\n", encoding="utf-8")
+        with open(output_path, "w", encoding="utf-8", newline="\n") as handle:
+            handle.write(rendered + "\n")
         print(f"Wrote {output_path}", file=sys.stderr)
 
     return 0

--- a/scripts/generate_elf_inventory.py
+++ b/scripts/generate_elf_inventory.py
@@ -119,22 +119,28 @@ def build_inventory(samples_root: Path, check_bin: Path, jobs: int, timeout_seco
         for project in project_names
     }
 
-    total_objects = sum(project["object_count"] for project in projects.values())
-    total_sections = sum(
-        obj["section_count"] for project in projects.values() for obj in project["objects"].values()
-    )
-    total_programs = sum(
-        obj["program_count"] for project in projects.values() for obj in project["objects"].values()
-    )
-
-    return {
+    inventory = {
         "schema_version": 1,
-        "summary": {
-            "object_count": total_objects,
-            "section_count": total_sections,
-            "program_count": total_programs,
-        },
+        "summary": {},
         "projects": projects,
+    }
+    recompute_summary(inventory)
+    return inventory
+
+
+def recompute_summary(inventory: dict) -> None:
+    """Recompute the aggregate summary from the current per-object counts.
+
+    Must be called after any pass that changes per-object counts (e.g.
+    preserve_timed_out_sections restoring a timed-out object's sections), so the
+    summary never disagrees with the objects it aggregates.
+    """
+    projects = inventory.get("projects", {})
+    objects = [obj for project in projects.values() for obj in project.get("objects", {}).values()]
+    inventory["summary"] = {
+        "object_count": sum(project.get("object_count", 0) for project in projects.values()),
+        "section_count": sum(obj.get("section_count", 0) for obj in objects),
+        "program_count": sum(obj.get("program_count", 0) for obj in objects),
     }
 
 
@@ -227,6 +233,9 @@ def main() -> int:
             existing = json.loads(output_path.read_text(encoding="utf-8"))
             merge_existing_overrides(inventory, existing)
             preserve_timed_out_sections(inventory, existing)
+            # preserve_timed_out_sections may restore per-object counts, so bring the
+            # aggregate summary back in sync with them.
+            recompute_summary(inventory)
 
     rendered = json.dumps(inventory, indent=2, sort_keys=True)
 

--- a/scripts/generate_verify_project_tests.py
+++ b/scripts/generate_verify_project_tests.py
@@ -226,12 +226,49 @@ def generate(inventory: dict, project: str) -> str:
         for section_name in sorted(obj["sections"].keys()):
             programs = obj["sections"][section_name]
             if len(programs) == 1:
+                # Single-program sections are keyed at section scope; warn if an override
+                # was left at program scope, where it will not be consulted.
+                stray = program_override(obj, section_name, programs[0]["function"])
+                if stray is not None:
+                    print(
+                        f"warning: {project}/{object_name} {section_name}: program-scope override for "
+                        f"'{programs[0]['function']}' is ignored for a single-program section "
+                        "(overrides are read at section scope); it degrades to a pass test.",
+                        file=sys.stderr,
+                    )
                 status, kind, reason = classify_section(obj, section_name, programs)
                 append_entry(
                     status,
                     kind,
                     reason,
                     render_test(project, object_name, section_name, status, kind, reason),
+                    object_name,
+                    section_name,
+                )
+                continue
+
+            # Multi-program sections are keyed at program scope; warn if an override was
+            # left at section scope, where it will not be consulted.
+            stray_section = section_override(obj, section_name)
+            if stray_section is not None:
+                print(
+                    f"warning: {project}/{object_name} {section_name}: section-scope override is ignored "
+                    "for a multi-program section (overrides are read at program scope); "
+                    "it degrades to pass tests.",
+                    file=sys.stderr,
+                )
+
+            # A section that fails to load rejects every program in it, so a program-scope
+            # reject_load override is rendered as a single section-level load-rejection test.
+            if any(
+                (program_override(obj, section_name, program["function"]) or {}).get("status") == "reject_load"
+                for program in programs
+            ):
+                append_entry(
+                    "reject_load",
+                    None,
+                    None,
+                    render_test(project, object_name, section_name, "reject_load", None, None),
                     object_name,
                     section_name,
                 )
@@ -310,7 +347,8 @@ def main() -> int:
         for project in sorted(inventory.get("projects", {}).keys()):
             rendered = generate(inventory, project)
             output_path = output_dir / project_to_filename(project)
-            output_path.write_text(rendered + "\n", encoding="utf-8")
+            with open(output_path, "w", encoding="utf-8", newline="\n") as handle:
+                handle.write(rendered + "\n")
             print(f"Wrote {output_path}", file=sys.stderr)
         return 0
 
@@ -320,7 +358,8 @@ def main() -> int:
 
     output_path = Path(args.output)
     rendered = generate(inventory, args.project)
-    output_path.write_text(rendered + "\n", encoding="utf-8")
+    with open(output_path, "w", encoding="utf-8", newline="\n") as handle:
+        handle.write(rendered + "\n")
     return 0
 
 

--- a/scripts/update_verify_expectations.py
+++ b/scripts/update_verify_expectations.py
@@ -286,21 +286,16 @@ def refresh_expectations(
                         reason_to_store = reason
                     section_overrides[section] = {"status": status, "kind": kind, "reason": reason_to_store}
             else:
-                if status == "reject_load":
-                    section_overrides[section] = {"status": "reject_load"}
-                    program_overrides.pop(section, None)
-                    if not section_overrides:
-                        test_overrides.pop("sections", None)
-                    if not program_overrides:
-                        test_overrides.pop("programs", None)
-                    if not test_overrides:
-                        odata.pop("test_overrides", None)
-                    continue
-
+                # Multi-program sections are read by generate_verify_project_tests.py at
+                # program scope only, so every override (including reject_load) must be
+                # recorded per-program keyed by function name. Keying by function makes the
+                # result independent of the order in which sibling programs are classified.
                 section_overrides.pop(section, None)
                 section_program_overrides = program_overrides.setdefault(section, {})
                 current = section_program_overrides.get(function_name)
-                if status == "pass":
+                if status == "reject_load":
+                    section_program_overrides[function_name] = {"status": "reject_load"}
+                elif status == "pass":
                     section_program_overrides.pop(function_name, None)
                     if not section_program_overrides:
                         program_overrides.pop(section, None)
@@ -349,7 +344,8 @@ def main() -> int:
 
     inventory = json.loads(inventory_path.read_text(encoding="utf-8"))
     unknown_diagnostics = refresh_expectations(inventory, samples_root, check_bin, args.jobs, args.timeout_seconds)
-    inventory_path.write_text(json.dumps(inventory, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    with open(inventory_path, "w", encoding="utf-8", newline="\n") as handle:
+        handle.write(json.dumps(inventory, indent=2, sort_keys=True) + "\n")
     print(f"Wrote {inventory_path}", file=sys.stderr)
     if unknown_diagnostics:
         print(


### PR DESCRIPTION
Fixes #1171.

Grouped test-generation / inventory script correctness gaps:
1. `update_verify_expectations.py` — record a multi-program section's `reject_load` at the scope `generate_verify_project_tests.py` actually reads (program-level), order-independently.
2. `generate_verify_project_tests.py` — warn (stderr) when an override sits in the scope not consulted for a section, instead of silently degrading to a pass test.
3. `generate_elf_inventory.py` — wrap `subprocess.run` timeout so one slow ELF doesn't abort the whole inventory.
4. `generate_elf_inventory.py` — merge existing curated `test_overrides` instead of clobbering them.
5. `check_conformance_list.py` — strip comments before scanning so a commented-out `TEST_CONFORMANCE` no longer counts as listed.
6. Force LF newlines on generated `.cpp`/`.json` writes across the four scripts.

## Verification
All scripts `py_compile` clean; regenerating projects from the real inventory produces byte-identical, LF-only output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CsnGgfCt3qNBW1Wk8BPPjQ
