### PR TITLE
Measure coverage on Release only and file it against the reviewed commit

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -11,14 +11,14 @@ name: CPP Code Coverage
 
 jobs:
   build_ubuntu:
-    strategy:
-      matrix:
-        configurations: [Debug, Release]
+    # Coverage is measured on Release only. An unoptimized build of the verifier,
+    # instrumented and running the whole sample corpus, took between 56 min and 2h34m
+    # per run against 8-10 min for Release, and gated every pull request on it. Debug
+    # is still compiled, tested, and leak-checked by the CPP CI workflow, so nothing
+    # stops being exercised here -- only the second instrumented build goes away.
     runs-on: ubuntu-latest
     env:
-      # Configuration type to build.  For documentation on how build matrices work, see
-      # https://docs.github.com/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
-      BUILD_CONFIGURATION: ${{matrix.configurations}}
+      BUILD_CONFIGURATION: Release
 
     steps:
       - name: Install dependencies
@@ -43,25 +43,20 @@ jobs:
       - name: Run unit tests
         run: bin/tests --abort --reporter compact
 
-      # Comment only change to test coverage report to coveralls
       - name: Generate code coverage report
         run: |
           mkdir coverage
           lcov --ignore-errors all --capture --directory build --include "*/${REPO_NAME}/src/*" --exclude "*/${REPO_NAME}/src/test/*" --output-file coverage/lcov.info
 
-      - name: Coveralls Parallel
+      # git-branch/git-commit default to GITHUB_REF/GITHUB_SHA, which on a
+      # pull_request event name the ephemeral merge ref rather than the branch and
+      # commit under review. Coveralls then files the build against a commit that
+      # exists on no branch (`Merge <head> into <base>`), so its status lands on a
+      # SHA the pull request never shows and its delta compares against a phantom
+      # parent. Name the head explicitly; on push both fall back to the pushed ref.
+      - name: Coveralls
         uses: coverallsapp/github-action@v2
         with:
           github-token: ${{ secrets.github_token }}
-          flag-name: run-${{ matrix.configurations }}
-          parallel: true
-
-  finish:
-    needs: build_ubuntu
-    runs-on: ubuntu-latest
-    steps:
-      - name: Coveralls Finished
-        uses: coverallsapp/github-action@v2
-        with:
-          github-token: ${{ secrets.github_token }}
-          parallel-finished: true
+          git-branch: ${{ github.head_ref || github.ref_name }}
+          git-commit: ${{ github.event.pull_request.head.sha || github.sha }}


### PR DESCRIPTION
Coverage runs were taking 1–2.5h and gating every PR, and nothing about them was visible on a PR. Two separate causes; both fixed here.

## The Debug leg was the entire cost

Same workflow, same steps, per leg:

| Run | Release | Debug |
|---|---|---|
| main `de799d87` | 8 min | 56 min |
| #1216 | 9 min | 65 min |
| #1217 | 10 min | **2h34m** |

An unoptimized build of the verifier, instrumented with `--coverage -fprofile-update=atomic` and running the whole sample corpus, is 6–15× the optimized one, and it swings with shared-runner contention — that is where "it used to take an hour, now it takes two" comes from. Nothing regressed; the Debug leg was always the bill.

Dropping it costs no Debug testing: `build.yml` compiles and tests Debug on both Ubuntu and Windows and runs the Debug-only leak check. What goes away is only the second *instrumented* build, whose sole product was a second lcov file. With one leg left, the parallel upload and its `finish` job have nothing to coordinate, so both go as well.

Expect the reported percentage to move slightly: code compiled out under `NDEBUG` (assertions) stops counting as relevant lines rather than as uncovered ones.

## PR builds were filed against a commit that exists on no branch

`git-branch`/`git-commit` default to `GITHUB_REF`/`GITHUB_SHA`. On a `pull_request` event those name the **ephemeral merge ref**, not the branch and commit under review. For #1218, whose head is `4b26c5a6`, Coveralls recorded:

```
commit_sha:      ea68be359e
commit_message:  "Merge 4b26c5a6 into de799d87"
```

A status posted to that SHA lands somewhere the PR never displays, and the coverage delta compares against a phantom parent. This PR names the head explicitly; on `push` both expressions fall back to the pushed ref.

## What this does not fix

The upload itself was never broken — it succeeds, the parallel-done webhook fires, and the data is live at [coveralls.io/github/vbpf/prevail](https://coveralls.io/github/vbpf/prevail) (86.8%, badge on README line 1, and you can watch it move 86.78 → 86.83 across today's merges).

For Coveralls to comment on a PR, its docs additionally require:

- the `@coveralls` user invited to the repo with **Write** role (`GET /repos/vbpf/prevail/collaborators/coveralls` returns 404, though that endpoint also 404s without sufficient scope, so it is not conclusive);
- **LEAVE COMMENTS?** enabled under Pull Request Alerts in the Coveralls repo settings.

Neither is visible from CI or checkable without an authenticated Coveralls session — worth a look next time you are in that dashboard, since with the SHA fixed those two settings are all that stand between this and PR-level feedback.

Unrelated leftover, not touched: the workflow installs `gcovr`, which nothing uses (the report is produced by `lcov`). Easy follow-up if you want the install time back.
