### PR TITLE
Narrow sign-extending memory loads, extend to ctx inline fields

### DIFF
--- a/src/crab/ebpf_transformer.cpp
+++ b/src/crab/ebpf_transformer.cpp
@@ -477,8 +477,24 @@ void EbpfTransformer::do_load_stack(TypeToNumDomain& state, const Reg& target_re
     }
 }
 
+// Narrow the destination of a width-N load to the range implied by that width.
+// Zero-extending loads constrain both svalue and uvalue. Signed loads havoc
+// uvalue: a negative sign-extended value's unsigned 64-bit view is not a single
+// interval, so it cannot be represented. The caller must ensure the type is T_NUM.
+static void narrow_num_by_load_width(TypeToNumDomain& state, const RegPack& target, const int width,
+                                     const bool is_signed) {
+    if (is_signed && (width == 1 || width == 2 || width == 4)) {
+        state.values.set(target.svalue, Interval::signed_int(width * 8));
+        state.values.havoc(target.uvalue);
+    } else if (width == 1 || width == 2) {
+        const Interval full = Interval::unsigned_int(width * 8);
+        state.values.set(target.svalue, full);
+        state.values.set(target.uvalue, full);
+    }
+}
+
 static void do_load_ctx(TypeToNumDomain& state, const AnalysisContext& context, const Reg& target_reg,
-                        const LinearExpression& addr_vague, const int width) {
+                        const LinearExpression& addr_vague, const int width, const bool is_signed) {
     using namespace dsl_syntax;
     if (state.values.is_bottom()) {
         return;
@@ -491,6 +507,7 @@ static void do_load_ctx(TypeToNumDomain& state, const AnalysisContext& context, 
     if (desc->end < 0) {
         state.havoc_register(target_reg);
         state.assign_type(target_reg, T_NUM);
+        narrow_num_by_load_width(state, target, width, is_signed);
         return;
     }
 
@@ -506,6 +523,7 @@ static void do_load_ctx(TypeToNumDomain& state, const AnalysisContext& context, 
             state.havoc_type(target_reg);
         } else {
             state.assign_type(target_reg, T_NUM);
+            narrow_num_by_load_width(state, target, width, is_signed);
         }
         return;
     }
@@ -537,7 +555,9 @@ static void do_load_ctx(TypeToNumDomain& state, const AnalysisContext& context, 
         if (may_touch_ptr) {
             state.havoc_type(target_reg);
         } else {
+            // Inline ctx field (not data/data_end/meta): a plain scalar.
             state.assign_type(target_reg, T_NUM);
+            narrow_num_by_load_width(state, target, width, is_signed);
         }
         return;
     }
@@ -559,14 +579,7 @@ static void do_load_packet_or_shared(TypeToNumDomain& state, const Reg& target_r
     state.assign_type(target_reg, T_NUM);
 
     // Small copies can be range-limited and useful for later arithmetic.
-    if (is_signed && (width == 1 || width == 2 || width == 4)) {
-        state.values.set(target.svalue, Interval::signed_int(width * 8));
-        state.values.set(target.uvalue, Interval::unsigned_int(width * 8));
-    } else if (width == 1 || width == 2) {
-        const Interval full = Interval::unsigned_int(width * 8);
-        state.values.set(target.svalue, full);
-        state.values.set(target.uvalue, full);
-    }
+    narrow_num_by_load_width(state, target, width, is_signed);
 }
 
 void EbpfTransformer::do_load(const Mem& b, const Reg& target_reg) {
@@ -583,7 +596,7 @@ void EbpfTransformer::do_load(const Mem& b, const Reg& target_reg) {
     }
     dom.state = dom.state.join_over_types(b.access.basereg, [&](TypeToNumDomain& state, const TypeEncoding type) {
         switch (type) {
-        case T_CTX: do_load_ctx(state, context, target_reg, mem_reg.ctx_offset + offset, width); break;
+        case T_CTX: do_load_ctx(state, context, target_reg, mem_reg.ctx_offset + offset, width, b.is_signed); break;
         case T_STACK: do_load_stack(state, target_reg, mem_reg.stack_offset + offset, width, b.access.basereg); break;
         case T_PACKET:
         case T_SHARED:

--- a/test-data/ctx.yaml
+++ b/test-data/ctx.yaml
@@ -122,3 +122,118 @@ post:
   - r2.svalue=0
   - r2.type=number
   - r2.uvalue=0
+
+---
+# A load of an inline ctx field (outside the data/data_end/meta slots) is a
+# scalar load, narrowed to the range implied by the load width.
+test-case: load u8 from ctx inline field narrows to byte range
+
+pre: ["r1.type=ctx", "r1.ctx_offset=0"]
+
+code:
+  <start>: |
+    r2 = *(u8 *)(r1 + 8)
+
+post:
+  - r1.ctx_offset=0
+  - r1.type=ctx
+  - r2.type=number
+  - r2.svalue=[0, 255]
+  - r2.uvalue=[0, 255]
+
+---
+test-case: load u16 from ctx inline field narrows to half-word range
+
+pre: ["r1.type=ctx", "r1.ctx_offset=0"]
+
+code:
+  <start>: |
+    r2 = *(u16 *)(r1 + 8)
+
+post:
+  - r1.ctx_offset=0
+  - r1.type=ctx
+  - r2.type=number
+  - r2.svalue=[0, 65535]
+  - r2.uvalue=[0, 65535]
+
+---
+# Width-4 zero-extending loads are intentionally not narrowed, matching
+# do_load_packet_or_shared which only narrows zero-extended loads of width 1 or 2.
+test-case: load u32 from ctx inline field leaves value unconstrained
+
+pre: ["r1.type=ctx", "r1.ctx_offset=0"]
+
+code:
+  <start>: |
+    r2 = *(u32 *)(r1 + 8)
+
+post:
+  - r1.ctx_offset=0
+  - r1.type=ctx
+  - r2.type=number
+
+---
+# A full 8-byte load is also not narrowed (it would be a no-op tautology).
+test-case: load u64 from ctx inline field leaves value unconstrained
+
+pre: ["r1.type=ctx", "r1.ctx_offset=0"]
+
+code:
+  <start>: |
+    r2 = *(u64 *)(r1 + 8)
+
+post:
+  - r1.ctx_offset=0
+  - r1.type=ctx
+  - r2.type=number
+
+---
+# Sign-extending load: svalue narrows to the signed-byte range, but uvalue is
+# havoced (left absent below) since a negative result's unsigned 64-bit view is
+# not a single interval.
+test-case: load s8 from ctx inline field narrows svalue to signed-byte range
+
+pre: ["r1.type=ctx", "r1.ctx_offset=0"]
+
+code:
+  <start>: |
+    r2 = *(s8 *)(r1 + 8)
+
+post:
+  - r1.ctx_offset=0
+  - r1.type=ctx
+  - r2.type=number
+  - r2.svalue=[-128, 127]
+
+---
+test-case: load s16 from ctx inline field narrows svalue to signed-half-word range
+
+pre: ["r1.type=ctx", "r1.ctx_offset=0"]
+
+code:
+  <start>: |
+    r2 = *(s16 *)(r1 + 8)
+
+post:
+  - r1.ctx_offset=0
+  - r1.type=ctx
+  - r2.type=number
+  - r2.svalue=[-32768, 32767]
+
+---
+# Sign-extending 32-bit load: svalue narrowed to [INT32_MIN, INT32_MAX].
+# uvalue unconstrained for the same reason as the s8 case.
+test-case: load s32 from ctx inline field narrows svalue to signed-word range
+
+pre: ["r1.type=ctx", "r1.ctx_offset=0"]
+
+code:
+  <start>: |
+    r2 = *(s32 *)(r1 + 8)
+
+post:
+  - r1.ctx_offset=0
+  - r1.type=ctx
+  - r2.type=number
+  - r2.svalue=[-2147483648, 2147483647]

--- a/test-data/packet.yaml
+++ b/test-data/packet.yaml
@@ -30,6 +30,24 @@ post: ["meta_offset=0", "packet_size=20",
 messages: []
 
 ---
+# Sign-extending load: svalue narrows to the signed-byte range, but uvalue is
+# havoced (left absent below) since a negative result's unsigned 64-bit view is
+# not a single interval.
+test-case: read 8bit signed narrows svalue only
+
+pre: ["meta_offset=0", "packet_size=20",
+      "r1.type=packet", "r1.packet_offset=0", "r1.svalue=[4098, 2147418112]", "r1.uvalue=[4098, 2147418112]"]
+
+code:
+  <start>: |
+    r2 = *(s8 *)(r1 + 0)
+
+post: ["meta_offset=0", "packet_size=20",
+       "r1.type=packet", "r1.packet_offset=0", "r1.svalue=[4098, 2147418112]", "r1.uvalue=[4098, 2147418112]",
+       "r2.type=number", "r2.svalue=[-128, 127]"]
+messages: []
+
+---
 test-case: simple invalid write
 
 pre: ["meta_offset=0",


### PR DESCRIPTION
On a signed memory load the narrow helper set uvalue to the
zero-extended range [0, 2^(8*width) - 1]. That is unsound: the unsigned
64-bit view of a sign-extended negative result sits up near 2^64,
disjoint from that range, so no concrete value satisfies the resulting
abstract state (e.g. an s8 of -1 has svalue=-1 but uvalue=2^64-1, not
uvalue<=255).

The fix is to havoc uvalue on signed loads, matching what FiniteDomain
already does for arithmetic: sign_extend routes through overflow_bounds,
which havocs uvalue when the value wraps. The narrow helper was the one
load path that bypassed this. Register MOVSX was already sound and is
unchanged.

The narrowing logic moves into a shared helper that is now also applied
to ctx inline-field loads, which previously got no width-based bound at
all (only packet/shared loads did). Reusing the helper also fixes the
same uvalue unsoundness on the packet/shared signed path.

Tests cover signed and unsigned loads across widths for ctx inline
fields, plus a signed packet load checking that svalue narrows while
uvalue is left unconstrained.

---

This is the first of two PRs split out from #1153 at the maintainer's
request. It is independent of the other half (#1199, ptr-sum bound-check tracking) and can be reviewed and merged on its own.

🤖 Co-authored with Claude (Anthropic).
