### PR TITLE
Type a ctx load by the bytes it reads, not by its start offset (fixes #1204)

### DIFF
--- a/src/arith/num_int128.hpp
+++ b/src/arith/num_int128.hpp
@@ -7,10 +7,15 @@
 // this header provides a Boost-free fallback for compilers without a 128-bit builtin
 // (MSVC), so consumers of the installed library do not need Boost.Multiprecision.
 //
-// Semantics match two's-complement __int128 exactly: wrap-around add/sub/mul, truncation-
-// toward-zero div/mod, arithmetic right shift, and signed/unsigned comparisons. Correctness
-// is checked against native __int128 in test_int128.cpp and by running the whole test suite
-// with -DPREVAIL_FORCE_CUSTOM_INT128 on a platform that has __int128.
+// Semantics match two's-complement __int128 over the range where __int128 is defined:
+// wrap-around add/sub/mul, truncation-toward-zero div/mod, arithmetic right shift, and
+// signed/unsigned comparisons. Shift counts outside [0, 127] are undefined for __int128;
+// this header instead defines them (a negative count is a no-op, a count of 128 or more
+// yields zero, or all sign bits for a negative arithmetic right shift), so the two backends
+// agree everywhere a caller is allowed to go and only diverge past that boundary.
+// Number::operator>> and operator<< reject such counts before dispatching to either
+// backend. Correctness is checked against native __int128 in test_int128.cpp and by running
+// the whole test suite with -DPREVAIL_FORCE_CUSTOM_INT128 on a platform that has __int128.
 
 #include <compare>
 #include <concepts>

--- a/src/crab/array_domain.cpp
+++ b/src/crab/array_domain.cpp
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <algorithm>
+#include <array>
+#include <cstring>
 #include <optional>
 #include <set>
 #include <unordered_map>
@@ -464,7 +466,8 @@ std::optional<uint8_t> get_value_byte(const NumAbsDomain& inv, const offset_t o,
         break;
     default: CRAB_ERROR("Unexpected width ", width);
     }
-    const auto bytes = reinterpret_cast<uint8_t*>(&n);
+    std::array<uint8_t, sizeof(Index)> bytes{};
+    std::memcpy(bytes.data(), &n, sizeof(n));
     return bytes[o % width];
 }
 
@@ -509,7 +512,8 @@ std::optional<LinearExpression> ArrayDomain::load(const NumAbsDomain& inv, const
                     return *result_buffer;
                 }
                 if (size == 2) {
-                    uint16_t b = *reinterpret_cast<uint16_t*>(result_buffer);
+                    uint16_t b{};
+                    std::memcpy(&b, result_buffer, sizeof(b));
                     if (big_endian) {
                         b = boost::endian::native_to_big<uint16_t>(b);
                     } else {
@@ -518,7 +522,8 @@ std::optional<LinearExpression> ArrayDomain::load(const NumAbsDomain& inv, const
                     return b;
                 }
                 if (size == 4) {
-                    uint32_t b = *reinterpret_cast<uint32_t*>(result_buffer);
+                    uint32_t b{};
+                    std::memcpy(&b, result_buffer, sizeof(b));
                     if (big_endian) {
                         b = boost::endian::native_to_big<uint32_t>(b);
                     } else {
@@ -527,7 +532,8 @@ std::optional<LinearExpression> ArrayDomain::load(const NumAbsDomain& inv, const
                     return b;
                 }
                 if (size == 8) {
-                    Index b = *reinterpret_cast<Index*>(result_buffer);
+                    Index b{};
+                    std::memcpy(&b, result_buffer, sizeof(b));
                     if (big_endian) {
                         b = boost::endian::native_to_big<Index>(b);
                     } else {

--- a/src/crab/ebpf_transformer.cpp
+++ b/src/crab/ebpf_transformer.cpp
@@ -493,6 +493,21 @@ static void narrow_num_by_load_width(TypeToNumDomain& state, const RegPack& targ
     }
 }
 
+// The byte range a load of `width` bytes reads, over every address the load may use.
+static Interval read_range(const Interval& addr, const int width) {
+    return addr + Interval{Number{0}, Number{width - 1}};
+}
+
+// Whether a load covering `bytes` can see any byte of the inline pointer slot at
+// `field_offset`. A field the context descriptor does not define is negative.
+static bool may_read_ptr_field(const Interval& bytes, const int field_offset, const int offset_width) {
+    if (field_offset < 0) {
+        return false;
+    }
+    const Interval field{Number{field_offset}, Number{field_offset + offset_width - 1}};
+    return !(bytes & field).is_bottom();
+}
+
 static void do_load_ctx(TypeToNumDomain& state, const AnalysisContext& context, const Reg& target_reg,
                         const LinearExpression& addr_vague, const int width, const bool is_signed) {
     using namespace dsl_syntax;
@@ -515,8 +530,19 @@ static void do_load_ctx(TypeToNumDomain& state, const AnalysisContext& context, 
     const std::optional<Number> maybe_addr = interval.singleton();
     state.havoc_register(target_reg);
 
-    const bool may_touch_ptr =
-        interval.contains(desc->data) || interval.contains(desc->meta) || interval.contains(desc->end);
+    // We use offsets for packet data, data_end, and meta during verification,
+    // but at runtime they will be 64-bit pointers.  We can use the offset values
+    // for verification like we use map_fd's as a proxy for maps which
+    // at runtime are actually 64-bit memory pointers.
+    const int offset_width = desc->end - desc->data;
+
+    // A load that reads even one byte of a pointer slot yields pointer bytes, so its
+    // result must not be typed as a number: a partial or straddling read would
+    // otherwise launder a real pointer into a scalar the program can leak.
+    const Interval bytes = read_range(interval, width);
+    const bool may_touch_ptr = may_read_ptr_field(bytes, desc->data, offset_width) ||
+                               may_read_ptr_field(bytes, desc->meta, offset_width) ||
+                               may_read_ptr_field(bytes, desc->end, offset_width);
 
     if (!maybe_addr) {
         if (may_touch_ptr) {
@@ -530,11 +556,6 @@ static void do_load_ctx(TypeToNumDomain& state, const AnalysisContext& context, 
 
     const Number& addr = *maybe_addr;
 
-    // We use offsets for packet data, data_end, and meta during verification,
-    // but at runtime they will be 64-bit pointers.  We can use the offset values
-    // for verification like we use map_fd's as a proxy for maps which
-    // at runtime are actually 64-bit memory pointers.
-    const int offset_width = desc->end - desc->data;
     if (addr == desc->data) {
         if (width == offset_width) {
             state.values.assign(target.packet_offset, 0);

--- a/test-data/ctx.yaml
+++ b/test-data/ctx.yaml
@@ -1,17 +1,23 @@
 # Copyright (c) Prevail Verifier contributors.
 # SPDX-License-Identifier: MIT
 #
-# Regression tests for writes through a context pointer.
+# Regression tests for accesses through a context pointer.
 #
 # The context descriptor used by the YAML test harness is {size=64, data=0,
 # end=4, meta=-1}: the data and data_end pointer slots occupy bytes [0,4) and
-# [4,8). A *load* of those slots synthesizes a typed packet pointer
+# [4,8). A *load* of a whole slot synthesizes a typed packet pointer
 # (do_load_ctx), but writes are not tracked by the abstract transformer. A write
 # to e.g. ctx->data that is accepted as a silent no-op, followed by a reload,
 # would hand the program a fresh "valid" packet pointer for a field it corrupted
 # at runtime -- a false PASS for an out-of-bounds dereference. Writes that may
 # overlap a pointer slot must therefore be rejected, regardless of the stored
 # value. Writes to other (scalar) context fields remain allowed.
+#
+# A load that reads only part of a pointer slot yields pointer bytes without
+# yielding a usable pointer, so its result is left untyped: typing it as a number
+# would launder those bytes into a scalar the program may store into a
+# userspace-visible region. Loads that stay clear of every slot are scalars,
+# narrowed to the range implied by the load width.
 ---
 test-case: store number to ctx data pointer slot is rejected
 
@@ -237,3 +243,69 @@ post:
   - r1.type=ctx
   - r2.type=number
   - r2.svalue=[-2147483648, 2147483647]
+
+---
+# A load straddling a pointer slot reads real pointer bytes. Typing the result as
+# a number would let the program store those bytes into a map shared with
+# userspace -- a pointer/KASLR leak (#1204). The result must carry no type, so the
+# store to the shared region is rejected.
+test-case: value straddling ctx pointer slots cannot escape to a shared region
+
+pre: ["r1.type=ctx", "r1.ctx_offset=0",
+      "r3.type=shared", "r3.shared_offset=0", "r3.shared_region_size=16",
+      "r3.svalue=[1, 2147418112]", "r3.uvalue=r3.svalue"]
+
+code:
+  <start>: |
+    r2 = *(u32 *)(r1 + 2)
+    *(u64 *)(r3 + 0) = r2
+
+post:
+  - "_|_"
+
+messages:
+  - "1: Only numbers can be stored to externally-visible regions (r3.type != stack -> r2.type == number)"
+
+---
+# The same holds when the load address is a range: every address in [6, 10] reads
+# eight bytes, and the lowest of them reach back into the data_end slot at [4,8).
+test-case: ranged load reaching a ctx pointer slot cannot escape to a shared region
+
+pre: ["r1.type=ctx", "r1.ctx_offset=[6, 10]",
+      "r3.type=shared", "r3.shared_offset=0", "r3.shared_region_size=16",
+      "r3.svalue=[1, 2147418112]", "r3.uvalue=r3.svalue"]
+
+code:
+  <start>: |
+    r2 = *(u64 *)(r1 + 0)
+    *(u64 *)(r3 + 0) = r2
+
+post:
+  - "_|_"
+
+messages:
+  - "1: Only numbers can be stored to externally-visible regions (r3.type != stack -> r2.type == number)"
+
+---
+# Precision guard for the two cases above: a load clear of every pointer slot is
+# still a plain number and may be stored to a shared region.
+test-case: value loaded from a ctx scalar field may be stored to a shared region
+
+pre: ["r1.type=ctx", "r1.ctx_offset=0",
+      "r3.type=shared", "r3.shared_offset=0", "r3.shared_region_size=16",
+      "r3.svalue=[1, 2147418112]", "r3.uvalue=r3.svalue"]
+
+code:
+  <start>: |
+    r2 = *(u32 *)(r1 + 8)
+    *(u64 *)(r3 + 0) = r2
+
+post:
+  - r1.ctx_offset=0
+  - r1.type=ctx
+  - r2.type=number
+  - r3.shared_offset=0
+  - r3.shared_region_size=16
+  - r3.svalue=[1, 2147418112]
+  - r3.type=shared
+  - r3.uvalue=r3.svalue


### PR DESCRIPTION
Fixes #1204, and the first (substantive) item of #1206.

## The hole

`do_load_ctx` decided whether a context load touches an inline pointer field (`data`/`data_end`/`meta`) from the load's **start offset** alone:

```cpp
const bool may_touch_ptr =
    interval.contains(desc->data) || interval.contains(desc->meta) || interval.contains(desc->end);
```

That is true only when the address can equal a field's first byte. A load that starts inside or before a slot and reads across it was therefore typed `T_NUM`. With the harness descriptor `{size=64, data=0, end=4}`, `r2 = *(u32 *)(r1 + 2)` covers bytes `[2,6)` — three bytes of `ctx->data` and one of `ctx->data_end` — and the verifier came out believing `r2` is a scalar. The program can then store those pointer bytes into a map shared with userspace and the verifier reports PASS: a pointer/KASLR leak.

The Linux kernel's ctx `is_valid_access` rejects such a misaligned read, so this is **major** on Linux and **critical for standalone deployments** (userspace / Windows eBPF), which have no kernel backstop.

## The fix

Decide by intersecting the byte range the load actually reads, `[addr, addr + width)`, against each slot's range `[field, field + offset_width)`.

This subsumes the old test — an address equal to a field start always intersects that field — and additionally catches partial and straddling reads, for a singleton address and for a range of addresses alike. A load that may read pointer bytes leaves the destination's type havoced, exactly as an ambiguous whole-slot load already did. A load clear of every slot is still a plain number, narrowed by width as before. Slots the descriptor does not define are encoded as a negative offset and are skipped, matching the old behavior for a nonnegative address.

## #1206 UB-1

Three `reinterpret_cast` reads of the stack byte-reconstruction buffer, and one of a scalar's bytes, become `std::memcpy`. Reading a `uint8_t[8]` through `uint16_t*`/`uint32_t*`/`uint64_t*` is a strict-aliasing and alignment violation; compilers fold the memcpy back to a single load, so this is UB removal at no cost.

The int128 header comment claimed the custom backend matches `__int128` "exactly", which is not true for shift counts outside `[0,127]`, where `__int128` is undefined and the custom path is defined. The comment now says where the two agree and who enforces it (#1206 UB-2, comment-only).

## Tests

Three cases in `test-data/ctx.yaml`:

- a straddling singleton address (`*(u32 *)(r1 + 2)`), stored into a shared region;
- a ranged address `[6, 10]` whose low addresses reach back into the `data_end` slot, stored into a shared region;
- a precision guard: a load clear of every slot is still a number and may be stored to a shared region.

The first two fail without the transformer fix (verified by reverting it and rebuilding — the store is accepted); the third passes both ways, so it pins that the fix does not over-havoc.

Full suite green.
