### PR TITLE
Fix packaging and CI configuration gaps

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,11 @@ concurrency:
   group: build-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
+env:
+  # Keep in sync with BOOST_VERSION in cmake/SetupBoostHeaders.cmake so a version
+  # bump invalidates the Windows NuGet Boost cache.
+  BOOST_VERSION: "1.87.0"
+
 jobs:
   build_ubuntu:
     strategy:
@@ -77,7 +82,7 @@ jobs:
         uses: actions/cache@v6
         with:
           path: ${{ github.workspace }}\build\packages
-          key: boost-${{ runner.os }}
+          key: boost-${{ runner.os }}-${{ env.BOOST_VERSION }}
 
       - name: Configure CMake
         shell: pwsh

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -50,7 +50,7 @@ jobs:
           lcov --ignore-errors all --capture --directory build --include "*/${REPO_NAME}/src/*" --exclude "*/${REPO_NAME}/src/test/*" --output-file coverage/lcov.info
 
       - name: Coveralls Parallel
-        uses: coverallsapp/github-action@master
+        uses: coverallsapp/github-action@v2
         with:
           github-token: ${{ secrets.github_token }}
           flag-name: run-${{ matrix.configurations }}
@@ -61,7 +61,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Coveralls Finished
-        uses: coverallsapp/github-action@master
+        uses: coverallsapp/github-action@v2
         with:
           github-token: ${{ secrets.github_token }}
           parallel-finished: true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,6 +9,11 @@ name: Release
 permissions:
   contents: write
 
+env:
+  # Keep in sync with BOOST_VERSION in cmake/SetupBoostHeaders.cmake so a version
+  # bump invalidates the Windows NuGet Boost cache.
+  BOOST_VERSION: "1.87.0"
+
 jobs:
   build-and-package:
     name: Build on ${{ matrix.os }}
@@ -39,7 +44,7 @@ jobs:
         uses: actions/cache@v6
         with:
           path: ${{ github.workspace }}\build\packages
-          key: boost-${{ runner.os }}
+          key: boost-${{ runner.os }}-${{ env.BOOST_VERSION }}
 
       # 2. Configure CMake
       - name: Configure CMake (Linux/macOS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,11 +53,15 @@ if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" OR
   set(DEBUG_FLAGS -O0 -g3 -fno-omit-frame-pointer)
 
   set(SANITIZE_FLAGS -fsanitize=address -O1 -fno-omit-frame-pointer)
+  set(SANITIZE_LINK_FLAGS -fsanitize=address)
 endif ()
 
 if (MSVC)
   # Silence Windows version warnings
   add_compile_definitions(_WIN32_WINNT=0x0A00)
+  # AddressSanitizer flags (MSVC injects the ASan runtime automatically at link time).
+  set(SANITIZE_FLAGS /fsanitize=address)
+  set(SANITIZE_LINK_FLAGS "")
   # Add FuzzerDebug configuration (MSVC Address/Fuzzer sanitizer build)
   list(APPEND CMAKE_CONFIGURATION_TYPES FuzzerDebug)
   list(REMOVE_DUPLICATES CMAKE_CONFIGURATION_TYPES)
@@ -180,8 +184,22 @@ target_compile_options(prevail PRIVATE
   "$<$<CONFIG:Debug>:${DEBUG_FLAGS}>"
   "$<$<CONFIG:Release>:${RELEASE_FLAGS}>"
   "$<$<CONFIG:RelWithDebInfo>:${RELWITHDEBINFO_FLAGS}>"
-  "$<$<BOOL:${ENABLE_ASAN}>:${SANITIZE_FLAGS}>"
 )
+
+# Export the C++ standard as a usage requirement so consumers of the installed
+# package are compiled with the right -std.
+target_compile_features(prevail PUBLIC cxx_std_20)
+
+if (ENABLE_ASAN)
+  # Apply AddressSanitizer as a usage requirement (PUBLIC) so the CLI, tests, and
+  # any consumer linking `prevail` are both instrumented and linked consistently.
+  message(STATUS "AddressSanitizer enabled (ENABLE_ASAN=ON)")
+  target_compile_options(prevail PUBLIC ${SANITIZE_FLAGS})
+  if (NOT MSVC)
+    # GCC/Clang need -fsanitize=address at link time too; MSVC injects it automatically.
+    target_link_options(prevail PUBLIC ${SANITIZE_LINK_FLAGS})
+  endif ()
+endif ()
 
 add_subdirectory("${prevail_source_dir}/external/libbtf" "${CMAKE_CURRENT_BINARY_DIR}/libbtf")
 target_include_directories(libbtf INTERFACE

--- a/cmake/prevailConfig.cmake.in
+++ b/cmake/prevailConfig.cmake.in
@@ -4,11 +4,7 @@
 @PACKAGE_INIT@
 
 include(CMakeFindDependencyMacro)
-# Boost is a headers-only dependency. On the normal path it is a find_package-able
-# package, but the MSVC/NuGet build provisions Boost as raw headers with no
-# BoostConfig.cmake. Use a non-required find_package so consumption does not
-# hard-fail when the Boost CMake package is absent.
-find_package(Boost QUIET)
+find_dependency(Boost REQUIRED)
 find_dependency(Microsoft.GSL REQUIRED)
 
 include("${CMAKE_CURRENT_LIST_DIR}/prevailTargets.cmake")

--- a/cmake/prevailConfig.cmake.in
+++ b/cmake/prevailConfig.cmake.in
@@ -4,7 +4,11 @@
 @PACKAGE_INIT@
 
 include(CMakeFindDependencyMacro)
-find_dependency(Boost REQUIRED)
+# Boost is a headers-only dependency. On the normal path it is a find_package-able
+# package, but the MSVC/NuGet build provisions Boost as raw headers with no
+# BoostConfig.cmake. Use a non-required find_package so consumption does not
+# hard-fail when the Boost CMake package is absent.
+find_package(Boost QUIET)
 find_dependency(Microsoft.GSL REQUIRED)
 
 include("${CMAKE_CURRENT_LIST_DIR}/prevailTargets.cmake")


### PR DESCRIPTION
Addresses most of #1173.

## Included
1. **`ENABLE_ASAN`** — apply ASan as a PUBLIC usage requirement with matching link options (and MSVC handling) so the CLI/tests are actually instrumented and link (default OFF).
2. **Windows/NuGet Boost consume** — `prevailConfig.cmake.in` resolves Boost with a non-required `find_package` so consumption does not hard-fail on the headers-only path.
3. **`target_compile_features(prevail PUBLIC cxx_std_20)`** so consumers get the right `-std`.
4. **Pin `coverallsapp/github-action`** to `@v2`.
5. **Include the Boost version in the Windows NuGet cache key** (`build.yml`, `release.yaml`) via a `BOOST_VERSION` env var.

## Deferred (sub-issue 4: enable the install/consume CI workflow)
Enabling `test-installation.yml` surfaced **pre-existing, multi-OS install-path breakage** that is out of scope to fix reliably in this bundled PR, so the file is left as `.example`:
- The workflow provisions **no build dependencies** → `SetupBoostHeaders.cmake` fails "Boost headers not found" on ubuntu/macOS.
- On **Windows** the build + install succeed but the consumer's `find_package(prevail)` cannot locate the installed config (`Could not find a package configuration file provided by "prevail"`) — a real packaging-layout bug.

These deserve a dedicated follow-up (add per-OS Boost provisioning + fix the Windows install layout, iterated against CI) rather than being bundled with these five orthogonal fixes.

## Verification
Edited workflow YAML is yamllint-clean (matches the repo conventions in `build.yml`); CMake edits reviewed by hand; the ASan block is gated behind `ENABLE_ASAN` (default OFF) so the normal build/install path is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CsnGgfCt3qNBW1Wk8BPPjQ