### PR TITLE
Reconstruct inlined callee's internal edges in a second pass (fixes #1203)

### DIFF
--- a/src/ir/cfg_builder.cpp
+++ b/src/ir/cfg_builder.cpp
@@ -384,8 +384,7 @@ static void add_cfg_nodes(CfgBuilder& builder, const Label& caller_label, const 
         }
 
         // Walk all successor nodes, enqueuing any not-yet-cloned macro block.
-        for (const auto& next_macro_nodes = builder.prog.cfg().children_of(macro_label);
-             const auto& next_macro_label : next_macro_nodes) {
+        for (const auto& next_macro_label : builder.prog.cfg().children_of(macro_label)) {
             if (next_macro_label != builder.prog.cfg().exit_label() && !seen_labels.contains(next_macro_label)) {
                 macro_labels.insert(next_macro_label);
                 seen_labels.insert(next_macro_label);

--- a/src/ir/cfg_builder.cpp
+++ b/src/ir/cfg_builder.cpp
@@ -383,29 +383,32 @@ static void add_cfg_nodes(CfgBuilder& builder, const Label& caller_label, const 
             builder.add_child(caller_label, label);
         }
 
-        // Add an edge from any other predecessors.
-        for (const auto& prev_macro_nodes = builder.prog.cfg().parents_of(macro_label);
-             const auto& prev_macro_label : prev_macro_nodes) {
-            const Label prev_label(prev_macro_label.from, prev_macro_label.to, to_string(caller_label));
-            if (const auto& labels = builder.prog.cfg().labels();
-                std::ranges::find(labels, prev_label) != labels.end()) {
-                builder.add_child(prev_label, label);
-            }
-        }
-
-        // Walk all successor nodes.
+        // Walk all successor nodes, enqueuing any not-yet-cloned macro block.
         for (const auto& next_macro_nodes = builder.prog.cfg().children_of(macro_label);
              const auto& next_macro_label : next_macro_nodes) {
+            if (next_macro_label != builder.prog.cfg().exit_label() && !seen_labels.contains(next_macro_label)) {
+                macro_labels.insert(next_macro_label);
+                seen_labels.insert(next_macro_label);
+            }
+        }
+    }
+
+    // Reconstruct the cloned subprogram's internal edges now that every macro block
+    // has been cloned. This must run as a second pass: reconstructing edges while
+    // cloning (from already-cloned predecessors) loses any back-edge, because a loop
+    // latch is cloned after its head, so the latch->head edge is never re-added. The
+    // clone would then be analyzed straight-line, without widening or loop-counter
+    // insertion, missing a pointer that walks out of bounds across iterations (#1203).
+    for (const Label& macro_label : seen_labels) {
+        const Label label{macro_label.from, macro_label.to, stack_frame_prefix};
+        for (const auto& next_macro_label : builder.prog.cfg().children_of(macro_label)) {
             if (next_macro_label == builder.prog.cfg().exit_label()) {
-                // This is an exit transition, so add edge to the block to execute
+                // This is an exit transition, so add an edge to the block to execute
                 // upon returning from the macro.
                 builder.add_child(label, exit_to_label);
-            } else if (!seen_labels.contains(next_macro_label)) {
-                // Push any other unprocessed successor label onto the list to be processed.
-                if (!macro_labels.contains(next_macro_label)) {
-                    macro_labels.insert(next_macro_label);
-                }
-                seen_labels.insert(next_macro_label);
+            } else {
+                const Label next_label{next_macro_label.from, next_macro_label.to, stack_frame_prefix};
+                builder.add_child(label, next_label);
             }
         }
     }

--- a/test-data/calllocal.yaml
+++ b/test-data/calllocal.yaml
@@ -478,3 +478,47 @@ post:
   - pc[0/3]=4
   - r0.svalue=pc[0/3]
   - r0.uvalue=pc[0/3]
+---
+test-case: out-of-bounds packet walk in an inlined callee loop is rejected
+
+# Companion to the counted-loop regression above, demonstrating the *unsound*
+# outcome the #1203 fix removes. The callee walks a packet pointer one byte
+# further every iteration and reads through it, without re-checking the read
+# against packet_size. `assume r2 != r1` guarantees at least one byte, so the
+# first read (packet[0]) is in bounds. Before the fix the callee loop lost its
+# back-edge and was analyzed for that single iteration, so the read on later
+# iterations was never checked and the program was accepted (accept-unsafe).
+# With the back-edge restored the loop is widened, the read index is no longer
+# bounded by packet_size, and the access is correctly rejected.
+
+options: ["termination"]
+pre: [
+  "meta_offset=[-4098, 0]",
+  "packet_size=[0, 65534]",
+  "r1.ctx_offset=0", "r1.type=ctx",
+]
+
+code:
+  <start>: |
+    call <sub>
+    exit
+  <sub>: |
+    r2 = *(u32 *)(r1 + 4)
+    r1 = *(u32 *)(r1 + 0)
+    assume r2 != r1
+    r2 -= r1
+    r3 = 0
+  <sub_loop>: |
+    r4 = r1
+    r4 += r3
+    r4 = *(u8 *)(r4 + 0)
+    r3 += 1
+    if r3 < 100 goto <sub_loop>
+    exit
+
+post:
+  - "_|_"
+
+messages:
+  - "0/9: Upper bound must be at most packet_size (valid_access(r4.offset, width=1) for read)"
+  - "0/11:12: Code becomes unreachable (assume r3 >= 100)"

--- a/test-data/calllocal.yaml
+++ b/test-data/calllocal.yaml
@@ -449,3 +449,32 @@ post:
 
 messages:
   - "2:3: Code becomes unreachable (assume r6 >= r7)"
+---
+test-case: counted loop wholly inside a bpf-to-bpf callee keeps its back-edge
+
+# Regression for issue #1203: a loop contained entirely within an inlined
+# bpf-to-bpf subprogram must keep its back-edge after inlining. Otherwise the
+# clone is analyzed straight-line (no widening, no loop-counter insertion) and
+# the loop body is verified for a single iteration. The pc[...] loop counter in
+# the post-invariant only appears if the back-edge survived.
+
+options: ["termination"]
+pre: []
+
+code:
+  <start>: |
+    call <sub>
+    exit
+  <sub>: |
+    r0 = 0
+  <sub_loop>: |
+    r0 += 1
+    if r0 < 4 goto <sub_loop>
+  <sub_out>: |
+    exit
+
+post:
+  - r0.type=number
+  - pc[0/3]=4
+  - r0.svalue=pc[0/3]
+  - r0.uvalue=pc[0/3]


### PR DESCRIPTION
## Summary

Fixes #1203 — an accept-unsafe soundness hole where a loop wholly contained inside an inlined bpf-to-bpf callee lost its back-edge, so the clone was analyzed straight-line (no widening, no loop-counter insertion).

## Root cause

`add_cfg_nodes` reconstructed the clone's internal edges incrementally, pulling only from **already-cloned predecessors**. Nodes are processed in ascending instruction index, so a loop head is cloned before its latch:

- When the head is cloned, the latch clone does not exist yet → the back-edge `latch → head` is skipped.
- When the latch is later cloned, only *its* predecessors are consulted → the back-edge is never re-added.

`Wto` then finds no cycle, the ascending sequence never widens the loop, and `check_for_termination` inserts no `IncrementLoopCounter`/`BoundedLoopCount`. A pointer in bounds on iteration 1 but out of bounds by iteration *k* is never checked.

## Fix

Split into two passes: the first clones every block and walks successors to enqueue them; the second reconstructs **all** internal edges (and exit transitions) from the successor side, now that every clone exists. `Cfg` adjacency is a `std::set`, so edge insertion is idempotent.

## Test

Regression test in `test-data/calllocal.yaml`: a counted loop wholly inside a callee. With the fix, the loop counter `pc[0/3]` appears in the post-invariant; **verified** that without the fix no counter is produced and the loop is analyzed for a single iteration.

Full suite: 635 passed, 1 skipped, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QRunjNUunuZjp6KiBSZXzt