### PR TITLE
Fix 32-bit soundness holes that let unsafe programs pass verification

### DIFF
--- a/src/crab/ebpf_transformer.cpp
+++ b/src/crab/ebpf_transformer.cpp
@@ -1499,7 +1499,10 @@ void EbpfTransformer::operator()(const Bin& bin) {
         case Bin::Op::MOVSX32: {
             const int source_width = _movsx_bits(bin.op);
             // Keep relational information if operation is a no-op.
-            if (dst.svalue == src.svalue &&
+            // Only when the result is 64 bits wide: a 32-bit MOVSX must still zero-extend its
+            // 32-bit result into the upper half, and returning here would skip the truncation
+            // applied at the end of this function.
+            if (bin.is64 && dst.svalue == src.svalue &&
                 dom.state.values.eval_interval(dst.svalue) <= Interval::signed_int(source_width)) {
                 return;
             }

--- a/src/crab/finite_domain.cpp
+++ b/src/crab/finite_domain.cpp
@@ -235,22 +235,29 @@ FiniteDomain::assume_signed_64bit_lt(const bool strict, const Variable left_sval
     }
 }
 
-std::vector<LinearConstraint>
-FiniteDomain::assume_signed_32bit_lt(const bool strict, const Variable left_svalue, const Variable left_uvalue,
-                                     const Interval& left_interval_positive, const Interval& left_interval_negative,
-                                     const LinearExpression& right_svalue, const LinearExpression& right_uvalue,
-                                     const Interval& right_interval) const {
+std::vector<LinearConstraint> FiniteDomain::assume_signed_32bit_lt(const bool strict, const Variable left_svalue,
+                                                                   const Variable left_uvalue,
+                                                                   const Interval& left_interval_positive,
+                                                                   const LinearExpression& right_svalue,
+                                                                   const LinearExpression& right_uvalue) const {
 
     using namespace dsl_syntax;
 
-    if (right_interval <= Interval::negative(32)) {
-        // Interval can be represented as both an svalue and a uvalue since it fits in [INT_MIN, -1],
-        // aka [INT_MAX+1, UINT_MAX].
+    // The constraints below relate the 64-bit svalue/uvalue variables, so each branch has to
+    // establish that those variables already coincide with the 32-bit values being compared.
+    // Testing only the truncated 32-bit views is not enough: a register whose 64-bit value
+    // falls outside the 32-bit range has a 32-bit view that says nothing about how the
+    // 64-bit variables are ordered.
+    if (eval_interval(left_svalue) <= Interval::signed_int(32) &&
+        eval_interval(right_svalue) <= Interval::negative(32)) {
+        // left is a sign-extended 32-bit value and right is negative, so left < right forces left
+        // negative too: both then fit in [INT_MIN, -1], aka [INT_MAX+1, UINT_MAX], where the signed
+        // and unsigned orderings agree.
         return {std::numeric_limits<int32_t>::max() < left_uvalue,
                 strict ? left_uvalue < right_uvalue : left_uvalue <= right_uvalue,
                 strict ? left_svalue < right_svalue : left_svalue <= right_svalue};
-    } else if ((left_interval_negative | left_interval_positive) <= Interval::nonnegative(32) &&
-               right_interval <= Interval::nonnegative(32)) {
+    } else if (eval_interval(left_svalue) <= Interval::nonnegative(32) &&
+               eval_interval(right_svalue) <= Interval::nonnegative(32)) {
         // Interval can be represented as both an svalue and a uvalue since it fits in [0, INT_MAX]
         const auto lpub = left_interval_positive.truncate_to<int32_t>().ub();
         return {left_svalue >= 0,
@@ -301,16 +308,20 @@ FiniteDomain::assume_signed_64bit_gt(const bool strict, const Variable left_sval
     }
 }
 
-std::vector<LinearConstraint>
-FiniteDomain::assume_signed_32bit_gt(const bool strict, const Variable left_svalue, const Variable left_uvalue,
-                                     const Interval& left_interval_positive, const Interval& left_interval_negative,
-                                     const LinearExpression& right_svalue, const LinearExpression& right_uvalue,
-                                     const Interval& right_interval) const {
+std::vector<LinearConstraint> FiniteDomain::assume_signed_32bit_gt(const bool strict, const Variable left_svalue,
+                                                                   const Variable left_uvalue,
+                                                                   const Interval& left_interval_positive,
+                                                                   const LinearExpression& right_svalue,
+                                                                   const LinearExpression& right_uvalue) const {
 
     using namespace dsl_syntax;
 
-    if (right_interval <= Interval::nonnegative(32)) {
-        // Interval can be represented as both an svalue and a uvalue since it fits in [0, INT_MAX].
+    // As in assume_signed_32bit_lt, each branch must establish that the 64-bit svalue/uvalue
+    // variables coincide with the 32-bit values being compared before constraining them.
+    if (eval_interval(left_svalue) <= Interval::signed_int(32) &&
+        eval_interval(right_svalue) <= Interval::nonnegative(32)) {
+        // left is a sign-extended 32-bit value and right is non-negative, so left > right forces
+        // left non-negative too: it then fits in [0, INT_MAX], where svalue and uvalue coincide.
         const auto lpub = left_interval_positive.truncate_to<int32_t>().ub();
         return {left_svalue >= 0,
                 strict ? left_svalue > right_svalue : left_svalue >= right_svalue,
@@ -319,10 +330,10 @@ FiniteDomain::assume_signed_32bit_gt(const bool strict, const Variable left_sval
                 left_uvalue >= 0,
                 strict ? left_uvalue > right_uvalue : left_uvalue >= right_uvalue,
                 left_uvalue <= *lpub.number()};
-    } else if ((left_interval_negative | left_interval_positive) <= Interval::negative(32) &&
-               right_interval <= Interval::negative(32)) {
-        // Interval can be represented as both an svalue and a uvalue since it fits in [INT_MIN, -1],
-        // aka [INT_MAX+1, UINT_MAX].
+    } else if (eval_interval(left_svalue) <= Interval::negative(32) &&
+               eval_interval(right_svalue) <= Interval::negative(32)) {
+        // Both operands are sign-extended negative 32-bit values, so they fit in [INT_MIN, -1],
+        // aka [INT_MAX+1, UINT_MAX], and the signed and unsigned orderings agree.
         return {left_uvalue >= Number{std::numeric_limits<int32_t>::max()} + 1,
                 strict ? left_uvalue > right_uvalue : left_uvalue >= right_uvalue,
                 strict ? left_svalue > right_svalue : left_svalue >= right_svalue};
@@ -393,11 +404,11 @@ std::vector<LinearConstraint> FiniteDomain::assume_signed_cst_interval(const Con
     } else {
         // 32-bit compare.
         if (is_lt) {
-            return assume_signed_32bit_lt(strict, left_svalue, left_uvalue, left_interval_positive,
-                                          left_interval_negative, right_svalue, right_uvalue, right_interval);
+            return assume_signed_32bit_lt(strict, left_svalue, left_uvalue, left_interval_positive, right_svalue,
+                                          right_uvalue);
         } else {
-            return assume_signed_32bit_gt(strict, left_svalue, left_uvalue, left_interval_positive,
-                                          left_interval_negative, right_svalue, right_uvalue, right_interval);
+            return assume_signed_32bit_gt(strict, left_svalue, left_uvalue, left_interval_positive, right_svalue,
+                                          right_uvalue);
         }
     }
     return {};
@@ -513,16 +524,23 @@ FiniteDomain::assume_unsigned_64bit_gt(const bool strict, const Variable left_sv
     }
 }
 
-std::vector<LinearConstraint>
-FiniteDomain::assume_unsigned_32bit_gt(const bool strict, const Variable left_svalue, const Variable left_uvalue,
-                                       const Interval& left_interval_low, const Interval& left_interval_high,
-                                       const LinearExpression& right_svalue, const LinearExpression& right_uvalue,
-                                       const Interval& right_interval) const {
+std::vector<LinearConstraint> FiniteDomain::assume_unsigned_32bit_gt(const bool strict, const Variable left_svalue,
+                                                                     const Variable left_uvalue,
+                                                                     const LinearExpression& right_svalue,
+                                                                     const LinearExpression& right_uvalue) const {
 
     using namespace dsl_syntax;
 
-    if (right_interval <= Interval::unsigned_high(32)) {
-        // Interval can be represented as both an svalue and a uvalue since it fits in [INT_MAX+1, UINT_MAX].
+    // Constraining left_svalue requires both operands to be sign-extended negative 32-bit
+    // values; only then do the 64-bit svalues order the same way as the 32-bit values being
+    // compared. This mirrors the corresponding branch of assume_unsigned_32bit_lt. Operands
+    // that are merely in the high half of the 32-bit range fall through to the uvalue-only
+    // branch below, which stays sound because both values are then below 2^32.
+    if (eval_interval(left_svalue) <= Interval::signed_int(32) &&
+        eval_interval(right_svalue) <= Interval::negative(32)) {
+        // left is a sign-extended 32-bit value and right's 32-bit value is in the high half, so
+        // left > right (unsigned) forces left into the high half too. Both are then sign-extended
+        // negatives, where the signed and unsigned orderings agree.
         return {0 <= left_uvalue, strict ? left_uvalue > right_uvalue : left_uvalue >= right_uvalue,
                 strict ? left_svalue > right_svalue : left_svalue >= right_svalue};
     } else if (eval_interval(left_uvalue) <= Interval::unsigned_int(32) &&
@@ -607,8 +625,7 @@ std::vector<LinearConstraint> FiniteDomain::assume_unsigned_cst_interval(Conditi
         if (is_lt) {
             return assume_unsigned_32bit_lt(strict, left_svalue, left_uvalue, right_svalue, right_uvalue);
         } else {
-            return assume_unsigned_32bit_gt(strict, left_svalue, left_uvalue, left_interval_low, left_interval_high,
-                                            right_svalue, right_uvalue, right_interval);
+            return assume_unsigned_32bit_gt(strict, left_svalue, left_uvalue, right_svalue, right_uvalue);
         }
     }
 }

--- a/src/crab/finite_domain.hpp
+++ b/src/crab/finite_domain.hpp
@@ -209,10 +209,8 @@ class FiniteDomain {
                                                          const Interval& right_interval) const;
     std::vector<LinearConstraint> assume_signed_32bit_lt(bool strict, Variable left_svalue, Variable left_uvalue,
                                                          const Interval& left_interval_positive,
-                                                         const Interval& left_interval_negative,
                                                          const LinearExpression& right_svalue,
-                                                         const LinearExpression& right_uvalue,
-                                                         const Interval& right_interval) const;
+                                                         const LinearExpression& right_uvalue) const;
     std::vector<LinearConstraint> assume_signed_64bit_gt(bool strict, Variable left_svalue, Variable left_uvalue,
                                                          const Interval& left_interval_positive,
                                                          const Interval& left_interval_negative,
@@ -221,10 +219,8 @@ class FiniteDomain {
                                                          const Interval& right_interval) const;
     std::vector<LinearConstraint> assume_signed_32bit_gt(bool strict, Variable left_svalue, Variable left_uvalue,
                                                          const Interval& left_interval_positive,
-                                                         const Interval& left_interval_negative,
                                                          const LinearExpression& right_svalue,
-                                                         const LinearExpression& right_uvalue,
-                                                         const Interval& right_interval) const;
+                                                         const LinearExpression& right_uvalue) const;
     std::vector<LinearConstraint> assume_signed_cst_interval(Condition::Op op, bool is64, Variable left_svalue,
                                                              Variable left_uvalue, const LinearExpression& right_svalue,
                                                              const LinearExpression& right_uvalue) const;
@@ -239,10 +235,9 @@ class FiniteDomain {
     assume_unsigned_64bit_gt(bool strict, Variable left_svalue, Variable left_uvalue, const Interval& left_interval_low,
                              const Interval& left_interval_high, const LinearExpression& right_svalue,
                              const LinearExpression& right_uvalue, const Interval& right_interval) const;
-    std::vector<LinearConstraint>
-    assume_unsigned_32bit_gt(bool strict, Variable left_svalue, Variable left_uvalue, const Interval& left_interval_low,
-                             const Interval& left_interval_high, const LinearExpression& right_svalue,
-                             const LinearExpression& right_uvalue, const Interval& right_interval) const;
+    std::vector<LinearConstraint> assume_unsigned_32bit_gt(bool strict, Variable left_svalue, Variable left_uvalue,
+                                                           const LinearExpression& right_svalue,
+                                                           const LinearExpression& right_uvalue) const;
     std::vector<LinearConstraint> assume_unsigned_cst_interval(Condition::Op op, bool is64, Variable left_svalue,
                                                                Variable left_uvalue,
                                                                const LinearExpression& right_svalue,

--- a/src/ir/syntax.hpp
+++ b/src/ir/syntax.hpp
@@ -479,10 +479,9 @@ struct ValidMapType {
     bool operator==(const ValidMapType&) const = default;
 };
 
-using Assertion =
-    std::variant<Comparable, Addable, ValidDivisor, ValidAccess, ValidStore, ValidSize, ValidMapKeyValue,
-                 ValidCallbackTarget, TypeConstraint, FuncConstraint, ZeroCtxOffset, BoundedLoopCount, ValidArgZero,
-                 ValidMapType>;
+using Assertion = std::variant<Comparable, Addable, ValidDivisor, ValidAccess, ValidStore, ValidSize, ValidMapKeyValue,
+                               ValidCallbackTarget, TypeConstraint, FuncConstraint, ZeroCtxOffset, BoundedLoopCount,
+                               ValidArgZero, ValidMapType>;
 
 std::ostream& operator<<(std::ostream& os, Instruction const& ins);
 std::string to_string(Instruction const& ins);

--- a/test-data/movsx.yaml
+++ b/test-data/movsx.yaml
@@ -248,3 +248,83 @@ post:
   - r1.uvalue=r1.svalue
   - r2.type=number
   - r2.svalue=[-2147483648, 2147483647]
+---
+# Regression: a 32-bit MOVSX whose destination is also its source must still zero-extend
+# its 32-bit result. The no-op fast path used to skip that, leaving the verifier with a
+# sign-extended 64-bit value that the CPU never produces.
+test-case: movsx8 into the same register to 32 bits
+
+pre: ["r2.svalue=-1", "r2.uvalue=18446744073709551615", "r2.type=number"]
+
+code:
+  <start>: |
+    w2 s8= r2
+
+post:
+  - r2.type=number
+  - r2.svalue=4294967295
+  - r2.uvalue=4294967295
+---
+test-case: movsx32 into the same register to 32 bits
+
+pre: ["r2.svalue=-5", "r2.uvalue=18446744073709551611", "r2.type=number"]
+
+code:
+  <start>: |
+    w2 s32= r2
+
+post:
+  - r2.type=number
+  - r2.svalue=4294967291
+  - r2.uvalue=4294967291
+---
+test-case: movsx8 into the same register to 32 bits over a range
+
+pre: ["r2.svalue=[-2, -1]", "r2.uvalue=[18446744073709551614, 18446744073709551615]", "r2.type=number"]
+
+code:
+  <start>: |
+    w2 s8= r2
+
+post:
+  - r2.type=number
+  - r2.svalue=[4294967294, 4294967295]
+  - r2.uvalue=r2.svalue
+---
+# The 64-bit form really is a no-op for a value that already fits, so the fast path
+# must still apply there.
+test-case: movsx8 into the same register to 64 bits is a no-op
+
+pre: ["r2.svalue=-1", "r2.uvalue=18446744073709551615", "r2.type=number"]
+
+code:
+  <start>: |
+    r2 s8= r2
+
+post:
+  - r2.type=number
+  - r2.svalue=-1
+  - r2.uvalue=18446744073709551615
+---
+# End-to-end: dropping the zero-extension let this out-of-bounds stack write be accepted,
+# because the verifier computed r1 = r10 - 1 where the CPU computes r10 + 0xFFFFFFFF.
+test-case: movsx8 into the same register cannot hide an out-of-bounds stack write
+
+pre: ["r10.type=stack", "r10.stack_offset=512"]
+
+code:
+  <start>: |
+    r1 = r10
+    r2 = -1
+    w2 s8= r2
+    r1 += r2
+    r3 = 0
+    *(u8 *)(r1 - 8) = r3
+    r0 = 0
+    exit
+
+post:
+  - "_|_"
+
+messages:
+  - "5: Upper bound must be at most total_stack_size (valid_access(r1.offset-8, width=1) for write)"

--- a/test-data/unsigned.yaml
+++ b/test-data/unsigned.yaml
@@ -1297,3 +1297,31 @@ code:
 post: ["r1.type=number", "r1.svalue=[-1, 2]",
        "r2.type=number", "r2.svalue=[-2, 1]",
        "r2.svalue-r1.svalue<=-1"]
+---
+# Regression: a 32-bit comparison constrains only the low 32 bits, so it must not be turned
+# into a constraint on the 64-bit svalue/uvalue unless those already coincide with the
+# 32-bit values. When the register's 64-bit range straddles a 32-bit boundary they do not,
+# and these branches used to be pruned even though concrete values take them.
+test-case: "assume 32-bit s< with left straddling INT32_MAX keeps the branch live"
+pre: ["r1.type=number", "r1.svalue=[2147483646, 2147483650]", "r1.uvalue=[2147483646, 2147483650]"]
+code:
+  <start>: assume w1 s< -1
+post: ["r1.type=number", "r1.svalue=[2147483646, 2147483650]", "r1.uvalue=[2147483646, 2147483650]"]
+---
+test-case: "assume 32-bit s> with left straddling INT32_MAX keeps the branch live"
+pre: ["r1.type=number", "r1.svalue=[2147483646, 2147483650]", "r1.uvalue=[2147483646, 2147483650]"]
+code:
+  <start>: assume w1 s> 0
+post: ["r1.type=number", "r1.svalue=[2147483646, 2147483650]", "r1.uvalue=[2147483646, 2147483650]"]
+---
+test-case: "assume 32-bit unsigned > with left straddling 2^32 keeps the branch live"
+pre: ["r1.type=number", "r1.uvalue=[4294967293, 4294967298]"]
+code:
+  <start>: assume w1 > -3
+post: ["r1.type=number", "r1.uvalue=[4294967293, 4294967298]"]
+---
+test-case: "assume 32-bit s> with left straddling 2^32 keeps the branch live"
+pre: ["r1.type=number", "r1.uvalue=[4294967293, 4294967298]"]
+code:
+  <start>: assume w1 s> 0
+post: ["r1.type=number", "r1.uvalue=[4294967293, 4294967298]"]


### PR DESCRIPTION
Two independent 32-bit (ALU32/JMP32) unsoundness bugs let a crafted-but-valid program be **accepted** while performing an out-of-bounds stack access. Both are fixed here, with regression tests.

## MOVSX drops the ALU32 zero-extension

The no-op fast path in `EbpfTransformer::operator()(const Bin&)` returns early when the destination *is* the source, which skips the zero-extension applied at the end of the function. For a 32-bit MOVSX the result must still be zero-extended into the upper half, so the verifier kept a sign-extended 64-bit value where the CPU produces a zero-extended 32-bit one.

The verifier already contradicted itself: with `r1 = -1`, `w2 s8= r1` produced `4294967295` (correct) while `w2 s8= r2` produced `-1` for the same operation and input — the answer depended only on whether `dst == src`.

Consequence — this program was accepted:

```
r1 = r10
r2 = -1
w2 s8= r2
r1 += r2
r3 = 0
*(u8 *)(r1 - 8) = r3   ; proved in-bounds at s[503]
```

The verifier computes `r1 = r10 - 1`; the CPU computes `r10 + 0xFFFFFFFF`, roughly 4 GB out of bounds. Fixed by guarding the fast path with `bin.is64`. The 64-bit form is a genuine no-op and still takes it.

Every existing MOVSX test uses distinct registers (`w2 s8= r1`), so nothing exercised the same-register 32-bit form.

## 32-bit compares constrain the 64-bit svalue/uvalue

`assume_signed_32bit_lt`, `assume_signed_32bit_gt` and `assume_unsigned_32bit_gt` emitted constraints over the 64-bit `svalue`/`uvalue` variables after testing only the *truncated 32-bit views*. Once a register's 64-bit value falls outside the 32-bit range, those views say nothing about how the 64-bit variables are ordered, so the constraints could exclude feasible states — the verifier proved live branches dead and never checked the code on them.

With `r1 ∈ [0x7FFFFFFE, 0x80000002]`, `assume w1 s< -1` made the branch unreachable, although `0x80000000`, `0x80000001` and `0x80000002` all take it. Building an out-of-bounds store onto that branch produced an accepted program; the identical store reached unconditionally is correctly rejected.

The branch conditions now test the 64-bit intervals and fall back to the pre-existing no-constraint case. `assume_unsigned_32bit_lt` already guarded every branch this way, which is why only the `>`, `>=`, `s<`, `s<=`, `s>` and `s>=` paths were affected.

Precision is unchanged for registers holding genuine 32-bit values: in the branches where the comparison itself pins the operand's sign, the guard only requires the operand to be a sign-extended 32-bit value; the stricter sign check is kept only where the branch *asserts* a sign that the comparison does not force.

The interval parameters these helpers no longer read are dropped, which also makes `assume_unsigned_32bit_gt` match its `_lt` sibling's signature.

## Testing

Nine regression tests added to `test-data/movsx.yaml` and `test-data/unsigned.yaml`. Eight of them fail without the fix (verified by reverting the source change and rebuilding); the ninth asserts the 64-bit MOVSX no-op still applies and passes either way, guarding against over-fixing.

Also verified with four differential harnesses that compare branch pruning against concrete eBPF semantics — immediate and register-register compares, each over both concrete values and range states, ~19,000 generated cases. A branch is flagged when a concrete witness satisfies the condition but the verifier proves the state unreachable.

| | before | after |
|---|---|---|
| concrete-value compares (imm + reg-reg) | 0 | 0 |
| range-state compares, immediate | 162 | 0 |
| range-state compares, register-register | 189 | 0 |

Full suite green: 640 unit test cases (639 passed, 1 skipped, 417,024 assertions) and all 28 `test-data` suites.

The concrete-value harnesses find nothing either way — singleton inputs make the buggy abstract paths degenerate to correct behaviour, which is why range states were needed to expose these.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
