### PR TITLE
Replace Boost.Multiprecision with a portable int128 (#1189 phase 1)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -301,6 +301,7 @@ if (prevail_ENABLE_TESTS)
     src/test/test_conformance.cpp
     src/test/test_elf_loader.cpp
     src/test/test_failure_slice.cpp
+    src/test/test_int128.cpp
     src/test/test_interval_bitwise.cpp
     src/test/test_join.cpp
     src/test/test_marshal.cpp

--- a/src/arith/num_big.hpp
+++ b/src/arith/num_big.hpp
@@ -9,10 +9,15 @@
 #include <sstream>
 #include <string>
 
-#ifdef __GNUC__
-// GCC/Clang: use compiler-native 128-bit integers.
+// Use the compiler's native 128-bit integer when available (GCC/Clang). Compilers without
+// one (MSVC) use the Boost-free fallback in num_int128.hpp, so the installed library does not
+// pull Boost.Multiprecision into consumer builds. PREVAIL_FORCE_CUSTOM_INT128 forces the
+// fallback everywhere for testing (see test_int128.cpp and the full-suite run).
+#if defined(__GNUC__) && !defined(PREVAIL_FORCE_CUSTOM_INT128)
+#define PREVAIL_HAS_NATIVE_INT128 1
 #else
-#include <boost/multiprecision/cpp_int.hpp>
+#define PREVAIL_HAS_NATIVE_INT128 0
+#include "arith/num_int128.hpp"
 #endif
 
 #include "crab_utils/debug.hpp"
@@ -26,12 +31,12 @@ namespace prevail {
 // int64 values) without overflow, not as general 128-bit integer support.
 
 // --- Int128 type aliases ---
-#ifdef __GNUC__
+#if PREVAIL_HAS_NATIVE_INT128
 using Int128 = __int128;
 using UInt128 = unsigned __int128;
 #else
-using Int128 = boost::multiprecision::int128_t;
-using UInt128 = boost::multiprecision::uint128_t;
+using Int128 = detail::Int128Custom;
+using UInt128 = detail::UInt128Custom;
 #endif
 
 // Manual min/max since std::numeric_limits<__int128> is unspecialized.
@@ -42,7 +47,7 @@ inline constexpr Int128 kInt128Min = -kInt128Max - 1;
 // --- Checked arithmetic helpers ---
 
 inline Int128 checked_add(const Int128 a, const Int128 b) {
-#ifdef __GNUC__
+#if PREVAIL_HAS_NATIVE_INT128
     Int128 result;
     if (__builtin_add_overflow(a, b, &result)) {
         CRAB_ERROR("Number overflow during addition");
@@ -57,7 +62,7 @@ inline Int128 checked_add(const Int128 a, const Int128 b) {
 }
 
 inline Int128 checked_sub(const Int128 a, const Int128 b) {
-#ifdef __GNUC__
+#if PREVAIL_HAS_NATIVE_INT128
     Int128 result;
     if (__builtin_sub_overflow(a, b, &result)) {
         CRAB_ERROR("Number overflow during subtraction");
@@ -72,7 +77,7 @@ inline Int128 checked_sub(const Int128 a, const Int128 b) {
 }
 
 inline Int128 checked_mul(const Int128 a, const Int128 b) {
-#ifdef __GNUC__
+#if PREVAIL_HAS_NATIVE_INT128
     Int128 result;
     if (__builtin_mul_overflow(a, b, &result)) {
         CRAB_ERROR("Number overflow during multiplication");

--- a/src/arith/num_int128.hpp
+++ b/src/arith/num_int128.hpp
@@ -12,6 +12,8 @@
 // is checked against native __int128 in test_int128.cpp and by running the whole test suite
 // with -DPREVAIL_FORCE_CUSTOM_INT128 on a platform that has __int128.
 
+#include <compare>
+#include <concepts>
 #include <cstdint>
 #include <type_traits>
 

--- a/src/arith/num_int128.hpp
+++ b/src/arith/num_int128.hpp
@@ -1,0 +1,242 @@
+// Copyright (c) Prevail Verifier contributors.
+// SPDX-License-Identifier: MIT
+#pragma once
+
+// Portable 128-bit integers used only as an intermediate representation for widening
+// arithmetic over <=64-bit eBPF values (see num_big.hpp). GCC/Clang use native __int128;
+// this header provides a Boost-free fallback for compilers without a 128-bit builtin
+// (MSVC), so consumers of the installed library do not need Boost.Multiprecision.
+//
+// Semantics match two's-complement __int128 exactly: wrap-around add/sub/mul, truncation-
+// toward-zero div/mod, arithmetic right shift, and signed/unsigned comparisons. Correctness
+// is checked against native __int128 in test_int128.cpp and by running the whole test suite
+// with -DPREVAIL_FORCE_CUSTOM_INT128 on a platform that has __int128.
+
+#include <cstdint>
+#include <type_traits>
+
+namespace prevail::detail {
+
+struct Int128Custom;
+
+// Unsigned 128-bit integer as two 64-bit limbs (little-endian: lo is the low 64 bits).
+struct UInt128Custom {
+    uint64_t lo{};
+    uint64_t hi{};
+
+    constexpr UInt128Custom() = default;
+    constexpr UInt128Custom(const uint64_t high, const uint64_t low) : lo{low}, hi{high} {}
+
+    // From any integral: unsigned zero-extends, signed sign-extends (two's complement).
+    template <std::integral T>
+    constexpr UInt128Custom(const T v)
+        : lo{static_cast<uint64_t>(v)},
+          hi{(std::is_signed_v<T> && v < 0) ? ~static_cast<uint64_t>(0) : static_cast<uint64_t>(0)} {}
+
+    constexpr UInt128Custom(const Int128Custom& v);
+
+    // Explicit narrowing to a builtin integral: take the low bits (matches static_cast from __int128).
+    template <std::integral T>
+    explicit constexpr operator T() const {
+        return static_cast<T>(lo);
+    }
+    explicit constexpr operator bool() const { return (lo | hi) != 0; }
+
+    // -- comparisons --
+    constexpr bool operator==(const UInt128Custom& o) const { return lo == o.lo && hi == o.hi; }
+    constexpr auto operator<=>(const UInt128Custom& o) const {
+        if (hi != o.hi) {
+            return hi <=> o.hi;
+        }
+        return lo <=> o.lo;
+    }
+
+    // -- bitwise --
+    constexpr UInt128Custom operator~() const { return {~hi, ~lo}; }
+    constexpr UInt128Custom operator&(const UInt128Custom& o) const { return {hi & o.hi, lo & o.lo}; }
+    constexpr UInt128Custom operator|(const UInt128Custom& o) const { return {hi | o.hi, lo | o.lo}; }
+    constexpr UInt128Custom operator^(const UInt128Custom& o) const { return {hi ^ o.hi, lo ^ o.lo}; }
+
+    constexpr UInt128Custom operator<<(const int s) const {
+        if (s <= 0) {
+            return *this;
+        }
+        if (s >= 128) {
+            return {};
+        }
+        if (s >= 64) {
+            return {lo << (s - 64), 0};
+        }
+        return {(hi << s) | (lo >> (64 - s)), lo << s};
+    }
+    constexpr UInt128Custom operator>>(const int s) const {
+        if (s <= 0) {
+            return *this;
+        }
+        if (s >= 128) {
+            return {};
+        }
+        if (s >= 64) {
+            return {0, hi >> (s - 64)};
+        }
+        return {hi >> s, (lo >> s) | (hi << (64 - s))};
+    }
+
+    // -- arithmetic (wrap-around, two's complement) --
+    constexpr UInt128Custom operator-() const {
+        // ~x + 1
+        const uint64_t nlo = ~lo + 1;
+        const uint64_t carry = nlo == 0 ? 1 : 0;
+        return {~hi + carry, nlo};
+    }
+    constexpr UInt128Custom operator+(const UInt128Custom& o) const {
+        const uint64_t nlo = lo + o.lo;
+        const uint64_t carry = nlo < lo ? 1 : 0;
+        return {hi + o.hi + carry, nlo};
+    }
+    constexpr UInt128Custom operator-(const UInt128Custom& o) const { return *this + (-o); }
+
+    constexpr UInt128Custom operator*(const UInt128Custom& o) const {
+        // 64x64 -> 128 for the low product, plus cross terms into hi.
+        const uint64_t a0 = lo & 0xffffffffULL, a1 = lo >> 32;
+        const uint64_t b0 = o.lo & 0xffffffffULL, b1 = o.lo >> 32;
+        const uint64_t p00 = a0 * b0;
+        const uint64_t p01 = a0 * b1;
+        const uint64_t p10 = a1 * b0;
+        const uint64_t p11 = a1 * b1;
+        const uint64_t mid = (p00 >> 32) + (p01 & 0xffffffffULL) + (p10 & 0xffffffffULL);
+        const uint64_t reslo = (p00 & 0xffffffffULL) | (mid << 32);
+        const uint64_t reshi = p11 + (p01 >> 32) + (p10 >> 32) + (mid >> 32) + lo * o.hi + hi * o.lo;
+        return {reshi, reslo};
+    }
+
+    // Unsigned division and modulo via binary long division. Precondition: divisor != 0.
+    static constexpr void divmod(const UInt128Custom& n, const UInt128Custom& d, UInt128Custom& q, UInt128Custom& r) {
+        q = UInt128Custom{};
+        r = UInt128Custom{};
+        for (int i = 127; i >= 0; --i) {
+            r = r << 1;
+            const uint64_t bit = (i >= 64) ? ((n.hi >> (i - 64)) & 1) : ((n.lo >> i) & 1);
+            r.lo |= bit;
+            if (r >= d) {
+                r = r - d;
+                if (i >= 64) {
+                    q.hi |= (uint64_t{1} << (i - 64));
+                } else {
+                    q.lo |= (uint64_t{1} << i);
+                }
+            }
+        }
+    }
+    constexpr UInt128Custom operator/(const UInt128Custom& o) const {
+        UInt128Custom q, r;
+        divmod(*this, o, q, r);
+        return q;
+    }
+    constexpr UInt128Custom operator%(const UInt128Custom& o) const {
+        UInt128Custom q, r;
+        divmod(*this, o, q, r);
+        return r;
+    }
+
+    constexpr UInt128Custom& operator+=(const UInt128Custom& o) { return *this = *this + o; }
+    constexpr UInt128Custom& operator-=(const UInt128Custom& o) { return *this = *this - o; }
+    constexpr UInt128Custom& operator*=(const UInt128Custom& o) { return *this = *this * o; }
+    constexpr UInt128Custom& operator/=(const UInt128Custom& o) { return *this = *this / o; }
+    constexpr UInt128Custom& operator%=(const UInt128Custom& o) { return *this = *this % o; }
+    constexpr UInt128Custom& operator&=(const UInt128Custom& o) { return *this = *this & o; }
+    constexpr UInt128Custom& operator|=(const UInt128Custom& o) { return *this = *this | o; }
+    constexpr UInt128Custom& operator^=(const UInt128Custom& o) { return *this = *this ^ o; }
+    constexpr UInt128Custom& operator>>=(const int s) { return *this = *this >> s; }
+    constexpr UInt128Custom& operator<<=(const int s) { return *this = *this << s; }
+};
+
+// Signed 128-bit integer, stored as its two's-complement bit pattern in a UInt128Custom.
+struct Int128Custom {
+    UInt128Custom u{};
+
+    constexpr Int128Custom() = default;
+    constexpr Int128Custom(const UInt128Custom v) : u{v} {}
+
+    template <std::integral T>
+    constexpr Int128Custom(const T v) : u{v} {}
+
+    template <std::integral T>
+    explicit constexpr operator T() const {
+        return static_cast<T>(u.lo);
+    }
+    explicit constexpr operator bool() const { return static_cast<bool>(u); }
+
+    [[nodiscard]]
+    constexpr bool negative() const {
+        return (u.hi >> 63) != 0;
+    }
+
+    // -- comparisons (signed) --
+    constexpr bool operator==(const Int128Custom& o) const { return u == o.u; }
+    constexpr auto operator<=>(const Int128Custom& o) const {
+        const auto lhi = static_cast<int64_t>(u.hi);
+        const auto rhi = static_cast<int64_t>(o.u.hi);
+        if (lhi != rhi) {
+            return lhi <=> rhi;
+        }
+        return u.lo <=> o.u.lo;
+    }
+
+    // -- bitwise --
+    constexpr Int128Custom operator~() const { return {~u}; }
+    constexpr Int128Custom operator&(const Int128Custom& o) const { return {u & o.u}; }
+    constexpr Int128Custom operator|(const Int128Custom& o) const { return {u | o.u}; }
+    constexpr Int128Custom operator^(const Int128Custom& o) const { return {u ^ o.u}; }
+    constexpr Int128Custom operator<<(const int s) const { return {u << s}; }
+    constexpr Int128Custom operator>>(const int s) const {
+        // Arithmetic (sign-extending) right shift.
+        if (s <= 0) {
+            return *this;
+        }
+        const UInt128Custom logical = u >> s;
+        if (!negative()) {
+            return {logical};
+        }
+        // Fill the vacated high bits with ones.
+        const UInt128Custom ones = ~UInt128Custom{};
+        const UInt128Custom mask = s >= 128 ? ones : (ones << (128 - s));
+        return {logical | mask};
+    }
+
+    // -- arithmetic (wrap-around; div/mod truncate toward zero, like __int128) --
+    constexpr Int128Custom operator-() const { return {-u}; }
+    constexpr Int128Custom operator+(const Int128Custom& o) const { return {u + o.u}; }
+    constexpr Int128Custom operator-(const Int128Custom& o) const { return {u - o.u}; }
+    constexpr Int128Custom operator*(const Int128Custom& o) const { return {u * o.u}; }
+
+    constexpr Int128Custom operator/(const Int128Custom& o) const {
+        const bool neg = negative() != o.negative();
+        const UInt128Custom a = negative() ? (-u) : u;
+        const UInt128Custom b = o.negative() ? (-o.u) : o.u;
+        const UInt128Custom q = a / b;
+        return {neg ? -q : q};
+    }
+    constexpr Int128Custom operator%(const Int128Custom& o) const {
+        // Result takes the sign of the dividend (truncation toward zero).
+        const UInt128Custom a = negative() ? (-u) : u;
+        const UInt128Custom b = o.negative() ? (-o.u) : o.u;
+        const UInt128Custom r = a % b;
+        return {negative() ? -r : r};
+    }
+
+    constexpr Int128Custom& operator+=(const Int128Custom& o) { return *this = *this + o; }
+    constexpr Int128Custom& operator-=(const Int128Custom& o) { return *this = *this - o; }
+    constexpr Int128Custom& operator*=(const Int128Custom& o) { return *this = *this * o; }
+    constexpr Int128Custom& operator/=(const Int128Custom& o) { return *this = *this / o; }
+    constexpr Int128Custom& operator%=(const Int128Custom& o) { return *this = *this % o; }
+    constexpr Int128Custom& operator&=(const Int128Custom& o) { return *this = *this & o; }
+    constexpr Int128Custom& operator|=(const Int128Custom& o) { return *this = *this | o; }
+    constexpr Int128Custom& operator^=(const Int128Custom& o) { return *this = *this ^ o; }
+    constexpr Int128Custom& operator<<=(const int s) { return *this = *this << s; }
+    constexpr Int128Custom& operator>>=(const int s) { return *this = *this >> s; }
+};
+
+constexpr UInt128Custom::UInt128Custom(const Int128Custom& v) : lo{v.u.lo}, hi{v.u.hi} {}
+
+} // namespace prevail::detail

--- a/src/test/test_int128.cpp
+++ b/src/test/test_int128.cpp
@@ -1,0 +1,114 @@
+// Copyright (c) Prevail Verifier contributors.
+// SPDX-License-Identifier: MIT
+
+// Validates the Boost-free 128-bit integers in arith/num_int128.hpp against the compiler's
+// native __int128 as an oracle. Only meaningful where __int128 exists (GCC/Clang), which is
+// where the test suite runs; the custom types are what MSVC uses in production.
+
+#include <catch2/catch_all.hpp>
+
+#include <cstdint>
+#include <limits>
+#include <vector>
+
+#include "arith/num_int128.hpp"
+
+#ifdef __GNUC__
+
+using prevail::detail::Int128Custom;
+using prevail::detail::UInt128Custom;
+
+namespace {
+using i128 = __int128;
+using u128 = unsigned __int128;
+
+constexpr UInt128Custom to_cu(const u128 x) {
+    return UInt128Custom{static_cast<uint64_t>(x >> 64), static_cast<uint64_t>(x)};
+}
+constexpr Int128Custom to_ci(const i128 x) { return Int128Custom{to_cu(static_cast<u128>(x))}; }
+constexpr u128 from_cu(const UInt128Custom c) { return (static_cast<u128>(c.hi) << 64) | c.lo; }
+constexpr u128 from_ci(const Int128Custom c) { return from_cu(c.u); }
+
+// Interesting 128-bit bit patterns (used for both signed and unsigned interpretations).
+std::vector<u128> sample_values() {
+    std::vector<u128> v;
+    const std::vector<uint64_t> limbs = {
+        0, 1, 2, 3, 7, 0xff, 0x8000000000000000ULL, ~0ULL, 0x123456789abcdefULL, 0x7fffffffffffffffULL, 1000000007ULL};
+    for (const uint64_t hi : limbs) {
+        for (const uint64_t lo : limbs) {
+            v.push_back((static_cast<u128>(hi) << 64) | lo);
+        }
+    }
+    v.push_back(static_cast<u128>(-1));
+    v.push_back(static_cast<u128>(std::numeric_limits<int64_t>::min()));
+    v.push_back(~static_cast<u128>(0) >> 1);       // int128 max
+    v.push_back((~static_cast<u128>(0) >> 1) + 1); // int128 min
+    return v;
+}
+} // namespace
+
+TEST_CASE("custom uint128 matches native unsigned __int128", "[int128]") {
+    const auto vals = sample_values();
+    for (const u128 a : vals) {
+        const UInt128Custom ca = to_cu(a);
+        CHECK(from_cu(~ca) == static_cast<u128>(~a));
+        CHECK(from_cu(-ca) == static_cast<u128>(-a));
+        for (int s = 0; s < 128; ++s) {
+            CHECK(from_cu(ca << s) == static_cast<u128>(a << s));
+            CHECK(from_cu(ca >> s) == (a >> s));
+        }
+        for (const u128 b : vals) {
+            const UInt128Custom cb = to_cu(b);
+            CHECK(from_cu(ca + cb) == static_cast<u128>(a + b));
+            CHECK(from_cu(ca - cb) == static_cast<u128>(a - b));
+            CHECK(from_cu(ca * cb) == static_cast<u128>(a * b));
+            CHECK(from_cu(ca & cb) == (a & b));
+            CHECK(from_cu(ca | cb) == (a | b));
+            CHECK(from_cu(ca ^ cb) == (a ^ b));
+            CHECK((ca == cb) == (a == b));
+            CHECK((ca < cb) == (a < b));
+            CHECK((ca <= cb) == (a <= b));
+            CHECK((ca > cb) == (a > b));
+            if (b != 0) {
+                CHECK(from_cu(ca / cb) == (a / b));
+                CHECK(from_cu(ca % cb) == (a % b));
+            }
+        }
+    }
+}
+
+TEST_CASE("custom int128 matches native signed __int128", "[int128]") {
+    const auto vals = sample_values();
+    constexpr i128 int128_min = static_cast<i128>(static_cast<u128>(1) << 127);
+    for (const u128 ua : vals) {
+        const auto a = static_cast<i128>(ua);
+        const Int128Custom ca = to_ci(a);
+        CHECK(from_ci(-ca) == static_cast<u128>(-a));
+        CHECK(static_cast<int64_t>(ca) == static_cast<int64_t>(a));
+        CHECK(static_cast<uint64_t>(ca) == static_cast<uint64_t>(a));
+        CHECK(static_cast<int32_t>(ca) == static_cast<int32_t>(a));
+        for (int s = 0; s < 128; ++s) {
+            CHECK(from_ci(ca << s) == static_cast<u128>(a << s));
+            CHECK(from_ci(ca >> s) == static_cast<u128>(a >> s)); // arithmetic shift
+        }
+        for (const u128 ub : vals) {
+            const auto b = static_cast<i128>(ub);
+            const Int128Custom cb = to_ci(b);
+            CHECK(from_ci(ca + cb) == static_cast<u128>(a + b));
+            CHECK(from_ci(ca - cb) == static_cast<u128>(a - b));
+            CHECK(from_ci(ca * cb) == static_cast<u128>(a * b));
+            CHECK((ca == cb) == (a == b));
+            CHECK((ca < cb) == (a < b));
+            CHECK((ca <= cb) == (a <= b));
+            CHECK((ca > cb) == (a > b));
+            CHECK((ca >= cb) == (a >= b));
+            // Skip the one case that is UB for native __int128 too (INT128_MIN / -1).
+            if (b != 0 && !(a == int128_min && b == -1)) {
+                CHECK(from_ci(ca / cb) == static_cast<u128>(a / b));
+                CHECK(from_ci(ca % cb) == static_cast<u128>(a % b));
+            }
+        }
+    }
+}
+
+#endif // __GNUC__

--- a/src/test/test_int128.cpp
+++ b/src/test/test_int128.cpp
@@ -83,20 +83,24 @@ TEST_CASE("custom int128 matches native signed __int128", "[int128]") {
     for (const u128 ua : vals) {
         const auto a = static_cast<i128>(ua);
         const Int128Custom ca = to_ci(a);
-        CHECK(from_ci(-ca) == static_cast<u128>(-a));
+        // Two's-complement add/sub/mul/negate/left-shift have the same bit pattern as the
+        // unsigned ops, so compute expectations in unsigned to avoid signed-overflow UB
+        // (e.g. -INT128_MIN). Signed >> (arithmetic) and / % are well-defined and computed
+        // signed, skipping only the INT128_MIN / -1 overflow.
+        CHECK(from_ci(-ca) == static_cast<u128>(-ua));
         CHECK(static_cast<int64_t>(ca) == static_cast<int64_t>(a));
         CHECK(static_cast<uint64_t>(ca) == static_cast<uint64_t>(a));
         CHECK(static_cast<int32_t>(ca) == static_cast<int32_t>(a));
         for (int s = 0; s < 128; ++s) {
-            CHECK(from_ci(ca << s) == static_cast<u128>(a << s));
-            CHECK(from_ci(ca >> s) == static_cast<u128>(a >> s)); // arithmetic shift
+            CHECK(from_ci(ca << s) == (ua << s));
+            CHECK(from_ci(ca >> s) == static_cast<u128>(a >> s)); // arithmetic shift (defined)
         }
         for (const u128 ub : vals) {
             const auto b = static_cast<i128>(ub);
             const Int128Custom cb = to_ci(b);
-            CHECK(from_ci(ca + cb) == static_cast<u128>(a + b));
-            CHECK(from_ci(ca - cb) == static_cast<u128>(a - b));
-            CHECK(from_ci(ca * cb) == static_cast<u128>(a * b));
+            CHECK(from_ci(ca + cb) == (ua + ub));
+            CHECK(from_ci(ca - cb) == (ua - ub));
+            CHECK(from_ci(ca * cb) == (ua * ub));
             CHECK((ca == cb) == (a == b));
             CHECK((ca < cb) == (a < b));
             CHECK((ca <= cb) == (a <= b));


### PR DESCRIPTION
Phase 1 of #1189 — remove **Boost.Multiprecision** from prevail's public headers.

## Context
Investigating #1189 showed a consumer's `<prevail.hpp>` transitively pulls in **four** Boost-using public headers (not just one): `num_big.hpp` (multiprecision int128, MSVC only), `bitset_domain.hpp` (`dynamic_bitset`), and `zone_domain.hpp` + `adapt_sgraph.hpp` (`flat_map`) — the latter three on **all** platforms. So this is a multi-phase effort; #1189 is updated with the real scope. This PR is phase 1: the MSVC `int128`.

## Change
`num_big.hpp` used `boost::multiprecision::int128_t/uint128_t` where there's no native `__int128` (MSVC). Replace that fallback with a Boost-free `arith/num_int128.hpp`:
- Two-limb signed/unsigned 128-bit integers with **two's-complement semantics matching `__int128` exactly**: wrap-around add/sub/mul, truncation-toward-zero div/mod (binary long division), arithmetic right shift, signed/unsigned compares, narrowing conversions. All `constexpr`.
- GCC/Clang keep native `__int128`; the fallback is used only where there's no builtin. The `__builtin_*_overflow` paths are now gated on `PREVAIL_HAS_NATIVE_INT128`, not `__GNUC__`.

## Validation
- **Oracle test** (`test_int128.cpp`, runs in the normal suite): every op checked against native `__int128` over a large value/shift matrix — **407,992 assertions**.
- **Whole-verifier, forced**: built the full suite with `-DPREVAIL_FORCE_CUSTOM_INT128` (custom type used everywhere) → **bit-identical to native** (1811 cases, 417,410 assertions, 0 real failures).
- The **`build_windows` CI here** compiles and runs this path on real MSVC — the definitive check.

## Not yet
Boost is still pulled in by `dynamic_bitset` and `flat_map`, so `find_dependency(Boost)` stays. Those are the next #1189 phases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CsnGgfCt3qNBW1Wk8BPPjQ
