### PR TITLE
Check the divisor a 32-bit division actually uses (fixes #1205)

### DIFF
--- a/src/crab/ebpf_checker.cpp
+++ b/src/crab/ebpf_checker.cpp
@@ -181,6 +181,15 @@ void EbpfChecker::operator()(const Addable& s) const {
     }
 }
 
+// Whether the low half of a register can be zero. Zero has the same representation in the
+// signed and the unsigned view, so either view excluding it proves the low half nonzero.
+// Consulting both matters: a range like [1, 0xffffffff] crosses the 32-bit sign boundary,
+// so sign-extending it yields the whole signed range, while zero-extending keeps it exact.
+static bool may_be_zero_at_32_bits(const TypeToNumDomain& state, const RegPack& reg) {
+    return state.values->eval_interval(reg.uvalue, 32).contains(0) &&
+           state.values->eval_interval(reg.svalue, 32).contains(0);
+}
+
 void EbpfChecker::operator()(const ValidDivisor& s) const {
     using namespace dsl_syntax;
     if (!dom.state.implies_superset(s.reg, TS_POINTER, s.reg, TS_NUM)) {
@@ -188,13 +197,13 @@ void EbpfChecker::operator()(const ValidDivisor& s) const {
     }
     if (!context.runtime().allow_division_by_zero) {
         const auto reg = reg_pack(s.reg);
-        const auto v = s.is_signed ? reg.svalue : reg.uvalue;
-        // A 32-bit division divides by the register's low half, the same view the
-        // transformer divides by. Testing all 64 bits instead would accept a divisor
-        // like 0x1'0000'0000, whose low half -- the actual divisor -- is zero.
         if (s.is64) {
+            const auto v = s.is_signed ? reg.svalue : reg.uvalue;
             require_value(dom.state, v != 0, "Possible division by zero");
-        } else if (dom.state.values->eval_interval(v, 32).contains(0)) {
+        } else if (may_be_zero_at_32_bits(dom.state, reg)) {
+            // A 32-bit division divides by the register's low half, the same view the
+            // transformer divides by. Testing all 64 bits instead would accept a divisor
+            // like 0x1'0000'0000, whose low half -- the actual divisor -- is zero.
             throw_fail("Possible division by zero");
         }
     }

--- a/src/crab/ebpf_checker.cpp
+++ b/src/crab/ebpf_checker.cpp
@@ -189,7 +189,14 @@ void EbpfChecker::operator()(const ValidDivisor& s) const {
     if (!context.runtime().allow_division_by_zero) {
         const auto reg = reg_pack(s.reg);
         const auto v = s.is_signed ? reg.svalue : reg.uvalue;
-        require_value(dom.state, v != 0, "Possible division by zero");
+        // A 32-bit division divides by the register's low half, the same view the
+        // transformer divides by. Testing all 64 bits instead would accept a divisor
+        // like 0x1'0000'0000, whose low half -- the actual divisor -- is zero.
+        if (s.is64) {
+            require_value(dom.state, v != 0, "Possible division by zero");
+        } else if (dom.state.values->eval_interval(v, 32).contains(0)) {
+            throw_fail("Possible division by zero");
+        }
     }
 }
 

--- a/src/ir/assertions.cpp
+++ b/src/ir/assertions.cpp
@@ -332,7 +332,7 @@ class AssertExtractor {
             if (const auto src = std::get_if<Reg>(&ins.v)) {
                 const bool is_signed = (ins.op == Bin::Op::SDIV || ins.op == Bin::Op::SMOD);
                 return {Assertion{TypeConstraint{ins.dst, TypeGroup::number}},
-                        Assertion{ValidDivisor{*src, is_signed}}};
+                        Assertion{ValidDivisor{.reg = *src, .is_signed = is_signed, .is64 = ins.is64}}};
             }
             return {Assertion{TypeConstraint{ins.dst, TypeGroup::number}}};
         }

--- a/src/ir/syntax.hpp
+++ b/src/ir/syntax.hpp
@@ -394,10 +394,13 @@ struct Addable {
     constexpr bool operator==(const Addable&) const = default;
 };
 
-// Condition check whether a register contains a non-zero number.
+// Condition check whether a register contains a non-zero number. `is64` is the width of the
+// division that consumes it: a 32-bit division divides by the register's low half, so only
+// those bytes have to be non-zero.
 struct ValidDivisor {
     Reg reg;
     bool is_signed{};
+    bool is64{};
     constexpr bool operator==(const ValidDivisor&) const = default;
 };
 

--- a/src/printing.cpp
+++ b/src/printing.cpp
@@ -372,6 +372,10 @@ static string size(const int w, const bool is_signed = false) {
     return string(is_signed ? "s" : "u") + std::to_string(w * 8);
 }
 
+// llvm-objdump uses "w<number>" for 32-bit operations and "r<number>" for 64-bit operations.
+// We use the same convention here for consistency.
+static string reg_name(Reg const& a, const bool is64) { return string(is64 ? "r" : "w") + std::to_string(a.v); }
+
 // ReSharper disable CppMemberFunctionMayBeConst
 struct AssertionPrinterVisitor {
     std::ostream& _os;
@@ -436,7 +440,7 @@ struct AssertionPrinterVisitor {
         _os << TypeConstraint{a.ptr, TypeGroup::pointer} << " -> " << TypeConstraint{a.num, TypeGroup::number};
     }
 
-    void operator()(ValidDivisor const& a) { _os << a.reg << " != 0"; }
+    void operator()(ValidDivisor const& a) { _os << reg_name(a.reg, a.is64) << " != 0"; }
 
     void operator()(TypeConstraint const& tc) {
         const string cmp_op = is_singleton_type(tc.types) ? "==" : "in";
@@ -474,10 +478,6 @@ struct CommandPrinterVisitor {
             break;
         }
     }
-
-    // llvm-objdump uses "w<number>" for 32-bit operations and "r<number>" for 64-bit operations.
-    // We use the same convention here for consistency.
-    static std::string reg_name(Reg const& a, const bool is64) { return ((is64) ? "r" : "w") + std::to_string(a.v); }
 
     void operator()(Bin const& b) {
         os_ << reg_name(b.dst, b.is64) << " " << b.op << "= " << b.v;

--- a/test-data/sdivmod.yaml
+++ b/test-data/sdivmod.yaml
@@ -527,3 +527,41 @@ post:
   - r0.type=number
   - r0.svalue=[0, 2055]
   - r0.uvalue=r0.svalue
+
+---
+# As in the unsigned case (#1205): a 32-bit signed division divides by the low
+# half of the divisor register, which is zero here.
+test-case: 32-bit signed division by a register whose low half is zero
+
+pre: ["r1.type=number", "r1.svalue=6", "r1.uvalue=6",
+      "r2.type=number", "r2.svalue=4294967296", "r2.uvalue=4294967296"]
+
+options: ["!allow_division_by_zero"]
+
+code:
+  <start>: |
+    w1 s/= w2
+
+post:
+  - "_|_"
+
+messages:
+  - "0: Possible division by zero (w2 != 0)"
+
+---
+test-case: 32-bit signed modulo by a register whose low half is zero
+
+pre: ["r1.type=number", "r1.svalue=6", "r1.uvalue=6",
+      "r2.type=number", "r2.svalue=4294967296", "r2.uvalue=4294967296"]
+
+options: ["!allow_division_by_zero"]
+
+code:
+  <start>: |
+    w1 s%= w2
+
+post:
+  - "_|_"
+
+messages:
+  - "0: Possible division by zero (w2 != 0)"

--- a/test-data/sdivmod.yaml
+++ b/test-data/sdivmod.yaml
@@ -565,3 +565,47 @@ post:
 
 messages:
   - "0: Possible division by zero (w2 != 0)"
+
+---
+# The same divisor is a genuine nonzero divisor for a 64-bit signed division.
+test-case: 64-bit signed division by a register whose low half is zero
+
+pre: ["r1.type=number", "r1.svalue=6", "r1.uvalue=6",
+      "r2.type=number", "r2.svalue=4294967296", "r2.uvalue=4294967296"]
+
+options: ["!allow_division_by_zero"]
+
+code:
+  <start>: |
+    r1 s/= r2
+
+post:
+  - r1.type=number
+  - r1.svalue=0
+  - r1.uvalue=0
+  - r2.type=number
+  - r2.svalue=4294967296
+  - r2.uvalue=4294967296
+
+---
+# A nonzero divisor range that crosses the 32-bit sign boundary. Sign-extending it
+# yields the whole signed range, which contains zero, so proving the low half nonzero
+# has to consult the unsigned view as well.
+test-case: 32-bit signed division by a nonzero sign-crossing range
+
+pre: ["r1.type=number", "r1.svalue=6", "r1.uvalue=6",
+      "r2.type=number", "r2.svalue=[1, 4294967295]", "r2.uvalue=r2.svalue"]
+
+options: ["!allow_division_by_zero"]
+
+code:
+  <start>: |
+    w1 s/= w2
+
+post:
+  - r1.type=number
+  - r1.svalue=[0, 4294967295]
+  - r1.uvalue=r1.svalue
+  - r2.type=number
+  - r2.svalue=[1, 4294967295]
+  - r2.uvalue=r2.svalue

--- a/test-data/udivmod.yaml
+++ b/test-data/udivmod.yaml
@@ -513,3 +513,84 @@ post:
   - r0.type=number
   - r0.svalue=[0, 2055]
   - r0.uvalue=r0.svalue
+
+---
+# A 32-bit division divides by the low half of the divisor register. A divisor
+# that is a nonzero multiple of 2^32 has a zero low half, so the runtime divides
+# by zero; checking the full 64-bit value would accept it (#1205).
+test-case: 32-bit division by a register whose low half is zero
+
+pre: ["r1.type=number", "r1.svalue=6", "r1.uvalue=6",
+      "r2.type=number", "r2.svalue=4294967296", "r2.uvalue=4294967296"]
+
+options: ["!allow_division_by_zero"]
+
+code:
+  <start>: |
+    w1 /= w2
+
+post:
+  - "_|_"
+
+messages:
+  - "0: Possible division by zero (w2 != 0)"
+
+---
+test-case: 32-bit modulo by a register whose low half is zero
+
+pre: ["r1.type=number", "r1.svalue=6", "r1.uvalue=6",
+      "r2.type=number", "r2.svalue=4294967296", "r2.uvalue=4294967296"]
+
+options: ["!allow_division_by_zero"]
+
+code:
+  <start>: |
+    w1 %= w2
+
+post:
+  - "_|_"
+
+messages:
+  - "0: Possible division by zero (w2 != 0)"
+
+---
+# Precision guard: only the low half has to be nonzero. 2^32 + 5 divides as 5.
+test-case: 32-bit division by a register whose low half is nonzero
+
+pre: ["r1.type=number", "r1.svalue=6", "r1.uvalue=6",
+      "r2.type=number", "r2.svalue=4294967301", "r2.uvalue=4294967301"]
+
+options: ["!allow_division_by_zero"]
+
+code:
+  <start>: |
+    w1 /= w2
+
+post:
+  - r1.type=number
+  - r1.svalue=1
+  - r1.uvalue=1
+  - r2.type=number
+  - r2.svalue=4294967301
+  - r2.uvalue=4294967301
+
+---
+# The same divisor is a genuine nonzero divisor for a 64-bit division.
+test-case: 64-bit division by a register whose low half is zero
+
+pre: ["r1.type=number", "r1.svalue=6", "r1.uvalue=6",
+      "r2.type=number", "r2.svalue=4294967296", "r2.uvalue=4294967296"]
+
+options: ["!allow_division_by_zero"]
+
+code:
+  <start>: |
+    r1 /= r2
+
+post:
+  - r1.type=number
+  - r1.svalue=0
+  - r1.uvalue=0
+  - r2.type=number
+  - r2.svalue=4294967296
+  - r2.uvalue=4294967296


### PR DESCRIPTION
Fixes #1205.

## The mismatch

A 32-bit `DIV`/`MOD` divides by the **low half** of the divisor register, but the divide-by-zero check tested the full 64-bit value:

```cpp
const auto v = s.is_signed ? reg.svalue : reg.uvalue;
require_value(dom.state, v != 0, "Possible division by zero");
```

So a divisor that is a nonzero multiple of 2³² passed the check while the runtime divides by zero:

```
r1 = 1
r1 <<= 32          ; uvalue = 0x1_0000_0000, entails uvalue != 0
w0 /= w1           ; the CPU's divisor is (u32)r1 == 0
```

With `allow_division_by_zero=false` the verifier accepted a program it exists to reject.

Not a memory-safety hole — eBPF defines `/0 → 0` and `%0 → dividend`, and the transformer models that — but the checker and the transformer disagreed about what the divisor *is*: the transformer already reads it as `eval_interval(z, 32)`, while the checker read all 64 bits.

## The fix

`ValidDivisor` carried no width, so the checker could not tell the two cases apart. It now carries the `is64` of the division that produced it, and on the 32-bit path the checker tests the same 32-bit view of the divisor that the transformer divides by. The 64-bit path keeps the existing entailment check, which is more precise than an interval test on a relational domain.

## Message wording

The assertion prints as `w2 != 0` for a 32-bit division, matching the llvm-objdump register-naming convention already used for instruction operands, so the message says which half was checked. That `reg_name` helper moves to file scope in `printing.cpp` so the assertion printer can share it. 64-bit divisions still print `r2 != 0`, so no existing expected message changes.

## Tests

Four soundness cases — division and modulo, signed and unsigned, by a register holding 2³² — all of which are accepted without the fix (verified by reverting it and rebuilding).

Two precision guards, which pass either way:

- 32-bit division by 2³² + 5 is still accepted, and computes `6 / 5 == 1`;
- 64-bit division by 2³² is still accepted, since there the divisor is genuinely nonzero.

Full suite green.
