### PR TITLE
Havoc exact-match stack cell on kill (fixes #1202)

### DIFF
--- a/src/crab/array_domain.cpp
+++ b/src/crab/array_domain.cpp
@@ -82,13 +82,13 @@ class offset_map_t final {
 
     void insert_cell(const Cell& c);
 
-    [[nodiscard]]
-    std::optional<Cell> get_cell(offset_t o, unsigned size);
-
     Cell mk_cell(offset_t o, unsigned size);
 
   public:
     offset_map_t() = default;
+
+    [[nodiscard]]
+    std::optional<Cell> get_cell(offset_t o, unsigned size);
 
     [[nodiscard]]
     std::size_t size() const {
@@ -334,6 +334,13 @@ static std::optional<std::pair<offset_t, unsigned>> kill_and_find_var(StackCellR
             // -- Constant index: kill overlapping cells
             offset_t o(n->narrow<Index>());
             overlaps = offset_map.get_overlap_cells(o, size);
+            // get_overlap_cells deliberately excludes the exact-match cell (o, size),
+            // which is correct for loads (get_cell handles it separately) but wrong for
+            // a kill: a pure-havoc caller (e.g. storing an uninitialized register over an
+            // exact-match cell) must forget the stale value/type, so include it here.
+            if (const auto exact = offset_map.get_cell(o, size)) {
+                overlaps.push_back(*exact);
+            }
             res = std::make_pair(o, size);
         }
     }

--- a/test-data/stack.yaml
+++ b/test-data/stack.yaml
@@ -923,3 +923,21 @@ observe:
     mode: consistent
     constraints:
       - r0.svalue=0
+---
+test-case: overwrite exact-match stack cell with uninitialized register havocs stale value
+
+# Regression for issue #1202: overwriting an exact-match stack cell with an
+# uninitialized register must havoc the cell's value/type. Otherwise a later
+# aligned load reads back the stale known value.
+
+pre: ["r10.type=stack", "r10.stack_offset=512",
+      "s[504...511].type=number", "s[504...511].svalue=42", "s[504...511].uvalue=42"]
+
+code:
+  <start>: |
+    *(u64 *)(r10 - 8) = r6 ; r6 is uninitialized: must havoc the exact (504,8) cell
+    r0 = *(u64 *)(r10 - 8) ; reload must NOT read back the stale 42
+
+post:
+  - r10.type=stack
+  - r10.stack_offset=512


### PR DESCRIPTION
## Summary

Fixes #1202 — an accept-unsafe soundness hole where overwriting an exact-match stack cell with an **uninitialized register** left the cell's value/type stale, so a later aligned load read back the known value.

## Root cause

`offset_map_t::get_overlap_cells(o, size)` deliberately **excludes** the exact-match cell `(o, size)` — correct for loads, since `get_cell` handles the exact cell separately. But `kill_and_find_var` reuses `get_overlap_cells` for the **havoc** path. When `ebpf_transformer`'s pure-havoc branch (store of an uninitialized register) runs, the exact cell is never havoced nor removed, and a subsequent aligned `load` returns the surviving stale cell.

## Fix

In `kill_and_find_var`'s constant-index branch, include the exact-match cell (via `get_cell`) in the kill set.

- **Strong-update callers** (`store`, `store_type`) re-create and reassign the cell right after, so they are unaffected.
- **Pure-havoc callers** (`havoc`, `havoc_type`) now correctly forget the value/type.

`get_cell` is moved to the class's public section (it is a pure query).

## Test

Regression test in `test-data/stack.yaml`: store a known 8-byte value → overwrite the same slot/width with an uninitialized register → reload. Assert the destination is fully havoced.

Verified the test **fails without the fix** (stale `s[504...511].svalue=42/uvalue=42` survive) and **passes with it**. Full suite: 635 passed, 1 skipped, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QRunjNUunuZjp6KiBSZXzt