### PR TITLE
Diff YAML invariants by line set instead of lattice subtraction

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -309,6 +309,7 @@ if (prevail_ENABLE_TESTS)
     src/test/test_print.cpp
     src/test/test_runtime_config.cpp
     src/test/test_sign_extension.cpp
+    src/test/test_string_constraints.cpp
     src/test/test_subsumption.cpp
     src/test/test_type_domain.cpp
     src/test/test_type_to_num.cpp

--- a/src/string_constraints.cpp
+++ b/src/string_constraints.cpp
@@ -10,17 +10,11 @@
 
 namespace prevail {
 
-StringInvariant StringInvariant::operator-(const StringInvariant& b) const {
-    if (this->is_bottom()) {
-        return bottom();
+std::set<std::string> StringInvariant::to_lines() const {
+    if (is_bottom()) {
+        return {"_|_"};
     }
-    StringInvariant res = top();
-    for (const std::string& cst : this->value()) {
-        if (b.is_bottom() || !b.contains(cst)) {
-            res.maybe_inv->insert(cst);
-        }
-    }
-    return res;
+    return *maybe_inv;
 }
 
 StringInvariant StringInvariant::operator+(const StringInvariant& b) const {

--- a/src/string_constraints.hpp
+++ b/src/string_constraints.hpp
@@ -47,8 +47,13 @@ struct StringInvariant {
         return *maybe_inv;
     }
 
-    StringInvariant operator-(const StringInvariant& b) const;
     StringInvariant operator+(const StringInvariant& b) const;
+
+    // Render as the set of text lines used for display/diffing. Bottom is the
+    // single line "_|_", exactly the form the YAML harness parses back into a
+    // bottom invariant; a non-bottom invariant is its set of constraint lines.
+    [[nodiscard]]
+    std::set<std::string> to_lines() const;
 
     bool operator==(const StringInvariant& other) const { return maybe_inv == other.maybe_inv; }
 

--- a/src/test/ebpf_yaml.cpp
+++ b/src/test/ebpf_yaml.cpp
@@ -448,7 +448,7 @@ std::optional<Failure> run_yaml_test_case(TestCase test_case, bool debug) {
             return {};
         }
         return Failure{
-            .invariant = make_diff(StringInvariant::top(), StringInvariant::top()),
+            .invariant = make_diff(StringInvariant::top().to_lines(), StringInvariant::top().to_lines()),
             .messages = make_diff(actual_messages, expected_messages),
         };
     }
@@ -501,7 +501,7 @@ std::optional<Failure> run_yaml_test_case(TestCase test_case, bool debug) {
             return {};
         }
         return Failure{
-            .invariant = make_diff(actual_last_invariant, test_case.expected_post_invariant),
+            .invariant = make_diff(actual_last_invariant.to_lines(), test_case.expected_post_invariant.to_lines()),
             .messages = make_diff(actual_messages, test_case.expected_messages),
         };
     } catch (InvalidControlFlow& ex) {
@@ -511,13 +511,13 @@ std::optional<Failure> run_yaml_test_case(TestCase test_case, bool debug) {
             return {};
         }
         return Failure{
-            .invariant = make_diff(StringInvariant::top(), test_case.expected_post_invariant),
+            .invariant = make_diff(StringInvariant::top().to_lines(), test_case.expected_post_invariant.to_lines()),
             .messages = make_diff(actual_messages, test_case.expected_messages),
         };
     } catch (const std::exception& ex) {
         const std::set<string> actual_messages{std::string{"Exception: "} + ex.what()};
         return Failure{
-            .invariant = make_diff(StringInvariant::top(), test_case.expected_post_invariant),
+            .invariant = make_diff(StringInvariant::top().to_lines(), test_case.expected_post_invariant.to_lines()),
             .messages = make_diff(actual_messages, test_case.expected_messages),
         };
     }
@@ -628,12 +628,18 @@ ConformanceTestResult run_conformance_test_case(const std::vector<uint8_t>& memo
 void print_failure(const Failure& failure, std::ostream& os) {
     constexpr auto INDENT = "  ";
     if (!failure.invariant.unexpected.empty()) {
-        os << "Unexpected properties:\n" << INDENT << failure.invariant.unexpected << "\n";
+        os << "Unexpected properties:\n";
+        for (const auto& item : failure.invariant.unexpected) {
+            os << INDENT << item << "\n";
+        }
     } else {
         os << "Unexpected properties: None\n";
     }
     if (!failure.invariant.unseen.empty()) {
-        os << "Unseen properties:\n" << INDENT << failure.invariant.unseen << "\n";
+        os << "Unseen properties:\n";
+        for (const auto& item : failure.invariant.unseen) {
+            os << INDENT << item << "\n";
+        }
     } else {
         os << "Unseen properties: None\n";
     }

--- a/src/test/ebpf_yaml.hpp
+++ b/src/test/ebpf_yaml.hpp
@@ -41,7 +41,7 @@ struct Diff {
 };
 
 struct Failure {
-    Diff<StringInvariant> invariant;
+    Diff<std::set<std::string>> invariant;
     Diff<std::set<std::string>> messages;
 };
 

--- a/src/test/test_string_constraints.cpp
+++ b/src/test/test_string_constraints.cpp
@@ -1,0 +1,49 @@
+// Copyright (c) Prevail Verifier contributors.
+// SPDX-License-Identifier: MIT
+#include <catch2/catch_all.hpp>
+
+#include <algorithm>
+#include <iterator>
+#include <set>
+#include <string>
+
+#include "string_constraints.hpp"
+
+using namespace prevail;
+
+namespace {
+// Mirror of the line-set difference the YAML harness uses to build its
+// "unexpected"/"unseen" diffs, so this test exercises the same operation.
+std::set<std::string> line_difference(const std::set<std::string>& a, const std::set<std::string>& b) {
+    std::set<std::string> res;
+    std::ranges::set_difference(a, b, std::inserter(res, res.begin()));
+    return res;
+}
+} // namespace
+
+// to_lines renders an invariant as the set of text lines the YAML harness diffs
+// on. Bottom must render as the single line "_|_" -- the exact form the harness
+// parses back into a bottom invariant -- so that the diff is an ordinary
+// set-difference over lines with no special-casing of bottom.
+TEST_CASE("StringInvariant::to_lines renders bottom as the \"_|_\" line", "[string_constraints]") {
+    CHECK(StringInvariant::bottom().to_lines() == std::set<std::string>{"_|_"});
+    CHECK(StringInvariant::top().to_lines() == std::set<std::string>{});
+    CHECK(StringInvariant{std::set<std::string>{"r0.type=number"}}.to_lines() ==
+          std::set<std::string>{"r0.type=number"});
+}
+
+// The harness diffs two invariants by line-set difference. A matching
+// `_|_`-vs-`_|_` comparison must produce empty diffs in both directions (so it
+// no longer reports the same `_|_` under both "unexpected" and "unseen"), while
+// a genuine mismatch still surfaces the differing lines.
+TEST_CASE("Line-set diff of invariants handles bottom uniformly", "[string_constraints]") {
+    const std::set<std::string> bottom = StringInvariant::bottom().to_lines();
+    const std::set<std::string> concrete = StringInvariant{std::set<std::string>{"r0.type=number"}}.to_lines();
+
+    SECTION("bottom vs bottom is empty in both directions") { CHECK(line_difference(bottom, bottom).empty()); }
+
+    SECTION("bottom vs concrete surfaces the difference on each side") {
+        CHECK(line_difference(bottom, concrete) == std::set<std::string>{"_|_"});
+        CHECK(line_difference(concrete, bottom) == std::set<std::string>{"r0.type=number"});
+    }
+}


### PR DESCRIPTION
## Problem

While investigating #1196, the YAML test harness printed a confusing diff for an
expected-bottom (`_|_`) post-invariant:

```
Expected post-invariant: _|_
...
Unexpected properties:
  _|_
Unseen properties:
  _|_
```

Both "Unexpected" and "Unseen" showed the identical `_|_`, even though the actual
and expected invariants **matched** (both bottom). The only real difference was in
the messages.

## Cause

The invariant diff was computed via `StringInvariant::operator-`, which
special-cased bottom by returning `bottom()`. Since `StringInvariant::empty()`
counts bottom as *non-empty*, a `_|_`-vs-`_|_` comparison yielded
`actual - expected == bottom` and `expected - actual == bottom`, so `print_failure`
listed `_|_` under both headings.

The deeper issue: a *diff result* is not an *invariant*. Typing it as the lattice
`StringInvariant` forced `operator-` to reason about a bottom sentinel and about the
constraint-set-vs-lattice duality (where "empty set of constraints" and "lattice
top" coincide) — subtle enough to hide this bug.

## Fix

Make the invariant diff the same honest representation already used for the
messages diff:

- Add `StringInvariant::to_lines()`, rendering an invariant as its set of text
  lines: bottom ↦ the single line `"_|_"` (exactly the form `read_invariant` parses
  back into bottom), non-bottom ↦ its constraint lines.
- Change `Failure::invariant` to `Diff<std::set<std::string>>` and diff via the
  ordinary set difference already used for messages — no special-casing of bottom.
- Remove the now-unused `StringInvariant::operator-`.

`_|_` now appears in a diff only when one side genuinely is bottom and the other is
not:

| actual | expected | unexpected | unseen |
|--------|----------|-----------|--------|
| `⊥` | `⊥` | — | — |
| `⊥` | `{c}` | `_|_` | `c` |
| `{c}` | `⊥` | `c` | `_|_` |
| `{a,b}` | `{b,c}` | `a` | `c` |

## Tests

- New `src/test/test_string_constraints.cpp` covers `to_lines()` and the
  bottom/non-bottom diff cases.
- Full suite passes (635 passed, 1 skipped, 0 failures).

> Note: this PR fixes only the harness display bug. The original #1196 termination
> question (prevail emits `Loop counter is too large` rather than the issue's
> expected `Loop has no reachable exit`) is left for a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PWoziCvt88zfAvcCqTshPo