### PR TITLE
Bump Docker base image to ubuntu:24.04 for CMake 3.24+

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt update


### PR DESCRIPTION
## Problem

`docker build` fails at the configure step. The Dockerfile builds from `ubuntu:22.04`, whose apt `cmake` is 3.22, but the top-level `CMakeLists.txt` sets `cmake_minimum_required(VERSION 3.24)`, so CMake aborts:

```
CMake Error at CMakeLists.txt:4 (cmake_minimum_required):
  CMake 3.24 or higher is required.  You are running version 3.22.1
```

`build.yml` lists `Dockerfile` under `paths-ignore`, so no CI job catches this.

## Fix

Bump the base image to `ubuntu:24.04`, which ships cmake 3.28 and the g++-13 toolchain that the ubuntu CI job already builds the project with. Minimal one-line change; all apt packages used (`build-essential`, `libboost-*`, `libyaml-cpp-dev`) are available in 24.04.

## Verification

No local Docker in my environment, but the ubuntu CI job already compiles the project on the 24.04 toolchain, so the configure + build path this Dockerfile exercises is known-good. A follow-up could add a docker-build smoke job (and drop `Dockerfile` from `paths-ignore`) so this can't silently regress again.

Fixes #1169

🤖 Generated with [Claude Code](https://claude.com/claude-code)