### PR TITLE
Fix developer script bugs (exit codes, format-code.ps1, bash 3.2, worktrees)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,9 @@ include(CMakePackageConfigHelpers)
 
 include(FetchContent)
 
-if (IS_DIRECTORY "${PROJECT_SOURCE_DIR}/.git" AND NOT CMAKE_CROSSCOMPILING)
+# Accept both a `.git` directory (normal clone) and a `.git` file (linked
+# worktrees, submodules) so tests and hooks are enabled in worktrees too.
+if (EXISTS "${PROJECT_SOURCE_DIR}/.git" AND NOT CMAKE_CROSSCOMPILING)
   file(COPY "${prevail_source_dir}/scripts/pre-commit" "${prevail_source_dir}/scripts/commit-msg" DESTINATION "${PROJECT_SOURCE_DIR}/.git/hooks")
   option(prevail_ENABLE_TESTS "Build tests" ON)
 else ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,10 +22,15 @@ include(CMakePackageConfigHelpers)
 include(FetchContent)
 
 # Accept both a `.git` directory (normal clone) and a `.git` file (linked
-# worktrees, submodules) so tests and hooks are enabled in worktrees too.
+# worktrees, submodules) so tests are enabled in worktrees too.
 if (EXISTS "${PROJECT_SOURCE_DIR}/.git" AND NOT CMAKE_CROSSCOMPILING)
-  file(COPY "${prevail_source_dir}/scripts/pre-commit" "${prevail_source_dir}/scripts/commit-msg" DESTINATION "${PROJECT_SOURCE_DIR}/.git/hooks")
   option(prevail_ENABLE_TESTS "Build tests" ON)
+  # Only a normal clone has a `.git` directory to install hooks into. In a linked
+  # worktree (or submodule) `.git` is a file, so copying to `.git/hooks` would fail
+  # configure with "Not a directory"; worktrees inherit the hooks from the main clone.
+  if (IS_DIRECTORY "${PROJECT_SOURCE_DIR}/.git")
+    file(COPY "${prevail_source_dir}/scripts/pre-commit" "${prevail_source_dir}/scripts/commit-msg" DESTINATION "${PROJECT_SOURCE_DIR}/.git/hooks")
+  endif ()
 else ()
   option(prevail_ENABLE_TESTS "Build tests" OFF)
 endif ()

--- a/scripts/check-license.sh
+++ b/scripts/check-license.sh
@@ -37,12 +37,22 @@ should_ignore() {
     false
 }
 
+# Portable replacement for 'realpath', which is not available on stock
+# macOS. Resolves an existing file or directory to an absolute path.
+resolve_path() {
+    if [[ -d $1 ]]; then
+        (cd "$1" && pwd -P)
+    else
+        (cd "$(dirname "$1")" 2>/dev/null && printf '%s/%s\n' "$(pwd -P)" "$(basename "$1")")
+    fi
+}
+
 # Create array of files to check, either from the given arguments or
 # all files in Git, ignore any that match a regex in the ignore file.
 files=()
 if [[ $# -ne 0 ]]; then
     for f in "$@"; do
-        file=$(realpath "$f")
+        file=$(resolve_path "$f")
 
         if [[ ! -f $file ]]; then # skip non-existent files
             continue
@@ -83,4 +93,6 @@ for file in "${files[@]}"; do
     done
 done
 
-exit $failures
+# Clamp to a single-bit exit status: 'exit' truncates its argument modulo
+# 256, so a raw count that is a multiple of 256 would wrongly report success.
+exit $(( failures ? 1 : 0 ))

--- a/scripts/format-code
+++ b/scripts/format-code
@@ -57,8 +57,8 @@ do
         # unavailable on stock macOS bash 3.2.
         userFiles=()
         while IFS= read -r line; do
-            userFiles+=("$line")
-        done <<< "$(git diff --cached --name-only --diff-filter=ACMR)"
+            [ -n "$line" ] && userFiles+=("$line")
+        done < <(git diff --cached --name-only --diff-filter=ACMR)
         ;;
 
     --exclude-dirs=*)

--- a/scripts/format-code
+++ b/scripts/format-code
@@ -53,8 +53,12 @@ do
         ;;
 
     -s | --staged)
-        # Split into array
-        mapfile -t userFiles <<< "$(git diff --cached --name-only --diff-filter=ACMR)"
+        # Split into array. Use a read loop rather than 'mapfile', which is
+        # unavailable on stock macOS bash 3.2.
+        userFiles=()
+        while IFS= read -r line; do
+            userFiles+=("$line")
+        done <<< "$(git diff --cached --name-only --diff-filter=ACMR)"
         ;;
 
     --exclude-dirs=*)
@@ -249,7 +253,12 @@ fi
 get_file_list()
 {
     if [[ -z "${userFiles[*]}" ]]; then
-        mapfile -t file_list < <(eval "$findargs")
+        # Use a read loop rather than 'mapfile', which is unavailable on
+        # stock macOS bash 3.2.
+        file_list=()
+        while IFS= read -r line; do
+            file_list+=("$line")
+        done < <(eval "$findargs")
         if [[ ${#file_list[@]} -eq 0 ]]; then
             echo "No files were found to format!"
             exit 1
@@ -301,4 +310,6 @@ done
 log_whatif "${filecount} files processed, ${changecount} changed."
 
 # If files are being edited, this count is zero so we exit with success.
-exit "$changecount"
+# Clamp to a single-bit exit status: 'exit' truncates its argument modulo
+# 256, so a raw count that is a multiple of 256 would wrongly report success.
+exit $(( changecount ? 1 : 0 ))

--- a/scripts/format-code.ps1
+++ b/scripts/format-code.ps1
@@ -265,6 +265,12 @@ function check_clang-format()
     $req_ver = $required_cfver -split '\.'
     $cf_ver  = $cfver -split '\.'
 
+    # Record the command before the version comparison: the '-gt' branch below
+    # (reachable once the version split is correct) returns early, and leaving
+    # $global:cf unset there would make the mainline build an empty clang-format
+    # command and silently format nothing.
+    $global:cf="clang-format"
+
     for ($i = 0; $i -lt 3; $i++)
     {
         if ( $cf_ver[$i] -gt $req_ver[$i])
@@ -279,7 +285,6 @@ function check_clang-format()
         }
         # Equal just keeps going
     }
-    $global:cf="clang-format"
     return $true
 }
 

--- a/scripts/format-code.ps1
+++ b/scripts/format-code.ps1
@@ -304,6 +304,7 @@ $findargs = get_find_args;
 $filelist = get_file_list;
 $filecount=0
 $changecount=0
+$failcount=0
 
 $cfargs="$global:cf -style=file"
 if ( !$whatif ) {
@@ -334,11 +335,19 @@ foreach ( $file in $filelist ) {
         }
         if ( -not $? ) {
             Write-Host "clang-format failed on file: $file."
+            $failcount++
         }
     }
 }
 
 log_whatif "$filecount files processed, $changecount changed."
+
+# A clang-format failure must fail the run even when no file was reported as
+# changed, so callers like the pre-commit hook block the commit.
+if ( $failcount -gt 0 ) {
+    Write-Host "$failcount file(s) failed to format."
+    exit 1
+}
 
 # If files are being edited, this count is zero so we exit with success.
 exit $changecount

--- a/scripts/format-code.ps1
+++ b/scripts/format-code.ps1
@@ -260,8 +260,10 @@ function check_clang-format()
         return $false
     }
 
-    $req_ver = $required_cfver -split '.'
-    $cf_ver  = $cfver -split '.'
+    # '-split' treats its argument as a regex, so the version separator must
+    # be escaped; a bare '.' matches every character and yields empty fields.
+    $req_ver = $required_cfver -split '\.'
+    $cf_ver  = $cfver -split '\.'
 
     for ($i = 0; $i -lt 3; $i++)
     {
@@ -310,7 +312,12 @@ foreach ( $file in $filelist ) {
 
     if ( $whatif ) {
         log_whatif "Formatting $file ..."
-        ( Invoke-Expression ($cf) ) | Compare-Object (get-content $file)
+        # A file differs when Compare-Object emits output; the pipeline
+        # succeeding ($?) does not by itself mean the file changed.
+        $diff = ( Invoke-Expression ($cf) ) | Compare-Object (get-content $file)
+        if ( $diff ) {
+            $changecount++
+        }
     }
     else {
         if ( $verbose ) {
@@ -320,14 +327,9 @@ foreach ( $file in $filelist ) {
         else {
             Invoke-Expression $cf > $null
         }
-    }
-    if ( $? ) {
-        if ( $whatif ) {
-            $changecount++
+        if ( -not $? ) {
+            Write-Host "clang-format failed on file: $file."
         }
-    }
-    else {
-        Write-Host "clang-format failed on file: $file."
     }
 }
 

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -25,7 +25,12 @@ if ! git diff-index --check --cached HEAD --; then
     exit_ "Commit failed: please fix the conflict markers or whitespace errors"
 fi
 
-mapfile -t files < <(git diff --cached --name-only --diff-filter=ACMR)
+# Use a read loop rather than 'mapfile', which is unavailable on stock
+# macOS bash 3.2.
+files=()
+while IFS= read -r file; do
+    files+=("$file")
+done < <(git diff --cached --name-only --diff-filter=ACMR)
 
 if [[ ${#files[@]} -eq 0 ]]; then
     # When 'git commit --amend' is used, the files list is empty. The


### PR DESCRIPTION
Fixes #1172.

Grouped developer-script defects:
1. **Exit code truncated mod 256** — `check-license.sh` and `format-code` now clamp a nonzero count to a nonzero exit.
2. **`format-code.ps1` version check always passed** — `-split '.'` → `-split '\.'`.
3. **`format-code.ps1 --whatif` exit code inverted** — count a file as changed only when `Compare-Object` reports a difference.
4. **macOS bash 3.2 portability** — replace `mapfile` with `while IFS= read -r` loops and `realpath` with a portable helper.
5. **`prevail_ENABLE_TESTS` off in git worktrees** — `IS_DIRECTORY ".git"` → `EXISTS`, matching the other `.git` check.

## Verification
`bash -n` clean on the shell scripts; LF line endings preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CsnGgfCt3qNBW1Wk8BPPjQ
