### PR TITLE
Bump Catch2 to v3.15.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -285,7 +285,7 @@ endif ()
 if (prevail_ENABLE_TESTS)
   FetchContent_Declare(Catch2
     GIT_REPOSITORY "https://github.com/catchorg/Catch2.git"
-    GIT_TAG "v3.14.0"
+    GIT_TAG "v3.15.2"
     GIT_SHALLOW ON
   )
   FetchContent_MakeAvailable(Catch2)


### PR DESCRIPTION
Updates the Catch2 `FetchContent` pin from `v3.14.0` to `v3.15.2`.

## Verification

Configured, built (Release), and ran the full suite locally against the newly fetched v3.15.2:

```
test cases:   1811 |   1583 passed | 1 skipped | 227 failed as expected
assertions: 417410 | 417183 passed | 227 failed as expected
```

No real failures — the 227 are the expected `[!shouldfail]` cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)