### PR TITLE
Cover the stale-svalue null-branch hole end to end (#1150)

### DIFF
--- a/test-data/elf_inventory.json
+++ b/test-data/elf_inventory.json
@@ -575,7 +575,7 @@
       }
     },
     "build": {
-      "object_count": 55,
+      "object_count": 56,
       "objects": {
         "badhelpercall.o": {
           "diagnostics": [],
@@ -1127,6 +1127,27 @@
                 "reject_load": false
               }
             ]
+          }
+        },
+        "map_sequential_lookup_unsafe.o": {
+          "diagnostics": [],
+          "exit_code": 0,
+          "program_count": 1,
+          "section_count": 1,
+          "sections": {
+            ".text": [
+              {
+                "function": "func",
+                "reject_load": false
+              }
+            ]
+          },
+          "test_overrides": {
+            "sections": {
+              ".text": {
+                "status": "reject"
+              }
+            }
           }
         },
         "mapoverflow.o": {
@@ -9416,8 +9437,8 @@
   },
   "schema_version": 1,
   "summary": {
-    "object_count": 261,
-    "program_count": 969,
-    "section_count": 756
+    "object_count": 262,
+    "program_count": 970,
+    "section_count": 757
   }
 }


### PR DESCRIPTION
Adds end-to-end coverage for the stale-`svalue` null-branch hole that #1155 closed, using the sample contributed with #1149.

## The gap

`ebpf-samples` ships `build/map_sequential_lookup_unsafe.o` — two sequential `bpf_map_lookup_elem` calls where the second result is dereferenced on its null branch. It came in with the submodule bump (090062e1) but was never registered, and it was the **only** object in the pinned submodule missing from `test-data/elf_inventory.json`, so nothing exercised it. (#1149 registers it in `test_verify_build.cpp`, which #1195 replaced with the inventory.)

## It is a real regression test

Built at `ee56790c`, the commit immediately before the #1155 fix:

```
$ pre-1155/bin/prevail ebpf-samples/build/map_sequential_lookup_unsafe.o
PASS: .text/func
```

On `main`:

```
$ bin/prevail ebpf-samples/build/map_sequential_lookup_unsafe.o
FAIL: .text/func
20: Invalid type (r1.type in {ctx, stack, packet, shared, socket, alloc_mem})
```

A false PASS on an unsafe program, fixed.

The mechanism differs from what the sample's own `.c` comments describe, which is worth recording since it is what makes the sample work as a test. The stale `svalue` does not come from the first lookup's null check: clang hoists the error return, so `r0 = 4294967295 ll` (`return -1`) executes before the second lookup and `r0` enters it already carrying `svalue = 4294967295`. Pre-fix, that survives the call:

```
r0.type=shared, r0.shared_offset=0, r0.shared_region_size=4,
r0.svalue=4294967295, r0.uvalue=[0, 2147418112]
```

`assume r0 == 0` then intersects `svalue == 0` with `4294967295` → bottom → the null branch is pruned and its dereference is never checked.

## The change

One `reject` override in the inventory, which asserts the rejection above. If the hole is reintroduced the program starts passing and this case fails.

This complements rather than duplicates the two `call.yaml` cases #1155 added — those drive the transformer through the YAML harness (one for a stale `svalue` planted before the call, one being #1150's reproducer verbatim; both fail at `ee56790c` with *both* branch successors reported unreachable). This one exercises the whole pipeline on a clang-compiled object.

Full suite green.
